### PR TITLE
[Agent] Reduce lint warnings by adjusting test globals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,8 @@ export default [
     languageOptions: {
       globals: {
         ...globals.jest,
+        ...globals.node,
+        ...globals.browser,
       },
     },
   },


### PR DESCRIPTION
Summary: Added node and browser globals to the Jest linting block so ESLint recognizes `process` and DOM objects in tests. This change resolves over 500 lint errors across test files.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (still with warnings)
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68409658c4f083318cacf3e14e45b6b7