### PR TITLE
Fix schema check test comment

### DIFF
--- a/tests/loaders/worldLoader.preLoopErrors.integration.test.js
+++ b/tests/loaders/worldLoader.preLoopErrors.integration.test.js
@@ -391,7 +391,6 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
         expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(componentSchemaId); // Pass
         expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(manifestSchemaId); // Pass
         expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(entitySchemaId); // Fail
-        // *** FIX: Correct typo isSChemaLoaded -> isSchemaLoaded ***
         expect(mockValidator.isSchemaLoaded).not.toHaveBeenCalledWith(actionsSchemaId);
         expect(mockValidator.isSchemaLoaded).not.toHaveBeenCalledWith(eventsSchemaId);
     });


### PR DESCRIPTION
## Summary
- remove obsolete "isSChemaLoaded" comment in WorldLoader pre-loop error tests

## Testing
- `npx jest --env=jsdom tests/loaders/worldLoader.preLoopErrors.integration.test.js --runInBand --colors`

------
https://chatgpt.com/codex/tasks/task_e_683f631cc89483319e8c00bb69403191