### PR TITLE
[Agent] fix memory prompt headers

### DIFF
--- a/src/prompting/assembling/goalsSectionAssembler.js
+++ b/src/prompting/assembling/goalsSectionAssembler.js
@@ -25,14 +25,12 @@ import { IPromptElementAssembler } from '../../interfaces/IPromptElementAssemble
  * ```
  */
 export class GoalsSectionAssembler extends IPromptElementAssembler {
-  /** @type {ILogger} */ #logger;
-
   /**
    * @param {{ logger?: ILogger }} [options]
    */
   constructor({ logger = console } = {}) {
     super();
-    this.#logger = logger;
+    // logger parameter preserved for API consistency
   }
 
   /**
@@ -69,9 +67,9 @@ export class GoalsSectionAssembler extends IPromptElementAssembler {
 
     if (goalLines === '') return '';
 
-    const header = 'Your Goals:';
-    const sectionCore = `${header}\n\n${goalLines}\n`;
-    return `\n${resolvedPrefix}${sectionCore}${resolvedSuffix}\n`;
+    // resolvedPrefix contains the header string (e.g. "\nYour Goals:\n")
+    const sectionCore = `${resolvedPrefix}\n${goalLines}\n${resolvedSuffix}`;
+    return sectionCore;
   }
 }
 

--- a/src/prompting/assembling/notesSectionAssembler.js
+++ b/src/prompting/assembling/notesSectionAssembler.js
@@ -13,15 +13,12 @@ import { IPromptElementAssembler } from '../../interfaces/IPromptElementAssemble
  */
 
 export class NotesSectionAssembler extends IPromptElementAssembler {
-  /** @type {ILogger} */
-  #logger;
-
   /**
    * @param {{logger?: ILogger}} [options]
    */
   constructor({ logger = console } = {}) {
     super();
-    this.#logger = logger;
+    // logger parameter preserved for API consistency
   }
 
   /**
@@ -53,10 +50,11 @@ export class NotesSectionAssembler extends IPromptElementAssembler {
 
     const bodyLines = sorted.map((n) => `- ${n.text}`).join('\n');
 
-    // Exactly one blank line after header and after list
-    const section = `\nImportant Things to Remember:\n\n${bodyLines}\n\n`;
+    // prefix is expected to contain the header text; just insert
+    // a blank line before and after the list for readability
+    const section = `${prefix}\n${bodyLines}\n${suffix}`;
 
-    return `${prefix}${section}${suffix}`;
+    return section;
   }
 }
 

--- a/tests/prompting/assembling/goalsSectionAssembler.test.js
+++ b/tests/prompting/assembling/goalsSectionAssembler.test.js
@@ -23,7 +23,7 @@ describe('GoalsSectionAssembler', () => {
     const pd = {
       goalsArray: [{ text: 'Finish quest', timestamp: '2025-01-01T00:00:00Z' }],
     };
-    const expected = '\nYour Goals:\n\n- Finish quest\n\n';
+    const expected = '\n- Finish quest\n';
     expect(assembler.assemble(cfg, pd, placeholderResolver)).toBe(expected);
   });
 
@@ -35,7 +35,7 @@ describe('GoalsSectionAssembler', () => {
         { text: 'Second', timestamp: '2025-01-02' },
       ],
     };
-    const expected = '\nYour Goals:\n\n- First\n- Second\n- Third\n\n';
+    const expected = '\n- First\n- Second\n- Third\n';
     expect(assembler.assemble(cfg, pd, placeholderResolver)).toBe(expected);
   });
 
@@ -46,7 +46,7 @@ describe('GoalsSectionAssembler', () => {
         { text: 'Invalid', timestamp: 'not-a-date' },
       ],
     };
-    const expected = '\nYour Goals:\n\n- Valid\n- Invalid\n\n';
+    const expected = '\n- Valid\n- Invalid\n';
     expect(assembler.assemble(cfg, pd, placeholderResolver)).toBe(expected);
   });
 });

--- a/tests/prompting/promptBuilder.goalsSection.test.js
+++ b/tests/prompting/promptBuilder.goalsSection.test.js
@@ -49,8 +49,8 @@ class DummyLLMConfigService {
     this._config = config;
   }
 
-  async getConfig(llmId) {
-    // Always return the same config, ignoring llmId
+  async getConfig(_llmId) {
+    // Always return the same config, ignoring input llmId
     return this._config;
   }
 }
@@ -61,7 +61,8 @@ describe('PromptBuilder → GoalsSectionAssembler integration', () => {
     promptElements: [
       {
         key: 'goals_wrapper',
-        // no prefix / suffix / condition
+        prefix: '\nYour Goals:\n',
+        suffix: '\n',
       },
     ],
     promptAssemblyOrder: ['goals_wrapper'],
@@ -107,11 +108,11 @@ describe('PromptBuilder → GoalsSectionAssembler integration', () => {
 
     const result = await promptBuilder.build('anyLlmId', promptData);
 
-    // Expect the header and both bullet points
-    expect(result).toContain('Your Goals:');
+    const occurrences = result.match(/Your Goals:/g) || [];
+    expect(occurrences.length).toBe(1);
     expect(result).toContain('- G1');
     expect(result).toContain('- G2');
-    // The result should begin with a newline (as per assembler)
+    // The result should begin with a newline (from prefix)
     expect(result.startsWith('\n')).toBe(true);
   });
 

--- a/tests/prompting/promptBuilder.notesSection.test.js
+++ b/tests/prompting/promptBuilder.notesSection.test.js
@@ -18,8 +18,8 @@ describe('PromptBuilder – NotesSectionAssembler integration', () => {
           { key: 'intro', prefix: 'Hello:\n', suffix: '\n', condition: null },
           {
             key: 'notes_wrapper',
-            prefix: '',
-            suffix: '',
+            prefix: '\nImportant Things to Remember:\n',
+            suffix: '\n',
             condition: null,
           },
           { key: 'outro', prefix: '\nGoodbye.', suffix: '', condition: null },
@@ -34,7 +34,7 @@ describe('PromptBuilder – NotesSectionAssembler integration', () => {
   beforeAll(() => {
     const llmConfigService = new FakeLlmConfigService();
     const placeholderResolver = {
-      resolve: (template, data) => {
+      resolve: (template, _data) => {
         // No placeholders used in this test
         return template;
       },
@@ -64,7 +64,8 @@ describe('PromptBuilder – NotesSectionAssembler integration', () => {
 
     const result = await builder.build('test-llm', promptData);
 
-    expect(result).toContain('Important Things to Remember:');
+    const occurrences = result.match(/Important Things to Remember:/g) || [];
+    expect(occurrences.length).toBe(1);
     expect(result).toContain('- Remember the keycode');
     // Ensure prefix and suffix of intro/outro are intact
     expect(result.startsWith('Hello:\n')).toBe(true);
@@ -77,7 +78,7 @@ describe('PromptBuilder – NotesSectionAssembler integration', () => {
     const result = await builder.build('test-llm', promptData);
 
     expect(result).not.toContain('Important Things to Remember:');
-    // intro + three new-lines + outro
+    // intro + suffix newline + outro prefix newline
     expect(result).toBe('Hello:\n\n\nGoodbye.');
   });
 

--- a/tests/services/promptElementAssemblers/notesSectionAssembler.test.js
+++ b/tests/services/promptElementAssemblers/notesSectionAssembler.test.js
@@ -10,13 +10,13 @@ describe('NotesSectionAssembler', () => {
     expect(out).toBe('');
   });
 
-  it('renders single note with header, list item and suffix/prefix', () => {
+  it('renders single note with prefix/suffix providing header', () => {
     const cfg = { prefix: '', suffix: '' };
     const pd = {
       notesArray: [{ text: 'Buy milk', timestamp: '2000-01-01T00:00:00Z' }],
     };
     const out = assembler.assemble(cfg, pd, mockResolver, undefined);
-    expect(out).toBe('\nImportant Things to Remember:\n\n- Buy milk\n\n');
+    expect(out).toBe('\n- Buy milk\n');
   });
 
   it('sorts by timestamp ascending', () => {
@@ -28,7 +28,7 @@ describe('NotesSectionAssembler', () => {
     };
     const out = assembler.assemble({}, pd, mockResolver, undefined);
     const lines = out.trim().split('\n'); // drop leading blank
-    expect(lines[2]).toBe('- first');
-    expect(lines[3]).toBe('- second');
+    expect(lines[0]).toBe('- first');
+    expect(lines[1]).toBe('- second');
   });
 });


### PR DESCRIPTION
## Summary
- revert llm-configs notes/goals wrappers
- rely on config prefix inside NotesSectionAssembler and GoalsSectionAssembler
- update associated tests to ensure headers appear only once
- remove obsolete llmConfigPrefixes test

## Testing
- `npm test --silent`
- `cd llm-proxy-server && npm test --silent`
- `npm run lint --silent` *(fails: jest/no-conditional-expect and other existing issues)*
- `cd llm-proxy-server && npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841ff86e6cc83319d99366a09c4c1ab