### PR TITLE
[Fix] Clean lint warnings for select modules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,6 +110,18 @@ export default [
     },
   },
 
+  // 5a. Configuration for root configuration files using CommonJS
+  {
+    files: ['babel.config.js', 'jest.config.js', 'jest.setup.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
   // 5b. Configuration for the LLM Proxy Server (Node.js environment)
   // This configuration will apply ONLY to files within 'llm-proxy-server/'
   // assuming the global ignores do NOT include 'llm-proxy-server/'
@@ -130,6 +142,10 @@ export default [
     rules: {
       // Node.js specific rules for your proxy server
       'no-console': 'off', // Often enabled for server logs
+      'no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
       // Add any other rules specific to this server environment
     },
   },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,7 +12,7 @@ global.TextDecoder = TextDecoder;
 
 // Import the fetch polyfill. This will automatically add fetch, Headers, Request, Response
 // to the global scope (window in jsdom) if they don't exist.
-import 'whatwg-fetch';
+require('whatwg-fetch');
 
 // Optional: You can add a check here to be extra sure, though it shouldn't be necessary
 if (typeof window !== 'undefined') {

--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -48,7 +48,7 @@ import {
  * @typedef {object} LLMConfigurationFileForProxy
  * @description Represents the structure of the parsed llm-configs.json file.
  * @property {string} [defaultConfigId] - The ID of the default LLM configuration.
- * @property {Object<string, LLMModelConfig>} llms - A dictionary of LLM configurations, keyed by llmId.
+ * @property {Object.<string, LLMModelConfig>} llms - A dictionary of LLM configurations, keyed by llmId.
  */
 
 /**
@@ -385,7 +385,8 @@ export class LlmConfigService {
   getInitializationErrorDetails() {
     if (this.#initializationError) {
       // Return a structure that's safe for external use, omitting the direct originalError object.
-      const { originalError, ...safeErrorDetails } = this.#initializationError;
+      const { originalError: _unusedOriginalError, ...safeErrorDetails } =
+        this.#initializationError;
       return safeErrorDetails;
     }
     return null;

--- a/llm-proxy-server/src/interfaces/IServerUtils.js
+++ b/llm-proxy-server/src/interfaces/IServerUtils.js
@@ -19,12 +19,14 @@ export class IFileSystemReader {
    *
    * @async
    * @param {string} filePath - The path to the file to be read.
+   * @param _filePath
+   * @param _encoding
    * @param {string} encoding - The character encoding to use (e.g., 'utf-8').
    * @returns {Promise<string>} A Promise that resolves with the file content as a string.
    * @throws {Error} If the file cannot be read (e.g., not found, insufficient permissions, or other I/O errors).
    * Implementations should allow specific errors from the underlying file system module to propagate.
    */
-  async readFile(filePath, encoding) {
+  async readFile(_filePath, _encoding) {
     throw new Error('IFileSystemReader.readFile method not implemented.');
   }
 }
@@ -38,9 +40,10 @@ export class IEnvironmentVariableReader {
    * Retrieves the value of an environment variable.
    *
    * @param {string} variableName - The name of the environment variable.
+   * @param _variableName
    * @returns {string | undefined} The value of the environment variable if set, otherwise undefined.
    */
-  getEnv(variableName) {
+  getEnv(_variableName) {
     throw new Error(
       'IEnvironmentVariableReader.getEnv method not implemented.'
     );

--- a/llm-proxy-server/src/nodeFileSystemReader.js
+++ b/llm-proxy-server/src/nodeFileSystemReader.js
@@ -2,8 +2,7 @@
 
 import * as fs from 'node:fs/promises';
 
-// No import needed for IFileSystemReader when using JSDoc @interface and @implements.
-// JSDoc tools will resolve the type name.
+/** @typedef {import('./interfaces/IServerUtils.js').IFileSystemReader} IFileSystemReader */
 
 /**
  * @class NodeFileSystemReader

--- a/llm-proxy-server/src/utils/proxyApiUtils.js
+++ b/llm-proxy-server/src/utils/proxyApiUtils.js
@@ -30,8 +30,7 @@ function _calculateRetryDelay(currentAttempt, baseDelayMs, maxDelayMs) {
 /**
  * @async
  * @function Workspace_retry
- * @description
- * Wraps a fetch API call to provide automatic retries for transient network
+ * @description Wraps a fetch API call to provide automatic retries for transient network
  * errors and specific HTTP status codes. It implements an exponential backoff
  * strategy with added jitter.
  *
@@ -69,8 +68,10 @@ export async function Workspace_retry(
   const currentLogger = ensureValidLogger(logger, 'Workspace_retry');
 
   /**
+   * Performs a single fetch attempt and recursively retries on failure.
    *
-   * @param currentAttempt
+   * @param {number} currentAttempt - The current attempt number.
+   * @returns {Promise<any>} The parsed JSON response if successful.
    */
   async function attemptFetchRecursive(currentAttempt) {
     // currentLogger is already defined in the outer scope and is valid
@@ -90,6 +91,9 @@ export async function Workspace_retry(
             `Attempt ${currentAttempt} for ${url} - Error response body (JSON): ${errorBodyText.substring(0, 500)}`
           );
         } catch (e_json) {
+          currentLogger.debug(
+            `Attempt ${currentAttempt} for ${url} - Failed to parse error body as JSON: ${e_json.message}`
+          );
           try {
             errorBodyText = await response.text();
             currentLogger.debug(

--- a/llm-proxy-server/src/utils/responseUtils.js
+++ b/llm-proxy-server/src/utils/responseUtils.js
@@ -34,7 +34,6 @@ import { ensureValidLogger } from './loggerUtils.js'; // MODIFIED: Import ensure
 /**
  * Sends a standardized JSON error response to the client and logs the error.
  *
- * @export
  * @param {ExpressResponse} res - The Express Response object.
  * @param {number} httpStatusCode - The HTTP status code to send to the client.
  * @param {string} stage - A machine-readable string indicating the stage where the error occurred.

--- a/llm-proxy-server/tests/utils/proxyApiUtils.test.js
+++ b/llm-proxy-server/tests/utils/proxyApiUtils.test.js
@@ -8,8 +8,7 @@ import {
   expect,
   jest,
   test,
-  fail,
-} from '@jest/globals'; // Added fail
+} from '@jest/globals';
 
 // SUT (System Under Test)
 import { Workspace_retry } from '../../src/utils/proxyApiUtils.js';
@@ -28,10 +27,12 @@ jest.mock('../../src/utils/loggerUtils.js', () => ({
 // we're copying its implementation here. In a typical scenario,
 // this utility would be exported for direct testing.
 /**
+ * Simplified copy of the private _calculateRetryDelay used for unit testing.
  *
- * @param currentAttempt
- * @param baseDelayMs
- * @param maxDelayMs
+ * @param {number} currentAttempt - The current attempt number.
+ * @param {number} baseDelayMs - Base delay in milliseconds.
+ * @param {number} maxDelayMs - Maximum delay in milliseconds.
+ * @returns {number} Calculated retry delay with jitter.
  */
 function _calculateRetryDelay_forTest(currentAttempt, baseDelayMs, maxDelayMs) {
   const delayFactor = Math.pow(2, currentAttempt - 1);

--- a/tests/llms/strategies/base/baseCompletionLLMStrategy.test.js
+++ b/tests/llms/strategies/base/baseCompletionLLMStrategy.test.js
@@ -1,7 +1,7 @@
 // tests/llms/strategies/base/baseCompletionLLMStrategy.test.js
 // --- UPDATED FILE START ---
 
-import { BaseCompletionLLMStrategy } from '../../../../src/llms/strategies/base/BaseCompletionLLMStrategy.js'; // Adjusted path
+import { BaseCompletionLLMStrategy } from '../../../../src/llms/strategies/base/baseCompletionLLMStrategy.js';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 // Mock Logger

--- a/tests/services/perceptionLogFormatter.test.js
+++ b/tests/services/perceptionLogFormatter.test.js
@@ -1,7 +1,7 @@
 // test/services/perceptionLogFormatter.test.js
 // --- FILE START ---
 
-import { PerceptionLogFormatter } from '../../src/services/PerceptionLogFormatter.js';
+import { PerceptionLogFormatter } from '../../src/services/perceptionLogFormatter.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'; // Import jest
 
 const mockLogger = {

--- a/tests/services/promptElementAssemblers/thoughtsSectionAssembler.test.js
+++ b/tests/services/promptElementAssemblers/thoughtsSectionAssembler.test.js
@@ -1,5 +1,5 @@
 // tests/promptElementAssemblers/ThoughtsSectionAssembler.test.js
-import { ThoughtsSectionAssembler } from '../../../src/services/promptElementAssemblers/ThoughtsSectionAssembler.js';
+import { ThoughtsSectionAssembler } from '../../../src/services/promptElementAssemblers/thoughtsSectionAssembler.js';
 import { describe, expect, test } from '@jest/globals';
 
 describe('ThoughtsSectionAssembler.assemble()', () => {

--- a/tests/turns/services/actorDataExtractor.test.js
+++ b/tests/turns/services/actorDataExtractor.test.js
@@ -1,7 +1,7 @@
 // tests/turns/services/actorDataExtractor.test.js
 // --- FILE START ---
 
-import { ActorDataExtractor } from '../../../src/turns/services/ActorDataExtractor.js';
+import { ActorDataExtractor } from '../../../src/turns/services/actorDataExtractor.js';
 import {
   NAME_COMPONENT_ID,
   DESCRIPTION_COMPONENT_ID,


### PR DESCRIPTION
Summary: Addressed ESLint errors in a handful of modules by refining config overrides, fixing unused variables and adjusting imports. Updated failing tests to use correct paths.

Changes Made:
- added commonjs override and node unused-var rules in `eslint.config.mjs`
- converted fetch polyfill import to require in `jest.setup.js`
- cleaned unused variables and improved JSDoc in proxy utils
- added typedef for NodeFileSystemReader
- prefixed unused parameters in interface
- removed invalid JSDoc tag in response utils
- corrected import paths in several tests

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` – target modules have no errors)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test


------
https://chatgpt.com/codex/tasks/task_e_68405eeb6f6083319784c021d8129fbd