### PR TITLE
[Agent] Introduce AIPromptPipeline facade

### DIFF
--- a/src/dependencyInjection/registrations/domainServicesRegistrations.js
+++ b/src/dependencyInjection/registrations/domainServicesRegistrations.js
@@ -32,6 +32,7 @@ import { LLMResponseProcessor } from '../../turns/services/LLMResponseProcessor.
 import { AIPromptContentProvider } from '../../prompting/AIPromptContentProvider.js';
 import { AIGameStateProvider } from '../../turns/services/AIGameStateProvider.js';
 import { AIFallbackActionFactory } from '../../turns/services/AIFallbackActionFactory.js';
+import { AIPromptPipeline } from '../../prompting/AIPromptPipeline.js';
 
 // --- PromptBuilder and its dependencies (NEW IMPORTS) ---
 import { PromptBuilder } from '../../prompting/promptBuilder.js'; // Corrected path
@@ -677,6 +678,19 @@ export function registerDomainServices(container) {
   });
   log.debug(
     `Domain Services Registration: Registered ${String(tokens.IAIFallbackActionFactory)}.`
+  );
+
+  r.singletonFactory(tokens.IAIPromptPipeline, (c) => {
+    return new AIPromptPipeline({
+      llmAdapter: c.resolve(tokens.ILLMAdapter),
+      gameStateProvider: c.resolve(tokens.IAIGameStateProvider),
+      promptContentProvider: c.resolve(tokens.IAIPromptContentProvider),
+      promptBuilder: c.resolve(tokens.IPromptBuilder),
+      logger: c.resolve(tokens.ILogger),
+    });
+  });
+  log.debug(
+    `Domain Services Registration: Registered ${String(tokens.IAIPromptPipeline)}.`
   );
 
   // --- Register Turn System Factories ---

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -264,6 +264,7 @@ export const tokens = Object.freeze({
   IPromptBuilder: 'IPromptBuilder',
   IAIGameStateProvider: 'IAIGameStateProvider',
   IAIPromptContentProvider: 'IAIPromptContentProvider',
+  IAIPromptPipeline: 'IAIPromptPipeline',
   ILLMResponseProcessor: 'ILLMResponseProcessor',
   IAIFallbackActionFactory: 'IAIFallbackActionFactory',
 

--- a/src/prompting/AIPromptPipeline.js
+++ b/src/prompting/AIPromptPipeline.js
@@ -1,0 +1,118 @@
+import { IAIPromptPipeline } from './interfaces/IAIPromptPipeline.js';
+
+/** @typedef {import('../turns/interfaces/ILLMAdapter.js').ILLMAdapter} ILLMAdapter */
+/** @typedef {import('../turns/interfaces/IAIGameStateProvider.js').IAIGameStateProvider} IAIGameStateProvider */
+/** @typedef {import('../turns/interfaces/IAIPromptContentProvider.js').IAIPromptContentProvider} IAIPromptContentProvider */
+/** @typedef {import('../interfaces/IPromptBuilder.js').IPromptBuilder} IPromptBuilder */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../entities/entity.js').default} Entity */
+/** @typedef {import('../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
+
+export class AIPromptPipeline extends IAIPromptPipeline {
+  #llmAdapter;
+  #gameStateProvider;
+  #promptContentProvider;
+  #promptBuilder;
+  #logger;
+
+  /**
+   * @param {object} dependencies
+   * @param {ILLMAdapter} dependencies.llmAdapter
+   * @param {IAIGameStateProvider} dependencies.gameStateProvider
+   * @param {IAIPromptContentProvider} dependencies.promptContentProvider
+   * @param {IPromptBuilder} dependencies.promptBuilder
+   * @param {ILogger} dependencies.logger
+   */
+  constructor({
+    llmAdapter,
+    gameStateProvider,
+    promptContentProvider,
+    promptBuilder,
+    logger,
+  }) {
+    super();
+
+    if (
+      !llmAdapter ||
+      typeof llmAdapter.getAIDecision !== 'function' ||
+      typeof llmAdapter.getCurrentActiveLlmId !== 'function'
+    ) {
+      throw new Error(
+        'AIPromptPipeline: Constructor requires a valid ILLMAdapter.'
+      );
+    }
+    if (
+      !gameStateProvider ||
+      typeof gameStateProvider.buildGameState !== 'function'
+    ) {
+      throw new Error(
+        'AIPromptPipeline: Constructor requires a valid IAIGameStateProvider.'
+      );
+    }
+    if (
+      !promptContentProvider ||
+      typeof promptContentProvider.getPromptData !== 'function'
+    ) {
+      throw new Error(
+        'AIPromptPipeline: Constructor requires a valid IAIPromptContentProvider instance with a getPromptData method.'
+      );
+    }
+    if (!promptBuilder || typeof promptBuilder.build !== 'function') {
+      throw new Error(
+        'AIPromptPipeline: Constructor requires a valid IPromptBuilder instance with a build method.'
+      );
+    }
+    if (!logger || typeof logger.info !== 'function') {
+      throw new Error(
+        'AIPromptPipeline: Constructor requires a valid ILogger instance.'
+      );
+    }
+
+    this.#llmAdapter = llmAdapter;
+    this.#gameStateProvider = gameStateProvider;
+    this.#promptContentProvider = promptContentProvider;
+    this.#promptBuilder = promptBuilder;
+    this.#logger = logger;
+  }
+
+  /**
+   * Generates the final prompt string for an AI actor.
+   *
+   * @param {Entity} actor
+   * @param {ITurnContext} context
+   * @returns {Promise<string>}
+   */
+  async generatePrompt(actor, context) {
+    const actorId = actor.id;
+    this.#logger.debug(
+      `AIPromptPipeline: Generating prompt for actor ${actorId}.`
+    );
+
+    const currentLlmId = await this.#llmAdapter.getCurrentActiveLlmId();
+    if (!currentLlmId) throw new Error('Could not determine active LLM ID.');
+
+    const gameStateDto = await this.#gameStateProvider.buildGameState(
+      actor,
+      context,
+      this.#logger
+    );
+    const promptData = await this.#promptContentProvider.getPromptData(
+      gameStateDto,
+      this.#logger
+    );
+    const finalPromptString = await this.#promptBuilder.build(
+      currentLlmId,
+      promptData
+    );
+
+    if (!finalPromptString)
+      throw new Error('PromptBuilder returned an empty or invalid prompt.');
+    this.#logger.info(
+      `AIPromptPipeline: Generated final prompt string for actor ${actorId} using LLM config for '${currentLlmId}'.`
+    );
+    this.#logger.debug(
+      `AIPromptPipeline: Final Prompt String for ${actorId}:\n${finalPromptString}`
+    );
+    return finalPromptString;
+  }
+}

