### PR TITLE
[Agent] add tests for bootstrap stages

### DIFF
--- a/src/alerting/Throttler.js
+++ b/src/alerting/Throttler.js
@@ -48,6 +48,7 @@ export class Throttler {
 
   /**
    * The duration in milliseconds to wait before sending a summary.
+   *
    * @private
    * @readonly
    * @type {number}
@@ -56,6 +57,7 @@ export class Throttler {
 
   /**
    * Creates an instance of Throttler.
+   *
    * @param {ISafeEventDispatcher} dispatcher - The event dispatcher for emitting summaries.
    * @param {AlertSeverity} severity - The type of alerts this instance handles ('warning' or 'error').
    * @throws {Error} If the dispatcher is invalid.
@@ -74,6 +76,7 @@ export class Throttler {
    * Determines if an event should be rendered immediately or suppressed.
    * If allowed, it initiates a 10-second tracking window for the event's key.
    * If suppressed, it increments a counter for that key.
+   *
    * @param {string} key - The unique key identifying the event.
    * @param {object} payload - The original event payload. Expected to have `message` and `details`.
    * @returns {boolean} `true` to allow the event, `false` to suppress it.
@@ -114,6 +117,7 @@ export class Throttler {
    * Checks if duplicates were suppressed for a given key and emits a summary message if so.
    * This method is called by the `setTimeout` scheduled in the `allow()` method.
    * After execution, it cleans up the state for the key.
+   *
    * @private
    * @param {string} key - The key of the event to summarize.
    */

--- a/tests/alerting/throttler.test.js
+++ b/tests/alerting/throttler.test.js
@@ -11,7 +11,7 @@ import {
   afterEach,
   jest,
 } from '@jest/globals';
-import { Throttler } from '../../src/alerting/throttler.js';
+import { Throttler } from '../../src/alerting/Throttler.js';
 
 // Create a mock dispatcher that conforms to the ISafeEventDispatcher interface for testing.
 const mockDispatcher = {

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -1,0 +1,88 @@
+import {
+  ensureCriticalDOMElementsStage,
+  setupGlobalEventListenersStage,
+  startGameStage,
+} from '../../src/bootstrapper/stages.js';
+import { UIBootstrapper } from '../../src/bootstrapper/UIBootstrapper.js';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+
+const createLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('ensureCriticalDOMElementsStage', () => {
+  it('returns elements from UIBootstrapper', async () => {
+    const mockElements = { root: document.body };
+    jest
+      .spyOn(UIBootstrapper.prototype, 'gatherEssentialElements')
+      .mockReturnValue(mockElements);
+    const result = await ensureCriticalDOMElementsStage(document);
+    expect(result).toBe(mockElements);
+  });
+
+  it('wraps errors with phase', async () => {
+    const error = new Error('fail');
+    jest
+      .spyOn(UIBootstrapper.prototype, 'gatherEssentialElements')
+      .mockImplementation(() => {
+        throw error;
+      });
+    await expect(
+      ensureCriticalDOMElementsStage(document)
+    ).rejects.toMatchObject({ phase: 'UI Element Validation' });
+  });
+});
+
+describe('setupGlobalEventListenersStage', () => {
+  it('attaches beforeunload listener and stops running game', async () => {
+    let listener;
+    const windowRef = {
+      addEventListener: jest.fn((evt, cb) => {
+        listener = cb;
+      }),
+    };
+    const stop = jest.fn().mockResolvedValue();
+    const gameEngine = {
+      getEngineStatus: () => ({ isLoopRunning: true }),
+      stop,
+    };
+    const logger = createLogger();
+
+    await setupGlobalEventListenersStage(gameEngine, logger, windowRef);
+    expect(windowRef.addEventListener).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+    await listener();
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('throws when windowRef missing', async () => {
+    const logger = createLogger();
+    await expect(
+      setupGlobalEventListenersStage({}, logger, null)
+    ).rejects.toMatchObject({ phase: 'Global Event Listeners Setup' });
+  });
+});
+
+describe('startGameStage', () => {
+  it('calls startNewGame with world name', async () => {
+    const startNewGame = jest.fn().mockResolvedValue();
+    const logger = createLogger();
+    await startGameStage({ startNewGame }, 'Earth', logger);
+    expect(startNewGame).toHaveBeenCalledWith('Earth');
+  });
+
+  it('throws when gameEngine missing', async () => {
+    const logger = createLogger();
+    await expect(startGameStage(null, 'Earth', logger)).rejects.toMatchObject({
+      phase: 'Start Game',
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added tests covering bootstrap stages that previously lacked coverage. The new suite exercises DOM element validation, global event listener setup, and game start logic. Updated imports after renaming `throttler.js` to `Throttler.js` for case consistency.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails globally but no new issues)
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684406fbf1b88331a8ccec60ed7273c5