### PR TITLE
[Agent] Promote name match candidate utility

### DIFF
--- a/src/utils/targetingUtils.js
+++ b/src/utils/targetingUtils.js
@@ -1,0 +1,100 @@
+// src/utils/targetingUtils.js
+
+/** @typedef {import('../interfaces/ILogger.js').ILogger} ILogger */
+/** @typedef {import('../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('./nameMatcher.js').NameMatchCandidate} NameMatchCandidate */
+/** @typedef {import('../entities/entity.js').default} Entity */
+
+/**
+ * @description Gathers and prepares a list of name match candidates from a given
+ * source of entity IDs. Each ID is resolved to an Entity via the provided
+ * EntityManager, then a display name is retrieved using the supplied
+ * getDisplayNameUtil function. Invalid IDs, missing entities, or entities
+ * without a valid name are skipped. An optional entity ID can be excluded from
+ * the results (useful for filtering out the actor themselves).
+ * @param {Iterable<string> | (() => Iterable<string>)} entityIdsIteratorOrFn -
+ *  An iterable of entity IDs or a function returning one.
+ * @param {EntityManager} entityManager - Manager used to resolve entity IDs.
+ * @param {(entity: Entity, fallback: string, logger: ILogger) => string} getDisplayNameUtil -
+ *  Utility used to obtain an entity's display name.
+ * @param {ILogger} logger - Logger for debug/warn messages.
+ * @param {{ entityIdToExclude?: string|null, domainContextForLogging?: string }} [options]
+ *  - Optional settings.
+ * @returns {Promise<NameMatchCandidate[]>} Array of {id, name} ready for
+ *  name-matching utilities.
+ */
+export async function prepareNameMatchCandidates(
+  entityIdsIteratorOrFn,
+  entityManager,
+  getDisplayNameUtil,
+  logger,
+  options = {}
+) {
+  const { entityIdToExclude = null, domainContextForLogging = 'unknown' } =
+    options;
+
+  logger.debug(
+    `prepareNameMatchCandidates called for domain: ${domainContextForLogging}`
+  );
+
+  const entityIds =
+    typeof entityIdsIteratorOrFn === 'function'
+      ? entityIdsIteratorOrFn()
+      : entityIdsIteratorOrFn;
+
+  const size =
+    entityIds && typeof entityIds.size === 'number'
+      ? entityIds.size
+      : Array.isArray(entityIds)
+        ? entityIds.length
+        : undefined;
+
+  if (!entityIds || size === 0) {
+    logger.debug(
+      `prepareNameMatchCandidates: No entity IDs provided by source for ${domainContextForLogging}.`
+    );
+    return [];
+  }
+
+  const candidates = [];
+  for (const itemId of entityIds) {
+    if (entityIdToExclude && itemId === entityIdToExclude) {
+      logger.debug(
+        `prepareNameMatchCandidates: Excluding entity ID '${itemId}' (actor) from domain '${domainContextForLogging}'.`
+      );
+      continue;
+    }
+
+    if (typeof itemId !== 'string' || itemId === '') {
+      logger.warn(
+        `prepareNameMatchCandidates: Invalid (non-string or empty) entity ID encountered in ${domainContextForLogging}: ${JSON.stringify(
+          itemId
+        )}. Skipping.`
+      );
+      continue;
+    }
+
+    const itemEntity = entityManager.getEntityInstance(itemId);
+
+    if (itemEntity) {
+      const name = getDisplayNameUtil(itemEntity, itemEntity.id, logger);
+      if (name && typeof name === 'string' && name.trim() !== '') {
+        candidates.push({ id: itemEntity.id, name });
+      } else {
+        logger.warn(
+          `prepareNameMatchCandidates: Entity '${itemId}' in ${domainContextForLogging} returned no valid name from getEntityDisplayName. Skipping. Name resolved to: ${name}`
+        );
+      }
+    } else {
+      logger.warn(
+        `prepareNameMatchCandidates: Entity '${itemId}' from ${domainContextForLogging} not found via entityManager. Skipping.`
+      );
+    }
+  }
+
+  logger.debug(
+    `prepareNameMatchCandidates: Produced ${candidates.length} candidates for domain: ${domainContextForLogging}.`
+  );
+
+  return candidates;
+}

--- a/tests/services/targetResolutionService.domain-equipment.test.js
+++ b/tests/services/targetResolutionService.domain-equipment.test.js
@@ -244,7 +244,7 @@ describe("TargetResolutionService - Domain 'equipment'", () => {
       );
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "TargetResolutionService.#_gatherNameMatchCandidates: Entity 'ghostHelmet' from equipment not found via entityManager. Skipping."
+        "prepareNameMatchCandidates: Entity 'ghostHelmet' from equipment not found via entityManager. Skipping."
       );
       expect(result.status).toBe(ResolutionStatus.NOT_FOUND);
       expect(result.targetType).toBe('entity');
@@ -428,7 +428,7 @@ describe("TargetResolutionService - Domain 'equipment'", () => {
       expect(result.error).toBeUndefined();
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "TargetResolutionService.#_gatherNameMatchCandidates: Entity 'nonExistentHelm' from equipment not found via entityManager. Skipping."
+        "prepareNameMatchCandidates: Entity 'nonExistentHelm' from equipment not found via entityManager. Skipping."
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `getEntityDisplayName: Entity 'namelessSwordId' has no usable name from component or 'entity.name'. Falling back to entity ID.`

--- a/tests/services/targetResolutionService.domain-inventory.test.js
+++ b/tests/services/targetResolutionService.domain-inventory.test.js
@@ -284,7 +284,7 @@ describe("TargetResolutionService - Domain 'inventory'", () => {
 
       // Expected Outcome
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "TargetResolutionService.#_gatherNameMatchCandidates: Entity 'nonExistentItem' from inventory not found via entityManager. Skipping."
+        "prepareNameMatchCandidates: Entity 'nonExistentItem' from inventory not found via entityManager. Skipping."
       );
       expect(result.status).toBe(ResolutionStatus.NOT_FOUND);
       expect(result.targetType).toBe('entity');


### PR DESCRIPTION
Summary: Extracted `_gatherNameMatchCandidates` into new `prepareNameMatchCandidates` utility for reuse and updated `TargetResolutionService` and tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: known repo issues)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6843ec40a7148331889f74f52364c1b2