### PR TITLE
[Fix] Adjust log levels in storage provider

### DIFF
--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -82,7 +82,7 @@ export class BrowserStorageProvider extends IStorageProvider {
           }
         }
         this.#rootHandle = handle;
-        this.#logger.info(`Root directory selected: ${this.#rootHandle.name}`);
+        this.#logger.debug(`Root directory selected: ${this.#rootHandle.name}`);
         return this.#rootHandle;
       } catch (error) {
         if (error.name === 'AbortError') {
@@ -340,7 +340,7 @@ export class BrowserStorageProvider extends IStorageProvider {
       });
       const file = await fileHandle.getFile();
       const contents = await file.arrayBuffer();
-      this.#logger.info(
+      this.#logger.debug(
         `BrowserStorageProvider: Successfully read file ${filePath}, size: ${contents.byteLength} bytes.`
       );
       return new Uint8Array(contents);
@@ -394,7 +394,7 @@ export class BrowserStorageProvider extends IStorageProvider {
       }
 
       await directoryHandle.removeEntry(fileName);
-      this.#logger.info(
+      this.#logger.debug(
         `BrowserStorageProvider: Successfully deleted file ${normalizedFilePath}`
       );
       return { success: true };
@@ -428,7 +428,7 @@ export class BrowserStorageProvider extends IStorageProvider {
     );
     try {
       await this.#getRelativeFileHandle(filePath, { create: false });
-      this.#logger.info(
+      this.#logger.debug(
         `BrowserStorageProvider: File exists: ${filePath.replace(/^\/+|\/+$/g, '')}`
       );
       return true;
@@ -437,7 +437,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         error.name === 'NotFoundError' ||
         (error.message && error.message.toLowerCase().includes('not found'))
       ) {
-        this.#logger.info(
+        this.#logger.debug(
           `BrowserStorageProvider: File does not exist: ${filePath.replace(/^\/+|\/+$/g, '')}`
         );
         return false;
@@ -446,7 +446,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         error.message &&
         error.message.startsWith('Failed to obtain root directory handle')
       ) {
-        this.#logger.info(
+        this.#logger.debug(
           `BrowserStorageProvider: Cannot check file existence for ${filePath.replace(/^\/+|\/+$/g, '')} as root directory selection was not completed. Assuming false. Error: ${error.message}`
         );
         return false;


### PR DESCRIPTION
Summary: Downgraded several info-level messages to debug in BrowserStorageProvider as these logs are mainly useful for troubleshooting rather than regular runtime visibility.

Changes Made:
- Updated root directory selection, file read, delete, and existence checks to use `logger.debug` instead of `logger.info`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation



------
https://chatgpt.com/codex/tasks/task_e_68454f995544833184b0649283fd1594