### PR TITLE
[Agent] include stack traces in system error events

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -611,6 +611,8 @@ class CommandProcessor {
     };
     if (originalError?.stack) {
       payload.details.stack = originalError.stack;
+    } else {
+      payload.details.stack = new Error().stack;
     }
 
     if (originalError) {

--- a/src/turns/turnManager.js
+++ b/src/turns/turnManager.js
@@ -674,7 +674,9 @@ class TurnManager extends ITurnManager {
         ? detailsOrError.message
         : String(detailsOrError);
     const stackString =
-      detailsOrError instanceof Error ? detailsOrError.stack : undefined;
+      detailsOrError instanceof Error
+        ? detailsOrError.stack
+        : new Error().stack;
     try {
       await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: message,

--- a/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -233,7 +233,11 @@ describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () =
       {
         message:
           'Internal Error: Turn order inconsistency detected. Stopping game.',
-        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
+        details: {
+          raw: expectedErrorMsg,
+          stack: expect.any(String),
+          timestamp: expect.any(String),
+        },
       }
     );
 

--- a/tests/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/turns/turnManager.advanceTurn.roundStart.test.js
@@ -180,7 +180,11 @@ describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
       {
         message:
           'System Error: No active actors found to start a round. Stopping game.',
-        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
+        details: {
+          raw: expectedErrorMsg,
+          stack: expect.any(String),
+          timestamp: expect.any(String),
+        },
       }
     );
 
@@ -227,7 +231,11 @@ describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
       {
         message:
           'System Error: No active actors found to start a round. Stopping game.',
-        details: { raw: expectedErrorMsg, timestamp: expect.any(String) },
+        details: {
+          raw: expectedErrorMsg,
+          stack: expect.any(String),
+          timestamp: expect.any(String),
+        },
       }
     );
 

--- a/tests/turns/turnManager.errorHandling.test.js
+++ b/tests/turns/turnManager.errorHandling.test.js
@@ -269,6 +269,7 @@ describe('TurnManager - Error Handling', () => {
           'Internal Error: Turn order inconsistency detected. Stopping game.',
         details: {
           raw: 'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.',
+          stack: expect.any(String),
           timestamp: expect.any(String),
         },
       })

--- a/tests/turns/turnManager.roundLifecycle.test.js
+++ b/tests/turns/turnManager.roundLifecycle.test.js
@@ -209,6 +209,7 @@ describe('TurnManager - Round Lifecycle and Turn Advancement', () => {
         'System Error: No active actors found to start a round. Stopping game.',
       details: {
         raw: 'Cannot start a new round: No active entities with an Actor component found.',
+        stack: expect.any(String),
         timestamp: expect.any(String),
       },
     });


### PR DESCRIPTION
## Summary
- always attach stack trace when dispatching system error events
- update TurnManager tests for new payload structure

## Testing
- `npm run format`
- `npm run lint` *(fails: 595 errors)*
- `npx eslint src/commands/commandProcessor.js src/turns/turnManager.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684437ba4c24833197e64fe8c4ffe770