### PR TITLE
[Agent] Improve coverage for bootstrap flow

### DIFF
--- a/tests/main/main.bootstrapFlow.test.js
+++ b/tests/main/main.bootstrapFlow.test.js
@@ -1,0 +1,119 @@
+import { jest, describe, it, afterEach, expect } from '@jest/globals';
+
+const mockEnsure = jest.fn();
+const mockSetupDI = jest.fn();
+const mockResolveCore = jest.fn();
+const mockInitEngine = jest.fn();
+const mockInitAux = jest.fn();
+const mockMenu = jest.fn();
+const mockGlobal = jest.fn();
+const mockStartGame = jest.fn();
+const mockDisplayFatal = jest.fn();
+
+jest.mock('../../src/bootstrapper/stages.js', () => ({
+  __esModule: true,
+  ensureCriticalDOMElementsStage: (...args) => mockEnsure(...args),
+  setupDIContainerStage: (...args) => mockSetupDI(...args),
+  resolveCoreServicesStage: (...args) => mockResolveCore(...args),
+  initializeGameEngineStage: (...args) => mockInitEngine(...args),
+  initializeAuxiliaryServicesStage: (...args) => mockInitAux(...args),
+  setupMenuButtonListenersStage: (...args) => mockMenu(...args),
+  setupGlobalEventListenersStage: (...args) => mockGlobal(...args),
+  startGameStage: (...args) => mockStartGame(...args),
+}));
+
+jest.mock('../../src/bootstrapper/errorUtils.js', () => ({
+  __esModule: true,
+  displayFatalStartupError: (...args) => mockDisplayFatal(...args),
+}));
+
+jest.mock('../../src/dependencyInjection/containerConfig.js', () => ({
+  __esModule: true,
+  configureContainer: jest.fn(),
+}));
+
+describe('main.js bootstrap extended coverage', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('executes all bootstrap stages successfully', async () => {
+    document.body.innerHTML = `
+      <div id="outputDiv"></div>
+      <div id="error-output"></div>
+      <input id="speech-input" />
+      <h1>Title</h1>
+    `;
+    const uiElements = {
+      outputDiv: document.querySelector('#outputDiv'),
+      errorDiv: document.querySelector('#error-output'),
+      inputElement: document.querySelector('#speech-input'),
+      titleElement: document.querySelector('h1'),
+      document,
+    };
+    const logger = { info: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    mockEnsure.mockResolvedValue(uiElements);
+    mockSetupDI.mockResolvedValue({});
+    mockResolveCore.mockResolvedValue({ logger });
+    mockInitEngine.mockResolvedValue({});
+    mockInitAux.mockResolvedValue();
+    mockMenu.mockResolvedValue();
+    mockGlobal.mockResolvedValue();
+    mockStartGame.mockResolvedValue();
+
+    await import('../../main.js');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockEnsure).toHaveBeenCalledTimes(1);
+    expect(mockSetupDI).toHaveBeenCalledTimes(1);
+    expect(mockResolveCore).toHaveBeenCalledTimes(1);
+    expect(mockInitEngine).toHaveBeenCalledTimes(1);
+    expect(mockInitAux).toHaveBeenCalledTimes(1);
+    expect(mockMenu).toHaveBeenCalledTimes(1);
+    expect(mockGlobal).toHaveBeenCalledTimes(1);
+    expect(mockStartGame).toHaveBeenCalledTimes(1);
+
+    const order = [
+      mockEnsure,
+      mockSetupDI,
+      mockResolveCore,
+      mockInitEngine,
+      mockInitAux,
+      mockMenu,
+      mockGlobal,
+      mockStartGame,
+    ].map((fn) => fn.mock.invocationCallOrder[0]);
+
+    const sorted = [...order].sort((a, b) => a - b);
+    expect(order).toEqual(sorted);
+  });
+
+  it('displays fatal error when game engine fails to initialize', async () => {
+    document.body.innerHTML = `<div id="outputDiv"></div>`;
+    const uiElements = {
+      outputDiv: document.querySelector('#outputDiv'),
+      errorDiv: null,
+      inputElement: null,
+      titleElement: null,
+      document,
+    };
+    const logger = { info: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    mockEnsure.mockResolvedValue(uiElements);
+    mockSetupDI.mockResolvedValue({});
+    mockResolveCore.mockResolvedValue({ logger });
+    mockInitEngine.mockResolvedValue(null);
+
+    await import('../../main.js');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockStartGame).not.toHaveBeenCalled();
+    expect(mockDisplayFatal).toHaveBeenCalledTimes(1);
+    const [elements, details] = mockDisplayFatal.mock.calls[0];
+    expect(elements.outputDiv).toBe(uiElements.outputDiv);
+    expect(details.phase).toContain('Start Game');
+  });
+});


### PR DESCRIPTION
Summary: Add new tests for `main.js` to cover full bootstrap sequence and failure when game engine initialization returns null.

Changes Made:
- Added `tests/main/main.bootstrapFlow.test.js` covering success path through all stages and error handling when the game engine fails to initialize.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm test -- --coverage=false`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test -- --coverage=false`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6848713a44c883319f0ba97dde091d58