### PR TITLE
[Feat] add mod validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ Mods can specify the range of engine versions they are compatible with using the
 _(Note: Schema validation, ID mismatch, and invalid gameVersion format errors are typically caught by specific
 loaders/validators but are included here for completeness as fatal loading errors related to manifests)._
 
+### Validating Mods Quickly
+
+Before committing new mods or deploying the game you can run a standalone
+validation step:
+
+```bash
+npm run validate-mods
+```
+
+This command scans every folder under `data/mods/`, validates each manifest,
+checks declared dependencies and conflicts, and verifies that all content files
+conform to their JSON schemas. If any problems are found they will be printed to
+the console; otherwise you will see **“All mods passed validation.”**
+
 ### Documentation ▶️
 
 **JSON Logic – Composite Operators ➜ docs/json-logic/composite-logical-operators.md**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint": "eslint . --fix",
     "test": "jest --env=jsdom --updateSnapshot --silent",
     "coverage": "jest --coverage --env=jsdom --silent",
+    "validate-mods": "node scripts/validateMods.mjs",
     "build": "esbuild main.js --bundle --outfile=dist/bundle.js --platform=browser --sourcemap && cpy index.html dist && cpy css dist && cpy data dist && cpy config dist && cpy favicon.ico dist",
     "start": "npm run build && http-server dist -o",
     "start:all": "concurrently \"npm run start\" \"npm run start --prefix llm-proxy-server\"",

--- a/scripts/validateMods.mjs
+++ b/scripts/validateMods.mjs
@@ -1,0 +1,150 @@
+import fs from 'fs/promises';
+import path from 'path';
+import StaticConfiguration from '../src/services/staticConfiguration.js';
+import DefaultPathResolver from '../src/services/defaultPathResolver.js';
+import AjvSchemaValidator from '../src/services/ajvSchemaValidator.js';
+import ConsoleLogger, { LogLevel } from '../src/services/consoleLogger.js';
+import SchemaLoader from '../src/loaders/schemaLoader.js';
+import ModManifestLoader from '../src/modding/modManifestLoader.js';
+import ModDependencyValidator from '../src/modding/modDependencyValidator.js';
+import validateModEngineVersions from '../src/modding/modVersionValidator.js';
+import InMemoryDataRegistry from '../src/services/inMemoryDataRegistry.js';
+
+/** Simple IDataFetcher implementation using Node's fs module. */
+class NodeDataFetcher {
+  async fetch(identifier) {
+    if (!identifier || typeof identifier !== 'string' || !identifier.trim()) {
+      throw new Error('NodeDataFetcher: invalid identifier');
+    }
+    const data = await fs.readFile(identifier, 'utf8');
+    return JSON.parse(data);
+  }
+}
+
+const logger = new ConsoleLogger(LogLevel.INFO);
+const config = new StaticConfiguration();
+const resolver = new DefaultPathResolver(config);
+const fetcher = new NodeDataFetcher();
+const validator = new AjvSchemaValidator(logger);
+const registry = new InMemoryDataRegistry();
+const schemaLoader = new SchemaLoader(
+  config,
+  resolver,
+  fetcher,
+  validator,
+  logger
+);
+const manifestLoader = new ModManifestLoader(
+  config,
+  resolver,
+  fetcher,
+  validator,
+  registry,
+  logger
+);
+
+/**
+ *
+ * @param modId
+ * @param manifest
+ */
+async function validateContent(modId, manifest) {
+  if (!manifest.content) return [];
+  const errors = [];
+  for (const [type, files] of Object.entries(manifest.content)) {
+    if (!Array.isArray(files)) continue;
+    const schemaId = config.getContentTypeSchemaId(type);
+    for (const file of files) {
+      try {
+        const filePath = resolver.resolveModContentPath(modId, type, file);
+        const data = await fetcher.fetch(filePath);
+        if (schemaId) {
+          const res = validator.validate(schemaId, data);
+          if (!res.isValid) {
+            errors.push(
+              `Mod ${modId}: file ${type}/${file} failed schema validation.`
+            );
+            logger.error(
+              `Validation errors for ${modId} ${type}/${file}:`,
+              res.errors
+            );
+          }
+        }
+      } catch (e) {
+        errors.push(
+          `Mod ${modId}: error processing ${type}/${file} - ${e.message}`
+        );
+        logger.error(
+          `Error processing ${modId} ${type}/${file}: ${e.message}`,
+          e
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ *
+ */
+async function run() {
+  try {
+    await schemaLoader.loadAndCompileAllSchemas();
+    const modsDir = path.join(
+      config.getBaseDataPath(),
+      config.getModsBasePath()
+    );
+    const dirEntries = await fs.readdir(modsDir, { withFileTypes: true });
+    const modIds = dirEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+    const manifests = await manifestLoader.loadRequestedManifests(modIds);
+
+    const manifestMap = new Map();
+    const duplicateErrors = [];
+    for (const [id, manifest] of manifests.entries()) {
+      const lc = id.toLowerCase();
+      if (manifestMap.has(lc)) {
+        duplicateErrors.push(
+          `Duplicate mod ID '${lc}' from directories '${manifestMap.get(lc).id}' and '${manifest.id}'.`
+        );
+      } else {
+        manifestMap.set(lc, manifest);
+      }
+    }
+
+    duplicateErrors.forEach((err) => logger.error(err));
+    if (duplicateErrors.length) {
+      console.log('Mod ID duplication errors detected.');
+    }
+
+    try {
+      ModDependencyValidator.validate(manifestMap, logger);
+      validateModEngineVersions(manifestMap, logger);
+    } catch (e) {
+      console.error(e.message);
+      process.exitCode = 1;
+    }
+
+    const contentErrors = [];
+    for (const [lcId, manifest] of manifestMap.entries()) {
+      const errs = await validateContent(manifest.id, manifest);
+      contentErrors.push(...errs);
+    }
+    contentErrors.forEach((e) => logger.error(e));
+
+    if (
+      duplicateErrors.length === 0 &&
+      contentErrors.length === 0 &&
+      process.exitCode !== 1
+    ) {
+      console.log('All mods passed validation.');
+    } else {
+      console.log('Mod validation completed with issues.');
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error('Fatal error during validation:', err);
+    process.exitCode = 1;
+  }
+}
+
+run();


### PR DESCRIPTION
Summary: Added a standalone script `npm run validate-mods` to validate mod manifests, dependencies, and content schemas. Documentation updated with instructions.

Changes Made:
- New script `scripts/validateMods.mjs` uses existing loaders and validators to scan `data/mods`.
- Added npm script entry `validate-mods` in `package.json`.
- Documented usage in README.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - fails with existing repo issues)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_684088628ec88331ba688dab19f47c70