### PR TITLE
[Agent] dispatch system errors via SafeEventDispatcher

### DIFF
--- a/scripts/validateMods.mjs
+++ b/scripts/validateMods.mjs
@@ -26,7 +26,11 @@ const logger = new ConsoleLogger(LogLevel.INFO);
 const config = new StaticConfiguration();
 const resolver = new DefaultPathResolver(config);
 const fetcher = new NodeDataFetcher();
-const validator = new AjvSchemaValidator(logger);
+const stubDispatcher = { dispatch: async () => true };
+const validator = new AjvSchemaValidator({
+  logger,
+  dispatcher: stubDispatcher,
+});
 const registry = new InMemoryDataRegistry();
 const schemaLoader = new SchemaLoader(
   config,

--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -81,13 +81,11 @@ export function registerLoaders(container) {
 
   // AjvSchemaValidator depends on ILogger
   // Corrected registration: Pass the resolved logger
-  registrar.singletonFactory(
-    tokens.ISchemaValidator,
-    (c) =>
-      new AjvSchemaValidator(
-        c.resolve(tokens.ILogger) // <-- Resolve and pass ILogger here
-      )
-  );
+  registrar.singletonFactory(tokens.ISchemaValidator, (c) => {
+    const logger = c.resolve(tokens.ILogger);
+    const dispatcher = c.resolve(tokens.ISafeEventDispatcher);
+    return new AjvSchemaValidator({ logger, dispatcher });
+  });
   logger.debug(`Loaders Registration: Registered ${tokens.ISchemaValidator}.`);
 
   registrar.singletonFactory(

--- a/tests/events/safeEventDispatcher.coreSystemEvents.test.js
+++ b/tests/events/safeEventDispatcher.coreSystemEvents.test.js
@@ -88,7 +88,10 @@ beforeAll(async () => {
   eventBus = new EventBus();
 
   /* Ajv validator and schema preload */
-  const schemaValidator = new AjvSchemaValidator(logger);
+  const schemaValidator = new AjvSchemaValidator({
+    logger,
+    dispatcher: { dispatch: jest.fn() },
+  });
   await schemaValidator.addSchema(
     warningEventDef.payloadSchema,
     SYSTEM_WARNING_OCCURRED_ID + '#payload'

--- a/tests/integration/EndToEndMemoryFlow.test.js
+++ b/tests/integration/EndToEndMemoryFlow.test.js
@@ -129,7 +129,10 @@ describe('End-to-End Short-Term Memory Flow', () => {
       notesSectionAssembler: new NotesSectionAssembler({ logger }),
     });
 
-    schemaValidator = new AjvSchemaValidator(logger);
+    schemaValidator = new AjvSchemaValidator({
+      logger,
+      dispatcher: { dispatch: jest.fn() },
+    });
 
     responseProcessor = new LLMResponseProcessor({
       schemaValidator,

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -116,7 +116,10 @@ describe('End-to-End Notes Persistence Flow', () => {
       notesSectionAssembler: new NotesSectionAssembler({ logger }),
     });
 
-    schemaValidator = new AjvSchemaValidator(logger);
+    schemaValidator = new AjvSchemaValidator({
+      logger,
+      dispatcher: { dispatch: jest.fn() },
+    });
     processor = new LLMResponseProcessor({ schemaValidator });
   });
 

--- a/tests/integration/modLoadDependencyFail.test.js
+++ b/tests/integration/modLoadDependencyFail.test.js
@@ -302,7 +302,10 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
 
     /* -------------------- Core plumbing ---------------------------------- */
     logger = createMockLogger();
-    validator = new AjvSchemaValidator(logger); // Use REAL validator
+    validator = new AjvSchemaValidator({
+      logger,
+      dispatcher: { dispatch: jest.fn() },
+    }); // Use REAL validator
 
     schemaLoader = {
       loadAndCompileAllSchemas: jest.fn().mockImplementation(async () => {

--- a/tests/services/ajvSchemaValidator.test.js
+++ b/tests/services/ajvSchemaValidator.test.js
@@ -398,7 +398,10 @@ describe('AjvSchemaValidator', () => {
       debug: jest.fn(),
     };
     // Pass the mock logger to the constructor
-    validator = new AjvSchemaValidator(mockLogger); // <-- Pass mockLogger
+    validator = new AjvSchemaValidator({
+      logger: mockLogger,
+      dispatcher: { dispatch: jest.fn() },
+    });
   });
 
   // --- Task 2: Test constructor ---
@@ -408,20 +411,31 @@ describe('AjvSchemaValidator', () => {
       // so we just need to ensure it didn't throw implicitly.
       // If beforeEach failed, the test wouldn't run.
       // We can add an explicit check for robustness.
-      expect(() => new AjvSchemaValidator(mockLogger)).not.toThrow();
+      expect(
+        () =>
+          new AjvSchemaValidator({
+            logger: mockLogger,
+            dispatcher: { dispatch: jest.fn() },
+          })
+      ).not.toThrow();
     });
 
     it('should throw an error if an invalid logger is provided', () => {
       // Test missing methods
-      expect(() => new AjvSchemaValidator({})).toThrow(
-        /Missing or invalid 'logger' dependency/
-      );
+      expect(
+        () =>
+          new AjvSchemaValidator({
+            logger: {},
+            dispatcher: { dispatch: jest.fn() },
+          })
+      ).toThrow(/Missing or invalid 'logger' dependency/);
       expect(
         () =>
           new AjvSchemaValidator({
             info: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
+            dispatcher: { dispatch: jest.fn() },
           })
       ).toThrow(/Missing or invalid 'logger' dependency/); // Missing debug
       // Test null/undefined

--- a/tests/services/gameStateValidationServiceForPrompting.test.js
+++ b/tests/services/gameStateValidationServiceForPrompting.test.js
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { GameStateValidationServiceForPrompting } from '../../src/validation/gameStateValidationServiceForPrompting.js';
 import { ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING } from '../../src/constants/textDefaults.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock ILogger dependency
 const mockLogger = {
@@ -32,11 +33,14 @@ const createMockGameStateDto = ({
 
 describe('GameStateValidationServiceForPrompting', () => {
   let service;
+  let stubDispatcher;
 
   beforeEach(() => {
     jest.clearAllMocks(); // Clear mocks before each test
+    stubDispatcher = { dispatch: jest.fn() };
     service = new GameStateValidationServiceForPrompting({
       logger: mockLogger,
+      dispatcher: stubDispatcher,
     });
   });
 
@@ -68,8 +72,12 @@ describe('GameStateValidationServiceForPrompting', () => {
       expect(result.errorContent).toBe(
         ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING
       );
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.'
+      expect(stubDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          message:
+            'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
+        })
       );
     });
 
@@ -79,8 +87,12 @@ describe('GameStateValidationServiceForPrompting', () => {
       expect(result.errorContent).toBe(
         ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING
       );
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.'
+      expect(stubDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          message:
+            'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
+        })
       );
     });
 
@@ -96,7 +108,7 @@ describe('GameStateValidationServiceForPrompting', () => {
         "GameStateValidationServiceForPrompting.validate: AIGameStateDTO is missing 'actorState'. This might affect prompt data completeness indirectly."
       );
       expect(mockLogger.warn).toHaveBeenCalledTimes(1); // Ensure only this warning
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(stubDispatcher.dispatch).not.toHaveBeenCalled();
     });
 
     it('should return valid and warn if actorPromptData is missing', () => {
@@ -111,7 +123,7 @@ describe('GameStateValidationServiceForPrompting', () => {
         "GameStateValidationServiceForPrompting.validate: AIGameStateDTO is missing 'actorPromptData'. Character info will be limited or use fallbacks."
       );
       expect(mockLogger.warn).toHaveBeenCalledTimes(1); // Ensure only this warning
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(stubDispatcher.dispatch).not.toHaveBeenCalled();
     });
 
     it('should return valid and warn if both actorState and actorPromptData are missing', () => {
@@ -129,7 +141,7 @@ describe('GameStateValidationServiceForPrompting', () => {
         "GameStateValidationServiceForPrompting.validate: AIGameStateDTO is missing 'actorPromptData'. Character info will be limited or use fallbacks."
       );
       expect(mockLogger.warn).toHaveBeenCalledTimes(2); // Expect two separate warnings
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(stubDispatcher.dispatch).not.toHaveBeenCalled();
     });
 
     it('should return valid if gameStateDto is valid and complete (has actorState and actorPromptData)', () => {
@@ -141,7 +153,7 @@ describe('GameStateValidationServiceForPrompting', () => {
       expect(result.isValid).toBe(true);
       expect(result.errorContent).toBeNull();
       expect(mockLogger.warn).not.toHaveBeenCalled();
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(stubDispatcher.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/services/modManifestLoader.harness.test.js
+++ b/tests/services/modManifestLoader.harness.test.js
@@ -160,7 +160,10 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
     // *** FIX START: Create logger first, then pass it to validator ***
     const mockLogger = createMockLogger(); // Create the logger instance
     // real validator and schema registration, now with logger dependency
-    const schemaValidator = new AjvSchemaValidator(mockLogger); // Pass the logger
+    const schemaValidator = new AjvSchemaValidator({
+      logger: mockLogger,
+      dispatcher: { dispatch: jest.fn() },
+    });
     await schemaValidator.addSchema(manifestSchema, MOD_SCHEMA_ID);
 
     deps = {

--- a/tests/services/modManifestLoader.test.js
+++ b/tests/services/modManifestLoader.test.js
@@ -161,7 +161,10 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
     // *** FIX START: Create logger first, then pass it to validator ***
     const mockLogger = createMockLogger(); // Create the logger instance
     // real validator and schema registration, now with logger dependency
-    const schemaValidator = new AjvSchemaValidator(mockLogger); // Pass the logger
+    const schemaValidator = new AjvSchemaValidator({
+      logger: mockLogger,
+      dispatcher: { dispatch: jest.fn() },
+    });
     await schemaValidator.addSchema(manifestSchema, MOD_SCHEMA_ID);
 
     deps = {


### PR DESCRIPTION
Summary: replaced direct logger.error calls in AjvSchemaValidator and GameStateValidationServiceForPrompting with SYSTEM_ERROR_OCCURRED_ID dispatches. Updated constructors to require SafeEventDispatcher and adjusted dependency registrations, scripts, and tests.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing repo errors)*
- [x] Root tests `npm test`
- [ ] Proxy tests `cd llm-proxy-server && npm test` *(fails coverage threshold)*
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6844505aa13c833187aa8d8c93873b98