### PR TITLE
[Agent] update action formatter to canonical entity name util

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -92,8 +92,8 @@ export function formatActionCommand(
         const targetEntity = entityManager.getEntityInstance(targetId);
 
         if (targetEntity) {
-          // Use getEntityDisplayName utility, which handles its own fallback to ID or 'unknown entity'
-          targetName = getEntityDisplayName(targetEntity, logger);
+          // Use getEntityDisplayName utility with ID as fallback and pass logger
+          targetName = getEntityDisplayName(targetEntity, targetId, logger);
           if (debug) {
             logger.debug(
               ` -> Found entity ${targetId}, display name: "${targetName}"`


### PR DESCRIPTION
Summary:
- use canonical getEntityDisplayName with id fallback

Testing Done:
- `npm run format`
- `npx eslint src/actions/actionFormatter.js --fix`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841cf8d981c833198b73a438e953b73