### PR TITLE
[Agent] add location exit helper utils

### DIFF
--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -1,0 +1,184 @@
+// src/utils/locationUtils.js
+
+import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
+
+/** @typedef {import('../entities/entity.js').default} Entity */
+/** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../interfaces/ILogger.js').ILogger} ILogger */
+
+/**
+ * @typedef {object} ExitData
+ * @property {string} direction - Keyword for this exit's direction.
+ * @property {string} targetLocationId - ID of the destination location.
+ * @property {string} [description] - Optional exit description.
+ * @property {string} [blocker] - Optional ID of an entity blocking the exit.
+ * @property {boolean} [locked] - Flag indicating if the exit is locked.
+ * @property {string[]} [requiredKeys] - IDs of entities that unlock the exit.
+ * @property {object} [conditions] - JsonLogic conditions for availability.
+ */
+
+/**
+ * Retrieve the exits component data from a location entity.
+ *
+ * @private
+ * @param {Entity | string} locationEntityOrId - Entity instance or ID to check.
+ * @param {IEntityManager} entityManager - Used to fetch the entity when an ID is provided.
+ * @param {ILogger} [logger] - Optional logger for debug messages.
+ * @returns {ExitData[] | null} Array of exit objects or null when unavailable.
+ */
+function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
+  let locationEntity = locationEntityOrId;
+
+  if (typeof locationEntityOrId === 'string') {
+    if (
+      !entityManager ||
+      typeof entityManager.getEntityInstance !== 'function'
+    ) {
+      logger?.error(
+        "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid."
+      );
+      return null;
+    }
+    locationEntity = entityManager.getEntityInstance(locationEntityOrId);
+  }
+
+  if (
+    !locationEntity ||
+    typeof locationEntity.getComponentData !== 'function'
+  ) {
+    const id =
+      typeof locationEntityOrId === 'string'
+        ? locationEntityOrId
+        : locationEntity?.id || 'unknown';
+    logger?.warn(
+      `_getExitsComponentData: Location entity not found or invalid for ID/object: ${id}`
+    );
+    return null;
+  }
+
+  const exitsData = locationEntity.getComponentData(EXITS_COMPONENT_ID);
+  if (!Array.isArray(exitsData)) {
+    logger?.debug(
+      `_getExitsComponentData: Location '${locationEntity.id}' has no '${EXITS_COMPONENT_ID}' component, or it's not an array.`
+    );
+    return null;
+  }
+  return /** @type {ExitData[]} */ (exitsData);
+}
+
+/**
+ * Get details for a specific exit by direction name.
+ *
+ * @param {Entity | string} locationEntityOrId - Location entity or its ID.
+ * @param {string} directionName - Direction to search for.
+ * @param {IEntityManager} entityManager - Manager used to fetch the entity.
+ * @param {ILogger} [logger] - Optional logger for diagnostics.
+ * @returns {ExitData | null} The exit data if found, otherwise null.
+ */
+export function getExitByDirection(
+  locationEntityOrId,
+  directionName,
+  entityManager,
+  logger
+) {
+  if (
+    !directionName ||
+    typeof directionName !== 'string' ||
+    directionName.trim() === ''
+  ) {
+    logger?.debug(
+      'getExitByDirection: Invalid or empty directionName provided.'
+    );
+    return null;
+  }
+
+  const exitsData = _getExitsComponentData(
+    locationEntityOrId,
+    entityManager,
+    logger
+  );
+  if (!exitsData || exitsData.length === 0) {
+    return null;
+  }
+
+  const normalizedDirName = directionName.toLowerCase().trim();
+  for (const exit of exitsData) {
+    if (
+      exit &&
+      typeof exit.direction === 'string' &&
+      exit.direction.toLowerCase().trim() === normalizedDirName
+    ) {
+      if (
+        typeof exit.targetLocationId === 'string' &&
+        exit.targetLocationId.trim() !== ''
+      ) {
+        return exit;
+      }
+      const locId =
+        typeof locationEntityOrId === 'string'
+          ? locationEntityOrId
+          : locationEntityOrId?.id || 'unknown';
+      logger?.warn(
+        `getExitByDirection: Found exit for direction '${directionName}' in location '${locId}', but its targetLocationId is invalid: ${JSON.stringify(
+          exit
+        )}`
+      );
+      return null;
+    }
+  }
+  const locId =
+    typeof locationEntityOrId === 'string'
+      ? locationEntityOrId
+      : locationEntityOrId?.id || 'unknown';
+  logger?.debug(
+    `getExitByDirection: No exit found for direction '${directionName}' in location '${locId}'.`
+  );
+  return null;
+}
+
+/**
+ * Get all valid and available exits from a location.
+ *
+ * @param {Entity | string} locationEntityOrId - Location entity or its ID.
+ * @param {IEntityManager} entityManager - Manager used to fetch the entity.
+ * @param {ILogger} [logger] - Optional logger for diagnostics.
+ * @returns {ExitData[]} Array of valid exit objects.
+ */
+export function getAvailableExits(locationEntityOrId, entityManager, logger) {
+  const exitsData = _getExitsComponentData(
+    locationEntityOrId,
+    entityManager,
+    logger
+  );
+  if (!exitsData || exitsData.length === 0) {
+    return [];
+  }
+
+  const validExits = [];
+  const locIdForLog =
+    typeof locationEntityOrId === 'string'
+      ? locationEntityOrId
+      : locationEntityOrId?.id || 'unknown';
+
+  for (const exit of exitsData) {
+    if (
+      exit &&
+      typeof exit === 'object' &&
+      typeof exit.direction === 'string' &&
+      exit.direction.trim() !== '' &&
+      typeof exit.targetLocationId === 'string' &&
+      exit.targetLocationId.trim() !== ''
+    ) {
+      validExits.push(exit);
+    } else {
+      logger?.warn(
+        `getAvailableExits: Invalid exit object found in location '${locIdForLog}': ${JSON.stringify(
+          exit
+        )}. Skipping.`
+      );
+    }
+  }
+  return validExits;
+}
+
+export { _getExitsComponentData };

