### PR TITLE
[Feat] handle LLM API errors

### DIFF
--- a/src/errors/llmInteractionErrors.js
+++ b/src/errors/llmInteractionErrors.js
@@ -1,0 +1,100 @@
+/**
+ * @file Defines custom error classes for LLM API interaction failures.
+ */
+
+/**
+ * @class LLMInteractionError
+ * @augments Error
+ * @description Base error for failures during interaction with a Large Language Model service.
+ */
+export class LLMInteractionError extends Error {
+  /**
+   * @param {string} message - The error message.
+   * @param {object} [details] - Optional contextual details.
+   * @param {number} [details.status] - HTTP status code associated with the failure.
+   * @param {string} [details.llmId] - Identifier of the LLM involved.
+   * @param {any} [details.responseBody] - Parsed response body from the LLM provider.
+   */
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'LLMInteractionError';
+    this.status = details.status;
+    this.llmId = details.llmId;
+    this.responseBody = details.responseBody;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMInteractionError);
+    }
+  }
+}
+
+/**
+ * @class ApiKeyError
+ * @augments LLMInteractionError
+ * @description Error representing invalid or missing API key issues.
+ */
+export class ApiKeyError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'ApiKeyError';
+  }
+}
+
+/**
+ * @class InsufficientCreditsError
+ * @augments LLMInteractionError
+ * @description Error indicating the account lacks sufficient credits.
+ */
+export class InsufficientCreditsError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'InsufficientCreditsError';
+  }
+}
+
+/**
+ * @class ContentPolicyError
+ * @augments LLMInteractionError
+ * @description Error thrown when the request violates content policy.
+ */
+export class ContentPolicyError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'ContentPolicyError';
+  }
+}
+
+/**
+ * @class PermissionError
+ * @augments LLMInteractionError
+ * @description Error representing a permission or authentication failure that is not content policy related.
+ */
+export class PermissionError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'PermissionError';
+  }
+}
+
+/**
+ * @class BadRequestError
+ * @augments LLMInteractionError
+ * @description Error representing a malformed or invalid request body.
+ */
+export class BadRequestError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'BadRequestError';
+  }
+}
+
+/**
+ * @class MalformedResponseError
+ * @augments LLMInteractionError
+ * @description Error thrown when the LLM returns malformed or unparsable JSON.
+ */
+export class MalformedResponseError extends LLMInteractionError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'MalformedResponseError';
+  }
+}

--- a/tests/turns/adapters/configurableLLMAdapter.apiErrorHandling.test.js
+++ b/tests/turns/adapters/configurableLLMAdapter.apiErrorHandling.test.js
@@ -1,0 +1,92 @@
+import { jest, beforeEach, describe, expect, test } from '@jest/globals';
+import { ConfigurableLLMAdapter } from '../../../src/turns/adapters/configurableLLMAdapter.js';
+import {
+  ApiKeyError,
+  InsufficientCreditsError,
+  BadRequestError,
+} from '../../../src/errors/llmInteractionErrors.js';
+import { CLOUD_API_TYPES } from '../../../src/llms/constants/llmConstants.js';
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+const mockEnvironmentContext = {
+  getExecutionEnvironment: jest.fn().mockReturnValue('server'),
+  getProjectRootPath: jest.fn(),
+  getProxyServerUrl: jest.fn(),
+  isClient: jest.fn().mockReturnValue(false),
+  isServer: jest.fn().mockReturnValue(true),
+};
+const mockApiKeyProvider = { getKey: jest.fn().mockResolvedValue('key') };
+const mockLlmStrategyFactory = { getStrategy: jest.fn() };
+const mockLlmConfigLoader = { loadConfigs: jest.fn() };
+const mockStrategy = { execute: jest.fn() };
+
+const baseConfig = (id) => ({
+  configId: id,
+  displayName: id,
+  apiType: CLOUD_API_TYPES[0] || 'openai',
+  modelIdentifier: 'model',
+  endpointUrl: 'https://api.test',
+  jsonOutputStrategy: { method: 'native_json' },
+  promptElements: [{ key: 'sys', prefix: '', suffix: '' }],
+  promptAssemblyOrder: ['sys'],
+});
+
+describe('ConfigurableLLMAdapter API error handling', () => {
+  let adapter;
+  const summary = 'hi';
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockLlmStrategyFactory.getStrategy.mockReturnValue(mockStrategy);
+    mockLlmConfigLoader.loadConfigs.mockResolvedValue({
+      defaultConfigId: 'a',
+      configs: { a: baseConfig('a') },
+    });
+    adapter = new ConfigurableLLMAdapter({
+      logger: mockLogger,
+      environmentContext: mockEnvironmentContext,
+      apiKeyProvider: mockApiKeyProvider,
+      llmStrategyFactory: mockLlmStrategyFactory,
+    });
+    await adapter.init({ llmConfigLoader: mockLlmConfigLoader });
+  });
+
+  test('maps 401 HttpClientError to ApiKeyError', async () => {
+    const err = new Error('unauthorized');
+    err.name = 'HttpClientError';
+    err.status = 401;
+    err.responseBody = { message: 'bad key' };
+    mockStrategy.execute.mockRejectedValueOnce(err);
+
+    const caught = await adapter.getAIDecision(summary).catch((e) => e);
+    expect(caught).toBeInstanceOf(ApiKeyError);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Status: 401'),
+      expect.objectContaining({ status: 401, llmId: 'a' })
+    );
+  });
+
+  test('maps 402 HttpClientError to InsufficientCreditsError', async () => {
+    const err = new Error('payment');
+    err.name = 'HttpClientError';
+    err.status = 402;
+    err.responseBody = { message: 'pay up' };
+    mockStrategy.execute.mockRejectedValueOnce(err);
+    const caught = await adapter.getAIDecision(summary).catch((e) => e);
+    expect(caught).toBeInstanceOf(InsufficientCreditsError);
+  });
+
+  test('maps 400 HttpClientError to BadRequestError', async () => {
+    const err = new Error('bad');
+    err.name = 'HttpClientError';
+    err.status = 400;
+    err.responseBody = { oops: true };
+    mockStrategy.execute.mockRejectedValueOnce(err);
+    const caught = await adapter.getAIDecision(summary).catch((e) => e);
+    expect(caught).toBeInstanceOf(BadRequestError);
+  });
+});

