### PR TITLE
[Agent] downgrade log level for save success message

### DIFF
--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -677,7 +677,7 @@ export class SaveGameUI extends BaseModalRenderer {
         saveSucceeded = true;
         finalMessage = `Game saved as "${currentSaveName}".`;
         finalMessageType = 'success';
-        this.logger.info(
+        this.logger.debug(
           `${this._logPrefix} Game saved successfully: ${result.message || `Saved as "${currentSaveName}"`}`
         );
 


### PR DESCRIPTION
## Summary
- reduce verbosity of save success message in SaveGameUI

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457fbfdc348331a888db2e8a4327ca