### PR TITLE
[Agent] protect entity definitions from mutation

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -310,7 +310,7 @@ class EntityManager extends IEntityManager {
       return null;
     }
 
-    entityDefinition.components =
+    const definitionComponents =
       entityDefinition.components &&
       typeof entityDefinition.components === 'object'
         ? entityDefinition.components
@@ -322,7 +322,7 @@ class EntityManager extends IEntityManager {
 
       /* --- copy + validate each component from definition --- */
       for (const [componentTypeId, componentData] of Object.entries(
-        entityDefinition.components
+        definitionComponents
       )) {
         const dataClone = this.#validateAndClone(
           componentTypeId,

--- a/tests/entities/entityManager.definitionMutation.test.js
+++ b/tests/entities/entityManager.definitionMutation.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import EntityManager from '../../src/entities/entityManager.js';
+
+const makeDeps = (definition) => {
+  const registry = {
+    getEntityDefinition: jest.fn().mockReturnValue(definition),
+  };
+  const validator = { validate: jest.fn().mockReturnValue({ isValid: true }) };
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  const spatialIndexManager = {
+    addEntity: jest.fn(),
+    removeEntity: jest.fn(),
+    updateEntityLocation: jest.fn(),
+    getEntitiesInLocation: jest.fn(() => new Set()),
+    clearIndex: jest.fn(),
+  };
+  return { registry, validator, logger, spatialIndexManager };
+};
+
+describe('EntityManager.createEntityInstance does not mutate definitions', () => {
+  test('components property remains unchanged when null', () => {
+    const definition = { id: 'test:nullComps', components: null };
+    const deps = makeDeps(definition);
+    const em = new EntityManager(
+      deps.registry,
+      deps.validator,
+      deps.logger,
+      deps.spatialIndexManager
+    );
+
+    const entity = em.createEntityInstance(definition.id);
+    expect(entity).not.toBeNull();
+    expect(definition.components).toBeNull();
+  });
+
+  test('components property remains unchanged when valid object', () => {
+    const definition = {
+      id: 'test:validComps',
+      components: { 'core:name': { value: 'A' } },
+    };
+    const deps = makeDeps(definition);
+    const em = new EntityManager(
+      deps.registry,
+      deps.validator,
+      deps.logger,
+      deps.spatialIndexManager
+    );
+
+    const entity = em.createEntityInstance(definition.id);
+    expect(entity).not.toBeNull();
+    expect(definition.components).toEqual({ 'core:name': { value: 'A' } });
+  });
+});


### PR DESCRIPTION
## Summary
- avoid mutating entity definitions in `createEntityInstance`
- test that definitions stay unchanged when creating entities

## Testing Done
- `npm run format`
- `npx eslint src/entities/entityManager.js tests/entities/entityManager.definitionMutation.test.js`
- `npm test -- -b` *(fails: coverage thresholds not met and integration timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684c83cf46c483318de448d09d408262