### PR TITLE
[Agent] fix retry error body reading

### DIFF
--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -76,14 +76,15 @@ export async function Workspace_retry(
         let errorBodyText = `Status: ${response.status}, StatusText: ${response.statusText}`;
         let parsedErrorBody = null;
         try {
-          parsedErrorBody = await response.json();
-          errorBodyText = JSON.stringify(parsedErrorBody); // [cite: 1]
-        } catch (e) {
+          const bodyText = await response.clone().text();
           try {
-            errorBodyText = await response.text(); // [cite: 1]
-          } catch (e_text) {
-            // If reading as text also fails, stick with the status text [cite: 1]
+            parsedErrorBody = JSON.parse(bodyText);
+            errorBodyText = JSON.stringify(parsedErrorBody); // [cite: 1]
+          } catch (parseErr) {
+            errorBodyText = bodyText;
           }
+        } catch (readErr) {
+          // If reading fails, keep the default status text
         }
 
         const isRetryableStatusCode = RETRYABLE_HTTP_STATUS_CODES.includes(


### PR DESCRIPTION
## Summary
- ensure `Workspace_retry` reads error body via `response.clone()`
- update retry utility tests with clone-aware mocks

## Testing Done
- `npm run format`
- `npm run lint` *(fails: TypeError: Cannot set properties of undefined (setting 'defaultMeta'))*
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c66ab3c008331b4b0e33a2319eef9