### PR TITLE
[Agent] log LLM response details at info level

### DIFF
--- a/src/turns/services/LLMResponseProcessor.js
+++ b/src/turns/services/LLMResponseProcessor.js
@@ -156,7 +156,7 @@ export class LLMResponseProcessor extends ILLMResponseProcessor {
       logger.info(
         `LLMResponseProcessor: Successfully validated and transformed LLM output for actor ${actorId}. Action: ${finalAction.actionDefinitionId}`
       );
-      logger.debug(
+      logger.info(
         `LLMResponseProcessor: Transformed ProcessedTurnAction details for ${actorId}:`,
         { actorId, action: finalAction, extractedData: { thoughts, notes } }
       );


### PR DESCRIPTION
## Summary
- elevate LLMResponseProcessor action detail logging from debug to info

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Avoid calling `expect` conditionally` etc.)*
- `npm test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68446be7049c8331a79b1b2d22735cd4