### PR TITLE
[Agent] use safe event dispatcher in input setup

### DIFF
--- a/src/dependencyInjection/registrations/runtimeRegistrations.js
+++ b/src/dependencyInjection/registrations/runtimeRegistrations.js
@@ -17,7 +17,7 @@ import InputSetupService from '../../setup/inputSetupService.js';
 /** @typedef {import('../../entities/entityManager.js').default} EntityManager */ // Assuming EntityManager is concrete
 /** @typedef {import('../../data/gameDataRepository.js').GameDataRepository} GameDataRepository */ // Assuming concrete
 /** @typedef {import('../../../interfaces/coreServices.js').IActionDiscoverySystem} IActionDiscoverySystem */
-/** @typedef {import('../../../interfaces/coreServices.js').IValidatedEventDispatcher} IValidatedEventDispatcher */
+/** @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 /** @typedef {import('../../../interfaces/coreServices.js').ITurnManager} ITurnManager */
 /** @typedef {import('../../turns/interfaces/ITurnHandlerResolver.js').ITurnHandlerResolver} ITurnHandlerResolver */
 
@@ -49,7 +49,7 @@ export function registerRuntime(container) {
       new InputSetupService({
         container: c,
         logger: c.resolve(tokens.ILogger),
-        validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         // REMOVED: GameLoop injection - InputSetupService no longer interacts directly with GameLoop.
         // gameLoop: c.resolve(tokens.GameLoop) // <<< LINE REMOVED
       })

--- a/src/setup/inputSetupService.js
+++ b/src/setup/inputSetupService.js
@@ -3,7 +3,7 @@
 // --- Type Imports ---
 /** @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../events/safeEventDispatcher.js').SafeEventDispatcher} SafeEventDispatcher */
 // GameLoop import removed
 /** @typedef {import('../interfaces/IInputHandler.js').IInputHandler} IInputHandler */ // Use Interface type
 
@@ -18,7 +18,7 @@ import { tokens } from '../dependencyInjection/tokens.js';
 class InputSetupService {
   #container;
   #logger;
-  #validatedEventDispatcher;
+  #safeEventDispatcher;
 
   // #gameLoop field removed
 
@@ -28,22 +28,22 @@ class InputSetupService {
    * @param {object} options - The dependencies.
    * @param {AppContainer} options.container
    * @param {ILogger} options.logger
-   * @param {ValidatedEventDispatcher} options.validatedEventDispatcher
+   * @param {SafeEventDispatcher} options.safeEventDispatcher
    * // gameLoop option removed
    * @throws {Error} If dependencies are missing.
    */
-  constructor({ container, logger, validatedEventDispatcher }) {
+  constructor({ container, logger, safeEventDispatcher }) {
     // gameLoop removed
     // Simplified validation for brevity, assume checks pass
     if (!container) throw new Error("InputSetupService: Missing 'container'.");
     if (!logger) throw new Error("InputSetupService: Missing 'logger'.");
-    if (!validatedEventDispatcher)
-      throw new Error("InputSetupService: Missing 'validatedEventDispatcher'.");
+    if (!safeEventDispatcher)
+      throw new Error("InputSetupService: Missing 'safeEventDispatcher'.");
     // gameLoop validation removed
 
     this.#container = container;
     this.#logger = logger;
-    this.#validatedEventDispatcher = validatedEventDispatcher;
+    this.#safeEventDispatcher = safeEventDispatcher;
     // #gameLoop assignment removed
 
     this.#logger.info('InputSetupService: Instance created.');
@@ -80,8 +80,8 @@ class InputSetupService {
         this.#logger.debug(
           `InputSetupService: Dispatching core:submit_command for command "${command}"`
         );
-        this.#validatedEventDispatcher
-          .dispatchValidated('core:submit_command', { command })
+        this.#safeEventDispatcher
+          .dispatch('core:submit_command', { command })
           .catch((e) =>
             this.#logger.error(
               `Failed dispatching core:submit_command for command "${command}"`,

--- a/tests/config/registrations/runtimeRegistrations.test.js
+++ b/tests/config/registrations/runtimeRegistrations.test.js
@@ -13,7 +13,7 @@
 /** @typedef {import('../../../src/entities/entityManager.js').default} EntityManager */
 /** @typedef {import('../../../src/data/gameDataRepository.js').GameDataRepository} GameDataRepository */
 /** @typedef {import('../../../src/actions/actionDiscoveryService.js').ActionDiscoveryService} ActionDiscoverySystem */
-/** @typedef {import('../../../src/events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../../../src/events/safeEventDispatcher.js').SafeEventDispatcher} SafeEventDispatcher */
 /** @typedef {import('../../../src/setup/inputSetupService.js').default} InputSetupService */
 /** @typedef {import('../../../src/turns/turnManager.js').default} TurnManager */
 /** @typedef {import('../../../src/turns/interfaces/ITurnOrderService.js').ITurnOrderService} ITurnOrderService */
@@ -95,8 +95,8 @@ const mockGameDataRepository = {
   getAllActionDefinitions: jest.fn(() => []),
 }; // Mock getAllActionDefinitions
 // REMOVED: mockActionDiscoverySystemObject - using imported mock now
-const mockValidatedEventDispatcher = {
-  dispatchValidated: jest.fn(),
+const mockSafeEventDispatcher = {
+  dispatch: jest.fn(),
   subscribe: jest.fn(),
   unsubscribe: jest.fn(),
 };
@@ -319,8 +319,8 @@ describe('registerRuntime', () => {
       lifecycle: 'singleton',
     });
     mockContainer.register(
-      tokens.IValidatedEventDispatcher,
-      mockValidatedEventDispatcher,
+      tokens.ISafeEventDispatcher,
+      mockSafeEventDispatcher,
       { lifecycle: 'singleton' }
     );
 
@@ -401,9 +401,7 @@ describe('registerRuntime', () => {
     Object.values(mockEntityManager).forEach((fn) => fn?.mockClear?.());
     Object.values(mockGameDataRepository).forEach((fn) => fn?.mockClear?.());
     // REMOVED: Clearing mockActionDiscoverySystemObject
-    Object.values(mockValidatedEventDispatcher).forEach((fn) =>
-      fn?.mockClear?.()
-    );
+    Object.values(mockSafeEventDispatcher).forEach((fn) => fn?.mockClear?.());
     Object.values(mockTurnHandlerResolverObject).forEach((fn) =>
       fn?.mockClear?.()
     );
@@ -485,8 +483,8 @@ describe('registerRuntime', () => {
       lifecycle: 'singleton',
     });
     mockContainer.register(
-      tokens.IValidatedEventDispatcher,
-      mockValidatedEventDispatcher,
+      tokens.ISafeEventDispatcher,
+      mockSafeEventDispatcher,
       { lifecycle: 'singleton' }
     );
 
@@ -510,7 +508,7 @@ describe('registerRuntime', () => {
       expect.objectContaining({
         container: mockContainer, // The factory passes the container itself
         logger: mockLogger, // The factory resolves ILogger -> returns mockLogger
-        validatedEventDispatcher: mockValidatedEventDispatcher, // Factory resolves IValidatedEventDispatcher -> returns mockValidatedEventDispatcher
+        safeEventDispatcher: mockSafeEventDispatcher, // Factory resolves ISafeEventDispatcher -> returns mockSafeEventDispatcher
       })
     );
 
@@ -519,7 +517,7 @@ describe('registerRuntime', () => {
     // It should have been called internally by the factory function
     expect(mockContainer.resolve).toHaveBeenCalledWith(tokens.ILogger);
     expect(mockContainer.resolve).toHaveBeenCalledWith(
-      tokens.IValidatedEventDispatcher
+      tokens.ISafeEventDispatcher
     );
 
     // Check that other potentially indirect dependencies were NOT resolved *directly* by this factory's execution


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into InputSetupService
- update runtime registration to resolve ISafeEventDispatcher
- adjust tests for new dependency

## Testing
- `npm run format`
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435c45cfe08331b167d0fa6e53d9ea