### PR TITLE
[Agent] fix resolvePath empty segment bug

### DIFF
--- a/src/utils/resolvePath.js
+++ b/src/utils/resolvePath.js
@@ -14,8 +14,13 @@ export default function resolvePath(root, dotPath) {
 
   if (root === null || root === undefined) return undefined; // early null/undefined bail-out
 
+  const segments = dotPath.trim().split('.');
+  if (segments.some((seg) => seg === '')) {
+    return undefined;
+  }
+
   let current = root;
-  for (const segment of dotPath.trim().split('.').filter(Boolean)) {
+  for (const segment of segments) {
     if (current === null || current === undefined) return undefined; // any null/undefined hop → undefined
     current = current[segment];
   }

--- a/tests/integration/aiDecisionMetadata.test.js
+++ b/tests/integration/aiDecisionMetadata.test.js
@@ -14,7 +14,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
 // --- System Under Test imports ---------------------------------------------
 // ⚠️ PATH‑TO – please fix to real locations in your project
-import { LLMChooser } from '../../src/turns/adapters/LLMChooser.js';
+import { LLMChooser } from '../../src/turns/adapters/llmChooser.js';
 import { AIDecisionOrchestrator } from '../../src/turns/orchestration/aiDecisionOrchestrator.js';
 
 // ---------------------------------------------------------------------------

--- a/tests/utils/resolvePath.test.js
+++ b/tests/utils/resolvePath.test.js
@@ -81,6 +81,17 @@ describe('utils/resolvePath', () => {
   });
 
   /* -------------------------------------------------
+   *  Dot path with empty segments
+   * ------------------------------------------------- */
+  describe('invalid path segments', () => {
+    const obj = { a: { b: 1 } };
+
+    it.each(['.a', 'a.', 'a..b', 'a..'])('returns undefined for %p', (path) => {
+      expect(resolvePath(obj, path)).toBeUndefined();
+    });
+  });
+
+  /* -------------------------------------------------
    *  Invalid dotPath parameter
    * ------------------------------------------------- */
   describe('bad path param', () => {


### PR DESCRIPTION
Summary: fix resolvePath to return undefined for paths with empty segments and update tests. also corrected import path in aiDecisionMetadata test.

Testing Done:
- [x] Code formatted     `npx prettier -w src/utils/resolvePath.js tests/utils/resolvePath.test.js tests/integration/aiDecisionMetadata.test.js`
- [ ] Lint passes        `npm run lint` *(fails: TypeError from eslint config)*
- [x] Root tests         `npm test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684c5318087083319865e025332438a3