### PR TITLE
[Agent] update system error payloads

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -605,11 +605,13 @@ class CommandProcessor {
     // Payload for core:system_error_occurred does NOT include eventName within it.
     const payload = {
       message: userMessage,
-      type: 'error',
-      details: internalDetails,
+      details: {
+        raw: internalDetails,
+        timestamp: new Date().toISOString(),
+      },
     };
-    if (originalError?.stack && typeof payload.details === 'string') {
-      payload.details += `\nOriginalErrorStack: ${originalError.stack}`;
+    if (originalError?.stack) {
+      payload.details.stack = originalError.stack;
     }
 
     if (originalError) {

--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -67,8 +67,10 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
       this.#logger.error(errorMsg, { receivedContextType: typeof turnContext });
       await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'Invalid turn context received by CommandOutcomeInterpreter.',
-        type: 'error',
-        details: `turnContext was ${turnContext === null ? 'null' : typeof turnContext}. Expected ITurnContext object.`,
+        details: {
+          raw: `turnContext was ${turnContext === null ? 'null' : typeof turnContext}. Expected ITurnContext object.`,
+          timestamp: new Date().toISOString(),
+        },
       });
       throw new Error(errorMsg);
     }
@@ -79,8 +81,10 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
       this.#logger.error(errorMsg, { actorInContext: actor });
       await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'Invalid actor in turn context for CommandOutcomeInterpreter.',
-        type: 'error',
-        details: `Actor object in context was ${JSON.stringify(actor)}.`,
+        details: {
+          raw: `Actor object in context was ${JSON.stringify(actor)}.`,
+          timestamp: new Date().toISOString(),
+        },
       });
       throw new Error(errorMsg);
     }
@@ -92,8 +96,10 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
       this.#logger.error(baseErrorMsg, { receivedResult: result });
       await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: baseErrorMsg,
-        type: 'error',
-        details: `Actor ${actorId}, Received Result: ${JSON.stringify(result)}`,
+        details: {
+          raw: `Actor ${actorId}, Received Result: ${JSON.stringify(result)}`,
+          timestamp: new Date().toISOString(),
+        },
       });
       throw new Error(baseErrorMsg);
     }

--- a/src/domUI/uiMessageRenderer.js
+++ b/src/domUI/uiMessageRenderer.js
@@ -294,7 +294,7 @@ export class UiMessageRenderer extends BoundDomRendererBase {
       return;
     }
     let msg = payload.message;
-    if (payload.error?.message) msg += `\nDetails: ${payload.error.message}`;
+    if (payload.details?.raw) msg += `\nDetails: ${payload.details.raw}`;
     this.logger.error(`${this._logPrefix} Fatal error displayed: ${msg}`); // Log before render as render also logs
     this.render(msg, 'fatal');
   }

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -510,12 +510,11 @@ export class ProcessingCommandState extends AbstractTurnState {
         // dispatch should not throw
         await systemErrorDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `System error in ${this.getStateName()} for actor ${currentActorIdForLog}: ${error.message}`,
-          type: 'error',
-          details: `OriginalError: ${error.name} - ${error.message}${
-            error.stack ? `\nStack: ${error.stack}` : ''
-          }`,
-          actorId: currentActorIdForLog,
-          turnState: this.getStateName(),
+          details: {
+            raw: `OriginalError: ${error.name} - ${error.message}`,
+            stack: error.stack,
+            timestamp: new Date().toISOString(),
+          },
         });
       } catch (dispatchError) {
         // Should not be reached

--- a/src/turns/turnManager.js
+++ b/src/turns/turnManager.js
@@ -678,9 +678,11 @@ class TurnManager extends ITurnManager {
     try {
       await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: message,
-        type: 'error',
-        details: detailString,
-        stack: stackString, // Optionally include stack
+        details: {
+          raw: detailString,
+          stack: stackString,
+          timestamp: new Date().toISOString(),
+        },
       });
     } catch (dispatchError) {
       this.#logger.error(

--- a/tests/domUI/uiMessageRenderer.test.js
+++ b/tests/domUI/uiMessageRenderer.test.js
@@ -165,7 +165,7 @@ describe('UiMessageRenderer', () => {
       )[1];
       fatalHandler({
         type: SYSTEM_ERROR_OCCURRED_ID,
-        payload: { message: baseText, error: new Error(errorDetails) },
+        payload: { message: baseText, details: { raw: errorDetails } },
       });
       const messageElement = renderer.elements.messageList.querySelector('li');
       expect(messageElement).not.toBeNull();

--- a/tests/events/alertRouter.test.js
+++ b/tests/events/alertRouter.test.js
@@ -3,6 +3,7 @@
  */
 
 import AlertRouter from '../../src/alerting/alertRouter.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 import {
   afterEach,
   beforeEach,
@@ -72,8 +73,8 @@ describe('AlertRouter', () => {
 
     const payload = { message: 'Test error message' };
     // Simulate an error event
-    mockDispatcher.listeners['core:system_error_occurred'](
-      'core:system_error_occurred',
+    mockDispatcher.listeners[SYSTEM_ERROR_OCCURRED_ID](
+      SYSTEM_ERROR_OCCURRED_ID,
       payload
     );
 

--- a/tests/turns/states/processingCommandState.coverage.test.js
+++ b/tests/turns/states/processingCommandState.coverage.test.js
@@ -137,7 +137,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('No actor present'),
-        actorId: expect.any(String),
+        details: expect.any(Object),
       })
     );
 
@@ -183,7 +183,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Error retrieving ITurnAction'),
-        actorId: actor.id,
+        details: expect.any(Object),
       })
     );
     // And endTurn called
