### PR TITLE
[Agent] fix dependency-cruiser warnings

### DIFF
--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -4,7 +4,7 @@
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('../interfaces/IWorldContext.js').default} IWorldContext */
 /** @typedef {import('../data/gameDataRepository.js').default} GameDataRepository */
-/** @typedef {import('../services/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
 /** @typedef {import('../../data/schemas/entity.schema.json').EntityDefinition} EntityDefinition */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/coreServices.js').ISpatialIndexManager} ISpatialIndexManager */

--- a/src/interfaces/CommonTypes.js
+++ b/src/interfaces/CommonTypes.js
@@ -1,0 +1,11 @@
+// src/interfaces/CommonTypes.js
+
+/**
+ * @typedef {string} NamespacedId
+ * @description A unique identifier string namespaced with a colon, e.g. `core:player`.
+ */
+
+/**
+ * @typedef {string | null} NullableNamespacedId
+ * @description A namespaced identifier or `null`.
+ */

--- a/src/interfaces/IGamePersistenceService.js
+++ b/src/interfaces/IGamePersistenceService.js
@@ -6,8 +6,8 @@
  */
 
 // --- JSDoc Type Imports ---
-/** @typedef {import('../../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
-/** @typedef {import('../../interfaces/ISaveLoadService.js').SaveResult} SaveResult */ // For return type clarity
+/** @typedef {import('./ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
+/** @typedef {import('./ISaveLoadService.js').SaveResult} SaveResult */ // For return type clarity
 
 // --- Interface Specific Types ---
 

--- a/src/interfaces/IReferenceResolver.js
+++ b/src/interfaces/IReferenceResolver.js
@@ -1,0 +1,23 @@
+// src/interfaces/IReferenceResolver.js
+
+/**
+ * @interface IReferenceResolver
+ * @description Contract for services that resolve definition identifiers to
+ * instance identifiers within component data.
+ */
+export class IReferenceResolver {
+  /**
+   * Resolves references in component data according to a provided specification.
+   *
+   * @param {object} componentDataInstance - The component data being processed.
+   * @param {object} spec - The resolution specification.
+   * @param {string} entityId - Identifier of the entity being processed.
+   * @param {string} componentTypeId - Identifier of the component type.
+   * @returns {{resolvedValue: any, valueChanged: boolean}}
+   * An object describing the resolved value and whether any change occurred.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  resolve(componentDataInstance, spec, entityId, componentTypeId) {
+    throw new Error('IReferenceResolver.resolve not implemented');
+  }
+}

--- a/src/interfaces/coreServices.js
+++ b/src/interfaces/coreServices.js
@@ -132,7 +132,7 @@
  */
 
 // --- Spatial Indexing ---
-/** @typedef {import('../../entities/entityManager.js').default} EntityManager */ // Adjusted path assuming coreServices.js is in src/interfaces/
+/** @typedef {import('../entities/entityManager.js').default} EntityManager */
 
 /**
  * Interface for managing a spatial index of entities based on their location.

--- a/src/llms/LLMStrategyFactory.js
+++ b/src/llms/LLMStrategyFactory.js
@@ -13,7 +13,7 @@ import { OpenRouterToolCallingStrategy } from './strategies/openRouterToolCallin
 // DefaultPromptEngineeringStrategy import removed
 
 /**
- * @typedef {import('../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfigType
+ * @typedef {import('./services/llmConfigLoader.js').LLMModelConfig} LLMModelConfigType
  */
 
 const strategyMappings = {

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -6,7 +6,7 @@ import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
  * @typedef {import('./services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
- * @typedef {import('./interfaces/ILogger.js').ILogger} ILogger
+ * @typedef {import('../interfaces/ILogger.js').ILogger} ILogger
  */
 
 /**

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -11,7 +11,7 @@ import {
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
  * @typedef {import('./services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
- * @typedef {import('./interfaces/ILogger.js').ILogger} ILogger
+ * @typedef {import('../interfaces/ILogger.js').ILogger} ILogger
  */
 
 export class ServerApiKeyProvider extends IApiKeyProvider {

--- a/src/llms/services/llmConfigLoader.js
+++ b/src/llms/services/llmConfigLoader.js
@@ -14,11 +14,11 @@ import { performSemanticValidations } from '../../validation/llmConfigSemanticVa
  */
 
 /**
- * @typedef {import('../interfaces/coreServices.js').ISchemaValidator} ISchemaValidator
+ * @typedef {import('../../interfaces/coreServices.js').ISchemaValidator} ISchemaValidator
  */
 
 /**
- * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
+ * @typedef {import('../../interfaces/coreServices.js').IConfiguration} IConfiguration
  */
 
 // --- NEW JSDoc Type Definitions based on schema ---

--- a/src/llms/strategies/base/baseOpenRouterStrategy.js
+++ b/src/llms/strategies/base/baseOpenRouterStrategy.js
@@ -12,7 +12,7 @@ import { LLMStrategyError } from '../../errors/LLMStrategyError.js';
  * @typedef {import('../../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
  * @typedef {import('../../interfaces/ILLMStrategy.js').LLMStrategyExecuteParams} LLMStrategyExecuteParams
- * @typedef {import('../../../environmentContext.js').EnvironmentContext} EnvironmentContext
+ * @typedef {import('../../environmentContext.js').EnvironmentContext} EnvironmentContext
  */
 
 /**

--- a/src/llms/strategies/openRouterJsonSchemaStrategy.js
+++ b/src/llms/strategies/openRouterJsonSchemaStrategy.js
@@ -5,7 +5,7 @@ import { LLMStrategyError } from '../errors/LLMStrategyError.js';
 import { OPENROUTER_GAME_AI_ACTION_SPEECH_SCHEMA } from '../constants/llmConstants.js'; // Still potentially used for tool_calls fallback logic's expected name
 
 /**
- * @typedef {import('../../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
+ * @typedef {import('../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
  * @typedef {import('../interfaces/IHttpClient.js').IHttpClient} IHttpClient
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  */

--- a/src/llms/strategies/openRouterToolCallingStrategy.js
+++ b/src/llms/strategies/openRouterToolCallingStrategy.js
@@ -9,8 +9,8 @@ import {
 
 /**
  * @typedef {import('../interfaces/IHttpClient.js').IHttpClient} IHttpClient
- * @typedef {import('../../../interfaces/coreServices.js').ILogger} ILogger
- * @typedef {import('../../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
+ * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
  */
 
 /**

--- a/src/prompting/interfaces/IAIPromptPipeline.js
+++ b/src/prompting/interfaces/IAIPromptPipeline.js
@@ -3,7 +3,7 @@
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
-/** @typedef {import('../turns/dtos/actionComposite.js').ActionComposite} ActionComposite */
+/** @typedef {import('../../turns/dtos/actionComposite.js').ActionComposite} ActionComposite */
 
 export class IAIPromptPipeline {
   /**


### PR DESCRIPTION
Summary: Addressed various incorrect import paths causing dependency-cruiser warnings. Added missing interface files and updated JSDoc imports.

Changes Made:
- Corrected relative imports across LLM strategies and services.
- Added `IReferenceResolver` and `CommonTypes` interfaces.
- Fixed references in `worldInitializer` and other modules.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy) – **fails due to ESLint configuration error**
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684c6d32bb80833181a9d85d127cc38a