### PR TITLE
[Agent] Downgrade TurnOrderService info logs to debug

### DIFF
--- a/src/turns/order/turnOrderService.js
+++ b/src/turns/order/turnOrderService.js
@@ -145,7 +145,7 @@ export class TurnOrderService extends ITurnOrderService {
    * @throws {Error} If entities array is invalid, strategy is unsupported, or initiative data is missing/invalid when required.
    */
   startNewRound(entities, strategy, initiativeData) {
-    this.#logger.info(
+    this.#logger.debug(
       `TurnOrderService: Starting new round with strategy "${strategy}".`
     );
     this.clearCurrentRound(); // Clear previous state first
@@ -202,7 +202,7 @@ export class TurnOrderService extends ITurnOrderService {
               this.#currentQueue.add(entity, initiativeScore);
             }
           }
-          this.#logger.info(
+          this.#logger.debug(
             `TurnOrderService: Populated InitiativePriorityQueue with ${entities.length} entities.`
           );
           break;
@@ -215,7 +215,7 @@ export class TurnOrderService extends ITurnOrderService {
           for (const entity of entities) {
             this.#currentQueue.add(entity); // Priority is ignored by SimpleRoundRobinQueue
           }
-          this.#logger.info(
+          this.#logger.debug(
             `TurnOrderService: Populated SimpleRoundRobinQueue with ${entities.length} entities.`
           );
           break;
@@ -237,7 +237,7 @@ export class TurnOrderService extends ITurnOrderService {
       throw error; // Re-throw the error after logging and cleanup
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `TurnOrderService: New round successfully started with ${this.#currentQueue.size()} active entities.`
     );
   }
@@ -262,7 +262,7 @@ export class TurnOrderService extends ITurnOrderService {
         `TurnOrderService: Advancing turn to entity "${nextEntity.id}".`
       );
     } else {
-      this.#logger.info(
+      this.#logger.debug(
         'TurnOrderService: getNextEntity returned null (queue is likely empty).'
       );
     }
@@ -320,7 +320,7 @@ export class TurnOrderService extends ITurnOrderService {
           `Internal error: Unknown current strategy "${this.#currentStrategy}"`
         );
       }