@@ -219,7 +219,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('No ITurnAction available'),
-        actorId: actor.id,
+        details: expect.any(Object),
       })
     );
     // endTurn should be invoked
@@ -258,7 +258,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
         message: expect.stringContaining(
           'invalid: missing or empty actionDefinitionId'
         ),
-        actorId: actor.id,
+        details: expect.any(Object),
       })
     );
     expect(spyEndTurn).toHaveBeenCalledWith(expect.any(Error));
@@ -359,7 +359,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
         message: expect.stringContaining(
           'Failed to retrieve ICommandProcessor'
         ),
-        actorId: actor.id,
+        details: expect.any(Object),
       })
     );
   });
@@ -394,7 +394,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
         message: expect.stringContaining(
           'Failed to retrieve ICommandProcessor'
         ),
-        actorId: actor.id,
+        details: expect.any(Object),
       })
     );
   });

--- a/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -233,8 +233,7 @@ describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () =
       {
         message:
           'Internal Error: Turn order inconsistency detected. Stopping game.',
-        type: 'error',
-        details: expectedErrorMsg,
+        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
       }
     );
 
@@ -277,8 +276,11 @@ describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () =
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'System Error during turn advancement. Stopping game.',
-        type: 'error',
-        details: thrownError.message,
+        details: {
+          raw: thrownError.message,
+          timestamp: expect.any(String),
+          stack: expect.any(String),
+        },
       })
     );
     expect(stopSpy).toHaveBeenCalledTimes(1); // Stop *was* called internally

--- a/tests/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/turns/turnManager.advanceTurn.roundStart.test.js
@@ -180,8 +180,7 @@ describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
       {
         message:
           'System Error: No active actors found to start a round. Stopping game.',
-        type: 'error',
-        details: expectedErrorMsg,
+        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
       }
     );
 
@@ -228,8 +227,7 @@ describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
       {
         message:
           'System Error: No active actors found to start a round. Stopping game.',
-        type: 'error',
-        details: expectedErrorMsg,
+        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
       }
     );
 

--- a/tests/turns/turnManager.errorHandling.test.js
+++ b/tests/turns/turnManager.errorHandling.test.js
@@ -227,7 +227,11 @@ describe('TurnManager - Error Handling', () => {
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'System Error during turn advancement. Stopping game.',
-        details: resolveError.message,
+        details: {
+          raw: resolveError.message,
+          timestamp: expect.any(String),
+          stack: expect.any(String),
+        },
       })
     );
     // stop() calls clearCurrentRound
@@ -263,8 +267,10 @@ describe('TurnManager - Error Handling', () => {
       expect.objectContaining({
         message:
           'Internal Error: Turn order inconsistency detected. Stopping game.',
-        details:
-          'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.',
+        details: {
+          raw: 'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.',
+          timestamp: expect.any(String),
+        },
       })
     );
     // stop() calls clearCurrentRound

--- a/tests/turns/turnManager.lifecycle.test.js
+++ b/tests/turns/turnManager.lifecycle.test.js
@@ -181,9 +181,13 @@ describe('TurnManager - Lifecycle (Start/Stop)', () => {
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
-          details: expect.stringContaining(
-            'Subscription function did not return an unsubscribe callback'
-          ),
+          details: {
+            raw: expect.stringContaining(
+              'Subscription function did not return an unsubscribe callback'
+            ),
+            timestamp: expect.any(String),
+            stack: expect.any(String),
+          },
         })
       );
       expect(stopSpy).toHaveBeenCalledTimes(1);
@@ -205,7 +209,13 @@ describe('TurnManager - Lifecycle (Start/Stop)', () => {
       );
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({ details: subscribeError.message })
+        expect.objectContaining({
+          details: {
+            raw: subscribeError.message,
+            timestamp: expect.any(String),
+            stack: expect.any(String),
+          },
+        })
       );
       expect(stopSpy).toHaveBeenCalledTimes(1);
       stopSpy.mockRestore();

--- a/tests/turns/turnManager.roundLifecycle.test.js
+++ b/tests/turns/turnManager.roundLifecycle.test.js
@@ -207,9 +207,10 @@ describe('TurnManager - Round Lifecycle and Turn Advancement', () => {
     expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message:
         'System Error: No active actors found to start a round. Stopping game.',
-      type: 'error',
-      details:
-        'Cannot start a new round: No active entities with an Actor component found.',
+      details: {
+        raw: 'Cannot start a new round: No active entities with an Actor component found.',
+        timestamp: expect.any(String),
+      },
     });
     expect(logger.info).toHaveBeenCalledWith('Turn Manager stopped.');
     expect(mockUnsubscribeFunction).toHaveBeenCalled();


### PR DESCRIPTION
Summary: refactored dispatches of `SYSTEM_ERROR_OCCURRED_ID` to use new payload structure and replaced direct string usage in tests. Updated handlers and tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint executed `npm run lint` (fails: 595 errors, 1404 warnings)
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68442f42d86c83318c7e2967b507205b