### PR TITLE
[Test] Expand formatActionCommand coverage

### DIFF
--- a/tests/actions/actionFormatter.additional.test.js
+++ b/tests/actions/actionFormatter.additional.test.js
@@ -1,0 +1,87 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import { formatActionCommand } from '../../src/actions/actionFormatter.js';
+
+jest.mock('../../src/utils/entityUtils.js', () => ({
+  getEntityDisplayName: jest.fn(),
+}));
+
+const createMockLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('formatActionCommand additional cases', () => {
+  let entityManager;
+  let logger;
+
+  beforeEach(() => {
+    entityManager = { getEntityInstance: jest.fn() };
+    logger = createMockLogger();
+    jest.clearAllMocks();
+  });
+
+  it('returns null when entity context lacks entityId', () => {
+    const actionDef = { id: 'core:use', template: 'use {target}' };
+    const context = { type: 'entity' };
+
+    const result = formatActionCommand(actionDef, context, entityManager, {
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('entityId is missing')
+    );
+  });
+
+  it('returns null when direction context lacks direction', () => {
+    const actionDef = { id: 'core:move', template: 'move {direction}' };
+    const context = { type: 'direction' };
+
+    const result = formatActionCommand(actionDef, context, entityManager, {
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('direction string is missing')
+    );
+  });
+
+  it('warns when none domain template contains placeholders', () => {
+    const actionDef = {
+      id: 'core:wait',
+      template: 'wait {target} {direction}',
+    };
+    const context = { type: 'none' };
+
+    const result = formatActionCommand(actionDef, context, entityManager, {
+      logger,
+    });
+
+    expect(result).toBe('wait {target} {direction}');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('contains placeholders')
+    );
+  });
+
+  it('returns null and logs error if placeholder substitution throws', () => {
+    const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
+    const context = { type: 'entity', entityId: 'e1' };
+    entityManager.getEntityInstance.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const result = formatActionCommand(actionDef, context, entityManager, {
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('placeholder substitution'),
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add additional test cases for `formatActionCommand`

## Testing Done
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849b1a6bd38833181e6cfa14904d95d