### PR TITLE
[Agent] implement prompt logging

### DIFF
--- a/src/turns/adapters/configurableLLMAdapter.js
+++ b/src/turns/adapters/configurableLLMAdapter.js
@@ -835,6 +835,15 @@ export class ConfigurableLLMAdapter extends ILLMAdapter {
     }
 
     try {
+      if (this.#environmentContext.isClient()) {
+        const llmIdForPromptLog =
+          activeConfig.modelIdentifier || activeConfig.configId || 'unknown';
+        // eslint-disable-next-line no-console
+        console.info(
+          `[PromptLog][Model: ${llmIdForPromptLog}] Final assembled prompt being sent to proxy:\n${gameSummary}`
+        );
+      }
+
       const validationErrors = this.#validateConfig(activeConfig);
       if (validationErrors.length > 0) {
         const errorDetailsMessage = validationErrors


### PR DESCRIPTION
Summary: add standardized client-side prompt log message with model identifier before sending to the proxy.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 1950 problems)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843df055b5c833182d3c8f1f187d15a