### PR TITLE
[Agent] Downgrade noisy info logs

### DIFF
--- a/src/actions/targeting/targetResolutionService.js
+++ b/src/actions/targeting/targetResolutionService.js
@@ -128,7 +128,7 @@ class TargetResolutionService extends ITargetResolutionService {
     this.#gameDataRepository = gameDataRepository;
     this.#getEntityIdsForScopes = getEntityIdsForScopes;
 
-    this.#logger.info(
+    this.#logger.debug(
       'TargetResolutionService: Instance created and dependencies validated.'
     );
   }

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -117,7 +117,7 @@ export class ActionValidationService {
     // --- End Refactor-AVS-3.4 ---
 
     // Log message updated to reflect removed dependency implicitly
-    this.#logger.info(
+    this.#logger.debug(
       'ActionValidationService initialised (dependencies: EM, Logger, DCCC, PES).'
     );
   }

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -88,7 +88,7 @@ export class PrerequisiteEvaluationService {
     this.#jsonLogicEvaluationService = jsonLogicEvaluationService;
     this.#actionValidationContextBuilder = actionValidationContextBuilder;
 
-    this.#logger.info(
+    this.#logger.debug(
       'PrerequisiteEvaluationService initialised (with ActionValidationContextBuilder).'
     );
   }

--- a/src/initializers/systemInitializer.js
+++ b/src/initializers/systemInitializer.js
@@ -99,7 +99,7 @@ class SystemInitializer {
         );
         resolvedSystems = [];
       }
-      this.#logger.info(
+      this.#logger.debug(
         `SystemInitializer: Found ${resolvedSystems.length} systems tagged with '${this.#initializationTag}'.`
       );
       return resolvedSystems;

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -131,7 +131,7 @@ class WorldInitializer {
    * @private
    */
   async #_instantiateAllEntitiesFromDefinitions() {
-    this.#logger.info(
+    this.#logger.debug(
       'WorldInitializer (Pass 1): Instantiating entities from definitions...'
     );
     let totalInstantiatedCount = 0;
@@ -186,7 +186,7 @@ class WorldInitializer {
         );
       }
     }
-    this.#logger.info(
+    this.#logger.debug(
       `WorldInitializer (Pass 1): Completed. Instantiated ${totalInstantiatedCount} total entities.`
     );
     return { entities: instantiatedEntities, count: totalInstantiatedCount };
@@ -381,7 +381,7 @@ class WorldInitializer {
    * @private
    */
   async #_resolveReferencesAndPopulateSpatialIndex(instantiatedEntities) {
-    this.#logger.info(
+    this.#logger.debug(
       'WorldInitializer (Pass 2): Resolving component references and populating spatial index for entities...'
     );
     let entitiesAddedToSpatialIndex = 0;
@@ -394,7 +394,7 @@ class WorldInitializer {
       }
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `WorldInitializer (Pass 2): Completed entity processing. Processed ${instantiatedEntities.length} entities. Added ${entitiesAddedToSpatialIndex} entities to spatial index.`
     );
   }
@@ -409,7 +409,7 @@ class WorldInitializer {
    * @throws {Error} If a critical error occurs during initialization that should stop the process.
    */
   async initializeWorldEntities() {
-    this.#logger.info(
+    this.#logger.debug(
       'WorldInitializer: Starting world entity initialization process...'
     );
     // Event 'initialization:world_initializer:started' could be dispatched here if needed.
@@ -423,12 +423,12 @@ class WorldInitializer {
           instantiatedEntities
         );
       } else {
-        this.#logger.info(
+        this.#logger.debug(
           'WorldInitializer (Pass 2): Skipped. No entities were instantiated in Pass 1.'
         );
       }
 
