### PR TITLE
[Agent] reduce info log noise

### DIFF
--- a/llm-proxy-server/src/config/appConfig.js
+++ b/llm-proxy-server/src/config/appConfig.js
@@ -153,7 +153,7 @@ class AppConfigService {
       this._proxyProjectRootPathForApiKeyFiles,
       'API key file retrieval relative to a project root will not be available unless this is set'
     );
-    this._logger.info('AppConfigService: Configuration loading complete.');
+    this._logger.debug('AppConfigService: Configuration loading complete.');
   }
 
   /**

--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -178,7 +178,7 @@ export class LlmConfigService {
    * @returns {Promise<void>}
    */
   async initialize() {
-    this.#logger.info('LlmConfigService: Initialization started.');
+    this.#logger.debug('LlmConfigService: Initialization started.');
     this.#isProxyOperational = false; // Default to not operational until success
 
     const customPath = this.#appConfig.getLlmConfigPath();

--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -65,7 +65,7 @@ export function persistNotes(action, actorEntity, logger) {
 
   if (wasModified) {
     addedNotes.forEach((note) => {
-      logger.info(`Added note: "${note.text}" at ${note.timestamp}`);
+      logger.debug(`Added note: "${note.text}" at ${note.timestamp}`);
     });
 
     if (typeof actorEntity?.addComponent === 'function') {

--- a/src/dependencyInjection/containerConfig.js
+++ b/src/dependencyInjection/containerConfig.js
@@ -132,7 +132,7 @@ export function configureContainer(container, uiElements) {
   registerOrchestration(container);
   // --- *** END CORRECTION *** ---
 
-  logger.info('[ContainerConfig] All core bundles registered.');
+  logger.debug('[ContainerConfig] All core bundles registered.');
 
   // --- Populate Registries (Post-Registration Steps) ---
   try {

--- a/src/dependencyInjection/registrations/orchestrationRegistrations.js
+++ b/src/dependencyInjection/registrations/orchestrationRegistrations.js
@@ -98,5 +98,5 @@ export function registerOrchestration(container) {
     `Orchestration Registration: Registered ${tokens.ShutdownService} (Singleton).`
   );
 
-  logger.info('Orchestration Registration: Complete.');
+  logger.debug('Orchestration Registration: Complete.');
 }

--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -481,7 +481,7 @@ class GameEngine {
             type: 'info',
           }
         );
-        this.#logger.info(
+        this.#logger.debug(
           `GameEngine.triggerManualSave: Dispatched ENGINE_MESSAGE_DISPLAY_REQUESTED (info) for "${saveName}".`
         );
       } else {
@@ -649,7 +649,7 @@ class GameEngine {
       );
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `GameEngine._finalizeLoadSuccess: Game loaded from "${saveIdentifier}" (World: ${this.#activeWorld}) and resumed.`
     );
     return { success: true, data: loadedSaveData };
@@ -711,7 +711,7 @@ class GameEngine {
    * @memberof GameEngine
    */
   async loadGame(saveIdentifier) {
-    this.#logger.info(
+    this.#logger.debug(
       `GameEngine: loadGame called for identifier: ${saveIdentifier}`
     );
 
@@ -784,7 +784,7 @@ class GameEngine {
     if (
       this.#gamePersistenceService.isSavingAllowed(this.#isEngineInitialized)
     ) {
-      this.#logger.info(
+      this.#logger.debug(
         'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
       );
       // --- FIX START ---
@@ -822,7 +822,7 @@ class GameEngine {
       });
       return;
     }
-    this.#logger.info(
+    this.#logger.debug(
       'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
     );
     this.#safeEventDispatcher.dispatch(REQUEST_SHOW_LOAD_GAME_UI, {});

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -68,7 +68,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
       this.#logger = logger;
     }
 
