### PR TITLE
[Agent] Downgrade info log in ProcessingCommandState

### DIFF
--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -165,7 +165,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     // Logging `turnAction.resolvedParameters` here which is no longer expected from LLMResponseProcessor output.
     // This log will show `Params: {}` if turnAction.resolvedParameters is undefined.
     // The actual speech is in `turnAction.speech`.
-    logger.info(
+    logger.debug(
       `${this.getStateName()}: Actor ${actorId} processing action. ` +
         `ID: "${turnAction.actionDefinitionId}". ` +
         `Params: ${JSON.stringify(turnAction.resolvedParameters || {})}. ` + // This line shows resolvedParameters which should be undefined

--- a/tests/turns/states/processingCommandState.enterState.test.js
+++ b/tests/turns/states/processingCommandState.enterState.test.js
@@ -287,7 +287,7 @@ describe('ProcessingCommandState', () => {
         `ProcessingCommandState: Entered. Actor: ${actor.getId()}. Previous state: None.`
       );
       // Log from ProcessingCommandState's enterState (about actor and command)
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `ProcessingCommandState: Actor ${actor.getId()} processing action.`
         )


### PR DESCRIPTION
Summary:
- change ProcessingCommandState to log action processing at debug level
- update unit test expectations

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684579a0d9a483318fd4edcfa2b9a355