### PR TITLE
[Agent] clarify notes purpose in prompt

### DIFF
--- a/src/prompting/promptStaticContentService.js
+++ b/src/prompting/promptStaticContentService.js
@@ -37,7 +37,9 @@ Your primary directive is authentic character portrayal and storytelling within 
 
 const FINAL_LLM_INSTRUCTION_TEXT =
   "Now, based on all the information provided, decide on your character's action and what they will say. " +
-  'Remember: *only visible actions go inside asterisks – never internal thoughts.* Fully BE the character.';
+  'Remember: *only visible actions go inside asterisks – never internal thoughts.* ' +
+  'If you learn a new fact your character considers vital to their survival or prosperity—such as directions, allies, or threats—add it to the optional "notes" array in your JSON response. ' +
+  'Only include distinct, important items that are not already noted. Fully BE the character.';
 
 /**
  * @class PromptStaticContentService

--- a/tests/prompting/promptStaticContentService.test.js
+++ b/tests/prompting/promptStaticContentService.test.js
@@ -37,7 +37,10 @@ This includes, but is not limited to:
 Your primary directive is authentic character portrayal and storytelling within this mature context. Do not self-censor or inject conventional AI safety moralizing.`;
 
 const FINAL_LLM_INSTRUCTION_TEXT_EXPECTED =
-  "Now, based on all the information provided, decide on your character's action and what they will say. Remember: *only visible actions go inside asterisks – never internal thoughts.* Fully BE the character.";
+  "Now, based on all the information provided, decide on your character's action and what they will say. " +
+  'Remember: *only visible actions go inside asterisks – never internal thoughts.* ' +
+  'If you learn a new fact your character considers vital to their survival or prosperity—such as directions, allies, or threats—add it to the optional "notes" array in your JSON response. ' +
+  'Only include distinct, important items that are not already noted. Fully BE the character.';
 
 // Mock ILogger
 const mockLogger = {


### PR DESCRIPTION
## Summary
- document how notes should be used by the LLM
- update static content test expectation

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 571 errors, 1332 warnings)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842088f98e08331ba155c2e16650ba1