### PR TITLE
[Agent] update notes schema and merge logic

### DIFF
--- a/src/turns/schemas/llmOutputSchemas.js
+++ b/src/turns/schemas/llmOutputSchemas.js
@@ -7,7 +7,7 @@
 //   • commandString: non‐empty string
 //   • speech: string (may be empty)
 //   • thoughts: string
-//   • notes (optional): array of { text: string (minLength:1), timestamp: date‐time }, no extra props
+//   • notes (optional): array of strings (minLength: 1)
 // -----------------------------------------------------------------------------
 
 /**
@@ -35,15 +35,7 @@ export const LLM_TURN_ACTION_RESPONSE_SCHEMA = {
     notes: {
       type: 'array',
       minItems: 0,
-      items: {
-        type: 'object',
-        properties: {
-          text: { type: 'string', minLength: 1 },
-          timestamp: { type: 'string', format: 'date-time' },
-        },
-        required: ['text', 'timestamp'],
-        additionalProperties: false,
-      },
+      items: { type: 'string', minLength: 1 },
     },
   },
   required: ['actionDefinitionId', 'commandString', 'speech', 'thoughts'],

--- a/tests/turns/services/LLMResponseProcessor.mergeNotes.test.js
+++ b/tests/turns/services/LLMResponseProcessor.mergeNotes.test.js
@@ -79,10 +79,14 @@ describe('_mergeNotesIntoEntity', () => {
   });
 
   test('creates component when missing and adds unique, valid notes', () => {
-    const notes = [
-      { text: 'First Note', timestamp: '2025-06-05T12:00:00.000Z' },
-      { text: 'Second Note', timestamp: '2025-06-05T13:00:00.000Z' },
-    ];
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValueOnce('2025-06-05T12:00:00.000Z')
+      .mockReturnValueOnce('2025-06-05T12:00:00.000Z')
+      .mockReturnValueOnce('2025-06-05T13:00:00.000Z')
+      .mockReturnValue('2025-06-05T13:00:00.000Z');
+
+    const notes = ['First Note', 'Second Note'];
 
     processor._mergeNotesIntoEntity(notes, actor, logger);
 
@@ -106,9 +110,7 @@ describe('_mergeNotesIntoEntity', () => {
     actor.components[NOTES_COMPONENT_ID] = {
       notes: [{ text: 'Buy milk!', timestamp: '2025-06-05T10:00:00.000Z' }],
     };
-    const dup = [
-      { text: '  buy   MILK ', timestamp: '2025-06-05T11:00:00.000Z' },
-    ];
+    const dup = ['  buy   MILK '];
 
     processor._mergeNotesIntoEntity(dup, actor, logger);
 
@@ -120,10 +122,12 @@ describe('_mergeNotesIntoEntity', () => {
   });
 
   test('incoming duplicates (Alpha vs alpha) only adds one', () => {
-    const incoming = [
-      { text: 'Alpha', timestamp: '2025-06-01T00:00:00.000Z' },
-      { text: 'alpha', timestamp: '2025-06-02T00:00:00.000Z' },
-    ];
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValueOnce('2025-06-01T00:00:00.000Z')
+      .mockReturnValueOnce('2025-06-02T00:00:00.000Z');
+
+    const incoming = ['Alpha', 'alpha'];
 
     processor._mergeNotesIntoEntity(incoming, actor, logger);
 
@@ -140,11 +144,15 @@ describe('_mergeNotesIntoEntity', () => {
   });
 
   test('mixed valid and invalid notes: logs error for invalid, adds only valid', () => {
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValue('2025-06-05T12:00:00.000Z');
+
     const mixed = [
-      { text: '', timestamp: '2025-06-05T10:00:00.000Z' }, // invalid: empty text
-      { text: 'Valid Note', timestamp: '2025-06-05T12:00:00.000Z' }, // valid
-      { text: 'Also Valid', timestamp: 'invalid-date' }, // invalid: bad timestamp
-      { foo: 'bar' }, // invalid: missing fields
+      '', // invalid: empty string
+      'Valid Note', // valid
+      123, // invalid: not a string
+      { foo: 'bar' }, // invalid: wrong type
     ];
 
     processor._mergeNotesIntoEntity(mixed, actor, logger);
@@ -168,15 +176,11 @@ describe('_mergeNotesIntoEntity', () => {
     // Stub Date.prototype.toISOString() to return a fixed value
     jest
       .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValue('2025-06-04T12:00:00Z');
+      .mockReturnValueOnce('2025-06-04T11:00:00Z')
+      .mockReturnValueOnce('2025-06-04T12:00:00Z');
 
     // Prepare one valid note
-    const singleNote = [
-      {
-        text: 'Example note text',
-        timestamp: '2025-06-04T11:00:00Z',
-      },
-    ];
+    const singleNote = ['Example note text'];
 
     processor._mergeNotesIntoEntity(singleNote, actor, logger);
 

--- a/tests/turns/services/LLMResponseProcessor.notesGuards.test.js
+++ b/tests/turns/services/LLMResponseProcessor.notesGuards.test.js
@@ -7,6 +7,9 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 /**
  * Simple in-memory “entity” that mimics the minimal shape of an IEntityManager-backed entity.
+ *
+ * @param {string} id - identifier for the fake entity
+ * @returns {object} simple entity object
  */
 function createFakeActorEntity(id) {
   return {
@@ -41,7 +44,7 @@ describe('LLMResponseProcessor - merge notes logic', () => {
     // Fake entity manager with spies
     entityManagerMock = {
       getEntityInstance: jest.fn(),
-      addComponent: jest.fn((entityId, compId, data) => {
+      addComponent: jest.fn(() => {
         // we’ll call actorEntity.addComponent manually from the entity
       }),
       saveEntity: jest.fn().mockResolvedValue(undefined),
@@ -71,15 +74,19 @@ describe('LLMResponseProcessor - merge notes logic', () => {
       notes: [{ text: 'Existing note', timestamp: '2025-06-01T12:00:00Z' }],
     };
 
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValue('2025-06-02T15:00:00Z');
+
     const validJson = {
       actionDefinitionId: 'some:action',
       commandString: 'do something',
       speech: 'hello',
       thoughts: 'thinking...',
       notes: [
-        { text: 'New note', timestamp: '2025-06-02T15:00:00Z' },
+        'New note',
         // duplicate text (normalized) should be skipped
-        { text: 'existing NOTE', timestamp: '2025-06-03T16:00:00Z' },
+        'existing NOTE',
       ],
     };
 


### PR DESCRIPTION
Summary:
- remove timestamp field from LLM notes schema
- adapt merging logic to add timestamps when notes are saved
- update merge notes tests for string-only notes
- update notes guard tests

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(errors fixed for changed files)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841efeaf02883319607f150e92aee25