### PR TITLE
[Fix] lint clean up for config files

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
-// babel.config.js
+/* eslint-env node */
 
+/**
+ * @description Babel configuration used by Jest and the build step.
+ * @type {import('@babel/core').TransformOptions}
+ */
 module.exports = {
   presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,9 @@
-// jest.config.js
+/* eslint-env node */
+
+/**
+ * @description Jest configuration for the root project.
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.js'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 // jest.setup.js
 
 // --- Polyfills for Jest Node environment ---

--- a/list_components.js
+++ b/list_components.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 // Import the promises API from the 'fs' module
 const fs = require('fs').promises;
 // Import the 'path' module
@@ -9,9 +12,9 @@ const relativeDirPath = 'data/components';
 // Construct the absolute path relative to where 'node' is executed
 const directoryPath = path.join(process.cwd(), relativeDirPath);
 
-// Define the asynchronous function to get filenames
 /**
- *
+ * @description Retrieve all filenames in the components data directory.
+ * @returns {Promise<string[]>} Array of filenames or an empty array on error.
  */
 async function getFilenames() {
   try {

--- a/list_events.js
+++ b/list_events.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 // Import the promises API from the 'fs' module
 const fs = require('fs').promises;
 // Import the 'path' module
@@ -9,9 +12,9 @@ const relativeDirPath = 'data/events';
 // Construct the absolute path relative to where 'node' is executed
 const directoryPath = path.join(process.cwd(), relativeDirPath);
 
-// Define the asynchronous function to get filenames
 /**
- *
+ * @description Retrieve all filenames in the events data directory.
+ * @returns {Promise<string[]>} Array of filenames or an empty array on error.
  */
 async function getFilenames() {
   try {


### PR DESCRIPTION
Summary: Fixed linting errors in root configuration scripts and helper utilities by adding Node environment annotations, JSDoc comments and disabling console warnings. This ensures these modules lint cleanly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified files (`npx eslint babel.config.js jest.config.js jest.setup.js list_components.js list_events.js`)
- [ ] Root tests (`npm test`) – **failed** (several missing module errors)
- [x] Proxy tests (`cd llm-proxy-server && npm test`)

🚫 tests failing—needs human review

------
https://chatgpt.com/codex/tasks/task_e_68405c3b81dc8331b6cc3e1252d6ffe1