### PR TITLE
[Test] Expand messages utils coverage

### DIFF
--- a/tests/utils/messages.test.js
+++ b/tests/utils/messages.test.js
@@ -1,9 +1,20 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../../src/utils/entityUtils.js', () => ({
+  getEntityDisplayName: jest.fn(),
+}));
+
+import { getEntityDisplayName } from '../../src/utils/entityUtils.js';
 import {
   formatSpecifyItemMessage,
   formatNounPhraseNotFoundMessage,
   formatNothingOfKindMessage,
+  TARGET_MESSAGES,
 } from '../../src/utils/messages.js';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('messages utility formatters', () => {
   describe('formatSpecifyItemMessage', () => {
@@ -22,6 +33,12 @@ describe('messages utility formatters', () => {
     it('trims domain details', () => {
       expect(formatSpecifyItemMessage('equipped item', '  here ')).toBe(
         'You need to specify which equipped item here.'
+      );
+    });
+
+    it('ignores blank domain details', () => {
+      expect(formatSpecifyItemMessage('item', '   ')).toBe(
+        'You need to specify which item.'
       );
     });
   });
@@ -54,12 +71,71 @@ describe('messages utility formatters', () => {
         })
       ).toBe('You don\'t see any "potion" here.');
     });
+
+    it('handles undefined context gracefully', () => {
+      expect(formatNounPhraseNotFoundMessage('orb', undefined)).toBe(
+        'You don\'t have "orb" .'
+      );
+    });
   });
 
   describe('formatNothingOfKindMessage', () => {
     it('creates message with context', () => {
       expect(formatNothingOfKindMessage('in your inventory')).toBe(
         "You don't have anything like that in your inventory."
+      );
+    });
+
+    it('handles missing context', () => {
+      expect(formatNothingOfKindMessage()).toBe(
+        "You don't have anything like that ."
+      );
+    });
+  });
+
+  describe('TARGET_MESSAGES helpers', () => {
+    it('formats target not found message', () => {
+      expect(TARGET_MESSAGES.TARGET_NOT_FOUND_CONTEXT('door')).toBe(
+        "Could not find 'door' nearby to target."
+      );
+    });
+
+    it('builds ambiguous target list using getEntityDisplayName', () => {
+      getEntityDisplayName.mockImplementation((entity) => `Name-${entity.id}`);
+      const entities = [{ id: 'e1' }, { id: 'e2' }];
+      const result = TARGET_MESSAGES.TARGET_AMBIGUOUS_CONTEXT(
+        'use potion on',
+        'potion',
+        entities
+      );
+      expect(result).toBe(
+        "Which 'potion' did you want to use potion on? (Name-e1, Name-e2)"
+      );
+      expect(getEntityDisplayName).toHaveBeenCalledTimes(2);
+      expect(getEntityDisplayName).toHaveBeenNthCalledWith(
+        1,
+        entities[0],
+        'e1'
+      );
+      expect(getEntityDisplayName).toHaveBeenNthCalledWith(
+        2,
+        entities[1],
+        'e2'
+      );
+    });
+
+    it('lists direction options or fallback', () => {
+      expect(
+        TARGET_MESSAGES.AMBIGUOUS_DIRECTION('west', [
+          'West Gate',
+          'Western Arch',
+        ])
+      ).toBe(
+        "There are multiple ways to go 'west'. Which one did you mean: West Gate, Western Arch?"
+      );
+
+      expect(TARGET_MESSAGES.AMBIGUOUS_DIRECTION('north', [])).toBe(
+        "There are multiple ways to go 'north'. Which one did you mean: unspecified options?"
       );
     });
   });


### PR DESCRIPTION
Summary: Added comprehensive tests for `messages.js` covering edge cases and TARGET_MESSAGES helper functions. This improves function and branch coverage for the utilities.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and llm-proxy-server)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [x] Manual smoke test / User validation (`npm run start` briefly)


------
https://chatgpt.com/codex/tasks/task_e_68473177990c8331a56d6bc9bec1c5d0