### PR TITLE
[Agent] Downgrade InputSetupService log

### DIFF
--- a/src/setup/inputSetupService.js
+++ b/src/setup/inputSetupService.js
@@ -94,7 +94,7 @@ class InputSetupService {
       // Set the callback on the InputHandler instance
       inputHandler.setCommandCallback(processInputCommand);
 
-      this.#logger.info(
+      this.#logger.debug(
         'InputSetupService: InputHandler resolved and command callback configured to dispatch core:submit_command events.'
       );
     } catch (error) {

--- a/tests/setup/inputSetupService.test.js
+++ b/tests/setup/inputSetupService.test.js
@@ -141,13 +141,13 @@ describe('InputSetupService', () => {
     });
 
     // --- UPDATED: Check for the new log message ---
-    it('should call logger.info with the correct configuration message', () => {
+    it('should log debug with the correct configuration message', () => {
       service.configureInputHandler();
-      // Check the specific info message was logged
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      // Check the specific debug message was logged
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'InputSetupService: InputHandler resolved and command callback configured to dispatch core:submit_command events.'
       );
-      // Optionally, check the debug message still occurs
+      // Optionally, check the initial debug message still occurs
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'InputSetupService: Attempting to configure InputHandler...'
       );


### PR DESCRIPTION
Summary: Downgraded a non-critical info log in `InputSetupService` to debug and updated the corresponding test expectation.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint executed `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68452aab4bb0833197cd327429169636