-    this.#logger.info('PlaytimeTracker: Instance created.');
+    this.#logger.debug('PlaytimeTracker: Instance created.');
   }
 
   /**
@@ -168,7 +168,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
   reset() {
     this.#accumulatedPlaytimeSeconds = 0;
     this.#sessionStartTime = 0;
-    this.#logger.info('PlaytimeTracker: Playtime reset.');
+    this.#logger.debug('PlaytimeTracker: Playtime reset.');
   }
 
   /**

--- a/src/perception/perceptionUpdateService.js
+++ b/src/perception/perceptionUpdateService.js
@@ -86,7 +86,7 @@ class PerceptionUpdateService {
 
     this.#logger = logger;
     this.#entityManager = entityManager;
-    this.#logger.info('PerceptionUpdateService: Instance created.');
+    this.#logger.debug('PerceptionUpdateService: Instance created.');
   }
 
   /**

--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -65,7 +65,7 @@ class GamePersistenceService extends IGamePersistenceService {
     this.#dataRegistry = dataRegistry;
     this.#playtimeTracker = playtimeTracker;
     this.#container = container;
-    this.#logger.info('GamePersistenceService: Instance created.');
+    this.#logger.debug('GamePersistenceService: Instance created.');
   }
 
   /**

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -47,7 +47,7 @@ class SaveLoadService extends ISaveLoadService {
       );
     this.#logger = logger;
     this.#storageProvider = storageProvider;
-    this.#logger.info('SaveLoadService initialized.');
+    this.#logger.debug('SaveLoadService initialized.');
   }
 
   /**
@@ -144,19 +144,19 @@ class SaveLoadService extends ISaveLoadService {
     const gameStateMessagePack = encode(finalSaveObject.gameState);
     finalSaveObject.integrityChecks.gameStateChecksum =
       await this.#generateChecksum(gameStateMessagePack); //
-    this.#logger.info(
+    this.#logger.debug(
       `Calculated gameStateChecksum: ${finalSaveObject.integrityChecks.gameStateChecksum}`
     );
 
     this.#logger.debug('Serializing full game state object to MessagePack...');
     const messagePackData = encode(finalSaveObject); //
-    this.#logger.info(
+    this.#logger.debug(
       `MessagePack Raw Size: ${messagePackData.byteLength} bytes`
     );
 
     this.#logger.debug('Compressing MessagePack data with Gzip...');
     const compressedData = pako.gzip(messagePackData); //
-    this.#logger.info(`Gzipped Size: ${compressedData.byteLength} bytes`);
+    this.#logger.debug(`Gzipped Size: ${compressedData.byteLength} bytes`);
 
     return { compressedData, finalSaveObject };
   }
@@ -247,7 +247,7 @@ class SaveLoadService extends ISaveLoadService {
    * @returns {Promise<Array<SaveFileMetadata>>}
    */
   async listManualSaveSlots() {
-    this.#logger.info(
+    this.#logger.debug(
       `Listing manual save slots from ${FULL_MANUAL_SAVE_DIRECTORY_PATH}...`
     );
     const collectedMetadata = [];
@@ -264,7 +264,7 @@ class SaveLoadService extends ISaveLoadService {
         FULL_MANUAL_SAVE_DIRECTORY_PATH,
         MANUAL_SAVE_PATTERN.source
       );
-      this.#logger.info(
+      this.#logger.debug(
         `Found ${files.length} potential manual save files in ${FULL_MANUAL_SAVE_DIRECTORY_PATH}.`
       );
     } catch (listError) {
@@ -274,7 +274,7 @@ class SaveLoadService extends ISaveLoadService {
         listError.message.toLowerCase().includes('not found')
       ) {
         // Example check
-        this.#logger.info(
+        this.#logger.debug(
           `${FULL_MANUAL_SAVE_DIRECTORY_PATH} not found. Assuming no manual saves yet.`
         );
         return []; // No directory means no saves
@@ -366,12 +366,12 @@ class SaveLoadService extends ISaveLoadService {
         timestamp: timestamp,
         playtimeSeconds: playtimeSeconds,
       });
-      this.#logger.info(
+      this.#logger.debug(
         `Successfully parsed metadata for ${filePath}: Name="${saveName}", Timestamp="${timestamp}"`
       );
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `Finished listing manual save slots. Returning ${collectedMetadata.length} items.`
     );
     return collectedMetadata;
@@ -469,9 +469,9 @@ class SaveLoadService extends ISaveLoadService {
       this.#logger.error(devMsg + ` User message: "${userMsg}"`);
       return { success: false, error: userMsg, data: null };
     }
-    this.#logger.info(`Checksum VERIFIED for ${saveIdentifier}.`);
+    this.#logger.debug(`Checksum VERIFIED for ${saveIdentifier}.`);
 
-    this.#logger.info(
+    this.#logger.debug(
       `Game data loaded and validated successfully from: "${saveIdentifier}"`
     );
     return { success: true, data: loadedObject, error: null };
