### PR TITLE
[Agent] Downgrade noisy info logs

### DIFF
--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -129,7 +129,7 @@ class GameConfigLoader {
       // 1. Locate Config Path
       configPath = this.#pathResolver.resolveGameConfigPath();
       const configFilename = this.#configuration.getGameConfigFilename(); // Get filename for logging
-      this.#logger.info(
+      this.#logger.debug(
         `GameConfigLoader: Attempting to load game config '${configFilename}' from ${configPath}...`
       );
 
@@ -209,7 +209,7 @@ class GameConfigLoader {
       }
 
       // 5. Validation Success - Check 'mods' array
-      this.#logger.info(
+      this.#logger.debug(
         `GameConfigLoader: Game config '${configFilename}' validation successful against schema '${schemaId}'.`
       );
 
@@ -241,13 +241,13 @@ class GameConfigLoader {
             (modId) => modId !== CORE_MOD_ID
           );
           parsedConfig.mods.unshift(CORE_MOD_ID);
-          this.#logger.info(
+          this.#logger.debug(
             `GameConfigLoader: CORE_MOD_ID mod found but was not first; moved to the beginning of the load order.`
           );
         } else {
           // If Core is missing entirely, prepend it
           parsedConfig.mods.unshift(CORE_MOD_ID);
-          this.#logger.info(
+          this.#logger.debug(
             `GameConfigLoader: Auto-injected CORE_MOD_ID mod at the beginning of the load order.`
           );
         }

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -221,7 +221,7 @@ class WorldLoader {
       },
     ];
 
-    this.#logger.info(
+    this.#logger.debug(
       'WorldLoader: Instance created with ALL loaders, order‑resolver, and ValidatedEventDispatcher.'
     );
   }
@@ -237,7 +237,7 @@ class WorldLoader {
    * @throws {Error | ModDependencyError} Re-throws critical errors encountered during the loading sequence.
    */
   async loadWorld(worldName) {
-    this.#logger.info(
+    this.#logger.debug(
       `WorldLoader: Starting load sequence (World Hint: '${worldName}') ...`
     );
 
@@ -292,7 +292,7 @@ class WorldLoader {
 
       // --- Step 4: Load Game Configuration ---
       requestedModIds = await this.#gameConfigLoader.loadConfig();
-      this.#logger.info(
+      this.#logger.debug(
         `WorldLoader: Game config loaded. Requested mods: [${requestedModIds.join(', ')}]`
       );
 
@@ -305,7 +305,7 @@ class WorldLoader {
         this.#registry.store('mod_manifests', lcModId, manifestObj);
         manifestsForValidation.set(lcModId, manifestObj);
       }
-      this.#logger.info(
+      this.#logger.debug(
         `WorldLoader: Stored ${manifestsForValidation.size} mod manifests in the registry.`
       );
 

--- a/src/modding/modDependencyValidator.js
+++ b/src/modding/modDependencyValidator.js
@@ -123,7 +123,7 @@ class ModDependencyValidator {
     }
 
     // If no fatals, validation passed successfully
-    logger.info(
+    logger.debug(
       'ModDependencyValidator: All dependency and conflict checks passed.'
     );
   }

--- a/src/turns/services/humanPlayerPromptService.js
+++ b/src/turns/services/humanPlayerPromptService.js
@@ -650,7 +650,7 @@ class HumanPlayerPromptService extends IHumanPlayerPromptService {
           selectedAction
         );
       }
-      this.#logger.info(
+      this.#logger.debug(
         `PlayerPromptService._handlePlayerTurnSubmittedEvent: Valid actionId '${submittedActionId}' (Name: '${selectedAction.name || 'N/A'}') for prompt (actor ${localPromptContext.actorId}). Resolving.`
       );
       resolve({ action: selectedAction, speech: speech || null });
