### PR TITLE
[Agent] add tests for TurnDirectiveStrategyResolver

### DIFF
--- a/src/turns/strategies/turnDirectiveStrategyResolver.js
+++ b/src/turns/strategies/turnDirectiveStrategyResolver.js
@@ -36,8 +36,12 @@ import WaitForTurnEndEventStrategy from './waitForTurnEndEventStrategy.js';
 const STRATEGY_SINGLETONS = new Map();
 
 /**
+ * Retrieves a singleton instance for the provided strategy class, creating it
+ * on first use.
  *
- * @param strategyClass
+ * @param {Constructor<ITurnDirectiveStrategy>} strategyClass - The class to
+ *        instantiate.
+ * @returns {ITurnDirectiveStrategy} The cached instance for the class.
  */
 function getOrCreate(strategyClass) {
   const key = strategyClass.name;
@@ -79,11 +83,16 @@ export default class TurnDirectiveStrategyResolver {
         // the legacy behaviour inside PlayerTurnHandler.
 
         /* istanbul ignore next */
-        if (process.env.NODE_ENV !== 'production') {
+        if (
+          typeof globalThis !== 'undefined' &&
+          globalThis.process &&
+          globalThis.process.env.NODE_ENV !== 'production'
+        ) {
           // Helpful debug log when running tests or dev builds.
           // We **do not** throw because production should keep rolling.
           // The caller retains ultimate responsibility for safe execution.
           //  – If that is undesirable, swap the console.warn() for an Error.
+          // eslint-disable-next-line no-console
           console.warn(
             `${this.name}: Unrecognised TurnDirective (\u201c${directive}\u201d). Falling back to WAIT_FOR_EVENT.`
           );

--- a/tests/turns/strategies/turnDirectiveStrategyResolver.test.js
+++ b/tests/turns/strategies/turnDirectiveStrategyResolver.test.js
@@ -1,0 +1,80 @@
+// tests/turns/strategies/turnDirectiveStrategyResolver.test.js
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+import TurnDirectiveStrategyResolver from '../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
+import RepromptStrategy from '../../../src/turns/strategies/repromptStrategy.js';
+import EndTurnSuccessStrategy from '../../../src/turns/strategies/endTurnSuccessStrategy.js';
+import EndTurnFailureStrategy from '../../../src/turns/strategies/endTurnFailureStrategy.js';
+import WaitForTurnEndEventStrategy from '../../../src/turns/strategies/waitForTurnEndEventStrategy.js';
+
+// --- Test Suite ---
+
+describe('TurnDirectiveStrategyResolver', () => {
+  let consoleWarnSpy;
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('returns correct singleton strategies for known directives', () => {
+    const reprompt1 = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.RE_PROMPT
+    );
+    const reprompt2 = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.RE_PROMPT
+    );
+    expect(reprompt1).toBeInstanceOf(RepromptStrategy);
+    expect(reprompt1).toBe(reprompt2);
+
+    const success1 = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.END_TURN_SUCCESS
+    );
+    const success2 = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.END_TURN_SUCCESS
+    );
+    expect(success1).toBeInstanceOf(EndTurnSuccessStrategy);
+    expect(success1).toBe(success2);
+
+    const failure = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.END_TURN_FAILURE
+    );
+    expect(failure).toBeInstanceOf(EndTurnFailureStrategy);
+
+    const wait = TurnDirectiveStrategyResolver.resolveStrategy(
+      TurnDirective.WAIT_FOR_EVENT
+    );
+    expect(wait).toBeInstanceOf(WaitForTurnEndEventStrategy);
+  });
+
+  test('falls back to WAIT_FOR_EVENT and warns for unknown directive', () => {
+    const result = TurnDirectiveStrategyResolver.resolveStrategy('UNKNOWN');
+    expect(result).toBeInstanceOf(WaitForTurnEndEventStrategy);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain(
+      'Unrecognised TurnDirective'
+    );
+  });
+
+  test('does not warn in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const result = TurnDirectiveStrategyResolver.resolveStrategy('UNKNOWN');
+    expect(result).toBeInstanceOf(WaitForTurnEndEventStrategy);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the turn directive resolver
- document getOrCreate helper and use safe process check

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2010 problems)*
- `npm run test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ac287e78833193505e936e707cf9