-      this.#logger.info(
+      this.#logger.debug(
         `TurnOrderService: Entity "${entity.id}" successfully added to the turn order.`
       );
     } catch (error) {
@@ -366,7 +366,7 @@ export class TurnOrderService extends ITurnOrderService {
       // Log success info if the entity was directly removed (non-null return)
       // OR if it's the initiative strategy (where null signifies processing for lazy removal).
       if (removedEntity !== null || this.#currentStrategy === 'initiative') {
-        this.#logger.info(
+        this.#logger.debug(
           `TurnOrderService: Entity "${entityId}" processed for removal (actual removal may be lazy depending on queue type).`
         );
       }

--- a/tests/turns/turnOrder/turnOrderService.addEntity.initiative.test.js
+++ b/tests/turns/turnOrder/turnOrderService.addEntity.initiative.test.js
@@ -115,6 +115,7 @@ describe('TurnOrderService', () => {
 
   afterEach(() => {
     // Optional: Verify no unexpected errors were logged during any test
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
@@ -138,12 +139,13 @@ describe('TurnOrderService', () => {
       );
 
       // 2. Logging
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${priority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled(); // No warnings for valid input
@@ -167,12 +169,13 @@ describe('TurnOrderService', () => {
       );
 
       // 2. Logging
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled(); // Explicit default is not a warning case
@@ -202,12 +205,13 @@ describe('TurnOrderService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `TurnOrderService.addEntity (initiative): Invalid initiative value "${invalidPriority}" provided for entity "${entityToAdd.id}". Defaulting to ${expectedPriority}.`
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
     });
@@ -236,12 +240,13 @@ describe('TurnOrderService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `TurnOrderService.addEntity (initiative): Invalid initiative value "${invalidPriority}" provided for entity "${entityToAdd.id}". Defaulting to ${expectedPriority}.`
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
     });
@@ -265,12 +270,13 @@ describe('TurnOrderService', () => {
       );
 
       // 2. Logging
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled(); // Undefined defaults gracefully, no warning needed
@@ -299,12 +305,13 @@ describe('TurnOrderService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `TurnOrderService.addEntity (initiative): Invalid initiative value "${invalidPriority}" provided for entity "${entityToAdd.id}". Defaulting to ${expectedPriority}.`
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
     });
@@ -332,12 +339,13 @@ describe('TurnOrderService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `TurnOrderService.addEntity (initiative): Invalid initiative value "${invalidPriority}" provided for entity "${entityToAdd.id}". Defaulting to ${expectedPriority}.`
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" with initiative ${expectedPriority} to the current round.`
       );
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
     });

--- a/tests/turns/turnOrder/turnOrderService.addEntity.roundRobin.test.js
+++ b/tests/turns/turnOrder/turnOrderService.addEntity.roundRobin.test.js
@@ -111,13 +111,19 @@ describe('TurnOrderService', () => {
       );
 
       // Assert: Logging
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
         `TurnOrderService: Adding entity "${entityToAdd.id}" to the end of the round-robin queue.`
       );
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
+        `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
+      );
 
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
 
@@ -154,7 +160,7 @@ describe('TurnOrderService', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: Adding entity "${entityToAdd.id}" to the end of the round-robin queue.`
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: Entity "${entityToAdd.id}" successfully added to the turn order.`
       );
     });

--- a/tests/turns/turnOrder/turnOrderService.getNextEntity.test.js
+++ b/tests/turns/turnOrder/turnOrderService.getNextEntity.test.js
@@ -188,11 +188,11 @@ describe('TurnOrderService', () => {
       if (mockInitiativeQueueInstance) {
         expect(mockInitiativeQueueInstance.getNext).not.toHaveBeenCalled();
       }
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: getNextEntity returned null (queue is likely empty).'
       );
-      expect(mockLogger.debug).not.toHaveBeenCalled(); // No debug log for advancing turn
+      // The advancing turn debug is not called
       expect(mockLogger.warn).not.toHaveBeenCalled();
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
@@ -222,11 +222,11 @@ describe('TurnOrderService', () => {
       if (mockSimpleQueueInstance) {
         expect(mockSimpleQueueInstance.getNext).not.toHaveBeenCalled();
       }
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: getNextEntity returned null (queue is likely empty).'
       );
-      expect(mockLogger.debug).not.toHaveBeenCalled(); // No debug log for advancing turn
+      // The advancing turn debug is not called
       expect(mockLogger.warn).not.toHaveBeenCalled();
       expect(mockLogger.error).not.toHaveBeenCalled();
     });

--- a/tests/turns/turnOrder/turnOrderService.removeEntity.test.js
+++ b/tests/turns/turnOrder/turnOrderService.removeEntity.test.js
@@ -109,15 +109,16 @@ describe('TurnOrderService', () => {
       );
 
       // 2. Logging
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
+        `TurnOrderService: Attempting to remove entity "${entityIdToRemove}" from the turn order.`
+      );
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityIdToRemove}" processed for removal (actual removal may be lazy depending on queue type).`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        `TurnOrderService: Attempting to remove entity "${entityIdToRemove}" from the turn order.`
-      );
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 
@@ -179,19 +180,21 @@ describe('TurnOrderService', () => {
       );
 
       // 2. Logging
-      // Info log IS expected, because the service logs the attempt
-      expect(mockLogger.info).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      // Debug log is expected for the removal processing
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        1,
+        `TurnOrderService: Attempting to remove entity "${entityIdToRemove}" from the turn order.`
+      );
+      expect(mockLogger.debug).toHaveBeenNthCalledWith(
+        2,
         `TurnOrderService: Entity "${entityIdToRemove}" processed for removal (actual removal may be lazy depending on queue type).`
       );
       // Warn log for "not found" is NOT expected, because null IS expected from initiative queue remove
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
         expect.stringContaining('not found in the current turn order queue')
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        `TurnOrderService: Attempting to remove entity "${entityIdToRemove}" from the turn order.`
-      );
+      // The two debug logs already asserted above
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 

--- a/tests/turns/turnOrder/turnOrderService.roundTransitions.test.js
+++ b/tests/turns/turnOrder/turnOrderService.roundTransitions.test.js
@@ -213,16 +213,12 @@ describe('TurnOrderService - Round Transitions', () => {
       expect(capturedMockRRQueue.toArray).not.toHaveBeenCalled();
 
       // 6. Logging (Focus on logs during the *second* startNewRound call + subsequent calls in Assert block)
-      // Check the specific INFO calls *after* the mocks were cleared
-      expect(mockLogger.info).toHaveBeenCalledTimes(3); // Start, Clear, Populate, Success
-      expect(mockLogger.info).toHaveBeenNthCalledWith(
-        1,
-        `TurnOrderService: Starting new round with strategy "${strategy2}".`
-      );
+      // No info logs expected after downgrading to debug
+      expect(mockLogger.info).not.toHaveBeenCalled();
 
       // Check the specific DEBUG calls *after* the mocks were cleared
       // Expected: Clear existing queue, Init new queue, Advance turn
-      expect(mockLogger.debug).toHaveBeenCalledTimes(4);
+      expect(mockLogger.debug).toHaveBeenCalledTimes(7);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: Cleared existing turn queue.'
       ); // Call 1 (from startNewRound -> clearCurrentRound)

--- a/tests/turns/turnOrder/turnOrderService.startNewRound.initiative.test.js
+++ b/tests/turns/turnOrder/turnOrderService.startNewRound.initiative.test.js
@@ -116,7 +116,7 @@ describe('TurnOrderService', () => {
         'TurnOrderService: Initialized InitiativePriorityQueue.'
       );
       // Check *specific* calls during startNewRound BEFORE triggering more logs
-      expect(mockLogger.debug).toHaveBeenCalledTimes(3); // <<< MOVED CHECK HERE
+      expect(mockLogger.debug).toHaveBeenCalledTimes(6); // Updated for debug downgrades (includes constructor log)
 
       // Other logs from startNewRound
       expect(mockLogger.warn).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ describe('TurnOrderService', () => {
         'TurnOrderService: Adding entity "c" with initiative 5 to the current round.'
       );
       // Total debug calls are now 2
-      expect(mockLogger.debug).toHaveBeenCalledTimes(4);
+      expect(mockLogger.debug).toHaveBeenCalledTimes(8);
     });
 
     // Test Case: Initiative with Missing/Invalid Individual Priority
@@ -182,7 +182,7 @@ describe('TurnOrderService', () => {
         'TurnOrderService: Initialized InitiativePriorityQueue.'
       );
       // Check *specific* calls during startNewRound BEFORE triggering more logs
-      expect(mockLogger.debug).toHaveBeenCalledTimes(3); // <<< MOVED CHECK HERE
+      expect(mockLogger.debug).toHaveBeenCalledTimes(6); // Updated for debug downgrades
 
       // Check other startNewRound logs
       expect(mockLogger.error).not.toHaveBeenCalled();
@@ -198,8 +198,8 @@ describe('TurnOrderService', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: Adding entity "e" with initiative 20 to the current round.'
       );
-      // Total debug calls are now 2
-      expect(mockLogger.debug).toHaveBeenCalledTimes(4);
+      // Total debug calls are now higher due to debug level changes
+      expect(mockLogger.debug).toHaveBeenCalledTimes(8);
     });
 
     // Test Case: Invalid/Missing initiativeData map (No changes needed here)
@@ -273,7 +273,7 @@ describe('TurnOrderService', () => {
       expect(InitiativePriorityQueue).toHaveBeenCalledTimes(1);
       expect(mockQueueInstances.length).toBe(1);
       expect(mockAddFn).toHaveBeenCalledTimes(firstEntities.length);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: New round successfully started with ${firstEntities.length} active entities.`
       ); // Check first round final log
 
@@ -329,7 +329,7 @@ describe('TurnOrderService', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: Initialized InitiativePriorityQueue.'
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(3);
+      expect(mockLogger.debug).toHaveBeenCalledTimes(6);
     });
   }); // End describe("startNewRound ('initiative')")
 }); // End describe('TurnOrderService')

--- a/tests/turns/turnOrder/turnOrderService.startNewRound.roundRobin.test.js
+++ b/tests/turns/turnOrder/turnOrderService.startNewRound.roundRobin.test.js
@@ -147,7 +147,7 @@ describe('TurnOrderService', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: Adding entity "${newEntity.id}" to the end of the round-robin queue.`
       ); // From addEntity
-      expect(mockLogger.debug).toHaveBeenCalledTimes(4); // init + add
+      expect(mockLogger.debug).toHaveBeenCalledTimes(8); // updated for debug downgrades
 
       expect(mockLogger.warn).not.toHaveBeenCalled();
       expect(mockLogger.error).not.toHaveBeenCalled();
@@ -167,7 +167,7 @@ describe('TurnOrderService', () => {
       // Verify initial state if needed (optional)
       expect(SimpleRoundRobinQueue).toHaveBeenCalledTimes(1);
       expect(mockAdd).toHaveBeenCalledTimes(firstEntities.length);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: New round successfully started with ${firstEntities.length} active entities.`
       );
       // Retrieve the first instance if needed for clarity, although we'll assert on shared mocks
@@ -229,7 +229,7 @@ describe('TurnOrderService', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: Initialized SimpleRoundRobinQueue.'
       );
-      expect(mockLogger.debug).toHaveBeenCalledTimes(3); // Both debug logs expected this time
+      expect(mockLogger.debug).toHaveBeenCalledTimes(6); // updated for debug downgrades
 
       // Check size mock calls specifically for the second phase
       expect(mockSize).toHaveBeenCalledTimes(1); // Only for the final log in the second startNewRound


### PR DESCRIPTION
Summary: Converted info-level logs in TurnOrderService to debug and updated related tests to reflect new log levels.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint executed `npm run lint` *(fails: existing repo issues)*
- [x] Root tests pass `npm test`
- [x] Proxy tests pass `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684584b62254833180a818d44ed716a8