### PR TITLE
[Agent] Downgrade noisy info logs to debug

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -341,7 +341,7 @@ class EntityManager extends IEntityManager {
         this.#commitEntity(entity, definitionId, actualInstanceId);
       }
 
-      this.#logger.info(
+      this.#logger.debug(
         `createEntityInstance: created '${actualInstanceId}' from '${definitionId}'.`
       );
       return entity;

--- a/src/llms/retryHttpClient.js
+++ b/src/llms/retryHttpClient.js
@@ -208,7 +208,7 @@ export class RetryHttpClient extends IHttpClient {
         const response = await fetch(url, options);
 
         if (response.ok) {
-          this.#logger.info(
+          this.#logger.debug(
             `RetryHttpClient.request: Success ${response.status} ${url}`
           );
           return await response.json();


### PR DESCRIPTION
Summary: 
- changed RetryHttpClient to log successful requests at debug instead of info
- changed EntityManager createEntityInstance success log to debug

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint (fails: numerous unrelated warnings/errors)
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68455189e86c8331ae28e849b1a54cb4