-      this.#logger.info(
+      this.#logger.debug(
         'WorldInitializer: World entity initialization and spatial indexing complete.'
       );
       // Event 'initialization:world_initializer:completed' could be dispatched here.

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -384,7 +384,9 @@ class SaveLoadService extends ISaveLoadService {
    */
   async loadGameData(saveIdentifier) {
     //
-    this.#logger.info(`Attempting to load game data from: "${saveIdentifier}"`);
+    this.#logger.debug(
+      `Attempting to load game data from: "${saveIdentifier}"`
+    );
 
     if (
       !saveIdentifier ||

--- a/src/prompting/promptBuilder.js
+++ b/src/prompting/promptBuilder.js
@@ -140,7 +140,7 @@ export class PromptBuilder extends IPromptBuilder {
       this.#goalsSectionAssembler = goalsSectionAssembler;
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       'PromptBuilder initialized with LLMConfigService, PlaceholderResolver, and Assemblers (standard, perception‐log, thoughts, notes, goals).'
     );
   }
@@ -294,7 +294,7 @@ export class PromptBuilder extends IPromptBuilder {
       finalPromptString += currentElementOutput;
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `PromptBuilder.build: Successfully assembled prompt for llmId: ${llmId} using config ${selectedConfig.configId}. Length: ${finalPromptString.length}`
     );
     return finalPromptString;

--- a/tests/initializers/systemInitializer.initialization.test.js
+++ b/tests/initializers/systemInitializer.initialization.test.js
@@ -322,7 +322,7 @@ describe('SystemInitializer (Tag-Based)', () => {
         testInitializationTag
       );
       expect(mockResolver.resolveByTag).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `SystemInitializer: Found 6 systems tagged with '${testInitializationTag}'.`
       );
 
@@ -380,7 +380,7 @@ describe('SystemInitializer (Tag-Based)', () => {
       expect(mockResolver.resolveByTag).toHaveBeenCalledWith(
         testInitializationTag
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `SystemInitializer: Found 0 systems tagged with '${testInitializationTag}'.`
       );
 
@@ -403,7 +403,7 @@ describe('SystemInitializer (Tag-Based)', () => {
         `SystemInitializer: resolveByTag for tag '${testInitializationTag}' did not return an array. Treating as empty.`
       );
       // Should then proceed as if it were empty
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `SystemInitializer: Found 0 systems tagged with '${testInitializationTag}'.`
       );
 
@@ -464,7 +464,7 @@ describe('SystemInitializer (Tag-Based)', () => {
       expect(mockResolver.resolveByTag).toHaveBeenCalledWith(
         testInitializationTag
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `SystemInitializer: Found 3 systems tagged with '${testInitializationTag}'.`
       );
 

--- a/tests/initializers/systemInitializer.test.js
+++ b/tests/initializers/systemInitializer.test.js
@@ -477,7 +477,7 @@ describe('SystemInitializer (Tag-Based Refactor)', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `SystemInitializer: resolveByTag for tag '${testInitializationTag}' did not return an array. Treating as empty.`
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `SystemInitializer: Found 0 systems tagged with '${testInitializationTag}'.`
       );
 

--- a/tests/prompting/promptBuilder.errorConditions.test.js
+++ b/tests/prompting/promptBuilder.errorConditions.test.js
@@ -193,7 +193,7 @@ describe('PromptBuilder', () => {
           aContent: 'Data for A',
         })
       ).toBe('');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Successfully assembled prompt for llmId: vendor/empty_order_model using config ${cfg.configId}. Length: 0`
         )

--- a/tests/prompting/promptBuilder.test.js
+++ b/tests/prompting/promptBuilder.test.js
@@ -104,7 +104,7 @@ describe('PromptBuilder', () => {
   describe('Constructor', () => {
     test('initializes with default console logger when none provided', () => {
       const consoleSpy = jest
-        .spyOn(console, 'info')
+        .spyOn(console, 'debug')
         .mockImplementation(() => {});
       const pb = new PromptBuilder({
         llmConfigService: mockLlmConfigService,
@@ -130,7 +130,7 @@ describe('PromptBuilder', () => {
       });
 
       expect(promptBuilder).toBeInstanceOf(PromptBuilder);
-      expect(logger.info).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
+      expect(logger.debug).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
     });
 
     test('initializes correctly when LLMConfigService might have initialConfigs', () => {
@@ -144,7 +144,7 @@ describe('PromptBuilder', () => {
       });
 
       expect(promptBuilder).toBeInstanceOf(PromptBuilder);
-      expect(logger.info).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
+      expect(logger.debug).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
     });
 
     test('initializes correctly when LLMConfigService might have empty initialConfigs', () => {
@@ -158,7 +158,7 @@ describe('PromptBuilder', () => {
       });
 
       expect(promptBuilder).toBeInstanceOf(PromptBuilder);
-      expect(logger.info).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
+      expect(logger.debug).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
     });
 
     test('initializes correctly when LLMConfigService uses configSourceIdentifier', () => {
@@ -172,7 +172,7 @@ describe('PromptBuilder', () => {
       });
 
       expect(promptBuilder).toBeInstanceOf(PromptBuilder);
-      expect(logger.info).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
+      expect(logger.debug).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
     });
 
     test('initializes correctly regardless of LLMConfigService details', () => {
@@ -186,7 +186,7 @@ describe('PromptBuilder', () => {
       });
 
       expect(promptBuilder).toBeInstanceOf(PromptBuilder);
-      expect(logger.info).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
+      expect(logger.debug).toHaveBeenCalledWith(EXPECTED_INIT_MSG);
     });
 
     test('throws when LLMConfigService not provided', () => {

--- a/tests/services/prerequisiteEvaluationService.test.js
+++ b/tests/services/prerequisiteEvaluationService.test.js
@@ -90,6 +90,7 @@ describe('PrerequisiteEvaluationService', () => {
       jsonLogicEvaluationService: mockJsonLogicServiceInstance,
       actionValidationContextBuilder: mockBuilderInstance,
     });
+    mockLogger.debug.mockClear();
   });
 
   // --- Test Cases (Should remain the same as the previous correct version) ---

--- a/tests/services/targetResolutionService.constructor.test.js
+++ b/tests/services/targetResolutionService.constructor.test.js
@@ -70,8 +70,8 @@ describe('TargetResolutionService', () => {
       }).not.toThrow();
 
       expect(service).toBeInstanceOf(TargetResolutionService);
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'TargetResolutionService: Instance created and dependencies validated.'
       );
     });


### PR DESCRIPTION
## Summary
- downgrade various info logs to debug level
- update affected unit tests to expect debug logs

## Testing
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a8422b188331b5fe581b76a62e87