--- a/src/prompting/interfaces/IAIPromptPipeline.js
+++ b/src/prompting/interfaces/IAIPromptPipeline.js
@@ -1,0 +1,10 @@
+/** @typedef {import('../../entities/entity.js').default} Entity */
+/** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
+
+export class IAIPromptPipeline {
+  async generatePrompt(actor, context) {
+    throw new Error(
+      'Method "generatePrompt" must be implemented by concrete classes.'
+    );
+  }
+}

--- a/src/turns/factories/concreteAIPlayerStrategyFactory.js
+++ b/src/turns/factories/concreteAIPlayerStrategyFactory.js
@@ -6,9 +6,7 @@ import { AIPlayerStrategy } from '../strategies/aiPlayerStrategy.js';
 
 /**
  * @typedef {import('../interfaces/ILLMAdapter.js').ILLMAdapter} ILLMAdapter
- * @typedef {import('../interfaces/IAIGameStateProvider.js').IAIGameStateProvider} IAIGameStateProvider
- * @typedef {import('../interfaces/IAIPromptContentProvider.js').IAIPromptContentProvider} IAIPromptContentProvider
- * @typedef {import('../../interfaces/IPromptBuilder.js').IPromptBuilder} IPromptBuilder
+ * @typedef {import('../../prompting/interfaces/IAIPromptPipeline.js').IAIPromptPipeline} IAIPromptPipeline
  * @typedef {import('../interfaces/ILLMResponseProcessor.js').ILLMResponseProcessor} ILLMResponseProcessor
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy
@@ -27,9 +25,7 @@ export class ConcreteAIPlayerStrategyFactory extends IAIPlayerStrategyFactory {
    *
    * @param {object} dependencies - The dependencies required by the AI player strategy.
    * @param {ILLMAdapter} dependencies.llmAdapter
-   * @param {IAIGameStateProvider} dependencies.gameStateProvider
-   * @param {IAIPromptContentProvider} dependencies.promptContentProvider
-   * @param {IPromptBuilder} dependencies.promptBuilder
+   * @param {IAIPromptPipeline} dependencies.aiPromptPipeline
    * @param {ILLMResponseProcessor} dependencies.llmResponseProcessor
    * @param {IAIFallbackActionFactory} dependencies.aiFallbackActionFactory
    * @param {ILogger} dependencies.logger
@@ -37,18 +33,14 @@ export class ConcreteAIPlayerStrategyFactory extends IAIPlayerStrategyFactory {
    */
   create({
     llmAdapter,
-    gameStateProvider,
-    promptContentProvider,
-    promptBuilder,
+    aiPromptPipeline,
     llmResponseProcessor,
     aiFallbackActionFactory,
     logger,
   }) {
     return new AIPlayerStrategy({
       llmAdapter,
-      gameStateProvider,
-      promptContentProvider,
-      promptBuilder,
+      aiPromptPipeline,
       llmResponseProcessor,
       aiFallbackActionFactory,
       logger,

--- a/tests/turns/strategies/aiPlayerStrategy.constructor.test.js
+++ b/tests/turns/strategies/aiPlayerStrategy.constructor.test.js
@@ -1,6 +1,3 @@
-// tests/turns/strategies/aiPlayerStrategy.constructor.test.js
-// --- FILE START ---
-
 import { AIPlayerStrategy } from '../../../src/turns/strategies/aiPlayerStrategy.js';
 import { AIFallbackActionFactory } from '../../../src/turns/services/AIFallbackActionFactory.js';
 import {
@@ -11,72 +8,30 @@ import {
   expect,
   afterEach,
 } from '@jest/globals';
-// Removed DEFAULT_FALLBACK_ACTION as it's not directly used in constructor tests
-// import {DEFAULT_FALLBACK_ACTION} from "../../../src/llms/constants/llmConstants.js";
-// Removed AIPromptContentProvider import as its static method is no longer spied on here
-// import {AIPromptContentProvider} from "../../../src/services/AIPromptContentProvider.js";
 
-// --- Typedefs for Mocks ---
 /** @typedef {import('../../../src/turns/interfaces/ILLMAdapter.js').ILLMAdapter} ILLMAdapter */
-/** @typedef {import('../../../src/turns/interfaces/IAIGameStateProvider.js').IAIGameStateProvider} IAIGameStateProvider */
-/** @typedef {import('../../../src/turns/interfaces/IAIPromptContentProvider.js').IAIPromptContentProvider} IAIPromptContentProvider */
-/** @typedef {import('../../../src/prompting/promptBuilder.js').PromptBuilder} PromptBuilder */
+/** @typedef {import('../../../src/prompting/interfaces/IAIPromptPipeline.js').IAIPromptPipeline} IAIPromptPipeline */
 /** @typedef {import('../../../src/turns/interfaces/ILLMResponseProcessor.js').ILLMResponseProcessor} ILLMResponseProcessor */
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../../src/turns/interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} IAIFallbackActionFactory */
-// Removed unused typedefs for PromptData and AIGameStateDTO_Test as they are not relevant for constructor tests
-// /** @typedef {import('../../../src/types/promptData.js').PromptData} PromptData */
-// /** @typedef {import('../../../src/turns/dtos/AIGameStateDTO.js').AIGameStateDTO} AIGameStateDTO_Test */
 
-// --- Mock Implementations ---
-
-/**
- * @returns {jest.Mocked<ILLMAdapter>}
- */
 const mockLlmAdapter = () => ({
   getAIDecision: jest.fn(),
   getCurrentActiveLlmId: jest.fn(),
 });
 
-/**
- * @returns {jest.Mocked<IAIGameStateProvider>}
- */
-const mockGameStateProvider = () => ({
-  buildGameState: jest.fn(),
+const mockAiPromptPipeline = () => ({
+  generatePrompt: jest.fn(),
 });
 
-/**
- * @returns {jest.Mocked<IAIPromptContentProvider>}
- */
-const mockAIPromptContentProvider = () => ({
-  getPromptData: jest.fn(),
-  // validateGameStateForPrompting: jest.fn(), // Not needed for constructor tests
-});
-
-/**
- * @returns {jest.Mocked<PromptBuilder>}
- */
-const mockPromptBuilder = () => ({
-  build: jest.fn(),
-});
-
-/**
- * @returns {jest.Mocked<ILLMResponseProcessor>}
- */
 const mockLlmResponseProcessor = () => ({
   processResponse: jest.fn(),
 });
 
-/**
- * @returns {jest.Mocked<IAIFallbackActionFactory>}
- */
 const mockAIFallbackActionFactory = () => ({
   create: jest.fn(),
 });
 
-/**
- * @returns {jest.Mocked<ILogger>}
- */
 const mockLogger = () => ({
   info: jest.fn(),
   warn: jest.fn(),
@@ -84,516 +39,111 @@ const mockLogger = () => ({
   debug: jest.fn(),
 });
 
-// Removed MockEntity and createMockActor as they are not used in constructor tests
-
-describe('AIPlayerStrategy', () => {
+describe('AIPlayerStrategy constructor', () => {
   /** @type {ReturnType<typeof mockLlmAdapter>} */
   let llmAdapter;
-  /** @type {ReturnType<typeof mockGameStateProvider>} */
-  let gameStateProvider;
-  /** @type {ReturnType<typeof mockAIPromptContentProvider>} */
-  let promptContentProvider;
-  /** @type {ReturnType<typeof mockPromptBuilder>} */
-  let promptBuilder;
+  /** @type {ReturnType<typeof mockAiPromptPipeline>} */
+  let aiPromptPipeline;
   /** @type {ReturnType<typeof mockLlmResponseProcessor>} */
   let llmResponseProcessor;
   /** @type {ReturnType<typeof mockAIFallbackActionFactory>} */
   let aiFallbackActionFactory;
   /** @type {ReturnType<typeof mockLogger>} */
-  let currentLoggerMock;
-  // Removed checkCriticalGameStateSpy as it's not relevant for constructor tests
-  // /** @type {jest.SpyInstance} */
-  // let checkCriticalGameStateSpy;
+  let logger;
 
   beforeEach(() => {
     llmAdapter = mockLlmAdapter();
-    gameStateProvider = mockGameStateProvider();
-    promptContentProvider = mockAIPromptContentProvider();
-    promptBuilder = mockPromptBuilder();
+    aiPromptPipeline = mockAiPromptPipeline();
     llmResponseProcessor = mockLlmResponseProcessor();
     aiFallbackActionFactory = mockAIFallbackActionFactory();
-    currentLoggerMock = mockLogger();
-
-    jest.clearAllMocks();
-    // The spy on AIPromptContentProvider.checkCriticalGameState is removed
-    // as it's not used by the AIPlayerStrategy constructor and the method no longer exists.
+    logger = mockLogger();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe('constructor', () => {
-    test('should successfully create an instance with valid dependencies', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).not.toThrow();
-      const instance = new AIPlayerStrategy({
-        llmAdapter,
-        gameStateProvider,
-        promptContentProvider,
-        promptBuilder,
-        llmResponseProcessor,
-        aiFallbackActionFactory,
-        logger: currentLoggerMock,
-      });
-      expect(instance).toBeInstanceOf(AIPlayerStrategy);
+  test('creates instance with valid dependencies', () => {
+    const instance = new AIPlayerStrategy({
+      llmAdapter,
+      aiPromptPipeline,
+      llmResponseProcessor,
+      aiFallbackActionFactory,
+      logger,
     });
+    expect(instance).toBeInstanceOf(AIPlayerStrategy);
+  });
 
-    const commonILLMAdapterError =
-      'AIPlayerStrategy: Constructor requires a valid ILLMAdapter.';
-    test('should throw an error if llmAdapter is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            // llmAdapter missing
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
-    test('should throw an error if llmAdapter is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter: null,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
-    test('should throw an error if llmAdapter does not have getAIDecision method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            // @ts-ignore
-            llmAdapter: { getCurrentActiveLlmId: jest.fn() },
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
-    test('should throw an error if llmAdapter.getAIDecision is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            // @ts-ignore
-            llmAdapter: {
-              getAIDecision: 'not-a-function',
-              getCurrentActiveLlmId: jest.fn(),
-            },
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
-    test('should throw an error if llmAdapter does not have getCurrentActiveLlmId method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            // @ts-ignore
-            llmAdapter: { getAIDecision: jest.fn() },
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
-    test('should throw an error if llmAdapter.getCurrentActiveLlmId is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            // @ts-ignore
-            llmAdapter: {
-              getAIDecision: jest.fn(),
-              getCurrentActiveLlmId: 'not-a-function',
-            },
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMAdapterError);
-    });
+  test('throws if aiPromptPipeline is missing', () => {
+    expect(
+      () =>
+        new AIPlayerStrategy({
+          llmAdapter,
+          aiPromptPipeline: null,
+          llmResponseProcessor,
+          aiFallbackActionFactory,
+          logger,
+        })
+    ).toThrow(
+      'AIPlayerStrategy: Constructor requires a valid IAIPromptPipeline.'
+    );
+  });
 
-    const commonIAIGameStateProviderError =
-      'AIPlayerStrategy: Constructor requires a valid IAIGameStateProvider.';
-    test('should throw an error if gameStateProvider is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            // gameStateProvider missing
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonIAIGameStateProviderError);
-    });
-    test('should throw an error if gameStateProvider is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider: null,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonIAIGameStateProviderError);
-    });
-    test('should throw an error if gameStateProvider does not have buildGameState method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            // @ts-ignore
-            gameStateProvider: {},
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonIAIGameStateProviderError);
-    });
-    test('should throw an error if gameStateProvider.buildGameState is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            // @ts-ignore
-            gameStateProvider: { buildGameState: 'not-a-function' },
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonIAIGameStateProviderError);
-    });
+  test('throws if llmAdapter is missing', () => {
+    expect(
+      () =>
+        new AIPlayerStrategy({
+          llmAdapter: null,
+          aiPromptPipeline,
+          llmResponseProcessor,
+          aiFallbackActionFactory,
+          logger,
+        })
+    ).toThrow('AIPlayerStrategy: Constructor requires a valid ILLMAdapter.');
+  });
 
-    const commonAIPromptContentProviderError =
-      'AIPlayerStrategy: Constructor requires a valid IAIPromptContentProvider instance with a getPromptData method.';
-    test('should throw an error if promptContentProvider is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            // promptContentProvider missing
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIPromptContentProviderError);
-    });
-    test('should throw an error if promptContentProvider is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider: null,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIPromptContentProviderError);
-    });
-    test('should throw an error if promptContentProvider does not have getPromptData method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            // @ts-ignore
-            promptContentProvider: {}, // Missing getPromptData
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIPromptContentProviderError);
-    });
-    test('should throw an error if promptContentProvider.getPromptData is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            // @ts-ignore
-            promptContentProvider: { getPromptData: 'not-a-function' },
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIPromptContentProviderError);
-    });
+  test('throws if llmResponseProcessor missing', () => {
+    expect(
+      () =>
+        new AIPlayerStrategy({
+          llmAdapter,
+          aiPromptPipeline,
+          llmResponseProcessor: null,
+          aiFallbackActionFactory,
+          logger,
+        })
+    ).toThrow(
+      'AIPlayerStrategy: Constructor requires a valid ILLMResponseProcessor.'
+    );
+  });
 
-    const commonPromptBuilderError =
-      'AIPlayerStrategy: Constructor requires a valid IPromptBuilder instance with a build method.';
-    test('should throw an error if promptBuilder is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            // promptBuilder missing
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonPromptBuilderError);
-    });
-    test('should throw an error if promptBuilder is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder: null,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonPromptBuilderError);
-    });
-    test('should throw an error if promptBuilder does not have build method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            // @ts-ignore
-            promptBuilder: {}, // Missing build method
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonPromptBuilderError);
-    });
-    test('should throw an error if promptBuilder.build is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            // @ts-ignore
-            promptBuilder: { build: 'not-a-function' },
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonPromptBuilderError);
-    });
+  test('throws if aiFallbackActionFactory missing', () => {
+    expect(
+      () =>
+        new AIPlayerStrategy({
+          llmAdapter,
+          aiPromptPipeline,
+          llmResponseProcessor,
+          aiFallbackActionFactory: null,
+          logger,
+        })
+    ).toThrow(
+      'AIPlayerStrategy: Constructor requires a valid IAIFallbackActionFactory.'
+    );
+  });
 
