### PR TITLE
[Agent] Downgrade info logs in PerceptionUpdateService

### DIFF
--- a/src/perception/perceptionUpdateService.js
+++ b/src/perception/perceptionUpdateService.js
@@ -214,7 +214,7 @@ class PerceptionUpdateService {
     // </editor-fold>
 
     try {
-      this.#logger.info(
+      this.#logger.debug(
         `PerceptionUpdateService: Processing event to add log entry in location '${locationId}'. Entry: ${entry.descriptionText}`
       );
 
@@ -238,7 +238,7 @@ class PerceptionUpdateService {
       );
 
       if (perceiverEntityIds.length === 0) {
-        this.#logger.info(
+        this.#logger.debug(
           `PerceptionUpdateService: No entities with '${PERCEPTION_LOG_COMPONENT_ID}' found in location '${locationId}'. No logs will be updated.`
         );
         return { success: true, logsUpdated: 0, warnings };
@@ -330,7 +330,7 @@ class PerceptionUpdateService {
         }
       }
 
-      this.#logger.info(
+      this.#logger.debug(
         `PerceptionUpdateService: Processed location ${locationId}. Logs updated for ${updatedCount} out of ${perceiverEntityIds.length} targeted entities. Warnings: ${warnings.length}`
       );
       return { success: true, logsUpdated: updatedCount, warnings };

--- a/tests/services/perceptionUpdateService.test.js
+++ b/tests/services/perceptionUpdateService.test.js
@@ -453,7 +453,7 @@ describe('PerceptionUpdateService', () => {
         expect(mockEntityManager.hasComponent).not.toHaveBeenCalled();
         expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();
         expect(mockEntityManager.addComponent).not.toHaveBeenCalled();
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           `PerceptionUpdateService: No entities with '${PERCEPTION_LOG_COMPONENT_ID}' found in location '${locationId}'. No logs will be updated.`
         );
       });
@@ -484,7 +484,7 @@ describe('PerceptionUpdateService', () => {
         );
         expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();
         expect(mockEntityManager.addComponent).not.toHaveBeenCalled();
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           `PerceptionUpdateService: No entities with '${PERCEPTION_LOG_COMPONENT_ID}' found in location '${locationId}'. No logs will be updated.`
         );
       });
@@ -633,7 +633,7 @@ describe('PerceptionUpdateService', () => {
             logEntries: [entry],
           }
         );
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.debug).toHaveBeenCalledWith(
           `PerceptionUpdateService: Processed location ${locationId}. Logs updated for 2 out of 2 targeted entities. Warnings: ${result.warnings.length}`
         );
       });


### PR DESCRIPTION
## Summary
- demote info logs to debug in PerceptionUpdateService
- update corresponding unit tests

## Testing
- `npm run format`
- `npm run lint` *(fails: 2011 problems)*
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456abd7c44833196a6fffe104733a8