@@ -481,7 +481,7 @@ class SaveLoadService extends ISaveLoadService {
    * @inheritdoc
    */
   async saveManualGame(saveName, gameStateObject) {
-    this.#logger.info(`Attempting to save manual game: "${saveName}"`);
+    this.#logger.debug(`Attempting to save manual game: "${saveName}"`);
 
     if (!saveName || typeof saveName !== 'string' || saveName.trim() === '') {
       const userMsg = 'Invalid save name provided. Please enter a valid name.';
@@ -505,7 +505,7 @@ class SaveLoadService extends ISaveLoadService {
           await this.#storageProvider.ensureDirectoryExists(
             FULL_MANUAL_SAVE_DIRECTORY_PATH
           );
-          this.#logger.info(
+          this.#logger.debug(
             `Ensured directory exists: ${FULL_MANUAL_SAVE_DIRECTORY_PATH}`
           );
         } catch (dirError) {
@@ -537,7 +537,7 @@ class SaveLoadService extends ISaveLoadService {
       );
 
       if (writeResult.success) {
-        this.#logger.info(
+        this.#logger.debug(
           `Manual game "${saveName}" saved successfully to ${filePath}.`
         );
         return {
@@ -575,7 +575,7 @@ class SaveLoadService extends ISaveLoadService {
    * @param {string} saveIdentifier - The full path to the save file to delete (e.g., "saves/manual_saves/my_save.sav").
    */
   async deleteManualSave(saveIdentifier) {
-    this.#logger.info(`Attempting to delete manual save: "${saveIdentifier}"`);
+    this.#logger.debug(`Attempting to delete manual save: "${saveIdentifier}"`);
     if (
       !saveIdentifier ||
       typeof saveIdentifier !== 'string' ||
@@ -601,7 +601,7 @@ class SaveLoadService extends ISaveLoadService {
 
       const deleteResult = await this.#storageProvider.deleteFile(filePath);
       if (deleteResult.success) {
-        this.#logger.info(`Manual save "${filePath}" deleted successfully.`);
+        this.#logger.debug(`Manual save "${filePath}" deleted successfully.`);
       } else {
         this.#logger.error(
           `Failed to delete manual save "${filePath}": ${deleteResult.error}`

--- a/src/shutdown/services/shutdownService.js
+++ b/src/shutdown/services/shutdownService.js
@@ -247,7 +247,7 @@ class ShutdownService {
       }
 
       // --- Final Success ---
-      this.#logger.info('ShutdownService: Shutdown sequence finished.');
+      this.#logger.debug('ShutdownService: Shutdown sequence finished.');
       const completedPayload = {};
       try {
         await this.#validatedEventDispatcher.dispatch(

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -50,7 +50,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         (await this.#rootHandle.requestPermission({ mode: 'readwrite' })) ===
         'granted'
       ) {
-        this.#logger.info('Permission re-granted to root directory.');
+        this.#logger.debug('Permission re-granted to root directory.');
         return this.#rootHandle;
       }
       this.#logger.warn(

--- a/tests/ai/notesPersistenceHook.test.js
+++ b/tests/ai/notesPersistenceHook.test.js
@@ -71,7 +71,7 @@ describe('persistNotes', () => {
     persistNotes(action, actor, logger);
 
     // --- FIX: Updated the assertion to match the new, specific log message ---
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Added note: "A valid note" at')
     );
   });

--- a/tests/engine/gameEngine.test.js
+++ b/tests/engine/gameEngine.test.js
@@ -716,7 +716,7 @@ describe('GameEngine', () => {
     it('should successfully orchestrate loading a game and call helpers in order', async () => {
       const result = await gameEngine.loadGame(SAVE_ID);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `GameEngine: loadGame called for identifier: ${SAVE_ID}`
       );
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
@@ -898,7 +898,7 @@ describe('GameEngine', () => {
       mockGamePersistenceService.isSavingAllowed.mockReturnValue(true);
       gameEngine.showSaveGameUI(); // Method is now sync
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
       );
       expect(mockGamePersistenceService.isSavingAllowed).toHaveBeenCalledWith(
@@ -982,7 +982,7 @@ describe('GameEngine', () => {
     it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
       gameEngine.showLoadGameUI(); // Method is now sync
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
       );
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(

--- a/tests/engine/playtimeTracker.test.js
+++ b/tests/engine/playtimeTracker.test.js
@@ -82,7 +82,7 @@ describe('PlaytimeTracker', () => {
     tracker.reset();
     expect(tracker._getAccumulatedPlaytimeSeconds()).toBe(0);
     expect(tracker._getSessionStartTime()).toBe(0);
-    expect(mockLogger.info).toHaveBeenLastCalledWith(
+    expect(mockLogger.debug).toHaveBeenLastCalledWith(
       'PlaytimeTracker: Playtime reset.'
     );
   });

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -52,9 +52,10 @@ describe('GamePersistenceService', () => {
       playtimeTracker: mockPlaytimeTracker,
       container: mockAppContainer,
     });
-    // Clear the logger.info call made by the constructor, if any,
+    // Clear the logger.info/debug calls made by the constructor, if any,
     // to not interfere with test-specific logger assertions.
     mockLogger.info.mockClear();
+    mockLogger.debug.mockClear();
   });
 
   describe('isSavingAllowed(isEngineInitialized)', () => {

--- a/tests/services/perceptionUpdateService.test.js
+++ b/tests/services/perceptionUpdateService.test.js
@@ -83,7 +83,7 @@ describe('PerceptionUpdateService', () => {
         entityManager: mockEntityManager,
       });
       expect(service).toBeInstanceOf(PerceptionUpdateService);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'PerceptionUpdateService: Instance created.'
       );
     });

--- a/tests/shutdown/services/shutdownService.test.js
+++ b/tests/shutdown/services/shutdownService.test.js
@@ -346,9 +346,9 @@ describe('ShutdownService', () => {
       ); // Index: 10 + 1 = 11
 
       // 6. Final logs and events (Index 12 for log, check event dispatch)
-      expect(loggerInfoCalls[12]).toBe(
+      expect(loggerDebugCalls).toContain(
         'ShutdownService: Shutdown sequence finished.'
-      ); // Index: 11 + 1 = 12
+      );
       // Check completed event dispatch (should be the 3rd dispatch call overall)
       expect(dispatchCalls[2][0]).toBe('shutdown:shutdown_service:completed');
       expect(loggerDebugCalls).toContain(
@@ -364,8 +364,8 @@ describe('ShutdownService', () => {
       );
 
       // Verify total info calls match expected count
-      // Constructor(1) + Seq Start(1) + TM Resolve/Stop(2) + Resolve Systems(2) + Sys1(1) + Sys2(1) + Finished Sys(1) + Dispose Check/Attempt/Success(3) + Finished Seq(1) = 13
-      expect(mockLogger.info).toHaveBeenCalledTimes(13);
+      // Constructor(1) + Seq Start(1) + TM Resolve/Stop(2) + Resolve Systems(2) + Sys1(1) + Sys2(1) + Finished Sys(1) + Dispose Check/Attempt/Success(3) = 12
+      expect(mockLogger.info).toHaveBeenCalledTimes(12);
     });
 
     // REMOVED: Test for game loop already stopped - now redundant as TurnManager is always resolved/stopped unless resolve fails.
@@ -404,7 +404,7 @@ describe('ShutdownService', () => {
       expect(mockContainer.disposeSingletons).toHaveBeenCalledTimes(1);
 
       // Verify sequence completes successfully overall (error was contained)
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
@@ -466,7 +466,7 @@ describe('ShutdownService', () => {
       expect(mockContainer.disposeSingletons).toHaveBeenCalledTimes(1);
 
       // Verify sequence completes successfully overall
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
@@ -507,7 +507,7 @@ describe('ShutdownService', () => {
       expect(mockContainer.disposeSingletons).toHaveBeenCalledTimes(1);
 
       // Verify sequence completes successfully overall
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
@@ -545,7 +545,7 @@ describe('ShutdownService', () => {
       );
 
       // Verify sequence still "finishes" and dispatches completed event
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
@@ -597,7 +597,7 @@ describe('ShutdownService', () => {
       expect(mockContainer.resolveByTag).toHaveBeenCalledWith(SHUTDOWNABLE[0]);
       expect(mockShutdownableSystem1.shutdown).toHaveBeenCalledTimes(1); // Assuming resolveByTag succeeded
       expect(mockContainer.disposeSingletons).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
       // *** CORRECTED: Only 1 error expected now (the TM stop error) ***
@@ -654,7 +654,7 @@ describe('ShutdownService', () => {
       // Verify sequence ran fully
       expect(mockTurnManager.stop).toHaveBeenCalled(); // <<< CHECK ADDED
       expect(mockContainer.disposeSingletons).toHaveBeenCalled();
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'ShutdownService: Shutdown sequence finished.'
       );
 


### PR DESCRIPTION
## Summary
- downgrade common info logs to debug across services
- adjust unit tests to expect debug logs instead of info

## Testing
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844976032e88331a610a7150c475559