### PR TITLE
[Agent] Refactor ActionValidationContextBuilder to use validateDependency

### DIFF
--- a/tests/services/actionValidationContextBuilder.test.js
+++ b/tests/services/actionValidationContextBuilder.test.js
@@ -92,7 +92,7 @@ describe('ActionValidationContextBuilder', () => {
           logger: mockLogger,
         })
     ).toThrow(
-      'ActionValidationContextBuilder requires a valid EntityManager with getEntityInstance and getComponentData methods.'
+      'Missing required dependency: ActionValidationContextBuilder: entityManager.'
     );
     const incompleteEntityManager = { getEntityInstance: jest.fn() }; // Missing getComponentData
     expect(
@@ -102,7 +102,7 @@ describe('ActionValidationContextBuilder', () => {
           logger: mockLogger,
         })
     ).toThrow(
-      'ActionValidationContextBuilder requires a valid EntityManager with getEntityInstance and getComponentData methods.'
+      "Invalid or missing method 'getComponentData' on dependency 'ActionValidationContextBuilder: entityManager'."
     );
     const anotherIncompleteEntityManager = { getComponentData: jest.fn() }; // Missing getEntityInstance
     expect(
@@ -112,7 +112,7 @@ describe('ActionValidationContextBuilder', () => {
           logger: mockLogger,
         })
     ).toThrow(
-      'ActionValidationContextBuilder requires a valid EntityManager with getEntityInstance and getComponentData methods.'
+      "Invalid or missing method 'getEntityInstance' on dependency 'ActionValidationContextBuilder: entityManager'."
     );
     // --- END FIX ---
   });
@@ -131,7 +131,7 @@ describe('ActionValidationContextBuilder', () => {
           logger: null,
         })
     ).toThrow(
-      'ActionValidationContextBuilder requires a valid ILogger instance.'
+      'ActionValidationContextBuilder Constructor: CRITICAL - Invalid or missing ILogger instance. Error: Missing required dependency: ActionValidationContextBuilder: logger.'
     );
     expect(
       () =>
@@ -140,7 +140,7 @@ describe('ActionValidationContextBuilder', () => {
           logger: { debug: jest.fn(), error: jest.fn() }, // Missing warn
         })
     ).toThrow(
-      'ActionValidationContextBuilder requires a valid ILogger instance.'
+      "ActionValidationContextBuilder Constructor: CRITICAL - Invalid or missing ILogger instance. Error: Invalid or missing method 'warn' on dependency 'ActionValidationContextBuilder: logger'."
     );
   });
 


### PR DESCRIPTION
Summary: Updated ActionValidationContextBuilder to use centralized validateDependency for constructor dependency checks.

Changes Made:
- Imported validateDependency and applied it to logger then entityManager.
- Updated unit tests to expect new validation error messages.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6841b2120a4483318b3acce70c1c597a