### PR TITLE
[Agent] downgrade schema loader info logs

### DIFF
--- a/src/loaders/schemaLoader.js
+++ b/src/loaders/schemaLoader.js
@@ -157,7 +157,7 @@ class SchemaLoader {
       return; // Exit if no schemas are configured
     }
 
-    this.#logger.info(
+    this.#logger.debug(
       `SchemaLoader: Processing ${schemaFiles.length} schemas listed in configuration...`
     );
 
@@ -170,7 +170,7 @@ class SchemaLoader {
       const loadedSchemaCount = results.filter(
         (result) => result === true
       ).length;
-      this.#logger.info(
+      this.#logger.debug(
         `SchemaLoader: Schema processing complete. Added ${loadedSchemaCount} new schemas to the validator (others may have been skipped).`
       );
     } catch (error) {

--- a/tests/services/schemaLoader.success.test.js
+++ b/tests/services/schemaLoader.success.test.js
@@ -168,6 +168,7 @@ describe('SchemaLoader Success Case', () => {
     );
     // Clear constructor log call immediately AFTER instantiation
     mockLogger.info.mockClear();
+    mockLogger.debug.mockClear();
   });
 
   // --- The Test ---
@@ -215,13 +216,13 @@ describe('SchemaLoader Success Case', () => {
     }
 
     // Check logs
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       `SchemaLoader: Processing ${loadedCount} schemas listed in configuration...`
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       `SchemaLoader: Schema processing complete. Added ${loadedCount} new schemas to the validator (others may have been skipped).`
     );
-    expect(mockLogger.info).toHaveBeenCalledTimes(2); // Start and End info logs
+    expect(mockLogger.debug).toHaveBeenCalledTimes(2); // Start and End logs
     expect(mockLogger.warn).not.toHaveBeenCalled();
     expect(mockLogger.error).not.toHaveBeenCalled();
   });

--- a/tests/services/schemaLoader.test.js
+++ b/tests/services/schemaLoader.test.js
@@ -103,6 +103,7 @@ describe('SchemaLoader', () => {
     );
     // Clear constructor log call immediately AFTER instantiation
     mockLogger.info.mockClear();
+    mockLogger.debug.mockClear();
   });
 
   // --- Test Scenarios ---
@@ -191,7 +192,7 @@ describe('SchemaLoader', () => {
 
     // Check logs - *** UPDATED Assertions ***
     // Check the initial processing log
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       `SchemaLoader: Processing ${filesToLoad.length} schemas listed in configuration...`
     );
 
@@ -201,7 +202,7 @@ describe('SchemaLoader', () => {
     );
 
     // Check final success log message (only 1 *new* schema was added)
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Schema processing complete. Added 1 new schemas')
     );
     // Ensure only expected logs were called


### PR DESCRIPTION
## Summary
- downgrade verbose info logs in SchemaLoader to debug
- adjust related tests to expect debug-level logs

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error 'module' is not defined; jsdoc warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458c4540f48331b379e6806eeab671