### PR TITLE
[Agent] fix broken imports

### DIFF
--- a/src/interfaces/IPromptCoordinator.js
+++ b/src/interfaces/IPromptCoordinator.js
@@ -1,0 +1,22 @@
+// src/interfaces/IPromptCoordinator.js
+
+/** @typedef {import('../entities/entity.js').default} Entity */
+
+/**
+ * @interface IPromptCoordinator
+ * @description Coordinates prompting a player for their action.
+ */
+export class IPromptCoordinator {
+  /**
+   * Prompts the player for an action.
+   * @param {Entity} actor - The actor being prompted.
+   * @param {object} [options]
+   * @param {AbortSignal} [options.cancellationSignal] - Signal to cancel the prompt.
+   * @returns {Promise<any>} Resolves with prompt data.
+   */
+  async prompt(actor, options) {
+    throw new Error('IPromptCoordinator.prompt not implemented.');
+  }
+}
+
+export default IPromptCoordinator;

--- a/src/interfaces/manifestItems.js
+++ b/src/interfaces/manifestItems.js
@@ -1,0 +1,14 @@
+// src/interfaces/manifestItems.js
+
+/**
+ * @typedef {object} ModManifest
+ * @property {string} id
+ * @property {string} version
+ */
+
+/**
+ * @typedef {object} ComponentDefinition
+ * Generic structure for a component definition object.
+ */
+
+export {};

--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -13,7 +13,7 @@
 /** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/manifestItems.js').ModManifest} ModManifest */ // Assuming ModManifest type is defined here or imported
-/** @typedef {import('../interfaces/validation.js').ValidationResult} ValidationResult */
+/** @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult */
 
 // --- Base Class Import ---
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js'; // Correct path assumed based on sibling loaders

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -8,7 +8,7 @@
  * @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../interfaces/manifestItems.js').ModManifest} ModManifest
