### PR TITLE
[Agent] dispatch system error events

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -101,6 +101,7 @@ export function registerInterpreters(container) {
       new AddComponentHandler({
         entityManager: c.resolve(tokens.IEntityManager), // Use IEntityManager
         logger: c.resolve(tokens.ILogger),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
   logger.debug('Interpreter Registrations: Registered AddComponentHandler.');

--- a/tests/config/registrations/interpreterRegistrations.test.js
+++ b/tests/config/registrations/interpreterRegistrations.test.js
@@ -74,8 +74,7 @@ const mockvalidatedEventDispatcher = {
   dispatch: jest.fn().mockResolvedValue(true),
 };
 const mockSystemDataRegistry = { query: jest.fn(), registerSource: jest.fn() };
-// If ICommandOutcomeInterpreter gets resolved and ISafeEventDispatcher is needed:
-// const mockSafeEventDispatcher = { dispatch: jest.fn() };
+const mockSafeEventDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
 // --- Mock DI Container ---
 const createMockContainer = () => {
@@ -233,8 +232,14 @@ describe('registerInterpreters', () => {
       lifecycle: 'singleton',
     });
 
-    // If ICommandOutcomeInterpreter depends on ISafeEventDispatcher and is resolved in tests:
-    // mockContainer.register(tokens.ISafeEventDispatcher, mockSafeEventDispatcher, {lifecycle: 'singleton'});
+    // Register SafeEventDispatcher for handlers that require it
+    mockContainer.register(
+      tokens.ISafeEventDispatcher,
+      mockSafeEventDispatcher,
+      {
+        lifecycle: 'singleton',
+      }
+    );
 
     // Clear implementation mocks
     Object.values(mockLogger).forEach((fn) => fn.mockClear?.());
@@ -246,7 +251,7 @@ describe('registerInterpreters', () => {
       fn.mockClear?.()
     );
     Object.values(mockSystemDataRegistry).forEach((fn) => fn.mockClear?.());
-    // if (mockSafeEventDispatcher) Object.values(mockSafeEventDispatcher).forEach(fn => fn.mockClear?.());
+    Object.values(mockSafeEventDispatcher).forEach((fn) => fn.mockClear?.());
 
     // Clear constructor mocks defined via jest.mock() for USED handlers/interpreters
     OperationRegistry.mockClear?.();

--- a/tests/turns/adapters/eventBusTurnEndAdapter.test.js
+++ b/tests/turns/adapters/eventBusTurnEndAdapter.test.js
@@ -197,10 +197,12 @@ describe('EventBusTurnEndAdapter', () => {
     const entityId = 'system_actor';
 
     await expect(adapter.turnEnded(entityId)).rejects.toThrow(dispatchError);
-    expect(mockVed.dispatch).toHaveBeenCalledTimes(1);
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      `EventBusTurnEndAdapter: Error dispatching ${TURN_ENDED_ID} for ${entityId}. Error: ${dispatchError.message}`,
-      dispatchError
+    expect(mockVed.dispatch).toHaveBeenCalledTimes(2);
+    expect(mockVed.dispatch).toHaveBeenLastCalledWith(
+      'core:system_error_occurred',
+      expect.objectContaining({
+        message: expect.stringContaining('failed to dispatch'),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- dispatch `SYSTEM_ERROR_OCCURRED_ID` instead of logging errors
- support SafeEventDispatcher in AddComponentHandler
- register SafeEventDispatcher in interpreter registrations
- update affected unit tests
- require SafeEventDispatcher in AddComponentHandler constructor

## Testing
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68443d3a1d808331a8e72f77cd33e875