### PR TITLE
[Feat] accessibility for chat alert bubbles

### DIFF
--- a/css/components/_chat-alerts.css
+++ b/css/components/_chat-alerts.css
@@ -22,41 +22,41 @@
  * }
  */
 :root {
-    /*
+  /*
      * --error-color: The text and border color for error bubbles.
      * Override to change the primary color of error alerts.
      */
-    --error-color: #b00020;
+  --error-color: #b00020;
 
-    /*
+  /*
      * --error-background: The background color for error bubbles.
      * Override to change the fill color of error alerts.
      */
-    --error-background: #ffcdd2;
+  --error-background: #ffcdd2;
 
-    /*
+  /*
      * --warning-color: The text and border color for warning bubbles.
      * Override to change the primary color of warning alerts.
      */
-    --warning-color: #ffa000;
+  --warning-color: #e65100;
 
-    /*
+  /*
      * --warning-background: The background color for warning bubbles.
      * Override to change the fill color of warning alerts.
      */
-    --warning-background: #fff8e1;
+  --warning-background: #fff8e1;
 
-    /*
+  /*
      * --alert-padding: The inner padding for both error and warning bubbles.
      * Override to adjust the spacing inside alerts.
      */
-    --alert-padding: 8px;
+  --alert-padding: 8px;
 
-    /*
+  /*
      * --alert-border-radius: The corner roundness for both error and warning bubbles.
      * Override to make alerts more or less rounded.
      */
-    --alert-border-radius: 12px;
+  --alert-border-radius: 12px;
 }
 
 /**
@@ -66,10 +66,10 @@
  * these variables will take precedence over the :root defaults.
  */
 [data-theme='dark'] {
-    --error-color: #ff8a80;
-    --error-background: #4d0000;
-    --warning-color: #ffd740;
-    --warning-background: #4d4000;
+  --error-color: #ff8a80;
+  --error-background: #4d0000;
+  --warning-color: #ffd740;
+  --warning-background: #4d4000;
 }
 
 /*
@@ -81,27 +81,27 @@
  */
 
 .chat-errorBubble {
-    background-color: var(--error-background);
-    color: var(--error-color);
-    border: 1px solid var(--error-color);
-    border-radius: var(--alert-border-radius);
-    padding: var(--alert-padding);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    animation: fadeIn 0.3s ease-out;
-    max-width: 300px;
-    word-break: break-all;
+  background-color: var(--error-background);
+  color: var(--error-color);
+  border: 1px solid var(--error-color);
+  border-radius: var(--alert-border-radius);
+  padding: var(--alert-padding);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.3s ease-out;
+  max-width: 300px;
+  word-break: break-all;
 }
 
 .chat-warningBubble {
-    background-color: var(--warning-background);
-    color: var(--warning-color);
-    border: 1px solid var(--warning-color);
-    border-radius: var(--alert-border-radius);
-    padding: var(--alert-padding);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    animation: fadeIn 0.3s ease-out;
-    max-width: 300px;
-    word-break: break-all;
+  background-color: var(--warning-background);
+  color: var(--warning-color);
+  border: 1px solid var(--warning-color);
+  border-radius: var(--alert-border-radius);
+  padding: var(--alert-padding);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.3s ease-out;
+  max-width: 300px;
+  word-break: break-all;
 }
 
 /*
@@ -111,12 +111,12 @@
  */
 
 @keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(-5px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/domUI/chatAlertRenderer.js
+++ b/src/domUI/chatAlertRenderer.js
@@ -253,6 +253,8 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
     if (iconElement) {
       iconElement.setAttribute('aria-hidden', 'true');
       bubbleElement.appendChild(iconElement);
+      const srText = this.#domElementFactory.span('visually-hidden', title);
+      if (srText) bubbleElement.appendChild(srText);
     }
 
     const contentWrapper = this.#domElementFactory.div('chat-alert-content');

--- a/tests/css/chatAlerts.contrast.test.js
+++ b/tests/css/chatAlerts.contrast.test.js
@@ -1,0 +1,67 @@
+// tests/css/chatAlerts.contrast.test.js
+import { describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ *
+ * @param hex
+ */
+function hexToRgb(hex) {
+  const cleaned = hex.replace('#', '');
+  const bigint = parseInt(cleaned, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.r
+ * @param root0.g
+ * @param root0.b
+ */
+function luminance({ r, g, b }) {
+  const [R, G, B] = [r, g, b].map((v) => {
+    const srgb = v / 255;
+    return srgb <= 0.03928
+      ? srgb / 12.92
+      : Math.pow((srgb + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+/**
+ *
+ * @param hex1
+ * @param hex2
+ */
+function contrast(hex1, hex2) {
+  const L1 = luminance(hexToRgb(hex1));
+  const L2 = luminance(hexToRgb(hex2));
+  const [light, dark] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (light + 0.05) / (dark + 0.05);
+}
+
+describe('Chat alert colors meet contrast guidelines', () => {
+  const css = fs
+    .readFileSync(path.resolve('css/components/_chat-alerts.css'), 'utf8')
+    .split('\n');
+  const errorColor = css
+    .find((l) => l.trim().startsWith('--error-color'))
+    .match(/#[0-9a-fA-F]{6}/)[0];
+  const warningColor = css
+    .find((l) => l.trim().startsWith('--warning-color'))
+    .match(/#[0-9a-fA-F]{6}/)[0];
+
+  it('error color has at least 4.5:1 contrast against white', () => {
+    expect(contrast(errorColor, '#FFFFFF')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('warning color has at least 3:1 contrast against white', () => {
+    expect(contrast(warningColor, '#FFFFFF')).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/domUI/chatAlertRenderer.a11y.test.js
+++ b/tests/domUI/chatAlertRenderer.a11y.test.js
@@ -1,0 +1,106 @@
+// tests/domUI/chatAlertRenderer.a11y.test.js
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ChatAlertRenderer } from '../../src/domUI/index.js';
+import DomElementFactory from '../../src/domUI/domElementFactory.js';
+
+/** Utility to set up ChatAlertRenderer in a real DOM environment */
+function setupRenderer() {
+  const listeners = new Map();
+  const dispatcher = {
+    dispatch: jest.fn((evt, payload) => {
+      if (listeners.has(evt)) listeners.get(evt)({ payload });
+    }),
+    subscribe: jest.fn((evt, handler) => {
+      listeners.set(evt, handler);
+      return () => listeners.delete(evt);
+    }),
+  };
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const docCtx = {
+    query: (sel) => document.querySelector(sel),
+    create: (tag) => document.createElement(tag),
+  };
+  const factory = new DomElementFactory(docCtx);
+  new ChatAlertRenderer({
+    logger,
+    documentContext: docCtx,
+    safeEventDispatcher: dispatcher,
+    domElementFactory: factory,
+    alertRouter: { notifyUIReady: jest.fn() },
+  });
+  return { dispatcher, chatPanel: document.getElementById('message-list') };
+}
+
+/**
+ *
+ * @param dispatcher
+ * @param name
+ * @param payload
+ */
+function fire(dispatcher, name, payload) {
+  const call = dispatcher.subscribe.mock.calls.find((c) => c[0] === name);
+  if (call) {
+    call[1]({ payload });
+  }
+}
+
+describe('ChatAlertRenderer ARIA behavior', () => {
+  let dispatcher;
+  let chatPanel;
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="message-list"></div><input id="chat-input">';
+    ({ dispatcher, chatPanel } = setupRenderer());
+  });
+
+  it('renders warning bubble with proper aria attributes and icon label', () => {
+    fire(dispatcher, 'ui:display_warning', {
+      message: 'Heads up',
+      details: {},
+    });
+    const bubble = chatPanel.firstElementChild;
+    expect(bubble.getAttribute('role')).toBe('status');
+    expect(bubble.getAttribute('aria-live')).toBe('polite');
+    const icon = bubble.querySelector('.chat-alert-icon');
+    expect(icon.getAttribute('aria-hidden')).toBe('true');
+    const label = icon.nextElementSibling;
+    expect(label.textContent).toBe('Warning');
+  });
+
+  it('renders error bubble with proper aria attributes and icon label', () => {
+    fire(dispatcher, 'ui:display_error', { message: 'Boom', details: {} });
+    const bubble = chatPanel.firstElementChild;
+    expect(bubble.getAttribute('role')).toBe('alert');
+    expect(bubble.getAttribute('aria-live')).toBe('assertive');
+    const icon = bubble.querySelector('.chat-alert-icon');
+    expect(icon.getAttribute('aria-hidden')).toBe('true');
+    const label = icon.nextElementSibling;
+    expect(label.textContent).toBe('Error');
+  });
+
+  it('keeps focus on input and toggle buttons receive focus sequentially', () => {
+    const input = document.getElementById('chat-input');
+    input.focus();
+    const longMsg = 'x'.repeat(250);
+    fire(dispatcher, 'ui:display_error', {
+      message: longMsg,
+      details: { statusCode: 500, url: '/foo' },
+    });
+    const bubble = chatPanel.firstElementChild;
+    expect(document.activeElement).toBe(input);
+    const buttons = bubble.querySelectorAll('button.chat-alert-toggle');
+    expect(buttons.length).toBe(2);
+    buttons[0].focus();
+    expect(document.activeElement).toBe(buttons[0]);
+    buttons[1].focus();
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+});


### PR DESCRIPTION
Summary: Added ARIA improvements for chat alert bubbles and verified color contrast.

Changes Made:
- Added visually-hidden text labels next to alert icons.
- Updated warning color to #e65100 for WCAG contrast.
- Added contrast checking test.
- Added accessibility-focused tests for ChatAlertRenderer.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`) *(fails: repository has existing issues)*
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test (not run)


------
https://chatgpt.com/codex/tasks/task_e_68441a84991c8331bb14c8439ffa55db