### PR TITLE
[Agent] Fix lint in test modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ cython_debug/
 
 # Private mods
 data/mods/onee
+
+# Node
+node_modules/

--- a/tests/engine/engineVersion.test.js
+++ b/tests/engine/engineVersion.test.js
@@ -32,25 +32,13 @@ describe('ENGINE_VERSION constant', () => {
     // attempting to reassign a constant imported from another module
     // should throw a TypeError.
     expect(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      /* eslint-disable no-import-assign */
       // @ts-ignore - Deliberately attempting to violate immutability for testing
       ENGINE_VERSION = '9.9.9';
+      /* eslint-enable no-import-assign */
     }).toThrow(Error);
 
     // Double-check that the value wasn't altered (it shouldn't be possible)
     expect(ENGINE_VERSION).toBe(pkg.version);
   });
-
-  // Optional: Test the error scenario (requires more complex setup)
-  // This would involve mocking package.json or using dynamic imports
-  // to load a version of the module linked to an invalid package.json.
-  // describe('when package.json version is invalid', () => {
-  //   it('should throw an error during module initialization', async () => {
-  //     // Mocking setup would go here...
-  //     // Example using dynamic import (syntax/feasibility depends on test env):
-  //     // jest.unstable_mockModule('../../package.json', () => ({ version: 'INVALID-VERSION' }), { virtual: true });
-  //     // await expect(import('../../src/core/ENGINE_VERSION.js')).rejects.toThrow(/Invalid engine version/);
-  //     // Reset mocks afterwards...
-  //   });
-  // });
 });

--- a/tests/integration/actionValidationService.test.js
+++ b/tests/integration/actionValidationService.test.js
@@ -1,16 +1,11 @@
 // src/tests/integration/actionValidationService.test.js
 
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment node
  */
-import {
-  describe,
-  expect,
-  test,
-  jest,
-  beforeEach,
-  afterEach,
-} from '@jest/globals';
+/* eslint-enable jsdoc/check-tag-names */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 
 // --- System Under Test (SUT) ---
 import { ActionValidationService } from '../../src/services/actionValidationService.js'; // Adjust path if needed
@@ -56,8 +51,6 @@ const mockDomainChecker = {
 // /** @type {jest.Mock<(actionDef: ActionDefinition, actor: Entity, target: ActionTargetContext, manager: EntityManager, logger: ILogger) => JsonLogicEvaluationContext>} */
 // const mockContextCreatorFn = jest.fn();
 
-// Mock PrerequisiteEvaluationService Instance (using mocked constructor)
-const MockPrerequisiteEvaluationService = PrerequisiteEvaluationService; // Alias for clarity
 /** @type {jest.Mocked<PrerequisiteEvaluationService>} */
 let mockPesInstance;
 
@@ -141,9 +134,6 @@ describe('Integration Test: ActionValidationService - Prerequisite Validation St
   });
 
   // --- Test Cases ---
-
-  // REMOVED: Test Context Creator Call (No longer relevant for AVS)
-  // test('should call createActionValidationContextFn with correct args when prerequisites exist', () => { ... });
 
   // AC3: Prerequisite Check - PES Called with Correct Arguments
   test('AC3: should call PrerequisiteEvaluationService.evaluate with correct args when prerequisites exist', () => {
@@ -316,9 +306,6 @@ describe('Integration Test: ActionValidationService - Prerequisite Validation St
     );
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);
   });
-
-  // REMOVED: Test for context creator throwing error (no longer AVS responsibility)
-  // test('should return false and log error if createActionValidationContextFn throws, does NOT call PES', () => { ... });
 
   // Optional: Test edge case where target entity resolution fails
   // AVS only warns, PES might fail later, but AVS itself proceeds. AVS Test should verify PES is still called.

--- a/tests/validation/domainContextCompatibilityChecker.test.js
+++ b/tests/validation/domainContextCompatibilityChecker.test.js
@@ -1,6 +1,8 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment node
  */
+/* eslint-enable jsdoc/check-tag-names */
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { DomainContextCompatibilityChecker } from '../../src/validation/domainContextCompatibilityChecker.js'; // Adjust path as needed
 import { ActionTargetContext } from '../../src/models/actionTargetContext.js'; // Adjust path as needed
@@ -16,10 +18,12 @@ const mockLogger = {
 
 // --- Helper to create Mock ActionDefinition objects ---
 /**
+ * Creates a minimal action definition object for testing.
+ *
  * @typedef {import('../types/actionDefinition.js').TargetDomain} TargetDomain
- * @param {string} id
- * @param {TargetDomain | undefined | null} targetDomain
- * @returns {import('../types/actionDefinition.js').ActionDefinition}
+ * @param {string} id - The action identifier.
+ * @param {TargetDomain | undefined | null} targetDomain - The domain to test.
+ * @returns {import('../types/actionDefinition.js').ActionDefinition} New action definition.
  */
 const createActionDef = (id, targetDomain) => ({
   id: id,


### PR DESCRIPTION
Summary: Resolved ESLint issues in three heavily warned test files and ignored node_modules. Updated JSDoc blocks, removed unused code, and adjusted lint directives so these files pass lint cleanly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on modified files `npx eslint tests/validation/domainContextCompatibilityChecker.test.js`, `tests/integration/actionValidationService.test.js`, `tests/engine/engineVersion.test.js`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68406519077883318dac2cae2f54fd28