### PR TITLE
[Agent] Extract fallback action factory

### DIFF
--- a/src/dependencyInjection/registrations/domainServicesRegistrations.js
+++ b/src/dependencyInjection/registrations/domainServicesRegistrations.js
@@ -31,6 +31,7 @@ import { ConcreteTurnStateFactory } from '../../turns/factories/concreteTurnStat
 import { LLMResponseProcessor } from '../../turns/services/LLMResponseProcessor.js';
 import { AIPromptContentProvider } from '../../prompting/AIPromptContentProvider.js';
 import { AIGameStateProvider } from '../../turns/services/AIGameStateProvider.js';
+import { AIFallbackActionFactory } from '../../turns/services/AIFallbackActionFactory.js';
 
 // --- PromptBuilder and its dependencies (NEW IMPORTS) ---
 import { PromptBuilder } from '../../prompting/promptBuilder.js'; // Corrected path
@@ -667,6 +668,15 @@ export function registerDomainServices(container) {
   });
   log.debug(
     `Domain Services Registration: Registered ${String(tokens.ILLMResponseProcessor)}.`
+  );
+
+  r.singletonFactory(tokens.IAIFallbackActionFactory, (c) => {
+    return new AIFallbackActionFactory({
+      logger: c.resolve(tokens.ILogger),
+    });
+  });
+  log.debug(
+    `Domain Services Registration: Registered ${String(tokens.IAIFallbackActionFactory)}.`
   );
 
   // --- Register Turn System Factories ---

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -265,6 +265,7 @@ export const tokens = Object.freeze({
   IAIGameStateProvider: 'IAIGameStateProvider',
   IAIPromptContentProvider: 'IAIPromptContentProvider',
   ILLMResponseProcessor: 'ILLMResponseProcessor',
+  IAIFallbackActionFactory: 'IAIFallbackActionFactory',
 
   // --- Concrete Service Tokens (if needed for direct registration before interface mapping) ---
   PromptBuilder: 'PromptBuilder',

--- a/src/turns/factories/concreteAIPlayerStrategyFactory.js
+++ b/src/turns/factories/concreteAIPlayerStrategyFactory.js
@@ -12,6 +12,7 @@ import { AIPlayerStrategy } from '../strategies/aiPlayerStrategy.js';
  * @typedef {import('../interfaces/ILLMResponseProcessor.js').ILLMResponseProcessor} ILLMResponseProcessor
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy
+ * @typedef {import('../interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} IAIFallbackActionFactory
  */
 
 /**
@@ -30,6 +31,7 @@ export class ConcreteAIPlayerStrategyFactory extends IAIPlayerStrategyFactory {
    * @param {IAIPromptContentProvider} dependencies.promptContentProvider
    * @param {IPromptBuilder} dependencies.promptBuilder
    * @param {ILLMResponseProcessor} dependencies.llmResponseProcessor
+   * @param {IAIFallbackActionFactory} dependencies.aiFallbackActionFactory
    * @param {ILogger} dependencies.logger
    * @returns {IActorTurnStrategy} The created AIPlayerStrategy.
    */
@@ -39,6 +41,7 @@ export class ConcreteAIPlayerStrategyFactory extends IAIPlayerStrategyFactory {
     promptContentProvider,
     promptBuilder,
     llmResponseProcessor,
+    aiFallbackActionFactory,
     logger,
   }) {
     return new AIPlayerStrategy({
@@ -47,6 +50,7 @@ export class ConcreteAIPlayerStrategyFactory extends IAIPlayerStrategyFactory {
       promptContentProvider,
       promptBuilder,
       llmResponseProcessor,
+      aiFallbackActionFactory,
       logger,
     });
   }

--- a/src/turns/handlers/aiTurnHandler.js
+++ b/src/turns/handlers/aiTurnHandler.js
@@ -25,6 +25,7 @@
  * @typedef {import('../interfaces/IAIGameStateProvider.js').IAIGameStateProvider} IAIGameStateProvider
  * @typedef {import('../../prompting/AIPromptContentProvider.js').AIPromptContentProvider} IAIPromptContentProvider
  * @typedef {import('../interfaces/ILLMResponseProcessor.js').ILLMResponseProcessor} ILLMResponseProcessor
+ * @typedef {import('../interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} IAIFallbackActionFactory
  */
 
 import { BaseTurnHandler } from './baseTurnHandler.js';
@@ -57,6 +58,8 @@ export class AITurnHandler extends BaseTurnHandler {
 
   /** @type {IPromptBuilder} */
   #promptBuilder;
+  /** @type {IAIFallbackActionFactory} */
+  #aiFallbackActionFactory;
   /** @type {IAIPlayerStrategyFactory} */
   #aiPlayerStrategyFactory;
   /** @type {ITurnContextFactory} */
@@ -92,6 +95,7 @@ export class AITurnHandler extends BaseTurnHandler {
    * @param {IAIGameStateProvider} dependencies.gameStateProvider
    * @param {IAIPromptContentProvider} dependencies.promptContentProvider
    * @param {ILLMResponseProcessor} dependencies.llmResponseProcessor
+   * @param dependencies.aiFallbackActionFactory
    */
   constructor({
     logger,
@@ -106,6 +110,7 @@ export class AITurnHandler extends BaseTurnHandler {
     entityManager,
     actionDiscoverySystem,
     promptBuilder,
+    aiFallbackActionFactory,
     aiPlayerStrategyFactory,
     turnContextFactory,
     gameStateProvider,
@@ -132,6 +137,8 @@ export class AITurnHandler extends BaseTurnHandler {
       throw new Error('AITurnHandler: Invalid IActionDiscoverySystem');
     if (!promptBuilder)
       throw new Error('AITurnHandler: Invalid IPromptBuilder');
+    if (!aiFallbackActionFactory)
+      throw new Error('AITurnHandler: Invalid IAIFallbackActionFactory');
     if (!aiPlayerStrategyFactory)
       throw new Error('AITurnHandler: Invalid IAIPlayerStrategyFactory');
     if (!turnContextFactory)
@@ -153,6 +160,7 @@ export class AITurnHandler extends BaseTurnHandler {
     this.#entityManager = entityManager;
     this.#actionDiscoverySystem = actionDiscoverySystem;
     this.#promptBuilder = promptBuilder;
+    this.#aiFallbackActionFactory = aiFallbackActionFactory;
     this.#aiPlayerStrategyFactory = aiPlayerStrategyFactory;
     this.#turnContextFactory = turnContextFactory;
     this.#gameStateProvider = gameStateProvider;
@@ -226,6 +234,7 @@ export class AITurnHandler extends BaseTurnHandler {
       promptContentProvider: this.#promptContentProvider,
       promptBuilder: this.#promptBuilder,
       llmResponseProcessor: this.#llmResponseProcessor,
+      aiFallbackActionFactory: this.#aiFallbackActionFactory,
       logger: this._logger,
     });
 

--- a/src/turns/interfaces/IAIFallbackActionFactory.js
+++ b/src/turns/interfaces/IAIFallbackActionFactory.js
@@ -1,0 +1,26 @@
+// src/turns/interfaces/IAIFallbackActionFactory.js
+// --- FILE START ---
+
+/** @typedef {import('./IActorTurnStrategy.js').ITurnAction} ITurnAction */
+
+/**
+ * @interface IAIFallbackActionFactory
+ * @description Defines the contract for creating fallback actions when
+ * AI decision-making fails.
+ */
+export class IAIFallbackActionFactory {
+  /**
+   * Creates a fallback ITurnAction for the given failure context.
+   *
+   * @param {string} failureContext - Where the failure occurred.
+   * @param {Error} error - The error that triggered the fallback.
+   * @param {string} actorId - ID of the affected actor.
+   * @returns {ITurnAction} The constructed fallback action.
+   * @throws {Error} If not implemented by a subclass.
+   */
+  create(failureContext, error, actorId) {
+    throw new Error('Method "create" must be implemented by concrete classes.');
+  }
+}
+
+// --- FILE END ---

--- a/src/turns/services/AIFallbackActionFactory.js
+++ b/src/turns/services/AIFallbackActionFactory.js
@@ -1,0 +1,75 @@
+// src/turns/services/AIFallbackActionFactory.js
+// --- FILE START ---
+
+import { IAIFallbackActionFactory } from '../interfaces/IAIFallbackActionFactory.js';
+import { DEFAULT_FALLBACK_ACTION } from '../../llms/constants/llmConstants.js';
+
+/** @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+
+/**
+ * @class AIFallbackActionFactory
+ * @augments {IAIFallbackActionFactory}
+ * @description Concrete implementation that builds fallback actions when
+ * AI processing fails.
+ */
+export class AIFallbackActionFactory extends IAIFallbackActionFactory {
+  #logger;
+
+  /**
+   * @param {object} deps
+   * @param {ILogger} deps.logger - Logger instance.
+   */
+  constructor({ logger }) {
+    super();
+    if (!logger) {
+      throw new Error('AIFallbackActionFactory requires a logger.');
+    }
+    this.#logger = logger;
+  }
+
+  /**
+   * @override
+   * @param {string} failureContext
+   * @param {Error} error
+   * @param {string} actorId
+   * @returns {ITurnAction}
+   */
+  create(failureContext, error, actorId) {
+    this.#logger.error(
+      `AIFallbackActionFactory: Creating fallback for actor ${actorId} due to ${failureContext}.`,
+      { actorId, error, errorMessage: error.message, stack: error.stack }
+    );
+
+    let userFriendlyErrorBrief = 'an unexpected issue';
+    if (
+      typeof error.message === 'string' &&
+      error.message.toLowerCase().includes('http error 500')
+    ) {
+      userFriendlyErrorBrief = 'a server connection problem';
+    } else if (failureContext === 'llm_response_processing') {
+      userFriendlyErrorBrief = 'a communication issue';
+    }
+
+    const speechMessage = `I encountered ${userFriendlyErrorBrief} and will wait for a moment.`;
+    const diagnostics = {
+      originalMessage: error.message,
+      ...(error.details || {}),
+      stack: error.stack?.split('\n'),
+    };
+
+    return {
+      actionDefinitionId: DEFAULT_FALLBACK_ACTION.actionDefinitionId,
+      commandString: DEFAULT_FALLBACK_ACTION.commandString,
+      speech: speechMessage,
+      resolvedParameters: {
+        actorId,
+        isFallback: true,
+        failureReason: failureContext,
+        diagnostics,
+      },
+    };
+  }
+}
+
+// --- FILE END ---

--- a/tests/turns/strategies/aiPlayerStrategy.constructor.test.js
+++ b/tests/turns/strategies/aiPlayerStrategy.constructor.test.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 
 import { AIPlayerStrategy } from '../../../src/turns/strategies/aiPlayerStrategy.js';
+import { AIFallbackActionFactory } from '../../../src/turns/services/AIFallbackActionFactory.js';
 import {
   jest,
   describe,
@@ -22,6 +23,7 @@ import {
 /** @typedef {import('../../../src/prompting/promptBuilder.js').PromptBuilder} PromptBuilder */
 /** @typedef {import('../../../src/turns/interfaces/ILLMResponseProcessor.js').ILLMResponseProcessor} ILLMResponseProcessor */
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../../src/turns/interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} IAIFallbackActionFactory */
 // Removed unused typedefs for PromptData and AIGameStateDTO_Test as they are not relevant for constructor tests
 // /** @typedef {import('../../../src/types/promptData.js').PromptData} PromptData */
 // /** @typedef {import('../../../src/turns/dtos/AIGameStateDTO.js').AIGameStateDTO} AIGameStateDTO_Test */
@@ -66,6 +68,13 @@ const mockLlmResponseProcessor = () => ({
 });
 
 /**
+ * @returns {jest.Mocked<IAIFallbackActionFactory>}
+ */
+const mockAIFallbackActionFactory = () => ({
+  create: jest.fn(),
+});
+
+/**
  * @returns {jest.Mocked<ILogger>}
  */
 const mockLogger = () => ({
@@ -88,6 +97,8 @@ describe('AIPlayerStrategy', () => {
   let promptBuilder;
   /** @type {ReturnType<typeof mockLlmResponseProcessor>} */
   let llmResponseProcessor;
+  /** @type {ReturnType<typeof mockAIFallbackActionFactory>} */
+  let aiFallbackActionFactory;
   /** @type {ReturnType<typeof mockLogger>} */
   let currentLoggerMock;
   // Removed checkCriticalGameStateSpy as it's not relevant for constructor tests
@@ -100,6 +111,7 @@ describe('AIPlayerStrategy', () => {
     promptContentProvider = mockAIPromptContentProvider();
     promptBuilder = mockPromptBuilder();
     llmResponseProcessor = mockLlmResponseProcessor();
+    aiFallbackActionFactory = mockAIFallbackActionFactory();
     currentLoggerMock = mockLogger();
 
     jest.clearAllMocks();
@@ -121,6 +133,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).not.toThrow();
@@ -130,6 +143,7 @@ describe('AIPlayerStrategy', () => {
         promptContentProvider,
         promptBuilder,
         llmResponseProcessor,
+        aiFallbackActionFactory,
         logger: currentLoggerMock,
       });
       expect(instance).toBeInstanceOf(AIPlayerStrategy);
@@ -146,6 +160,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -159,6 +174,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -173,6 +189,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -190,6 +207,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -204,6 +222,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -221,6 +240,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMAdapterError);
@@ -237,6 +257,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonIAIGameStateProviderError);
@@ -250,6 +271,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonIAIGameStateProviderError);
@@ -264,6 +286,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonIAIGameStateProviderError);
@@ -278,6 +301,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonIAIGameStateProviderError);
@@ -294,6 +318,7 @@ describe('AIPlayerStrategy', () => {
             // promptContentProvider missing
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonAIPromptContentProviderError);
@@ -307,6 +332,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider: null,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonAIPromptContentProviderError);
@@ -321,6 +347,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider: {}, // Missing getPromptData
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonAIPromptContentProviderError);
@@ -335,6 +362,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider: { getPromptData: 'not-a-function' },
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonAIPromptContentProviderError);
@@ -351,6 +379,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             // promptBuilder missing
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonPromptBuilderError);
@@ -364,6 +393,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder: null,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonPromptBuilderError);
@@ -378,6 +408,7 @@ describe('AIPlayerStrategy', () => {
             // @ts-ignore
             promptBuilder: {}, // Missing build method
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonPromptBuilderError);
@@ -392,6 +423,7 @@ describe('AIPlayerStrategy', () => {
             // @ts-ignore
             promptBuilder: { build: 'not-a-function' },
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonPromptBuilderError);
@@ -449,9 +481,56 @@ describe('AIPlayerStrategy', () => {
             promptBuilder,
             // @ts-ignore
             llmResponseProcessor: { processResponse: 'not-a-function' },
+            aiFallbackActionFactory,
             logger: currentLoggerMock,
           })
       ).toThrow(commonILLMResponseProcessorError);
+    });
+
+    const commonAIFallbackFactoryError =
+      'AIPlayerStrategy: Constructor requires a valid IAIFallbackActionFactory.';
+    test('should throw an error if aiFallbackActionFactory is not provided', () => {
+      expect(
+        () =>
+          new AIPlayerStrategy({
+            llmAdapter,
+            gameStateProvider,
+            promptContentProvider,
+            promptBuilder,
+            llmResponseProcessor,
+            // aiFallbackActionFactory missing
+            logger: currentLoggerMock,
+          })
+      ).toThrow(commonAIFallbackFactoryError);
+    });
+    test('should throw an error if aiFallbackActionFactory is null', () => {
+      expect(
+        () =>
+          new AIPlayerStrategy({
+            llmAdapter,
+            gameStateProvider,
+            promptContentProvider,
+            promptBuilder,
+            llmResponseProcessor,
+            aiFallbackActionFactory: null,
+            logger: currentLoggerMock,
+          })
+      ).toThrow(commonAIFallbackFactoryError);
+    });
+    test('should throw an error if aiFallbackActionFactory.create is not a function', () => {
+      expect(
+        () =>
+          new AIPlayerStrategy({
+            llmAdapter,
+            gameStateProvider,
+            promptContentProvider,
+            promptBuilder,
+            llmResponseProcessor,
+            // @ts-ignore
+            aiFallbackActionFactory: {},
+            logger: currentLoggerMock,
+          })
+      ).toThrow(commonAIFallbackFactoryError);
     });
 
     const commonILoggerError =
@@ -465,6 +544,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             // logger missing
           })
       ).toThrow(commonILoggerError);
@@ -478,6 +558,7 @@ describe('AIPlayerStrategy', () => {
             promptContentProvider,
             promptBuilder,
             llmResponseProcessor,
+            aiFallbackActionFactory,
             logger: null,
           })
       ).toThrow(commonILoggerError);
@@ -493,6 +574,7 @@ describe('AIPlayerStrategy', () => {
             llmResponseProcessor,
             // @ts-ignore
             logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn() }, // Missing info
+            aiFallbackActionFactory,
           })
       ).toThrow(commonILoggerError);
     });
