### PR TITLE
[Agent] Add AI processing events dispatch

### DIFF
--- a/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -14,7 +14,10 @@ import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  AI_TURN_PROCESSING_STARTED,
+} from '../../src/constants/eventIds.js';
 
 // --- Mock Dependencies ---
 const mockLogger = {
@@ -184,6 +187,10 @@ describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () =
       entityId: nextActor.id,
       entityType: entityType,
     });
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      AI_TURN_PROCESSING_STARTED,
+      { entityId: nextActor.id }
+    );
 
     // Verify resolver call
     expect(mockTurnHandlerResolver.resolveHandler).toHaveBeenCalledTimes(1);
@@ -318,6 +325,10 @@ describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () =
       entityId: nonActorEntity.id,
       entityType: entityType,
     });
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      AI_TURN_PROCESSING_STARTED,
+      { entityId: nonActorEntity.id }
+    );
 
     // Verify it proceeds to resolve handler
     expect(mockTurnHandlerResolver.resolveHandler).toHaveBeenCalledTimes(1);

--- a/tests/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/turns/turnManager.advanceTurn.roundStart.test.js
@@ -11,7 +11,10 @@ import {
 } from '@jest/globals';
 import TurnManager from '../../src/turns/turnManager.js';
 import { ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  AI_TURN_PROCESSING_STARTED,
+} from '../../src/constants/eventIds.js';
 
 // Mocks for dependencies
 const mockLogger = {
@@ -292,6 +295,10 @@ describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
       entityId: actor1.id,
       entityType: 'ai',
     }); // Assuming AI
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      AI_TURN_PROCESSING_STARTED,
+      { entityId: actor1.id }
+    );
     // It resolves the handler...
     expect(mockTurnHandlerResolver.resolveHandler).toHaveBeenCalledTimes(1);
     expect(mockTurnHandlerResolver.resolveHandler).toHaveBeenCalledWith(actor1);

--- a/tests/turns/turnManager.fixes.test.js
+++ b/tests/turns/turnManager.fixes.test.js
@@ -9,7 +9,10 @@ import {
   expect,
 } from '@jest/globals';
 import TurnManager from '../../src/turns/turnManager.js';
-import { TURN_ENDED_ID } from '../../src/constants/eventIds.js';
+import {
+  TURN_ENDED_ID,
+  AI_TURN_PROCESSING_ENDED,
+} from '../../src/constants/eventIds.js';
 import { ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
 
 // Mock Entity structure
@@ -174,6 +177,10 @@ describe('TurnManager', () => {
       await Promise.resolve(); // Flushes microtasks queue, including the Promise.resolve around destroy
 
       expect(mockResolvedHandler.destroy).toHaveBeenCalledTimes(1);
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        AI_TURN_PROCESSING_ENDED,
+        { entityId: 'actor1' }
+      );
     });
   });
 

--- a/tests/turns/turnManager.getCurrentActor.test.js
+++ b/tests/turns/turnManager.getCurrentActor.test.js
@@ -6,6 +6,7 @@ import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
+import { AI_TURN_PROCESSING_STARTED } from '../../src/constants/eventIds.js';
 import {
   afterEach,
   beforeEach,
@@ -218,6 +219,10 @@ describe('TurnManager', () => {
           entityType: entityType,
         }
       );
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        AI_TURN_PROCESSING_STARTED,
+        { entityId: mockActor.id }
+      );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `Resolving turn handler for entity ${mockActor.id}...`
       );
@@ -259,6 +264,10 @@ describe('TurnManager', () => {
           entityType: 'ai',
         }
       ); // Turn started event dispatched
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        AI_TURN_PROCESSING_STARTED,
+        { entityId: mockActor.id }
+      );
       expect(mockDispatcher.subscribe).toHaveBeenCalledTimes(1); // Subscribed during start
 
       // --- Clear mocks BEFORE calling stop() to isolate stop()'s effects ---


### PR DESCRIPTION
Summary: Implemented dispatching of AI turn processing start/end events in `TurnManager` and updated associated tests to reflect new behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(failed: missing dependency 'globals')*
- [ ] Root tests `npm test` *(failed: jest not found)*
- [ ] Proxy tests `cd llm-proxy-server && npm test` *(failed: jest not found)*
- [ ] Manual smoke run `npm run start` *(not executed)*


------
https://chatgpt.com/codex/tasks/task_e_6845bd99907083319265a6c4b7b23e3a