@@ -763,7 +763,7 @@ class HumanPlayerPromptService extends IHumanPlayerPromptService {
 
           // ── CHANGED LOGGING BEHAVIOUR ──────────────────────────────────────
           if (err instanceof DOMException && err.name === 'AbortError') {
-            this.#logger.info(
+            this.#logger.debug(
               `PlayerPromptService: Prompt for actor ${localPromptContext.actorId} aborted. ${err.message}`
             );
           } else {
@@ -797,7 +797,7 @@ class HumanPlayerPromptService extends IHumanPlayerPromptService {
 
       if (cancellationSignal) {
         const handleAbort = () => {
-          this.#logger.info(
+          this.#logger.debug(
             `PlayerPromptService.prompt: Abort signal received for actor ${localPromptContext.actorId}. Rejecting prompt.`
           );
           localPromptContext.reject(

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -117,7 +117,7 @@ export class AbstractTurnState extends ITurnState {
     }
 
     if (logger) {
-      logger.info(
+      logger.debug(
         `${this.getStateName()}: Entered. Actor: ${actorIdForLog}. Previous state: ${previousState?.getStateName() ?? 'None'}.`
       );
     } else {
@@ -158,7 +158,7 @@ export class AbstractTurnState extends ITurnState {
     }
 
     if (logger) {
-      logger.info(
+      logger.debug(
         `${this.getStateName()}: Exiting. Actor: ${actorIdForLog}. Transitioning to ${nextState?.getStateName() ?? 'None'}.`
       );
     } else {

--- a/src/turns/strategies/endTurnSuccessStrategy.js
+++ b/src/turns/strategies/endTurnSuccessStrategy.js
@@ -45,7 +45,7 @@ export default class EndTurnSuccessStrategy extends ITurnDirectiveStrategy {
       return;
     }
 
-    logger.info(
+    logger.debug(
       `${className}: Executing END_TURN_SUCCESS for actor ${contextActor.id}.`
     );
     turnContext.endTurn(null); // End turn via ITurnContext, null for success

--- a/tests/services/modDependencyValidator.test.js
+++ b/tests/services/modDependencyValidator.test.js
@@ -100,7 +100,7 @@ describe('ModDependencyValidator', () => {
       ModDependencyValidator.validate(manifests, mockLogger)
     ).not.toThrow();
     expect(mockLogger.warn).not.toHaveBeenCalled();
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('passed')
     );
   });
@@ -161,7 +161,7 @@ describe('ModDependencyValidator', () => {
         "Mod 'ModA' optional dependency 'MissingB' is not loaded."
       )
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('passed')
     );
   });
@@ -184,7 +184,7 @@ describe('ModDependencyValidator', () => {
         "Mod 'ModA' requires dependency 'ModB' version '>=2.0.0', but found version '1.5.0'. (Optional dependency mismatch)"
       )
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('passed')
     );
   });
@@ -207,7 +207,7 @@ describe('ModDependencyValidator', () => {
         /Mod 'ModA' dependency 'ModB' has an invalid version format: 'totally-invalid'\. Cannot check optional version requirement\./
       )
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('passed')
     );
   });

--- a/tests/turns/states/processingCommandState.enterState.test.js
+++ b/tests/turns/states/processingCommandState.enterState.test.js
@@ -283,7 +283,7 @@ describe('ProcessingCommandState', () => {
       await enterStatePromise;
 
       // Log from AbstractTurnState's enterState
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `ProcessingCommandState: Entered. Actor: ${actor.getId()}. Previous state: None.`
       );
       // Log from ProcessingCommandState's enterState (about actor and command)

--- a/tests/turns/states/turnIdleState.test.js
+++ b/tests/turns/states/turnIdleState.test.js
@@ -219,7 +219,7 @@ describe('TurnIdleState', () => {
       await turnIdleState.exitState(mockHandler, null);
 
       expect(mockContext.getLogger).toHaveBeenCalled(); // Logger from context should be used
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnIdleState: Exiting. Actor: ${testActor.id}. Transitioning to None.`
       );
     });

--- a/tests/turns/strategies/endTurnSuccessStrategy.test.js
+++ b/tests/turns/strategies/endTurnSuccessStrategy.test.js
@@ -84,7 +84,7 @@ describe('EndTurnSuccessStrategy', () => {
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       `EndTurnSuccessStrategy: Executing END_TURN_SUCCESS for actor ${mockActor.id}.`
     );
     expect(mockTurnContext.endTurn).toHaveBeenCalledWith(null);


### PR DESCRIPTION
Summary: 
- switched several high-volume info logs to debug in loaders and runtime classes
- adjusted tests to expect the new debug level

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint pass (fails expectedly) `npm run lint`
- [x] Root tests pass `npm test`
- [x] Proxy tests pass `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b3f37df48331a6e0a8f5e5eea4e6