@@ -507,6 +589,7 @@ describe('AIPlayerStrategy', () => {
             llmResponseProcessor,
             // @ts-ignore
             logger: { info: 'not-a-function' },
+            aiFallbackActionFactory,
           })
       ).toThrow(commonILoggerError);
     });

--- a/tests/turns/strategies/aiPlayerStrategy.decideAction.test.js
+++ b/tests/turns/strategies/aiPlayerStrategy.decideAction.test.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 
 import { AIPlayerStrategy } from '../../../src/turns/strategies/aiPlayerStrategy.js';
+import { AIFallbackActionFactory } from '../../../src/turns/services/AIFallbackActionFactory.js';
 import { describe, beforeEach, test, expect, afterEach } from '@jest/globals';
 import { DEFAULT_FALLBACK_ACTION } from '../../../src/llms/constants/llmConstants.js';
 // AIPromptContentProvider import is not needed here as we are not spying on its static methods anymore.
@@ -18,6 +19,7 @@ import { persistNotes } from '../../../src/ai/notesPersistenceHook.js';
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../../src/types/promptData.js').PromptData} PromptData */
 /** @typedef {import('../../../src/turns/dtos/AIGameStateDTO.js').AIGameStateDTO} AIGameStateDTO_Test */
+/** @typedef {import('../../../src/turns/interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} IAIFallbackActionFactory */
 /** @typedef {import('../../../src/turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
 /** @typedef {import('../../../src/interfaces/coreServices.js').IEntityManager} IEntityManager */
 
