### PR TITLE
[Agent] decouple ai strategy persistence

### DIFF
--- a/src/turns/interfaces/IActorTurnStrategy.js
+++ b/src/turns/interfaces/IActorTurnStrategy.js
@@ -46,6 +46,12 @@
  */
 
 /**
+ * @typedef {object} AIStrategyDecision
+ * @property {ITurnAction} action - The decided action.
+ * @property {object | null} extractedData - Additional data from the LLM response.
+ */
+
+/**
  * @interface IActorTurnStrategy
  * @description
  * Defines the contract for how an actor (human, AI, item with agency, etc.)
@@ -128,10 +134,11 @@ export class IActorTurnStrategy {
    * `context.getPlayerPromptService()`, `context.getGame()`,
    * a service to query available/valid actions)
    * that the strategy might need to make an informed decision.
-   * @returns {Promise<ITurnAction>} A Promise that resolves to an {@link ITurnAction}
-   * object. This object identifies the data-defined action chosen
-   * (e.g., via `actionDefinitionId`) and includes any parameters
-   * resolved for this specific instance (e.g., `resolvedParameters`).
+   * @returns {Promise<ITurnAction | AIStrategyDecision>} A Promise that resolves to
+   * either an {@link ITurnAction} or an {@link AIStrategyDecision}. When an
+   * AIStrategyDecision is returned, the `action` property contains the chosen
+   * {@link ITurnAction} and `extractedData` contains any additional data
+   * extracted from the LLM response.
    * If the actor decides to take no overt action (e.g., a "pass turn"
    * scenario, often represented by a "core:wait" or "core:pass" action),
    * the strategy should still resolve with an appropriate

--- a/tests/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/turns/states/awaitingPlayerInputState.test.js
@@ -387,20 +387,9 @@ describe('AwaitingPlayerInputState (PTH-REFACTOR-003.5.7)', () => {
     test('should end turn if strategy.decideAction returns null', async () => {
       mockTestStrategy.decideAction.mockResolvedValue(null);
       await awaitingPlayerInputState.enterState(mockHandler, mockPreviousState);
-      expect(superEnterSpy).toHaveBeenCalledWith(
-        mockHandler,
-        mockPreviousState
-      );
-      const expectedWarnMsg = `AwaitingPlayerInputState: Strategy for actor ${testActor.id} returned an invalid or null ITurnAction (must have actionDefinitionId).`;
-      expect(mockLogger.warn).toHaveBeenCalledWith(expectedWarnMsg, {
-        receivedAction: null,
-      });
-      expect(mockTestTurnContext.endTurn).toHaveBeenCalledWith(
-        expect.any(Error)
-      );
-      expect(mockTestTurnContext.endTurn.mock.calls[0][0].message).toBe(
-        expectedWarnMsg
-      );
+      expect(superEnterSpy).toHaveBeenCalledWith(mockHandler, mockPreviousState);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockTestTurnContext.endTurn).toHaveBeenCalledWith(expect.any(Error));
     });
 
     test('should end turn if strategy.decideAction returns ITurnAction without actionDefinitionId', async () => {


### PR DESCRIPTION
Summary: 
- add AIStrategyDecision typedef and update decideAction docs
- return decision object from AIPlayerStrategy instead of persisting
- dispatch `core:ai_action_decided` when extracted data present
- update AwaitingPlayerInputState to use new return shape
- adjust related unit tests

Testing Done:
- `npm run format`
- `npm run lint` *(fails: repository has many existing lint issues)*
- `npm test`
- `cd llm-proxy-server && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684317af979c83318fb0eaa4db9df29c