### PR TITLE
[Agent] Add message formatter utilities

### DIFF
--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -5,6 +5,57 @@ import { getEntityDisplayName } from './entityUtils.js';
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */ // Added for potential future use, though not strictly needed for these helpers
 
+/**
+ * Generates "You need to specify which {itemType}..." messages.
+ *
+ * @param {string} itemType - Type of item (e.g., "item", "equipped item").
+ * @param {string} [domainDetails] - Optional details like "from your inventory".
+ * @returns {string} Formatted error message.
+ */
+export function formatSpecifyItemMessage(itemType, domainDetails = '') {
+  let message = `You need to specify which ${itemType}`;
+  if (domainDetails && domainDetails.trim() !== '') {
+    message += ` ${domainDetails.trim()}`;
+  }
+  message += '.';
+  return message;
+}
+
+/**
+ * Generates "You don't have/see '{nounPhrase}'..." messages.
+ *
+ * @param {string} nounPhrase - The specific item name.
+ * @param {string} context - How/where it's missing (e.g., "in your inventory", "equipped", "here").
+ * @param {object} [options] - Optional parameters.
+ * @param {string} [options.verb] - The verb to use (e.g., "have", "see").
+ * @param {boolean} [options.useAny] - Whether to prefix the nounPhrase with "any ".
+ * @returns {string} Formatted error message.
+ */
+export function formatNounPhraseNotFoundMessage(
+  nounPhrase,
+  context,
+  { verb = 'have', useAny = false } = {}
+) {
+  const anyPrefix = useAny ? 'any ' : '';
+  let currentVerb = verb;
+  if (context?.toLowerCase() === 'here') {
+    currentVerb = 'see';
+  }
+  const safeContext = typeof context === 'string' ? context : '';
+  return `You don't ${currentVerb} ${anyPrefix}"${nounPhrase}" ${safeContext}.`;
+}
+
+/**
+ * Generates "You don't have anything like that..." messages.
+ *
+ * @param {string} context - Where this applies (e.g., "in your inventory", "equipped").
+ * @returns {string} Formatted error message.
+ */
+export function formatNothingOfKindMessage(context) {
+  const safeContext = typeof context === 'string' ? context : '';
+  return `You don't have anything like that ${safeContext}.`;
+}
+
 // getDisplayName helper removed in favor of canonical getEntityDisplayName
 
 /**

--- a/tests/utils/messages.test.js
+++ b/tests/utils/messages.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  formatSpecifyItemMessage,
+  formatNounPhraseNotFoundMessage,
+  formatNothingOfKindMessage,
+} from '../../src/utils/messages.js';
+
+describe('messages utility formatters', () => {
+  describe('formatSpecifyItemMessage', () => {
+    it('returns basic message when only itemType provided', () => {
+      expect(formatSpecifyItemMessage('item')).toBe(
+        'You need to specify which item.'
+      );
+    });
+
+    it('includes domain details when provided', () => {
+      expect(formatSpecifyItemMessage('item', 'from your inventory')).toBe(
+        'You need to specify which item from your inventory.'
+      );
+    });
+
+    it('trims domain details', () => {
+      expect(formatSpecifyItemMessage('equipped item', '  here ')).toBe(
+        'You need to specify which equipped item here.'
+      );
+    });
+  });
+
+  describe('formatNounPhraseNotFoundMessage', () => {
+    it('uses default verb and context', () => {
+      expect(
+        formatNounPhraseNotFoundMessage('potion', 'in your inventory')
+      ).toBe('You don\'t have "potion" in your inventory.');
+    });
+
+    it('overrides verb for here context', () => {
+      expect(formatNounPhraseNotFoundMessage('potion', 'here')).toBe(
+        'You don\'t see "potion" here.'
+      );
+    });
+
+    it('respects custom verb option', () => {
+      expect(
+        formatNounPhraseNotFoundMessage('potion', 'equipped', {
+          verb: 'carry',
+        })
+      ).toBe('You don\'t carry "potion" equipped.');
+    });
+
+    it('adds any prefix when requested and still overrides verb for here', () => {
+      expect(
+        formatNounPhraseNotFoundMessage('potion', 'here', {
+          useAny: true,
+        })
+      ).toBe('You don\'t see any "potion" here.');
+    });
+  });
+
+  describe('formatNothingOfKindMessage', () => {
+    it('creates message with context', () => {
+      expect(formatNothingOfKindMessage('in your inventory')).toBe(
+        "You don't have anything like that in your inventory."
+      );
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added reusable error message formatting functions to `messages.js` and provided unit tests. These helpers centralize common target resolution messages.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 1901 problems)*
- [x] Root tests `npm test`
- [ ] Proxy tests `cd llm-proxy-server && npm test` *(not run)*
- [ ] Manual smoke run `npm run start` *(not run)*

------
https://chatgpt.com/codex/tasks/task_e_6841e48427a88331a3609666ea7b5816