--- a/tests/utils/locationUtils.test.js
+++ b/tests/utils/locationUtils.test.js
@@ -1,0 +1,170 @@
+// tests/utils/locationUtils.test.js
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  getExitByDirection,
+  getAvailableExits,
+} from '../../src/utils/locationUtils.js';
+import { EXITS_COMPONENT_ID } from '../../src/constants/componentIds.js';
+
+/** @typedef {import('../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+/**
+ * Helper to create a mock location entity with exits.
+ *
+ * @param {string} id - Location identifier.
+ * @param {any} exitsData - Value to return for the exits component.
+ * @returns {object} Mocked entity object.
+ */
+function createMockLocation(id, exitsData) {
+  return {
+    id,
+    getComponentData: jest.fn((componentId) => {
+      if (componentId === EXITS_COMPONENT_ID) {
+        return exitsData;
+      }
+      return undefined;
+    }),
+  };
+}
+
+describe('locationUtils', () => {
+  /** @type {IEntityManager} */
+  let mockEntityManager;
+
+  beforeEach(() => {
+    mockLogger.info.mockReset();
+    mockLogger.error.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.debug.mockReset();
+
+    mockEntityManager = {
+      getEntityInstance: jest.fn(),
+    };
+  });
+
+  describe('getExitByDirection', () => {
+    it('should return the matching exit (case-insensitive)', () => {
+      const exits = [
+        { direction: 'North', targetLocationId: 'loc2' },
+        { direction: 'south', targetLocationId: 'loc3' },
+      ];
+      const location = createMockLocation('loc1', exits);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getExitByDirection(
+        'loc1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+
+      expect(result).toEqual({ direction: 'North', targetLocationId: 'loc2' });
+      expect(mockEntityManager.getEntityInstance).toHaveBeenCalledWith('loc1');
+    });
+
+    it('should return null when direction is not found', () => {
+      const exits = [{ direction: 'east', targetLocationId: 'loc2' }];
+      const location = createMockLocation('loc1', exits);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getExitByDirection(
+        'loc1',
+        'west',
+        mockEntityManager,
+        mockLogger
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when exits component is missing', () => {
+      const location = createMockLocation('loc1', null);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getExitByDirection(
+        'loc1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when location id cannot be resolved', () => {
+      mockEntityManager.getEntityInstance.mockReturnValue(undefined);
+
+      const result = getExitByDirection(
+        'missing',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should validate exit targetLocationId', () => {
+      const exits = [{ direction: 'north', targetLocationId: '' }];
+      const location = createMockLocation('loc1', exits);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getExitByDirection(
+        'loc1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAvailableExits', () => {
+    it('should return only valid exits', () => {
+      const exits = [
+        { direction: 'north', targetLocationId: 'loc2' },
+        { direction: '', targetLocationId: 'loc3' },
+        { direction: 'south', targetLocationId: '' },
+        { direction: 'east', targetLocationId: 'loc4' },
+      ];
+      const location = createMockLocation('loc1', exits);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+
+      expect(result).toEqual([
+        { direction: 'north', targetLocationId: 'loc2' },
+        { direction: 'east', targetLocationId: 'loc4' },
+      ]);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return empty array when exits component missing', () => {
+      const location = createMockLocation('loc1', null);
+      mockEntityManager.getEntityInstance.mockReturnValue(location);
+
+      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when location not found', () => {
+      mockEntityManager.getEntityInstance.mockReturnValue(undefined);
+
+      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `locationUtils.js` with helpers to fetch exit data
- implement `getExitByDirection` and `getAvailableExits`
- create tests covering exit lookup scenarios

## Testing Done
- `npx prettier --write src/utils/locationUtils.js tests/utils/locationUtils.test.js`
- `npx eslint src/utils/locationUtils.js tests/utils/locationUtils.test.js`
- `npm test`
- `cd llm-proxy-server && npm test`
- `npm run lint` *(fails: existing repo errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841d544eddc8331ae1a93a457651183