### PR TITLE
[Agent] fix lint warnings in modules

### DIFF
--- a/src/config/appContainer.js
+++ b/src/config/appContainer.js
@@ -1,5 +1,7 @@
 // src/core/config/appContainer.js
 // ****** CORRECTED FILE ******
+/* eslint-disable no-console */
+/** @typedef {import('./tokens.js').DiToken} DiToken */
 
 /**
  * @typedef {'singleton' | 'transient' | 'singletonFactory'} Lifecycle
@@ -61,7 +63,7 @@ class AppContainer {
         : '';
     // Only log deps info if the key actually exists in the effective options
     const depsInfo =
-      effectiveOptions.hasOwnProperty('dependencies') &&
+      Object.prototype.hasOwnProperty.call(effectiveOptions, 'dependencies') &&
       Array.isArray(effectiveOptions.dependencies) &&
       effectiveOptions.dependencies.length > 0
         ? ` Deps: [${effectiveOptions.dependencies.join(', ')}]`
@@ -167,7 +169,7 @@ class AppContainer {
     // (Registrar.single/transient always add this key, even if empty array).
     const isClassRegistration =
       typeof factoryOrValueOrClass === 'function' &&
-      options?.hasOwnProperty('dependencies'); // Check for key presence
+      Object.prototype.hasOwnProperty.call(options || {}, 'dependencies');
 
     const isFactoryFunction =
       typeof factoryOrValueOrClass === 'function' && !isClassRegistration;

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -88,7 +88,11 @@ class WorldContext extends IWorldContext {
 
     const errorMessage = `WorldContext: Expected exactly one entity with component '${CURRENT_ACTOR_COMPONENT_ID}', but found ${actorCount}.`;
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (
+      typeof globalThis !== 'undefined' &&
+      globalThis.process &&
+      globalThis.process.env.NODE_ENV !== 'production'
+    ) {
       this.#logger.error(errorMessage + ' (Throwing in dev mode)');
       throw new Error(errorMessage);
     } else {
@@ -101,7 +105,6 @@ class WorldContext extends IWorldContext {
    * Retrieves the primary entity currently marked as the active actor.
    *
    * @returns {Entity | null} The current actor entity instance, or null if none or multiple are found.
-   * @implements {IWorldContext.getCurrentActor}
    */
   getCurrentActor() {
     const actors = this.#entityManager.getEntitiesWithComponent(
@@ -119,7 +122,6 @@ class WorldContext extends IWorldContext {
    * The locationId in the actor's position component should be an instance ID.
    *
    * @returns {Entity | null} The entity instance representing the current location, or null if it cannot be determined.
-   * @implements {IWorldContext.getCurrentLocation}
    */
   getCurrentLocation() {
     const actor = this.getCurrentActor();
@@ -164,7 +166,6 @@ class WorldContext extends IWorldContext {
    *
    * @param {string} entityId - The unique ID of the entity whose location is requested.
    * @returns {Entity | null} The location entity instance where the specified entity resides.
-   * @implements {IWorldContext.getLocationOfEntity}
    */
   getLocationOfEntity(entityId) {
     if (typeof entityId !== 'string' || !entityId) {
@@ -319,7 +320,6 @@ class WorldContext extends IWorldContext {
    * Retrieves the current timestamp in ISO 8601 format.
    *
    * @returns {string} The current ISO 8601 timestamp (e.g., "YYYY-MM-DDTHH:mm:ss.sssZ").
-   * @implements {IWorldContext.getCurrentISOTimestamp}
    */
   getCurrentISOTimestamp() {
     return new Date().toISOString();
@@ -332,7 +332,6 @@ class WorldContext extends IWorldContext {
    * Can be a simple string (e.g., "getCurrentISOTimestamp")
    * or an object (e.g., { action: "getCurrentISOTimestamp" } or { query_type: "..."}).
    * @returns {any | undefined} The result of the query or undefined if not supported.
-   * @implements {IWorldContext.handleQuery}
    */
   handleQuery(queryDetails) {
     this.#logger.debug(
@@ -350,14 +349,14 @@ class WorldContext extends IWorldContext {
         queryDetails.action.trim() !== ''
       ) {
         actionToPerform = queryDetails.action;
-        const { action, ...rest } = queryDetails;
+        const { action: _unusedAction, ...rest } = queryDetails;
         queryParams = rest;
       } else if (
         typeof queryDetails.query_type === 'string' &&
         queryDetails.query_type.trim() !== ''
       ) {
         actionToPerform = queryDetails.query_type;
-        const { query_type, ...rest } = queryDetails;
+        const { query_type: _unusedQueryType, ...rest } = queryDetails;
         queryParams = rest;
       }
     }

--- a/src/domUI/__mocks__/boundDomRendererBase.js
+++ b/src/domUI/__mocks__/boundDomRendererBase.js
@@ -1,4 +1,5 @@
 // src/domUI/__mocks__/boundDomRendererBase.js
+import { jest } from '@jest/globals';
 
 const mockAddDomListener = jest.fn();
 const mockSuperDestroy = jest.fn();
@@ -92,4 +93,4 @@ const BoundDomRendererBase = jest.fn().mockImplementation(function ({
   BoundDomRendererBase._mockSuperDestroy = mockSuperDestroy;
 });
 
-module.exports = { BoundDomRendererBase };
+export { BoundDomRendererBase };

--- a/src/domUI/currentTurnActorRenderer.js
+++ b/src/domUI/currentTurnActorRenderer.js
@@ -16,8 +16,6 @@ import { TURN_STARTED_ID } from '../constants/eventIds.js';
 const DEFAULT_ACTOR_NAME = 'N/A';
 
 export class CurrentTurnActorRenderer extends BoundDomRendererBase {
-  /** @type {IEntityManager} */ // Kept for now, but aim to remove direct use
-  #entityManager;
   /** @type {EntityDisplayDataProvider} */
   #entityDisplayDataProvider;
 
@@ -27,18 +25,21 @@ export class CurrentTurnActorRenderer extends BoundDomRendererBase {
   // #actorNameElement;
 
   /**
-   * @param {object} dependencies
-   * @param {ILogger} dependencies.logger
-   * @param {IDocumentContext} dependencies.documentContext
-   * @param {IValidatedEventDispatcher} dependencies.validatedEventDispatcher
-   * @param {IEntityManager} dependencies.entityManager
-   * @param {EntityDisplayDataProvider} dependencies.entityDisplayDataProvider
+   * Creates a renderer that updates the UI with information about the actor
+   * whose turn is currently active.
+   *
+   * @param {object} dependencies - Runtime dependencies for this renderer.
+   * @param {ILogger} dependencies.logger - Logging utility for diagnostics.
+   * @param {IDocumentContext} dependencies.documentContext - Abstraction over the DOM.
+   * @param {IValidatedEventDispatcher} dependencies.validatedEventDispatcher - Dispatcher for validated events.
+   * @param {IEntityManager} dependencies._entityManager - Manager used for entity lookups.
+   * @param {EntityDisplayDataProvider} dependencies.entityDisplayDataProvider - Provides display data such as names and portraits.
    */
   constructor({
     logger,
     documentContext,
     validatedEventDispatcher,
-    entityManager,
+    _entityManager,
     entityDisplayDataProvider,
   }) {
     const elementsConfig = {
@@ -64,7 +65,6 @@ export class CurrentTurnActorRenderer extends BoundDomRendererBase {
       elementsConfig,
     }); // Call super with elementsConfig
 
-    this.#entityManager = entityManager; // Still store, though direct use should be minimized
     if (!entityDisplayDataProvider) {
       this.logger.error(
         `${this._logPrefix} EntityDisplayDataProvider dependency is missing.`

--- a/src/domUI/documentContext.js
+++ b/src/domUI/documentContext.js
@@ -1,4 +1,5 @@
 // src/domUI/documentContext.js
+/* eslint-disable no-console */
 /**
  * @file Implements DocumentContext for abstracting DOM access.
  * Provides a consistent interface for querying and creating DOM elements,
@@ -38,15 +39,15 @@ class DocumentContext {
     // Define the relevant constructors for the current environment dynamically AT INSTANTIATION TIME.
     // This avoids issues with stale constructors captured at module load time in test environments.
     const CurrentEnvDocument =
-      typeof global !== 'undefined' && global.Document
-        ? global.Document
+      typeof globalThis !== 'undefined' && globalThis.Document
+        ? globalThis.Document
         : typeof Document !== 'undefined'
           ? Document
           : undefined;
 
     const CurrentEnvHTMLElement =
-      typeof global !== 'undefined' && global.HTMLElement
-        ? global.HTMLElement
+      typeof globalThis !== 'undefined' && globalThis.HTMLElement
+        ? globalThis.HTMLElement
         : typeof HTMLElement !== 'undefined'
           ? HTMLElement
           : undefined;
@@ -87,12 +88,15 @@ class DocumentContext {
     // 3. If no context yet from `root`, explicitly try using the global document
     if (
       !contextFound &&
-      typeof global !== 'undefined' &&
-      typeof global.document !== 'undefined'
+      typeof globalThis !== 'undefined' &&
+      typeof globalThis.document !== 'undefined'
     ) {
       // Ensure the global document itself is usable
-      if (global.document.querySelector && global.document.createElement) {
-        this.#docContext = global.document;
+      if (
+        globalThis.document.querySelector &&
+        globalThis.document.createElement
+      ) {
+        this.#docContext = globalThis.document;
         contextFound = true;
       }
     }
@@ -137,10 +141,9 @@ class DocumentContext {
    * Creates the HTML element specified by tagName within the context.
    * Corresponds to `document.createElement`. Logs a warning if the context is unavailable.
    *
-   * @template {keyof HTMLElementTagNameMap} K - Ensures the tag name is a valid HTML tag.
-   * @param {K} tagName - The tag name for the element to create (e.g., 'div', 'span', 'button').
-   * @returns {HTMLElementTagNameMap[K] | null} The newly created HTML element, or null if the
-   * document context is missing. The return type matches the specific HTML element interface (e.g., HTMLDivElement).
+   * @param {string} tagName - The tag name for the element to create (e.g., 'div', 'span', 'button').
+   * @returns {HTMLElement | null} The newly created HTML element, or null if the
+   * document context is missing.
    */
   create(tagName) {
     if (!this.#docContext) {


### PR DESCRIPTION
## Summary
- suppress console logs in document context and app container
- allow jest usage in boundDomRendererBase mock
- clean up unused entity manager in currentTurnActorRenderer
- fix hasOwnProperty checks in appContainer
- guard against undefined `process` in worldContext
- adjust query parsing unused vars

## Testing Done
- `npm run format`
- `npm test`
- `cd llm-proxy-server && npm test`
- `npx eslint src/domUI/documentContext.js src/domUI/currentTurnActorRenderer.js src/domUI/__mocks__/boundDomRendererBase.js src/config/appContainer.js src/context/worldContext.js`


------
https://chatgpt.com/codex/tasks/task_e_68406185a07c833194916575e8ddbd3e