- * @typedef {import('../interfaces/validation.js').ValidationResult} ValidationResult
+ * @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult
  */
 // --- Add LoadItemsResult typedef here for clarity ---
 /**

--- a/src/prompting/interfaces/IAIPromptPipeline.js
+++ b/src/prompting/interfaces/IAIPromptPipeline.js
@@ -3,7 +3,7 @@
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
-/** @typedef {import('../dtos/actionComposite.js').ActionComposite} ActionComposite */
+/** @typedef {import('../turns/dtos/actionComposite.js').ActionComposite} ActionComposite */
 
 export class IAIPromptPipeline {
   /**

--- a/src/turns/dtos/AIGameStateDTO.js
+++ b/src/turns/dtos/AIGameStateDTO.js
@@ -82,9 +82,6 @@
  */
 
 /**
- * @typedef {import('./AIActorPromptDataDTO.js').ActorPromptDataDTO} ActorPromptDataDTO // Assuming path - Note: ActorPromptDataDTO is defined below in this file.
- */
-/**
  * Purpose: The top-level DTO that aggregates all other AI-relevant state information.
  * This is the primary object passed to the prompt formatter.
  *

--- a/src/turns/factories/concreteTurnContextFactory.js
+++ b/src/turns/factories/concreteTurnContextFactory.js
@@ -11,7 +11,7 @@ import { TurnContext } from '../context/turnContext.js';
  * @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy
  * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
- * @typedef {import('../../game/GameWorld.js').GameWorld} IWorldContext
+ * @typedef {import('../../interfaces/IWorldContext.js').IWorldContext} IWorldContext
  * @typedef {import('../ports/ITurnEndPort.js').ITurnEndPort} ITurnEndPort
  * @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor
  * @typedef {import('../../commands/interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreter

--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -17,7 +17,7 @@ import { HumanPlayerStrategy } from '../strategies/humanPlayerStrategy.js'; // A
 /** @typedef {import('../context/turnContext.js').TurnContextServices} TurnContextServices */
 /** @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy */
 /** @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState */
-/** @typedef {import('../interfaces/factories/ITurnStateFactory.js').ITurnStateFactory} ITurnStateFactory */
+/** @typedef {import('../interfaces/ITurnStateFactory.js').ITurnStateFactory} ITurnStateFactory */
 
 class HumanTurnHandler extends BaseTurnHandler {
   /** @type {ICommandProcessor} */

--- a/src/turns/order/queues/simpleRoundRobinQueue.js
+++ b/src/turns/order/queues/simpleRoundRobinQueue.js
@@ -8,7 +8,7 @@
 
 import { ITurnOrderQueue } from '../../interfaces/ITurnOrderQueue.js';
 // Use the Entity type defined in the interface file for consistency.
-/** @typedef {import('../ITurnOrderQueue.js').Entity} Entity */
+/** @typedef {import('../../interfaces/ITurnOrderQueue.js').Entity} Entity */
 
 /**
  * @class SimpleRoundRobinQueue

--- a/src/types/eventTypes.js
+++ b/src/types/eventTypes.js
@@ -1,0 +1,8 @@
+// src/types/eventTypes.js
+
+/**
+ * @typedef {Object.<string, any>} SystemEventPayloads
+ * @description Map of event IDs to their payload shapes.
+ */
+
+export {};

--- a/src/types/promptData.js
+++ b/src/types/promptData.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 
 /**
- * @typedef {import('../dtos/AIGameStateDTO.js').AIGameStateDTO} AIGameStateDTO // Assuming perceptionLogArray might be directly from DTO or processed
+ * @typedef {import('../turns/dtos/AIGameStateDTO.js').AIGameStateDTO} AIGameStateDTO // Assuming perceptionLogArray might be directly from DTO or processed
  */
 
 /**

--- a/src/utils/conditionContextUtils.js
+++ b/src/utils/conditionContextUtils.js
@@ -7,10 +7,9 @@ import { getObjectPropertyByPath } from './objectUtils.js';
 // and accessible via these paths in a real project. Adjust paths as needed.
 
 /**
- * @typedef {import('../services/conditionEvaluationService.js').ConditionDataAccess} ConditionDataAccess
- * Interface or class providing methods to access game data during condition evaluation,
- * specifically `getComponentClassByKey`.
- * Should have at least: { getComponentClassByKey: (key: string) => typeof Component | undefined }
+ * @typedef {object} ConditionDataAccess
+ * Interface providing methods to access game data during condition evaluation.
+ * @property {(key: string) => (typeof Component | undefined)} getComponentClassByKey
  */
 
 /**
@@ -20,12 +19,12 @@ import { getObjectPropertyByPath } from './objectUtils.js';
  */
 
 /**
- * @typedef {import('../components/connectionsComponent.js').Connection} Connection
- * Represents a connection object, likely used as context in some conditions.
+ * @typedef {object} Connection
+ * Represents a connection object used as context in some conditions.
  */
 
 /**
- * @typedef {import('../components/component.js').default} Component
+ * @typedef {object} Component
  * The base class for all components.
  */
 

--- a/tests/utils/apiUtils.retry.test.js
+++ b/tests/utils/apiUtils.retry.test.js
@@ -3,7 +3,13 @@ import { Workspace_retry } from '../../src/utils/apiUtils.js';
 
 jest.useFakeTimers();
 
-const mockResponse = (status, body, ok = false, headersObj = {}, withClone = false) => {
+const mockResponse = (
+  status,
+  body,
+  ok = false,
+  headersObj = {},
+  withClone = false
+) => {
   const headers = { get: (h) => headersObj[h] };
   const resp = {
     ok,
@@ -15,7 +21,9 @@ const mockResponse = (status, body, ok = false, headersObj = {}, withClone = fal
   };
   if (withClone) {
     const textValue = typeof body === 'string' ? body : JSON.stringify(body);
-    resp.clone = jest.fn(() => ({ text: jest.fn().mockResolvedValue(textValue) }));
+    resp.clone = jest.fn(() => ({
+      text: jest.fn().mockResolvedValue(textValue),
+    }));
   }
   return resp;
 };


### PR DESCRIPTION
Summary: fix invalid JSDoc import paths reported by dependency-cruiser by creating missing interface stubs and correcting paths.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: Cannot set properties of undefined (setting 'defaultMeta'))*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start` *(not executed)*

------
https://chatgpt.com/codex/tasks/task_e_684c6a1ac6d08331bd54f673886db247