### PR TITLE
[Fix] prevent prototype access in objectUtils

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -61,11 +61,11 @@ export const getObjectPropertyByPath = (obj, propertyPath) => {
       return undefined;
     }
 
-    // Check if the property exists on the current object/array
-    // Using `Object.prototype.hasOwnProperty.call` is safer for objects,
-    // but `part in current` works for both own properties and array indices.
-    // `current[part]` handles both object properties and array indices naturally.
-    if (part in current) {
+    // Check if the property exists directly on the current object/array.
+    // Using `hasOwnProperty` avoids traversing the prototype chain, which could
+    // expose built-in properties like `toString` when they are not explicitly
+    // defined on the object.
+    if (Object.prototype.hasOwnProperty.call(current, part)) {
       current = current[part];
       // If the value found is undefined, and it's not the last part of the path,
       // we cannot continue traversal.

--- a/tests/utils/objectUtils.test.js
+++ b/tests/utils/objectUtils.test.js
@@ -187,4 +187,15 @@ describe('getObjectPropertyByPath', () => {
     expect(getObjectPropertyByPath(testObj, 'a.length')).toBeUndefined(); // a is 1
     expect(getObjectPropertyByPath(testObj, 'b.c.length')).toBeUndefined(); // b.c is 'hello'
   });
+
+  it('should not access properties from the prototype chain', () => {
+    const obj = {};
+    // 'toString' exists on Object.prototype; should return undefined
+    expect(getObjectPropertyByPath(obj, 'toString')).toBeUndefined();
+    // Nested case: first part exists, second part is prototype property
+    const nested = { inner: {} };
+    expect(
+      getObjectPropertyByPath(nested, 'inner.hasOwnProperty')
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Summary: Improve `getObjectPropertyByPath` so it doesn't traverse the prototype chain. This avoids returning built‑in methods like `toString`. Added tests to verify the behavior.

Changes Made:
- use `Object.prototype.hasOwnProperty` when walking object paths
- added regression tests ensuring prototype properties are not exposed

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` failed due to environment)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684c6492c9e08331841152efd8a805aa