### PR TITLE
[Agent] Provide real entity scope lookup for ActionDiscoverySystem

### DIFF
--- a/src/dependencyInjection/registrations/coreSystemsRegistrations.js
+++ b/src/dependencyInjection/registrations/coreSystemsRegistrations.js
@@ -50,10 +50,13 @@ import { tokens } from '../tokens.js';
 import { Registrar } from '../registrarHelpers.js';
 import { formatActionCommand } from '../../actions/actionFormatter.js';
 import { INITIALIZABLE, SHUTDOWNABLE } from '../tags.js';
+import { getEntityIdsForScopes } from '../../entities/entityScopeService.js';
 
 /**
+ * Registers core game systems, turn handlers, and factories.
  *
- * @param container
+ * @param {AppContainer} container - The DI container to register into.
+ * @returns {void}
  */
 export function registerCoreSystems(container) {
   const registrar = new Registrar(container);
@@ -76,7 +79,7 @@ export function registerCoreSystems(container) {
         actionValidationService: c.resolve(tokens.ActionValidationService),
         logger: c.resolve(tokens.ILogger),
         formatActionCommandFn: formatActionCommand,
-        getEntityIdsForScopesFn: () => new Set(),
+        getEntityIdsForScopesFn: getEntityIdsForScopes,
       })
   );
   logger.debug(


### PR DESCRIPTION
## Summary
- inject getEntityIdsForScopes into ActionDiscoverySystem registration
- document registerCoreSystems param and return

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 1906 problems across repo)*
- `npx eslint src/dependencyInjection/registrations/coreSystemsRegistrations.js --max-warnings=0`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f3871c208331b9e0bd5a19c2b83d