### PR TITLE
[Agent] Downgrade noisy info logs to debug

### DIFF
--- a/src/dependencyInjection/registrations/adapterRegistrations.js
+++ b/src/dependencyInjection/registrations/adapterRegistrations.js
@@ -157,7 +157,7 @@ export function registerAdapters(container) {
 
   // --- Register ConfigurableLLMAdapter lazily ---
   registrar.singletonFactory(tokens.LLMAdapter, (c) => {
-    logger.info(
+    logger.debug(
       'Adapter Registration: Starting LLM Adapter setup for CLIENT environment...'
     );
 

--- a/src/dependencyInjection/registrations/orchestrationRegistrations.js
+++ b/src/dependencyInjection/registrations/orchestrationRegistrations.js
@@ -55,7 +55,7 @@ export function registerOrchestration(container) {
       validatedEventDispatcher: initDispatcher,
     });
   });
-  logger.info(
+  logger.debug(
     `Orchestration Registration: Registered ${tokens.IInitializationService} (Singleton).`
   );
 
@@ -94,7 +94,7 @@ export function registerOrchestration(container) {
       gameLoop: shutdownGameLoop, // GameLoop is resolved here
     });
   });
-  logger.info(
+  logger.debug(
     `Orchestration Registration: Registered ${tokens.ShutdownService} (Singleton).`
   );
 

--- a/src/llms/llmConfigService.js
+++ b/src/llms/llmConfigService.js
@@ -105,20 +105,20 @@ export class LLMConfigService {
     this.#logger = options.logger;
     this.#configSourceIdentifier = options.configSourceIdentifier;
 
-    this.#logger.info('LLMConfigService: Initializing...');
+    this.#logger.debug('LLMConfigService: Initializing...');
 
     if (options.initialConfigs) {
       if (
         Array.isArray(options.initialConfigs) &&
         options.initialConfigs.length > 0
       ) {
-        this.#logger.info(
+        this.#logger.debug(
           `LLMConfigService: Processing ${options.initialConfigs.length} initial configurations.`
         );
         this.addOrUpdateConfigs(options.initialConfigs, true); // Pass true to indicate these are initial
         if (this.#llmConfigsCache.size > 0) {
           this.#configsLoadedOrAttempted = true; // Mark as attempted if initial configs were successfully loaded
-          this.#logger.info(
+          this.#logger.debug(
             `LLMConfigService: Successfully loaded ${this.#llmConfigsCache.size} initial configurations into cache.`
           );
         } else {
@@ -130,7 +130,7 @@ export class LLMConfigService {
         Array.isArray(options.initialConfigs) &&
         options.initialConfigs.length === 0
       ) {
-        this.#logger.info(
+        this.#logger.debug(
           'LLMConfigService: Empty array provided for initialConfigs. No initial configurations loaded.'
         );
       } else if (!Array.isArray(options.initialConfigs)) {
@@ -141,16 +141,16 @@ export class LLMConfigService {
     }
 
     if (this.#configSourceIdentifier) {
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService: Configuration source identifier set to: ${this.#configSourceIdentifier}. Configurations will be loaded on demand.`
       );
     } else if (!this.#configsLoadedOrAttempted) {
       // Only log if no initial configs and no source ID
-      this.#logger.info(
+      this.#logger.debug(
         'LLMConfigService: No configuration source identifier provided and no initial configs loaded. Service will rely on programmatic additions.'
       );
     }
-    this.#logger.info('LLMConfigService: Initialization complete.');
+    this.#logger.debug('LLMConfigService: Initialization complete.');
   }
 
   /**
@@ -265,7 +265,7 @@ export class LLMConfigService {
     }
 
     if (addedCount > 0 || updatedCount > 0) {
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService.addOrUpdateConfigs: Processed ${configs.length} configs: ${addedCount} added, ${updatedCount} updated, ${skippedCount} skipped.`
       );
     } else if (skippedCount > 0) {
@@ -273,7 +273,7 @@ export class LLMConfigService {
         `LLMConfigService.addOrUpdateConfigs: Processed ${configs.length} configs: All were skipped due to validation errors.`
       );
     } else {
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService.addOrUpdateConfigs: No new or valid configurations to add/update from the provided array (length ${configs.length}).`
       );
     }
@@ -284,7 +284,7 @@ export class LLMConfigService {
       !this.#configsLoadedOrAttempted
     ) {
       if (this.#llmConfigsCache.size > 0) {
-        this.#logger.info(
+        this.#logger.debug(
           'LLMConfigService.addOrUpdateConfigs: Configurations added programmatically. Marking cache as "loaded/attempted" to potentially bypass source loading if not explicitly reset.'
         );
         this.#configsLoadedOrAttempted = true;
@@ -310,7 +310,7 @@ export class LLMConfigService {
       return;
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `LLMConfigService: Attempting to load configurations from source: ${this.#configSourceIdentifier}`
     );
     let rawData;
@@ -376,7 +376,7 @@ export class LLMConfigService {
       }
 
       if (loadedCount > 0) {
-        this.#logger.info(
+        this.#logger.debug(
           `LLMConfigService.#loadAndCacheConfigurationsFromSource: Successfully loaded and cached ${loadedCount} configurations from ${this.#configSourceIdentifier}. ${invalidCount} invalid configs skipped.`
         );
       } else {
@@ -502,7 +502,7 @@ export class LLMConfigService {
     // 1. Direct match by configId
     if (this.#llmConfigsCache.has(llmId)) {
       const config = this.#llmConfigsCache.get(llmId);
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService.getConfig: Found configuration by direct configId match for "${llmId}". ConfigId: "${config.configId}".`
       );
       return { ...config }; // Return a copy
@@ -554,14 +554,14 @@ export class LLMConfigService {
     }
 
     if (exactModelMatchConfig) {
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService.getConfig: Selected configuration by exact modelIdentifier match for "${llmId}". ConfigId: "${exactModelMatchConfig.configId}".`
       );
       return { ...exactModelMatchConfig }; // Return a copy
     }
 
     if (bestWildcardMatchConfig) {
-      this.#logger.info(
+      this.#logger.debug(
         `LLMConfigService.getConfig: Selected configuration by wildcard modelIdentifier match for "${llmId}". Pattern: "${bestWildcardMatchConfig.modelIdentifier}", ConfigId: "${bestWildcardMatchConfig.configId}".`
       );
       return { ...bestWildcardMatchConfig }; // Return a copy
@@ -583,7 +583,7 @@ export class LLMConfigService {
   resetCache() {
     this.#llmConfigsCache.clear();
     this.#configsLoadedOrAttempted = false;
-    this.#logger.info(
+    this.#logger.debug(
       'LLMConfigService: Cache cleared and loaded state reset. Configurations will be reloaded from source on next request if source is configured.'
     );
   }

--- a/src/llms/strategies/base/baseOpenRouterStrategy.js
+++ b/src/llms/strategies/base/baseOpenRouterStrategy.js
@@ -128,7 +128,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
       throw new ConfigurationError(errorMsg, { llmId });
     }
 
-    this.logger.info(
+    this.logger.debug(
       `${this.constructor.name}.execute called for LLM ID: ${llmId}.`
     );
 
@@ -213,7 +213,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
         targetHeaders: llmConfig.providerSpecificHeaders || {},
       };
       // MODIFICATION END
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): Client-side execution. Using proxy URL: ${targetUrl}. Payload prepared according to proxy API contract.`,
         { llmId }
       );
@@ -241,7 +241,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
         `${this.constructor.name} (${llmId}): Making API call to '${targetUrl}'. Payload length: ${JSON.stringify(finalPayload)?.length}`,
         { llmId }
       );
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): Final prompt to be sent to '${targetUrl}':`,
         { llmId, payload: JSON.stringify(finalPayload, null, 2) }
       );
@@ -272,7 +272,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
         typeof extractedJsonString === 'string' &&
         extractedJsonString.trim() !== ''
       ) {
-        this.logger.info(
+        this.logger.debug(
           `${this.constructor.name} (${llmId}): Successfully extracted JSON string. Length: ${extractedJsonString.length}.`,
           { llmId }
         );

--- a/src/llms/strategies/openRouterJsonSchemaStrategy.js
+++ b/src/llms/strategies/openRouterJsonSchemaStrategy.js
@@ -129,14 +129,14 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
       message.content.trim() !== ''
     ) {
       extractedJsonString = message.content.trim();
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): Extracted JSON string from message.content.`,
         { llmId }
       );
     } else if (message.content && typeof message.content === 'object') {
       // If the API directly returns a JSON object in message.content for json_schema mode
       extractedJsonString = JSON.stringify(message.content);
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): Extracted JSON object from message.content and stringified it.`,
         { llmId }
       );
@@ -159,7 +159,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
           }
         );
       } else {
-        this.logger.info(
+        this.logger.debug(
           `${this.constructor.name} (${llmId}): message.content is missing. Will check tool_calls fallback.`,
           { llmId }
         );
@@ -175,7 +175,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
       Array.isArray(message.tool_calls) &&
       message.tool_calls.length > 0
     ) {
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): message.content not usable, attempting tool_calls fallback.`,
         { llmId }
       );
@@ -193,7 +193,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
         toolCall.function.arguments.trim() !== ''
       ) {
         extractedJsonString = toolCall.function.arguments.trim();
-        this.logger.info(
+        this.logger.debug(
           `${this.constructor.name} (${llmId}): Extracted JSON string from tool_calls fallback (function: ${toolCall.function.name}).`,
           {
             llmId,

--- a/src/llms/strategies/openRouterToolCallingStrategy.js
+++ b/src/llms/strategies/openRouterToolCallingStrategy.js
@@ -211,7 +211,7 @@ export class OpenRouterToolCallingStrategy extends BaseOpenRouterStrategy {
       }
 
       const extractedJsonString = toolCall.function.arguments.trim();
-      this.logger.info(
+      this.logger.debug(
         `${this.constructor.name} (${llmId}): Successfully extracted JSON string from tool_calls[0].function.arguments for tool '${expectedToolName}'.`,
         {
           llmId,

--- a/tests/llms/strategies/openRouterJsonSchemaStrategy.test.js
+++ b/tests/llms/strategies/openRouterJsonSchemaStrategy.test.js
@@ -355,19 +355,19 @@ describe('OpenRouterJsonSchemaStrategy', () => {
         };
         const result = await strategy.execute(params);
         expect(result).toBe(expectedOutputJsonString);
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           expect.stringContaining(
             `OpenRouterJsonSchemaStrategy (${baseLlmConfig.configId}): message.content is missing. Will check tool_calls fallback.`
           ),
           expect.objectContaining({ llmId: baseLlmConfig.configId })
         );
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           expect.stringContaining(
             `OpenRouterJsonSchemaStrategy (${baseLlmConfig.configId}): message.content not usable, attempting tool_calls fallback.`
           ),
           expect.objectContaining({ llmId: baseLlmConfig.configId })
         );
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           expect.stringContaining(
             `OpenRouterJsonSchemaStrategy (${baseLlmConfig.configId}): Extracted JSON string from tool_calls fallback`
           ),

--- a/tests/prompting/promptBuilder.configLoading.test.js
+++ b/tests/prompting/promptBuilder.configLoading.test.js
@@ -155,7 +155,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(MOCK_CONFIG_FILE_PATH);
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `LLMConfigService.#loadAndCacheConfigurationsFromSource: Successfully loaded and cached 2 configurations from ${MOCK_CONFIG_FILE_PATH}. 0 invalid configs skipped.`
         )
@@ -401,7 +401,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
       expect(
         llmConfigService.getLlmConfigsCacheForTest().has('invalid_cfg')
       ).toBe(false);
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `LLMConfigService.#loadAndCacheConfigurationsFromSource: Successfully loaded and cached 2 configurations from ${MOCK_CONFIG_FILE_PATH}. 1 invalid configs skipped.`
         )
@@ -459,12 +459,12 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
       });
 
       // Check initial log from constructor
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'LLMConfigService: Processing 1 initial configurations.'
         )
       );
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'LLMConfigService: Successfully loaded 1 initial configurations into cache.'
         )
@@ -527,7 +527,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
       logger.info.mockClear();
 
       llmConfigService.resetCache();
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'LLMConfigService: Cache cleared and loaded state reset. Configurations will be reloaded from source on next request if source is configured.'
       );
       expect(llmConfigService.getLlmConfigsCacheForTest().size).toBe(0);
@@ -591,7 +591,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
       const newConfig = MOCK_CONFIG_2;
 
       llmConfigService.addOrUpdateConfigs([updatedMockConfig1, newConfig]);
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'LLMConfigService.addOrUpdateConfigs: Processed 2 configs: 1 added, 1 updated, 0 skipped.'
       );
       expect(llmConfigService.getLlmConfigsCacheForTest().size).toBe(2);
@@ -626,7 +626,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
       logger.info.mockClear(); // Clear init logs
 
       llmConfigService.addOrUpdateConfigs([]);
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'LLMConfigService.addOrUpdateConfigs: No new or valid configurations to add/update from the provided array (length 0).'
       );
       expect(llmConfigService.getLlmConfigsCacheForTest().size).toBe(0);
@@ -643,7 +643,7 @@ describe('PromptBuilder interaction with LLMConfigService for Configuration Load
         'LLMConfigService.addOrUpdateConfigs: Skipping invalid configuration object.',
         { configAttempted: invalidConfig }
       );
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         'LLMConfigService.addOrUpdateConfigs: Processed 2 configs: 1 added, 0 updated, 1 skipped.'
       );
       expect(llmConfigService.getLlmConfigsCacheForTest().size).toBe(1);

--- a/tests/prompting/promptBuilder.dynamicConfigSelection.test.js
+++ b/tests/prompting/promptBuilder.dynamicConfigSelection.test.js
@@ -177,7 +177,7 @@ describe('PromptBuilder', () => {
       });
       // exactMatchConfig is chosen because LLMConfigService finds it first for this modelIdentifier.
       expect(result).toBe('Exact:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by exact modelIdentifier match for "${llmIdToTest}". ConfigId: "${exactMatchConfig.configId}".`
       );
     });
@@ -188,7 +188,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('PriorityByID:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Found configuration by direct configId match for "${llmIdToTest}". ConfigId: "${configIdPriorityConfig.configId}".`
       );
     });
@@ -199,7 +199,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('MediumWild:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by wildcard modelIdentifier match for "${llmIdToTest}". Pattern: "${mediumWildcardConfig.modelIdentifier}", ConfigId: "${mediumWildcardConfig.configId}".`
       );
     });
@@ -210,7 +210,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('Exact:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by exact modelIdentifier match for "${llmIdToTest}". ConfigId: "${exactMatchConfig.configId}".`
       );
     });
@@ -221,7 +221,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('LongWild:data'); // "vendor/model-exact*" vs "vendor/model-*" vs "vendor/*"
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by wildcard modelIdentifier match for "${llmIdToTest}". Pattern: "${longWildcardConfig.modelIdentifier}", ConfigId: "${longWildcardConfig.configId}".`
       );
     });
@@ -234,7 +234,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('AnotherLongWild:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by wildcard modelIdentifier match for "${llmIdToTest}". Pattern: "${anotherLongWildcardConfig.modelIdentifier}", ConfigId: "${anotherLongWildcardConfig.configId}".`
       );
     });
@@ -260,7 +260,7 @@ describe('PromptBuilder', () => {
         testContent: 'data',
       });
       expect(result).toBe('ShortWild:data');
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         `LLMConfigService.getConfig: Selected configuration by wildcard modelIdentifier match for "${llmIdToTest}". Pattern: "${shortWildcardConfig.modelIdentifier}", ConfigId: "${shortWildcardConfig.configId}".`
       );
     });

--- a/tests/services/llmConfigService.test.js
+++ b/tests/services/llmConfigService.test.js
@@ -90,7 +90,7 @@ describe('LLMConfigService', () => {
         configSourceIdentifier: sourceId,
       });
       expect(service).toBeInstanceOf(LLMConfigService);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Configuration source identifier set to: ${sourceId}`
         )
@@ -109,7 +109,7 @@ describe('LLMConfigService', () => {
         service.getLlmConfigsCacheForTest().get(sampleConfig1.configId)
       ).toEqual(sampleConfig1);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(true);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'Successfully loaded 1 initial configurations into cache.'
         )
@@ -124,7 +124,7 @@ describe('LLMConfigService', () => {
       });
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(false); // No valid configs loaded, so flag remains false until source load or programmatic add
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'LLMConfigService: Empty array provided for initialConfigs. No initial configurations loaded.'
       );
     });
@@ -166,7 +166,7 @@ describe('LLMConfigService', () => {
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
       });
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'No configuration source identifier provided and no initial configs loaded.'
         )
@@ -276,7 +276,7 @@ describe('LLMConfigService', () => {
       expect(
         service.getLlmConfigsCacheForTest().get(sampleConfig2.configId)
       ).toEqual(sampleConfig2);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'Processed 2 configs: 2 added, 0 updated, 0 skipped.'
         )
@@ -294,7 +294,7 @@ describe('LLMConfigService', () => {
       expect(
         service.getLlmConfigsCacheForTest().get(sampleConfig1.configId)
       ).toEqual(updatedConfig1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'Processed 1 configs: 0 added, 1 updated, 0 skipped.'
         )
@@ -329,7 +329,7 @@ describe('LLMConfigService', () => {
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(false);
       service.addOrUpdateConfigs([{ ...sampleConfig1 }]);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(true);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           'Configurations added programmatically. Marking cache as "loaded/attempted"'
         )
@@ -364,7 +364,7 @@ describe('LLMConfigService', () => {
       expect(
         service.getLlmConfigsCacheForTest().get(sampleConfig1.configId)
       ).toEqual(sampleConfig1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Successfully loaded and cached 2 configurations from ${sourceId}`
         )
@@ -574,7 +574,7 @@ describe('LLMConfigService', () => {
       });
       const config = await service.getConfig(sampleConfig1.configId);
       expect(config).toEqual(sampleConfig1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Found configuration by direct configId match for "${sampleConfig1.configId}"`
         )
@@ -604,7 +604,7 @@ describe('LLMConfigService', () => {
       });
       const config = await service.getConfig(sampleConfig1.modelIdentifier);
       expect(config).toEqual(sampleConfig1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Selected configuration by exact modelIdentifier match for "${sampleConfig1.modelIdentifier}"`
         )
@@ -627,7 +627,7 @@ describe('LLMConfigService', () => {
       const targetModelId1 = 'provider/model-x-v3';
       let config = await service.getConfig(targetModelId1);
       expect(config.configId).toBe(sampleLongerWildcardConfig.configId);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Selected configuration by wildcard modelIdentifier match for "${targetModelId1}". Pattern: "${sampleLongerWildcardConfig.modelIdentifier}"`
         )
@@ -637,7 +637,7 @@ describe('LLMConfigService', () => {
       const targetModelId2 = 'provider/another-model';
       config = await service.getConfig(targetModelId2);
       expect(config.configId).toBe(sampleWildcardConfig.configId);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Selected configuration by wildcard modelIdentifier match for "${targetModelId2}". Pattern: "${sampleWildcardConfig.modelIdentifier}"`
         )
@@ -662,7 +662,7 @@ describe('LLMConfigService', () => {
 
       const config = await service.getConfig('provider/model-a-v1'); // This is a configId
       expect(config.configId).toBe(conflictingConfig.configId); // Should find by configId first
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Found configuration by direct configId match for "provider/model-a-v1"`
         )
@@ -684,7 +684,7 @@ describe('LLMConfigService', () => {
 
       const config = await service.getConfig('provider/model-x');
       expect(config.configId).toBe(exactMatchConfig.configId);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Selected configuration by exact modelIdentifier match for "provider/model-x"`
         )
@@ -723,7 +723,7 @@ describe('LLMConfigService', () => {
 
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(false);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'LLMConfigService: Cache cleared and loaded state reset. Configurations will be reloaded from source on next request if source is configured.'
       );
     });


### PR DESCRIPTION
## Summary
- reduce log.info noise in several modules
- update tests for new debug log level

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2013 problems)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844abaf40d88331a622b6193618a56e