### PR TITLE
[Agent] add contract tests for LLM payload schema

### DIFF
--- a/tests/schemas/PromptOutputContract.test.js
+++ b/tests/schemas/PromptOutputContract.test.js
@@ -1,0 +1,67 @@
+// tests/schemas/PromptOutputContract.test.js
+// -----------------------------------------------------------------------------
+// Contract tests for LLM_TURN_ACTION_WITH_THOUGHTS_SCHEMA.
+// Ensures that LLM payloads conform to the schema requirements for the
+// `thoughts` field.
+// -----------------------------------------------------------------------------
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { LLM_TURN_ACTION_WITH_THOUGHTS_SCHEMA } from '../../src/turns/schemas/llmOutputSchemas.js';
+import { jest, describe, beforeAll, test, expect } from '@jest/globals';
+
+// -----------------------------------------------------------------------------
+// Compile schema once for all tests
+// -----------------------------------------------------------------------------
+
+let validate;
+
+beforeAll(() => {
+  const ajv = new Ajv({ strict: true });
+  addFormats(ajv);
+  validate = ajv.compile(LLM_TURN_ACTION_WITH_THOUGHTS_SCHEMA);
+});
+
+// -----------------------------------------------------------------------------
+// Test Suite
+// -----------------------------------------------------------------------------
+
+describe('PromptOutputContract', () => {
+  test('fails validation when thoughts field is missing', () => {
+    const payload = {
+      actionDefinitionId: 'core:wait',
+      commandString: 'wait',
+      speech: '',
+    };
+
+    const isValid = validate(payload);
+    expect(isValid).toBe(false);
+    expect(validate.errors).toBeDefined();
+  });
+
+  test('fails validation when thoughts is not a string', () => {
+    const payload = {
+      actionDefinitionId: 'core:wait',
+      commandString: 'wait',
+      speech: '',
+      thoughts: 123,
+    };
+
+    const isValid = validate(payload);
+    expect(isValid).toBe(false);
+    expect(validate.errors).toBeDefined();
+  });
+
+  test('passes validation for a correct payload', () => {
+    const payload = {
+      actionDefinitionId: 'core:wait',
+      commandString: 'wait',
+      speech: '',
+      thoughts: 'Thinking about next move.',
+    };
+
+    const isValid = validate(payload);
+    expect(isValid).toBe(true);
+    expect(validate.errors).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary: Added new PromptOutputContract tests validating `thoughts` presence and type using Ajv with strict mode.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: many existing lint errors)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68407840adc0833197fe93f5067150e0