### PR TITLE
[Agent] Downgrade log level in ConfigurableLLMAdapter

### DIFF
--- a/src/turns/adapters/configurableLLMAdapter.js
+++ b/src/turns/adapters/configurableLLMAdapter.js
@@ -413,7 +413,7 @@ export class ConfigurableLLMAdapter extends ILLMAdapter {
           this.#defaultConfigIdFromFile = this.#llmRootConfig.defaultConfigId;
           this.#allConfigsMap = this.#llmRootConfig.configs;
 
-          this.#logger.info(
+          this.#logger.debug(
             'ConfigurableLLMAdapter: LLM configurations loaded successfully.',
             {
               numberOfConfigs: Object.keys(this.#allConfigsMap).length,


### PR DESCRIPTION
Summary: Reduced noise by downgrading the 'LLM configurations loaded successfully' message to `debug` level instead of `info`.

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: existing issues)*
- [x] `npm test`
- [x] `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a256b94483319b48ba9af0f3b2cc