### PR TITLE
[Agent] Fix AlertMessageFormatter test import

### DIFF
--- a/tests/alerting/alertMessageFormatter.test.js
+++ b/tests/alerting/alertMessageFormatter.test.js
@@ -1,4 +1,4 @@
-import { AlertMessageFormatter } from '../../src/alerting/AlertMessageFormatter.js';
+import { AlertMessageFormatter } from '../../src/alerting/alertMessageFormatter.js';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
 describe('AlertMessageFormatter', () => {


### PR DESCRIPTION
Summary: Fixes failing test by using correct casing in import path for AlertMessageFormatter. Ensures coverage for alerting module.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` & `cd llm-proxy-server && npm run lint`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)


------
https://chatgpt.com/codex/tasks/task_e_684362343a1c83319969daa64058fea0