### PR TITLE
Fix display name helper

### DIFF
--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -25,8 +25,16 @@ export const getDisplayName = (entity, fallback = 'unknown entity') => {
     // AC: Data is accessed using entity.getComponentData(entityId, "core:name") (via entity instance)
     const nameComponentData = entity.getComponentData(NAME_COMPONENT_ID);
     // AC: Default values or fallback logic are handled appropriately if components are missing.
-    // Assumes the name component data structure is { value: "Entity Name" }
-    return nameComponentData?.value ?? entity.id ?? fallback;
+    // Support both { text: "Entity Name" } and legacy { value: "Entity Name" } structures.
+    if (nameComponentData) {
+        if (typeof nameComponentData.text === 'string' && nameComponentData.text.trim() !== '') {
+            return nameComponentData.text;
+        }
+        if (typeof nameComponentData.value === 'string' && nameComponentData.value.trim() !== '') {
+            return nameComponentData.value;
+        }
+    }
+    return entity.id ?? fallback;
 };
 // --- END TICKET 4.4 REFACTOR ---
 

--- a/tests/utils/messages.getDisplayName.test.js
+++ b/tests/utils/messages.getDisplayName.test.js
@@ -1,0 +1,39 @@
+import {describe, it, expect} from '@jest/globals';
+import {getDisplayName} from '../../src/utils/messages.js';
+
+// Minimal mock entity class for tests
+class MockEntity {
+    constructor(id, nameComponentData = undefined, nameProp = undefined) {
+        this.id = id;
+        this._nameData = nameComponentData;
+        if (nameProp !== undefined) {
+            this.name = nameProp;
+        }
+    }
+    getComponentData(type) {
+        if (type === 'core:name') return this._nameData;
+        return undefined;
+    }
+}
+
+describe('getDisplayName', () => {
+    it('uses text property from core:name component when available', () => {
+        const entity = new MockEntity('e1', {text: 'Hero'});
+        expect(getDisplayName(entity)).toBe('Hero');
+    });
+
+    it('falls back to value property if text is missing', () => {
+        const entity = new MockEntity('e2', {value: 'LegacyName'});
+        expect(getDisplayName(entity)).toBe('LegacyName');
+    });
+
+    it('falls back to entity.id when name component missing', () => {
+        const entity = new MockEntity('e3');
+        expect(getDisplayName(entity)).toBe('e3');
+    });
+
+    it('uses provided fallback when id is also missing', () => {
+        const entity = {getComponentData: () => undefined};
+        expect(getDisplayName(entity, 'n/a')).toBe('n/a');
+    });
+});


### PR DESCRIPTION
## Summary
- handle both `text` and `value` for `core:name` components in `getDisplayName`
- add focused tests for `getDisplayName`

## Testing
- `npx jest --runTestsByPath tests/utils/messages.getDisplayName.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f5e5602b88331bfa128187d721691