### PR TITLE
[Agent] add stack info to system error events

### DIFF
--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -69,6 +69,7 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
         message: 'Invalid turn context received by CommandOutcomeInterpreter.',
         details: {
           raw: `turnContext was ${turnContext === null ? 'null' : typeof turnContext}. Expected ITurnContext object.`,
+          stack: new Error().stack,
           timestamp: new Date().toISOString(),
         },
       });
@@ -83,6 +84,7 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
         message: 'Invalid actor in turn context for CommandOutcomeInterpreter.',
         details: {
           raw: `Actor object in context was ${JSON.stringify(actor)}.`,
+          stack: new Error().stack,
           timestamp: new Date().toISOString(),
         },
       });
@@ -98,6 +100,7 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
         message: baseErrorMsg,
         details: {
           raw: `Actor ${actorId}, Received Result: ${JSON.stringify(result)}`,
+          stack: new Error().stack,
           timestamp: new Date().toISOString(),
         },
       });


### PR DESCRIPTION
Summary: Added a stack trace to all SYSTEM_ERROR_OCCURRED_ID dispatches in CommandOutcomeInterpreter so listeners receive richer details. This leverages the event definition's optional `stack` property.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: see log)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68443625d45c833199b94e2e7c25afee