### PR TITLE
[Agent] Add tests for throttleUtils

### DIFF
--- a/tests/alerting/throttleUtils.test.js
+++ b/tests/alerting/throttleUtils.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateKey } from '../../src/alerting/throttleUtils.js';
+
+describe('generateKey', () => {
+  it('creates key with status and url when provided', () => {
+    const result = generateKey('Message', { statusCode: 404, url: '/foo' });
+    expect(result).toBe('Message::404::/foo');
+  });
+
+  it('handles missing details gracefully', () => {
+    const result = generateKey('Missing');
+    expect(result).toBe('Missing::::');
+  });
+
+  it('handles null details', () => {
+    const result = generateKey('Missing', null);
+    expect(result).toBe('Missing::::');
+  });
+
+  it('handles partial details', () => {
+    const result = generateKey('Partial', { statusCode: 500 });
+    expect(result).toBe('Partial::500::');
+    const result2 = generateKey('OnlyUrl', { url: '/bar' });
+    expect(result2).toBe('OnlyUrl::::/bar');
+  });
+});


### PR DESCRIPTION
Summary: Added Jest unit tests covering the `generateKey` utility. This module previously lacked test coverage. Running tests now confirms the function behavior for various detail scenarios.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 595 errors)*
- [ ] Root tests `npm test` *(22 suites failing)*
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684404e1404c83319f929b7540a3ddde