### PR TITLE
[Agent] Downgrade LlmConfigService logs

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -187,7 +187,7 @@ export class LlmConfigService {
         ? path.resolve(customPath)
         : this.#_defaultLlmConfigPath;
 
-    this.#logger.info(
+    this.#logger.debug(
       `LlmConfigService: Attempting to load LLM configurations from: ${this.#resolvedConfigPath}`
     );
 
@@ -305,7 +305,7 @@ export class LlmConfigService {
 
       const llmCount = Object.keys(this.#loadedLlmConfigs.configs).length; // Using 'configs'
       const defaultId = this.#loadedLlmConfigs.defaultConfigId || 'Not set'; // CORRECTED
-      this.#logger.info(
+      this.#logger.debug(
         `LlmConfigService: Initialization successful. Loaded ${llmCount} LLM configurations. Default LLM ID: ${defaultId}. Proxy is operational.`
       );
     } catch (unexpectedError) {


### PR DESCRIPTION
Summary: Downgraded two `logger.info` calls in LlmConfigService to `debug` level to reduce non-essential info logging.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684557dabde08331ba8ecc414cd9adf1