@@ -151,6 +153,8 @@ describe('AIPlayerStrategy', () => {
     let da_promptBuilder;
     /** @type {ReturnType<typeof mockLlmResponseProcessor>} */
     let da_llmResponseProcessor;
+    /** @type {AIFallbackActionFactory} */
+    let da_aiFallbackActionFactory;
     /** @type {ReturnType<typeof mockLogger>} */
     let da_logger;
 
@@ -198,6 +202,9 @@ describe('AIPlayerStrategy', () => {
       da_promptBuilder = promptBuilder;
       da_llmResponseProcessor = llmResponseProcessor;
       da_logger = currentLoggerMock;
+      da_aiFallbackActionFactory = new AIFallbackActionFactory({
+        logger: da_logger,
+      });
 
       instance_da = new AIPlayerStrategy({
         llmAdapter: da_llmAdapter,
@@ -205,6 +212,7 @@ describe('AIPlayerStrategy', () => {
         promptContentProvider: da_promptContentProvider,
         promptBuilder: da_promptBuilder,
         llmResponseProcessor: da_llmResponseProcessor,
+        aiFallbackActionFactory: da_aiFallbackActionFactory,
         logger: da_logger,
       });
 
@@ -313,7 +321,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        'AIPlayerStrategy: Creating canonical fallback action for actor UnknownActor due to unhandled_orchestration_error.',
+        'AIFallbackActionFactory: Creating fallback for actor UnknownActor due to unhandled_orchestration_error.',
         expect.any(Object)
       );
     });
@@ -334,7 +342,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        'AIPlayerStrategy: Creating canonical fallback action for actor UnknownActor due to unhandled_orchestration_error.',
+        'AIFallbackActionFactory: Creating fallback for actor UnknownActor due to unhandled_orchestration_error.',
         expect.any(Object)
       );
     });