--- a/tests/utils/apiUtils.retry.test.js
+++ b/tests/utils/apiUtils.retry.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { Workspace_retry } from '../../src/utils/apiUtils.js';
+
+jest.useFakeTimers();
+
+const mockResponse = (status, body, ok = false, headersObj = {}) => {
+  const headers = { get: (h) => headersObj[h] };
+  return {
+    ok,
+    status,
+    statusText: `HTTP ${status}`,
+    headers,
+    json: jest.fn(),
+    text: jest.fn(),
+  };
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.clearAllMocks();
+});
+
+describe('Workspace_retry', () => {
+  const url = 'https://api.test.local';
+  const opts = { method: 'GET' };
+
+  test('parses JSON body for HTTP errors', async () => {
+    const body = { error: 'bad' };
+    const resp = mockResponse(400, body, false, {}, true);
+    resp.json.mockResolvedValue(body);
+    fetch.mockResolvedValueOnce(resp);
+
+    let caught;
+    try {
+      await Workspace_retry(url, opts, 1, 1, 1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.status).toBe(400);
+    expect(caught.body).toEqual(body);
+  });
+
+  test('falls back to text body for HTTP errors', async () => {
+    const resp = mockResponse(400, 'bad text', false, {}, false);
+    resp.json.mockRejectedValue(new Error('no json'));
+    resp.text.mockResolvedValue('bad text');
+    fetch.mockResolvedValueOnce(resp);
+
+    const err = await Workspace_retry(url, opts, 1, 1, 1).catch((e) => e);
+    expect(err.body).toBe('bad text');
+  });
+
+  test('uses Retry-After header for 429 delays', async () => {
+    const first = mockResponse(
+      429,
+      { retry: true },
+      false,
+      { 'Retry-After': '2' },
+      true
+    );
+    first.json.mockResolvedValue({});
+    const okResp = mockResponse(200, { ok: true }, true, {}, true);
+    okResp.json.mockResolvedValue({ ok: true });
+    fetch.mockResolvedValueOnce(first).mockResolvedValueOnce(okResp);
+
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const promise = Workspace_retry(url, opts, 2, 100, 1000);
+    await jest.runOnlyPendingTimersAsync();
+    await promise;
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
+    timeoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Summary: Add detailed error handling for LLM API failures and implement custom error classes.

Changes Made:
- Introduced specialized error classes in `llmInteractionErrors.js`.
- Enhanced `Workspace_retry` with response body parsing, Retry-After handling and status-aware errors.
- Updated `ConfigurableLLMAdapter` to map HttpClient errors to new error types and log details.
- Added unit tests covering retry utility and adapter API error mapping.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_6840b0fe83988331be688fecce7865e9