### PR TITLE
[Agent] Downgrade noisy info logs

### DIFF
--- a/src/configuration/httpConfigurationProvider.js
+++ b/src/configuration/httpConfigurationProvider.js
@@ -64,7 +64,7 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
       throw new Error(errorMessage);
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `HttpConfigurationProvider: Attempting to load configurations from ${sourceUrl}`
     );
 
@@ -102,7 +102,7 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
         );
       }
 
-      this.#logger.info(
+      this.#logger.debug(
         `HttpConfigurationProvider: Successfully fetched and parsed configuration from ${sourceUrl}.`
       );
       return jsonData;

--- a/src/dependencyInjection/containerConfig.js
+++ b/src/dependencyInjection/containerConfig.js
@@ -92,7 +92,7 @@ export function configureContainer(container, uiElements) {
           `[ContainerConfig] Failed to load logger configuration from '${loggerConfigResult.path || 'default path'}'. Error: ${loggerConfigResult.message}. Stage: ${loggerConfigResult.stage || 'N/A'}. Retaining current log level.`
         );
       } else {
-        logger.info(
+        logger.debug(
           '[ContainerConfig] Logger configuration file loaded but no specific logLevel found or file was empty. Retaining current log level.'
         );
       }
@@ -145,7 +145,7 @@ export function configureContainer(container, uiElements) {
       container.resolve(tokens.IGameDataRepository)
     );
     systemDataRegistry.registerSource('GameDataRepository', gameDataRepo);
-    logger.info(
+    logger.debug(
       `[ContainerConfig] Data source 'GameDataRepository' registered in SystemDataRegistry.`
     );
 
@@ -157,7 +157,7 @@ export function configureContainer(container, uiElements) {
       `[ContainerConfig] Registering data source '${worldContextKey}' in SystemDataRegistry...`
     );
     systemDataRegistry.registerSource(worldContextKey, worldContextInstance);
-    logger.info(
+    logger.debug(
       `[ContainerConfig] Data source '${worldContextKey}' successfully registered in SystemDataRegistry.`
     );
 
@@ -173,7 +173,7 @@ export function configureContainer(container, uiElements) {
       perceptionUpdateServiceKey,
       perceptionUpdateServiceInstance
     );
-    logger.info(
+    logger.debug(
       `[ContainerConfig] Data source '${perceptionUpdateServiceKey}' successfully registered in SystemDataRegistry.`
     );
   } catch (error) {
@@ -190,7 +190,7 @@ export function configureContainer(container, uiElements) {
     });
   }
 
-  logger.info(
+  logger.debug(
     '[ContainerConfig] Configuration and registry population complete.'
   );
 }

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -94,7 +94,7 @@ class WorldInitializer {
     this.#spatialIndexManager = spatialIndexManager;
     this.#referenceResolver = referenceResolver;
 
-    this.#logger.info(
+    this.#logger.debug(
       'WorldInitializer: Instance created (with ReferenceResolver).'
     );
   }

--- a/src/modding/modLoadOrderResolver.js
+++ b/src/modding/modLoadOrderResolver.js
@@ -271,7 +271,7 @@ function resolveOrder(requestedIds, manifestsMap, logger) {
     );
 
   if (differs) {
-    logger.info(
+    logger.debug(
       [
         'Mod load order adjusted to satisfy dependencies.',
         `Original: ${originalOrder.join(', ')}`,

--- a/src/modding/modManifestLoader.js
+++ b/src/modding/modManifestLoader.js
@@ -108,7 +108,7 @@ class ModManifestLoader {
     this.#dataRegistry = dataRegistry;
     this.#logger = logger;
 
-    this.#logger.info(
+    this.#logger.debug(
       'ModManifestLoader: Instance created and dependencies validated.'
     );
   }

--- a/tests/initializers/worldInitializer.test.js
+++ b/tests/initializers/worldInitializer.test.js
@@ -118,7 +118,7 @@ describe('WorldInitializer', () => {
 
   describe('constructor', () => {
     it('should instantiate successfully with all valid dependencies', () => {
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'WorldInitializer: Instance created (with ReferenceResolver).'
       );
     });

--- a/tests/services/httpConfigurationProvider.test.js
+++ b/tests/services/httpConfigurationProvider.test.js
@@ -61,10 +61,10 @@ describe('HttpConfigurationProvider', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(url);
       expect(result).toEqual(mockData);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `HttpConfigurationProvider: Attempting to load configurations from ${url}`
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `HttpConfigurationProvider: Successfully fetched and parsed configuration from ${url}.`
       );
       expect(mockLogger.error).not.toHaveBeenCalled();

--- a/tests/services/modLoadOrderResolver.test.js
+++ b/tests/services/modLoadOrderResolver.test.js
@@ -252,7 +252,7 @@ describe('resolveOrder – adjustment-log (Ticket T-4)', () => {
 
     resolveOrder(requested, manifests, mockLogger);
 
-    const logged = mockLogger.info.mock.calls.some(([msg]) =>
+    const logged = mockLogger.debug.mock.calls.some(([msg]) =>
       msg.includes('Mod load order adjusted to satisfy dependencies.')
     );
     expect(logged).toBe(true);
@@ -267,7 +267,7 @@ describe('resolveOrder – adjustment-log (Ticket T-4)', () => {
 
     resolveOrder(requested, manifests, mockLogger);
 
-    const logged = mockLogger.info.mock.calls.some(([msg]) =>
+    const logged = mockLogger.debug.mock.calls.some(([msg]) =>
       msg.includes('Mod load order adjusted to satisfy dependencies.')
     );
     expect(logged).toBe(false);


### PR DESCRIPTION
## Summary
- reclassify many initialization logs from info to debug
- update tests for world initializer, HTTP configuration provider, and load order resolver

## Testing
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a5fafc1883319290e7a08aec29df