### PR TITLE
[Feat] Add action button animations

### DIFF
--- a/css/components/_actions-widget.css
+++ b/css/components/_actions-widget.css
@@ -21,6 +21,38 @@
   margin: var(--spacing-xs); /* Consistent small margin around each button */
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  #action-buttons.actions-fade-in {
+    animation: actionsFadeIn 250ms ease-out both;
+  }
+
+  #action-buttons.actions-fade-out {
+    animation: actionsFadeOut 250ms ease-in both;
+  }
+
+  @keyframes actionsFadeIn {
+    from {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes actionsFadeOut {
+    from {
+      opacity: 1;
+      transform: scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+  }
+}
+
 /* Note: Styles for specific button states within #action-buttons
    (e.g., #action-buttons button.selected, #action-buttons button.selected:hover)
    should remain in the main style.css or be moved to _buttons.css

--- a/src/domUI/actionButtonsRenderer.js
+++ b/src/domUI/actionButtonsRenderer.js
@@ -2,6 +2,7 @@
 
 import { BaseListDisplayComponent } from './baseListDisplayComponent.js';
 import { PLAYER_TURN_SUBMITTED_ID } from '../constants/eventIds.js';
+import { DomUtils } from '../utils/domUtils.js';
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
@@ -57,6 +58,9 @@ import { PLAYER_TURN_SUBMITTED_ID } from '../constants/eventIds.js';
  */
 export class ActionButtonsRenderer extends BaseListDisplayComponent {
   _EVENT_TYPE_SUBSCRIBED = 'core:update_available_actions';
+
+  static FADE_IN_CLASS = 'actions-fade-in';
+  static FADE_OUT_CLASS = 'actions-fade-out';
 
   /** @type {AvailableAction | null} */
   selectedAction = null;
@@ -319,6 +323,16 @@ export class ActionButtonsRenderer extends BaseListDisplayComponent {
   _onListRendered(actionsData, container) {
     if (this.#isDisposed) return;
 
+    if (container) {
+      container.classList.remove(ActionButtonsRenderer.FADE_OUT_CLASS);
+      container.classList.add(ActionButtonsRenderer.FADE_IN_CLASS);
+      const removeClass = () => {
+        container.classList.remove(ActionButtonsRenderer.FADE_IN_CLASS);
+        container.removeEventListener('animationend', removeClass);
+      };
+      container.addEventListener('animationend', removeClass, { once: true });
+    }
+
     const actualActionButtons = container.querySelectorAll(
       'button.action-button'
     );
@@ -501,6 +515,15 @@ export class ActionButtonsRenderer extends BaseListDisplayComponent {
           if (selectedButton) {
             selectedButton.classList.remove('selected');
           }
+          const container = this.elements.listContainerElement;
+          container.classList.remove(ActionButtonsRenderer.FADE_IN_CLASS);
+          container.classList.add(ActionButtonsRenderer.FADE_OUT_CLASS);
+          const cleanup = () => {
+            DomUtils.clearElement(container);
+            container.classList.remove(ActionButtonsRenderer.FADE_OUT_CLASS);
+            container.removeEventListener('animationend', cleanup);
+          };
+          container.addEventListener('animationend', cleanup, { once: true });
         }
       } else {
         this.logger.error(

--- a/tests/domUI/actionButtonsRenderer.confirmActionButton.test.js
+++ b/tests/domUI/actionButtonsRenderer.confirmActionButton.test.js
@@ -211,6 +211,7 @@ describe('ActionButtonsRenderer', () => {
     }
     jest.spyOn(actionButtonsContainer, 'appendChild');
     jest.spyOn(actionButtonsContainer, 'removeChild');
+    jest.spyOn(actionButtonsContainer.classList, 'add');
 
     const sendButtonOriginal = currentDocument.getElementById(
       'player-confirm-turn-button'
@@ -410,6 +411,10 @@ describe('ActionButtonsRenderer', () => {
           'actionButtonInstance or its classList.remove spy is not defined for assertion.'
         );
       }
+
+      expect(actionButtonsContainer.classList.add).toHaveBeenCalledWith(
+        'actions-fade-out'
+      );
     });
 
     it('should dispatch event with speech: null if speech input is empty', async () => {

--- a/tests/domUI/actionButtonsRenderer.eventHandling.test.js
+++ b/tests/domUI/actionButtonsRenderer.eventHandling.test.js
@@ -153,6 +153,26 @@ beforeEach(() => {
     nodeType: 1,
     children: [],
     firstChild: null,
+    classList: {
+      _classes: new Set(),
+      add: jest.fn(function (...cls) {
+        cls.forEach((c) => this._classes.add(c));
+      }),
+      remove: jest.fn(function (cls) {
+        this._classes.delete(cls);
+      }),
+      contains: jest.fn(function (cls) {
+        return this._classes.has(cls);
+      }),
+      _reset() {
+        this._classes.clear();
+        this.add.mockClear();
+        this.remove.mockClear();
+        this.contains.mockClear();
+      },
+    },
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
     appendChild: jest.fn(function (child) {
       this.children.push(child);
       this.firstChild = this.children[0];
@@ -213,6 +233,9 @@ beforeEach(() => {
       this.removeChild.mockClear();
       this.querySelector.mockClear();
       this.querySelectorAll.mockClear();
+      this.classList._reset();
+      this.addEventListener.mockClear();
+      this.removeEventListener.mockClear();
     },
   };
 
@@ -515,6 +538,7 @@ describe('ActionButtonsRenderer', () => {
       instance.selectedAction = null;
       instance._onListRendered(instance.availableActions, mockContainer); // Pass available actions and container
       expect(mockSendButton.disabled).toBe(true);
+      expect(mockContainer.classList.add).toHaveBeenCalledWith('actions-fade-in');
 
       mockLogger.info.mockClear(); // Clear for next part of the test
 
@@ -528,6 +552,7 @@ describe('ActionButtonsRenderer', () => {
 
       expect(mockSendButton.disabled).toBe(false);
       expect(mockActionButton.classList.add).toHaveBeenCalledWith('selected'); // Check if selected class is added
+      expect(mockContainer.classList.add).toHaveBeenCalledWith('actions-fade-in');
     });
   });
 


### PR DESCRIPTION
Summary: Action buttons now animate in and out to reduce confusion when turns change.

Changes Made:
- Added fade-in/out animations to actions widget CSS.
- ActionButtonsRenderer triggers fade-out on successful turn submission and fade-in when rendering actions.
- Updated related tests for new classes and added mocks.

Testing Done:
- [ ] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [ ] Root tests pass (`npm test`) *(fails: followSystem.integration.test.js flaky)*
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm test`) *(not run)*


------
https://chatgpt.com/codex/tasks/task_e_68471e18a6c08331813dd0a5b0bc3d7e