-    const commonILLMResponseProcessorError =
-      'AIPlayerStrategy: Constructor requires a valid ILLMResponseProcessor.';
-    test('should throw an error if llmResponseProcessor is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            // llmResponseProcessor missing
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMResponseProcessorError);
-    });
-    test('should throw an error if llmResponseProcessor is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor: null,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMResponseProcessorError);
-    });
-    test('should throw an error if llmResponseProcessor does not have processResponse method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            // @ts-ignore
-            llmResponseProcessor: {}, // Missing processResponse method
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMResponseProcessorError);
-    });
-    test('should throw an error if llmResponseProcessor.processResponse is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            // @ts-ignore
-            llmResponseProcessor: { processResponse: 'not-a-function' },
-            aiFallbackActionFactory,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonILLMResponseProcessorError);
-    });
-
-    const commonAIFallbackFactoryError =
-      'AIPlayerStrategy: Constructor requires a valid IAIFallbackActionFactory.';
-    test('should throw an error if aiFallbackActionFactory is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            // aiFallbackActionFactory missing
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIFallbackFactoryError);
-    });
-    test('should throw an error if aiFallbackActionFactory is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory: null,
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIFallbackFactoryError);
-    });
-    test('should throw an error if aiFallbackActionFactory.create is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            // @ts-ignore
-            aiFallbackActionFactory: {},
-            logger: currentLoggerMock,
-          })
-      ).toThrow(commonAIFallbackFactoryError);
-    });
-
-    const commonILoggerError =
-      'AIPlayerStrategy: Constructor requires a valid ILogger instance.';
-    test('should throw an error if logger is not provided', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            // logger missing
-          })
-      ).toThrow(commonILoggerError);
-    });
-    test('should throw an error if logger is null', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            aiFallbackActionFactory,
-            logger: null,
-          })
-      ).toThrow(commonILoggerError);
-    });
-    test('should throw an error if logger does not have an info method', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            // @ts-ignore
-            logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn() }, // Missing info
-            aiFallbackActionFactory,
-          })
-      ).toThrow(commonILoggerError);
-    });
-    test('should throw an error if logger.info is not a function', () => {
-      expect(
-        () =>
-          new AIPlayerStrategy({
-            llmAdapter,
-            gameStateProvider,
-            promptContentProvider,
-            promptBuilder,
-            llmResponseProcessor,
-            // @ts-ignore
-            logger: { info: 'not-a-function' },
-            aiFallbackActionFactory,
-          })
-      ).toThrow(commonILoggerError);
-    });
+  test('throws if logger missing', () => {
+    expect(
+      () =>
+        new AIPlayerStrategy({
+          llmAdapter,
+          aiPromptPipeline,
+          llmResponseProcessor,
+          aiFallbackActionFactory,
+          logger: null,
+        })
+    ).toThrow(
+      'AIPlayerStrategy: Constructor requires a valid ILogger instance.'
+    );
   });
 });
-
-// --- FILE END ---


### PR DESCRIPTION
## Summary
- add IAIPromptPipeline token
- implement IAIPromptPipeline interface and AIPromptPipeline class
- register new AIPromptPipeline service
- refactor AIPlayerStrategy to use the pipeline
- update concrete AIPlayerStrategy factory
- adapt constructor and decideAction tests for new pipeline

## Testing Done
- `npm run format`
- `npm run lint` *(fails: eslint issues in repo)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684333da601483319f12c6ded1c1f246