### PR TITLE
[Agent] Downgrade per-mod world loader logs

### DIFF
--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -335,7 +335,7 @@ class WorldLoader {
         manifestsForValidation,
         this.#logger
       );
-      this.#logger.info(
+      this.#logger.debug(
         `WorldLoader: Final mod order resolved: [${this.#finalOrder.join(', ')}]`
       );
       this.#registry.store('meta', 'final_mod_order', this.#finalOrder);
@@ -540,7 +540,7 @@ class WorldLoader {
           .sort()
           .join(', ');
         const summaryMessage = `Mod '${modId}' loaded in ${modDurationMs.toFixed(2)}ms: ${typeCountsString.length > 0 ? typeCountsString : 'No items loaded'}${typeCountsString.length > 0 ? ' ' : ''}-> Overrides(${totalModOverrides}), Errors(${totalModErrors})`;
-        this.#logger.info(summaryMessage);
+        this.#logger.debug(summaryMessage);
         // --- End Per-Mod Summary Logging ---
 
         this.#logger.debug(

--- a/tests/loaders/worldLoader.timingLogs.integration.test.js
+++ b/tests/loaders/worldLoader.timingLogs.integration.test.js
@@ -241,11 +241,12 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
   });
 
   // ── Test Case: Verify Per-Mod Timing Logs ───────────────────────────────
-  it('should log per-mod performance timing information at INFO level', async () => {
+  it('should log per-mod performance timing information at DEBUG level', async () => {
     // --- Action ---
     await expect(worldLoader.loadWorld(worldName)).resolves.not.toThrow();
 
     // --- Assertions ---
+    const debugCalls = mockLogger.debug.mock.calls;
     const infoCalls = mockLogger.info.mock.calls;
 
     // Verify logs for each mod in the final order
@@ -256,7 +257,7 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
       ); // Regex to capture duration
 
       // Find the specific log message for this mod
-      const timingLogCall = infoCalls.find((call) =>
+      const timingLogCall = debugCalls.find((call) =>
         expectedLogRegex.test(call[0])
       );
 
@@ -283,7 +284,7 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
         }
       }
 
-      // 3. Assert log level is INFO (implicitly checked by searching mockLogger.info.mock.calls)
+      // 3. Assert log level is DEBUG (implicitly checked by searching mockLogger.debug.mock.calls)
       // If the log wasn't found in infoCalls, the expect(timingLogCall).toBeDefined() would fail.
     }
 


### PR DESCRIPTION
## Summary
- downgrade per-mod logs in WorldLoader from info to debug
- expect debug level in timingLogs integration test

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2007 problems)*
- `npm test`
- `cd llm-proxy-server && npm test`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68454ba57af88331b62520eacaeb9584