@@ -356,7 +364,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        'AIPlayerStrategy: Creating canonical fallback action for actor UnknownActor due to unhandled_orchestration_error.',
+        'AIFallbackActionFactory: Creating fallback for actor UnknownActor due to unhandled_orchestration_error.',
         expect.any(Object)
       );
     });
@@ -378,7 +386,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.any(Object)
       );
     });
@@ -475,7 +483,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.objectContaining({ error })
       );
     });
@@ -495,7 +503,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.objectContaining({ error })
       );
       // Ensure buildGameState was called before getPromptData
@@ -525,7 +533,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.any(Object)
       );
     });
@@ -549,7 +557,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.any(Object)
       );
     });
@@ -568,7 +576,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.objectContaining({ error })
       );
     });
@@ -587,7 +595,7 @@ describe('AIPlayerStrategy', () => {
         error.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.objectContaining({ error })
       );
     });
@@ -606,7 +614,7 @@ describe('AIPlayerStrategy', () => {
         processorError.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor ${mockActor_da.id} due to unhandled_orchestration_error.`,
         expect.objectContaining({ error: processorError })
       );
     });
@@ -632,7 +640,7 @@ describe('AIPlayerStrategy', () => {
         actorError.message
       );
       expect(da_logger.error).toHaveBeenCalledWith(
-        `AIPlayerStrategy: Creating canonical fallback action for actor UnknownActor due to unhandled_orchestration_error.`,
+        `AIFallbackActionFactory: Creating fallback for actor UnknownActor due to unhandled_orchestration_error.`,
         expect.objectContaining({ error: actorError })
       );
     });


### PR DESCRIPTION
## Summary
- add IAIFallbackActionFactory interface and implementation
- register new factory in DI container and expose DI token
- inject IAIFallbackActionFactory into AIPlayerStrategy and AITurnHandler
- update ConcreteAIPlayerStrategyFactory to pass factory
- refactor tests for the new fallback factory

## Testing
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND])*
- `npm test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68430bc5b4388331ae836d7ecb8a9bf0