### PR TITLE
[Agent] enhance world loader error handling

### DIFF
--- a/src/errors/worldLoaderError.js
+++ b/src/errors/worldLoaderError.js
@@ -1,0 +1,25 @@
+// src/errors/worldLoaderError.js
+/**
+ * Custom error class representing fatal failures during the world loading
+ * sequence. It wraps the original error to provide additional context
+ * while still preserving the underlying stack trace.
+ *
+ * @class WorldLoaderError
+ * @augments Error
+ * @param {string} message - A human friendly message describing the failure.
+ * @param {Error} [cause] - The original error that triggered this failure.
+ */
+class WorldLoaderError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = 'WorldLoaderError';
+    if (cause) {
+      this.cause = cause;
+    }
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, WorldLoaderError);
+    }
+  }
+}
+
+export default WorldLoaderError;

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -21,6 +21,7 @@
 import ModDependencyValidator from '../modding/modDependencyValidator.js';
 import validateModEngineVersions from '../modding/modVersionValidator.js';
 import ModDependencyError from '../errors/modDependencyError.js'; // Ensure this path is correct
+import WorldLoaderError from '../errors/worldLoaderError.js';
 // import {ENGINE_VERSION} from '../engineVersion.js'; // Not directly used in this logic, commented out
 import { resolveOrder } from '../modding/modLoadOrderResolver.js';
 
@@ -579,13 +580,16 @@ class WorldLoader {
         // This condition should now primarily catch the error thrown if the flag was set in Step 3
         const finalMessage = `WorldLoader failed: Essential schema '${missingSchemaId || 'unknown'}' missing or check failed – aborting world load. Original error: ${err.message}`;
         this.#logger.error(finalMessage, err); // Log the combined info
-        throw new Error(finalMessage, { cause: err }); // Throw a new error, preserving the original cause
+        throw new WorldLoaderError(finalMessage, err); // Throw a new error, preserving the original cause
       } else {
         // Re-throw any other unexpected error encountered during the try block
         this.#logger.debug(
           'Caught an unexpected error type, re-throwing original error.'
         );
-        throw err;
+        throw new WorldLoaderError(
+          `WorldLoader unexpected error: ${err.message}`,
+          err
+        );
       }
       // --- END REVISED CATCH BLOCK ---
     }

--- a/tests/loaders/worldLoader.preLoopErrors.integration.test.js
+++ b/tests/loaders/worldLoader.preLoopErrors.integration.test.js
@@ -7,6 +7,7 @@ import WorldLoader from '../../src/loaders/worldLoader.js';
 
 // --- Dependencies to Mock/Import ---
 import ModDependencyError from '../../src/errors/modDependencyError.js';
+import WorldLoaderError from '../../src/errors/worldLoaderError.js';
 
 // --- Mock Modules BEFORE they are potentially imported by SUT or other imports ---
 jest.mock('../../src/modding/modDependencyValidator.js', () => ({
@@ -254,7 +255,14 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
     mockGameConfigLoader.loadConfig.mockResolvedValue([modAId]);
 
     // Action & Assertions
-    await expect(worldLoader.loadWorld(worldName)).rejects.toBe(simulatedError);
+    let manifestErr;
+    try {
+      await worldLoader.loadWorld(worldName);
+    } catch (e) {
+      manifestErr = e;
+    }
+    expect(manifestErr).toBeInstanceOf(WorldLoaderError);
+    expect(manifestErr.cause).toBe(simulatedError);
 
     // Verify side effects
     expect(mockRegistry.clear).toHaveBeenCalledTimes(2); // Start + Catch
@@ -344,9 +352,14 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
     const expectedFinalErrorMessage = `WorldLoader failed: Essential schema '${gameSchemaId}' missing or check failed – aborting world load. Original error: ${expectedInternalErrorMessage}`;
 
     // Action & Assertions
-    await expect(worldLoader.loadWorld(worldName)).rejects.toThrow(
-      expectedFinalErrorMessage
-    );
+    let thrown;
+    try {
+      await worldLoader.loadWorld(worldName);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(WorldLoaderError);
+    expect(thrown.message).toBe(expectedFinalErrorMessage);
 
     // Verify side effects
     expect(mockRegistry.clear).toHaveBeenCalledTimes(2); // Start + Catch
@@ -395,9 +408,14 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
     const expectedFinalErrorMessage = `WorldLoader failed: Essential schema '${manifestSchemaId}' missing or check failed – aborting world load. Original error: ${expectedInternalErrorMessage}`;
 
     // Action & Assertions
-    await expect(worldLoader.loadWorld(worldName)).rejects.toThrow(
-      expectedFinalErrorMessage
-    );
+    let thrown2;
+    try {
+      await worldLoader.loadWorld(worldName);
+    } catch (e) {
+      thrown2 = e;
+    }
+    expect(thrown2).toBeInstanceOf(WorldLoaderError);
+    expect(thrown2.message).toBe(expectedFinalErrorMessage);
 
     // Verify side effects
     expect(mockRegistry.clear).toHaveBeenCalledTimes(2); // Start + Catch
@@ -457,9 +475,14 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
     const expectedFinalErrorMessage = `WorldLoader failed: Essential schema '${entitySchemaId}' missing or check failed – aborting world load. Original error: ${expectedInternalErrorMessage}`;
 
     // Action & Assertions
-    await expect(worldLoader.loadWorld(worldName)).rejects.toThrow(
-      expectedFinalErrorMessage
-    );
+    let thrown3;
+    try {
+      await worldLoader.loadWorld(worldName);
+    } catch (e) {
+      thrown3 = e;
+    }
+    expect(thrown3).toBeInstanceOf(WorldLoaderError);
+    expect(thrown3.message).toBe(expectedFinalErrorMessage);
 
     // Verify side effects
     expect(mockRegistry.clear).toHaveBeenCalledTimes(2); // Start + Catch


### PR DESCRIPTION
## Summary
- create `WorldLoaderError` custom error
- wrap fatal failures in `WorldLoader.loadWorld` with `WorldLoaderError`
- update tests to expect new error type when essential schemas missing or manifest loading fails

## Testing Done
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684080d878b083318fa98aca84a2b617