### PR TITLE
[Agent] Persist AI-generated thoughts and notes

### DIFF
--- a/data/mods/core/events/ai_action_decided.event.json
+++ b/data/mods/core/events/ai_action_decided.event.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://example.com/schemas/event-definition.schema.json",
+  "id": "core:ai_action_decided",
+  "description": "Dispatched when an AI actor has chosen its next action. Includes any thoughts or notes extracted during the decision process.",
+  "payloadSchema": {
+    "title": "Core: AI Action Decided Event Payload",
+    "description": "Payload for the 'core:ai_action_decided' event.",
+    "type": "object",
+    "properties": {
+      "actorId": {
+        "$ref": "http://example.com/schemas/common.schema.json#/definitions/namespacedId",
+        "description": "The ID of the AI actor that decided an action."
+      },
+      "extractedData": {
+        "type": "object",
+        "description": "Data extracted from the AI decision process.",
+        "properties": {
+          "thoughts": { "type": "string" },
+          "notes": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "required": ["actorId"],
+    "additionalProperties": false
+  }
+}

--- a/src/ai/NotesPersistenceListener.js
+++ b/src/ai/NotesPersistenceListener.js
@@ -1,0 +1,42 @@
+import { persistNotes } from './notesPersistenceHook.js';
+
+/**
+ * @file Handles persistence of AI-generated notes when an action is decided.
+ */
+
+/**
+ * @class NotesPersistenceListener
+ * @description Consumes AI decision events and merges generated notes into the actor's notes component.
+ */
+export class NotesPersistenceListener {
+  /**
+   * Constructs a NotesPersistenceListener.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger instance.
+   * @param {import('../interfaces/IEntityManager.js').IEntityManager} deps.entityManager - Entity manager used to retrieve actors.
+   */
+  constructor({ logger, entityManager }) {
+    this.logger = logger;
+    this.entityManager = entityManager;
+  }
+
+  /**
+   * Handles the core:ai_action_decided event.
+   *
+   * @param {{actor: {id: string}, extractedData: any}} payload - Event payload containing the actor and extracted data.
+   * @returns {void}
+   */
+  handleEvent({ actor, extractedData }) {
+    if (extractedData?.notes?.length > 0) {
+      const actorEntity = this.entityManager.getEntityInstance(actor.id);
+      if (actorEntity) {
+        persistNotes({ notes: extractedData.notes }, actorEntity, this.logger);
+      } else {
+        this.logger.warn(
+          `NotesPersistenceListener: Could not find entity for actor ID ${actor.id}.`
+        );
+      }
+    }
+  }
+}

--- a/src/ai/ThoughtPersistenceListener.js
+++ b/src/ai/ThoughtPersistenceListener.js
@@ -1,0 +1,47 @@
+import { persistThoughts } from './thoughtPersistenceHook.js';
+
+/**
+ * @file Handles persistence of AI-generated thoughts when an action is decided.
+ */
+
+/**
+ * @class ThoughtPersistenceListener
+ * @description Listens for AI decision events and persists any generated thoughts
+ * to the actor's short-term memory component.
+ */
+export class ThoughtPersistenceListener {
+  /**
+   * Constructs a ThoughtPersistenceListener.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger instance.
+   * @param {import('../interfaces/IEntityManager.js').IEntityManager} deps.entityManager - Entity manager used to retrieve actors.
+   */
+  constructor({ logger, entityManager }) {
+    this.logger = logger;
+    this.entityManager = entityManager;
+  }
+
+  /**
+   * Handles the core:ai_action_decided event.
+   *
+   * @param {{actor: {id: string}, extractedData: any}} payload - Event payload containing the actor and extracted data.
+   * @returns {void}
+   */
+  handleEvent({ actor, extractedData }) {
+    if (extractedData?.thoughts) {
+      const actorEntity = this.entityManager.getEntityInstance(actor.id);
+      if (actorEntity) {
+        persistThoughts(
+          { thoughts: extractedData.thoughts },
+          actorEntity,
+          this.logger
+        );
+      } else {
+        this.logger.warn(
+          `ThoughtPersistenceListener: Could not find entity for actor ID ${actor.id}.`
+        );
+      }
+    }
+  }
+}

--- a/tests/ai/notesPersistenceListener.test.js
+++ b/tests/ai/notesPersistenceListener.test.js
@@ -1,0 +1,59 @@
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import { NotesPersistenceListener } from '../../src/ai/NotesPersistenceListener.js';
+import { persistNotes } from '../../src/ai/notesPersistenceHook.js';
+
+jest.mock('../../src/ai/notesPersistenceHook.js', () => ({
+  persistNotes: jest.fn(),
+}));
+
+describe('NotesPersistenceListener', () => {
+  let logger;
+  let entityManager;
+  let listener;
+
+  beforeEach(() => {
+    logger = {
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    entityManager = { getEntityInstance: jest.fn() };
+    listener = new NotesPersistenceListener({ logger, entityManager });
+    persistNotes.mockClear();
+  });
+
+  test('persists notes when entity found', () => {
+    const actorEntity = {};
+    entityManager.getEntityInstance.mockReturnValue(actorEntity);
+    listener.handleEvent({
+      actor: { id: 'a1' },
+      extractedData: { notes: ['note'] },
+    });
+
+    expect(entityManager.getEntityInstance).toHaveBeenCalledWith('a1');
+    expect(persistNotes).toHaveBeenCalledWith(
+      { notes: ['note'] },
+      actorEntity,
+      logger
+    );
+  });
+
+  test('logs warning when entity missing', () => {
+    entityManager.getEntityInstance.mockReturnValue(null);
+    listener.handleEvent({
+      actor: { id: 'a1' },
+      extractedData: { notes: ['n'] },
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'NotesPersistenceListener: Could not find entity for actor ID a1.'
+    );
+    expect(persistNotes).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when notes array empty', () => {
+    listener.handleEvent({ actor: { id: 'a1' }, extractedData: { notes: [] } });
+    expect(persistNotes).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ai/thoughtPersistenceListener.test.js
+++ b/tests/ai/thoughtPersistenceListener.test.js
@@ -1,0 +1,59 @@
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import { ThoughtPersistenceListener } from '../../src/ai/ThoughtPersistenceListener.js';
+import { persistThoughts } from '../../src/ai/thoughtPersistenceHook.js';
+
+jest.mock('../../src/ai/thoughtPersistenceHook.js', () => ({
+  persistThoughts: jest.fn(),
+}));
+
+describe('ThoughtPersistenceListener', () => {
+  let logger;
+  let entityManager;
+  let listener;
+
+  beforeEach(() => {
+    logger = {
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    entityManager = { getEntityInstance: jest.fn() };
+    listener = new ThoughtPersistenceListener({ logger, entityManager });
+    persistThoughts.mockClear();
+  });
+
+  test('persists thoughts when entity found', () => {
+    const actorEntity = {};
+    entityManager.getEntityInstance.mockReturnValue(actorEntity);
+    listener.handleEvent({
+      actor: { id: 'a1' },
+      extractedData: { thoughts: 'hi' },
+    });
+
+    expect(entityManager.getEntityInstance).toHaveBeenCalledWith('a1');
+    expect(persistThoughts).toHaveBeenCalledWith(
+      { thoughts: 'hi' },
+      actorEntity,
+      logger
+    );
+  });
+
+  test('logs warning when entity missing', () => {
+    entityManager.getEntityInstance.mockReturnValue(null);
+    listener.handleEvent({
+      actor: { id: 'a1' },
+      extractedData: { thoughts: 'hi' },
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'ThoughtPersistenceListener: Could not find entity for actor ID a1.'
+    );
+    expect(persistThoughts).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when thoughts missing', () => {
+    listener.handleEvent({ actor: { id: 'a1' }, extractedData: null });
+    expect(persistThoughts).not.toHaveBeenCalled();
+  });
+});

--- a/tests/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/initializers/services/initializationService.facadeInit.test.js
@@ -105,6 +105,12 @@ beforeEach(() => {
   container.register(tokens.ILLMAdapter, mockLlmAdapterInstance);
   container.register(tokens.ISchemaValidator, mockSchemaValidatorInstance);
   container.register(tokens.IConfiguration, mockConfigurationInstance);
+  container.register(tokens.ISafeEventDispatcher, {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    dispatchSafely: jest.fn(),
+  });
+  container.register(tokens.IEntityManager, { getEntityInstance: jest.fn() });
 
   initializationService = new InitializationService({
     container,

--- a/tests/initializers/services/initializationService.runInitializationSequence.test.js
+++ b/tests/initializers/services/initializationService.runInitializationSequence.test.js
@@ -101,6 +101,14 @@ describe('InitializationService', () => {
             return mockSchemaValidator;
           case tokens.IConfiguration:
             return mockConfiguration;
+          case tokens.ISafeEventDispatcher:
+            return {
+              subscribe: jest.fn(),
+              unsubscribe: jest.fn(),
+              dispatchSafely: jest.fn(),
+            };
+          case tokens.IEntityManager:
+            return { getEntityInstance: jest.fn() };
           default:
             return undefined;
         }
@@ -186,6 +194,8 @@ describe('InitializationService', () => {
         tokens.SystemInitializer,
         tokens.WorldInitializer,
         tokens.InputSetupService,
+        tokens.ISafeEventDispatcher,
+        tokens.IEntityManager,
         tokens.DomUiFacade,
       ]);
 


### PR DESCRIPTION
Summary: Added event listeners to store AI-generated thoughts and notes. Registered listeners during initialization and defined new event schema.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68431d2a3a3083319e3fdf5e10ef19a8