### PR TITLE
[Agent] Downgrade mod manifest loader logs

### DIFF
--- a/src/modding/modManifestLoader.js
+++ b/src/modding/modManifestLoader.js
@@ -237,9 +237,12 @@ class ModManifestLoader {
 
     /* ── 6. summary ───────────────────────────────────────────────── */
     this.#lastLoadedManifests = stored;
-    this.#logger.info(
-      `${fn}: finished – fetched ${settled.filter((s) => s.status === 'fulfilled').length}/` +
-        `${trimmedIds.length}, validated ${validated.length}, stored ${stored.size}.`
+    this.#logger.debug(
+      `${fn}: finished – fetched ${
+        settled.filter((s) => s.status === 'fulfilled').length
+      }/${
+        trimmedIds.length
+      }, validated ${validated.length}, stored ${stored.size}.`
     );
     return stored;
   }

--- a/tests/services/modManifestLoader.harness.test.js
+++ b/tests/services/modManifestLoader.harness.test.js
@@ -124,7 +124,7 @@ describe('ModManifestLoader — branch edges', () => {
     expect(result.size).toBe(0);
     expect(deps.registry.store).not.toHaveBeenCalled();
     // *** FIX: Removed colon from 'fetched: 0/2' ***
-    expect(deps.logger.info).toHaveBeenCalledWith(
+    expect(deps.logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('fetched 0/2')
     );
   });
@@ -206,7 +206,7 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
 
     // final summary reflects 2/3 fetched ok
     // *** FIX: Removed colon from 'fetched: 2/3' ***
-    expect(deps.logger.info).toHaveBeenCalledWith(
+    expect(deps.logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('fetched 2/3')
     );
   });

--- a/tests/services/modManifestLoader.test.js
+++ b/tests/services/modManifestLoader.test.js
@@ -125,7 +125,7 @@ describe('ModManifestLoader — branch edges', () => {
     expect(result.size).toBe(0);
     expect(deps.registry.store).not.toHaveBeenCalled();
     // *** FIX: Ensure the colon is removed here ***
-    expect(deps.logger.info).toHaveBeenCalledWith(
+    expect(deps.logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('fetched 0/2')
     );
   });
@@ -206,7 +206,7 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
     );
 
     // final summary reflects 2/3 fetched ok
-    expect(deps.logger.info).toHaveBeenCalledWith(
+    expect(deps.logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('fetched 2/3')
     );
   });


### PR DESCRIPTION
Summary: Downgraded the final summary message in `ModManifestLoader` from info to debug. Updated unit tests to expect the debug call instead of info.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 602 errors, 1413 warnings)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68455a1c8bf08331a39d8bdf85c164a3