### PR TITLE
[Agent] standardize entity name resolution

### DIFF
--- a/src/actions/targeting/targetResolutionService.js
+++ b/src/actions/targeting/targetResolutionService.js
@@ -72,7 +72,7 @@ class TargetResolutionService extends ITargetResolutionService {
       this.#logger = logger;
     } catch (e) {
       const errorMsg = `TargetResolutionService Constructor: CRITICAL - Invalid or missing ILogger instance. Dependency validation utility reported: ${e.message}`;
-      console.error(errorMsg);
+      console.error(errorMsg); // eslint-disable-line no-console
       throw new Error(errorMsg);
     }
 
@@ -223,12 +223,16 @@ class TargetResolutionService extends ITargetResolutionService {
       const itemEntity = this.#entityManager.getEntityInstance(itemId);
 
       if (itemEntity) {
-        const name = getEntityDisplayName(itemEntity, this.#logger);
+        const name = getEntityDisplayName(
+          itemEntity,
+          itemEntity.id,
+          this.#logger
+        );
         if (name && typeof name === 'string' && name.trim() !== '') {
           candidates.push({ id: itemEntity.id, name: name });
         } else {
           this.#logger.warn(
-            `TargetResolutionService.#_gatherNameMatchCandidates: Entity '${itemId}' in ${domainContextForLogging} has no valid name. Skipping.`
+            `TargetResolutionService.#_gatherNameMatchCandidates: Entity '${itemId}' in ${domainContextForLogging} returned no valid name from getEntityDisplayName. Skipping. Name resolved to: ${name}`
           );
         }
       } else {

--- a/tests/services/targetResolutionService.domain-environment.test.js
+++ b/tests/services/targetResolutionService.domain-environment.test.js
@@ -288,7 +288,9 @@ describe("TargetResolutionService - Domain 'environment'", () => {
         actionContext
       );
 
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'namelessThing' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
       expect(result.status).toBe(ResolutionStatus.FOUND_UNIQUE);
       expect(result.targetType).toBe('entity');
       expect(result.targetId).toBe(namelessEntity.id);

--- a/tests/services/targetResolutionService.domain-equipment.test.js
+++ b/tests/services/targetResolutionService.domain-equipment.test.js
@@ -273,7 +273,9 @@ describe("TargetResolutionService - Domain 'equipment'", () => {
         actionContext
       );
 
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'namelessHelm' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
       expect(result.status).toBe(ResolutionStatus.NOT_FOUND);
       expect(result.targetType).toBe('entity');
       expect(result.targetId).toBeNull();
@@ -428,7 +430,7 @@ describe("TargetResolutionService - Domain 'equipment'", () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "TargetResolutionService.#_gatherNameMatchCandidates: Entity 'nonExistentHelm' from equipment not found via entityManager. Skipping."
       );
-      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         `getEntityDisplayName: Entity 'namelessSwordId' has no usable name from component or 'entity.name'. Falling back to entity ID.`
       );
     });

--- a/tests/services/targetResolutionService.domain-inventory.test.js
+++ b/tests/services/targetResolutionService.domain-inventory.test.js
@@ -320,7 +320,9 @@ describe("TargetResolutionService - Domain 'inventory'", () => {
       );
 
       // Expected Outcome
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'namelessItem' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
       expect(result.status).toBe(ResolutionStatus.NOT_FOUND);
       expect(result.targetType).toBe('entity');
       expect(result.targetId).toBeNull();

--- a/tests/services/targetResolutionService.matchingLogic.test.js
+++ b/tests/services/targetResolutionService.matchingLogic.test.js
@@ -285,7 +285,9 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
 
       expect(result.status).toBe(ResolutionStatus.FOUND_UNIQUE);
       expect(result.targetId).toBe('validItem');
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'noNameComp' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
     });
 
     test('should skip candidates with empty name string in name component and log a warning', async () => {
@@ -302,7 +304,9 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
 
       expect(result.status).toBe(ResolutionStatus.FOUND_UNIQUE);
       expect(result.targetId).toBe('validItem');
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'emptyNameItem' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
     });
 
     test('should correctly handle items with non-string names (logged by earlier stages) and find valid items', async () => {
@@ -321,7 +325,9 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
 
       expect(result.status).toBe(ResolutionStatus.FOUND_UNIQUE);
       expect(result.targetId).toBe('item1');
-      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'item2' has no usable name from component or 'entity.name'. Falling back to entity ID."
+      );
     });
   });
 
@@ -412,7 +418,7 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
       ['   ', 'whitespace string'],
     ])(
       'should return ENTITY with domain-specific error for nounPhrase %s',
-      async (nounPhraseValue, _description) => {
+      async (nounPhraseValue) => {
         const actionContext = createActionContext(nounPhraseValue); // Corrected context used here
 
         const result = await service.resolveActionTarget(
@@ -425,6 +431,7 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
         expect(result.targetId).toBeNull();
         expect(result.error).toBe(expectedError);
 
+        /* eslint-disable jest/no-conditional-expect */
         if (
           nounPhraseValue === null ||
           nounPhraseValue === undefined ||
@@ -436,6 +443,7 @@ describe('TargetResolutionService - Advanced Name Matching Logic (via Inventory 
             )
           );
         }
+        /* eslint-enable jest/no-conditional-expect */
       }
     );
   });


### PR DESCRIPTION
Summary: Updated TargetResolutionService to use canonical getEntityDisplayName with fallback id and logger. Adjusted warning messages and unit tests for inventory, equipment, environment, and matching logic domains. Fixed lint issues.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes for modified files `npx eslint ...`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d1803ebc833185a458d29e023079