### PR TITLE
[Agent] Downgrade mod load order resolution logging

### DIFF
--- a/src/modding/modLoadOrderResolver.js
+++ b/src/modding/modLoadOrderResolver.js
@@ -281,7 +281,7 @@ function resolveOrder(requestedIds, manifestsMap, logger) {
   }
 
   /* 7 – always log final order for diagnostics */
-  logger.info(
+  logger.debug(
     `modLoadOrderResolver: Resolved load order (${sorted.length} mods): ${sorted.join(' → ')}`
   );
 

--- a/tests/services/modLoadOrderResolver.test.js
+++ b/tests/services/modLoadOrderResolver.test.js
@@ -109,7 +109,7 @@ describe('modLoadOrderResolver – input validation', () => {
     const manifests = createEmptyManifestMap();
     const result = resolveOrder(requested, manifests, mockLogger);
     expect(result).toEqual([]);
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Resolved load order')
     );
   });


### PR DESCRIPTION
## Summary
- lower log level for final mod load order message
- update test expectation to match debug logging

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 598 errors, 1413 warnings)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68456c8111f08331a59098f06a0567fb