### PR TITLE
[Fix] EntityManager primary instance reassignment

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -597,7 +597,17 @@ class EntityManager extends IEntityManager {
       this.#definitionToPrimaryInstanceMap.get(entity.definitionId) ===
       instanceId
     ) {
-      this.#definitionToPrimaryInstanceMap.delete(entity.definitionId);
+      const replacement = Array.from(this.activeEntities.values()).find(
+        (e) => e.definitionId === entity.definitionId
+      );
+      if (replacement) {
+        this.#definitionToPrimaryInstanceMap.set(
+          entity.definitionId,
+          replacement.id
+        );
+      } else {
+        this.#definitionToPrimaryInstanceMap.delete(entity.definitionId);
+      }
     }
 
     /* ---------- final audit log ---------- */

--- a/tests/entities/entityManager.primaryInstanceReassignment.test.js
+++ b/tests/entities/entityManager.primaryInstanceReassignment.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import EntityManager from '../../src/entities/entityManager.js';
+
+const createMockDataRegistry = () => ({
+  getEntityDefinition: jest.fn(),
+});
+
+const createMockSchemaValidator = () => ({
+  validate: jest.fn(() => ({ isValid: true })),
+});
+
+const createMockLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+const createMockSpatialIndexManager = () => ({
+  addEntity: jest.fn(),
+  removeEntity: jest.fn(),
+  updateEntityLocation: jest.fn(),
+  getEntitiesInLocation: jest.fn(),
+  buildIndex: jest.fn(),
+  clearIndex: jest.fn(),
+});
+
+const DEF_ID = 'test:def-primary';
+
+describe('EntityManager primary instance reassignment', () => {
+  let registry;
+  let validator;
+  let logger;
+  let spatial;
+  let manager;
+
+  beforeEach(() => {
+    registry = createMockDataRegistry();
+    validator = createMockSchemaValidator();
+    logger = createMockLogger();
+    spatial = createMockSpatialIndexManager();
+    manager = new EntityManager(registry, validator, logger, spatial);
+
+    registry.getEntityDefinition.mockReturnValue({
+      id: DEF_ID,
+      components: {},
+    });
+  });
+
+  it('reassigns primary instance when removing current primary', () => {
+    const first = manager.createEntityInstance(DEF_ID, 'id1');
+    const second = manager.createEntityInstance(DEF_ID, 'id2');
+    expect(manager.getPrimaryInstanceByDefinitionId(DEF_ID)).toBe(first);
+
+    manager.removeEntityInstance('id1');
+
+    expect(manager.getPrimaryInstanceByDefinitionId(DEF_ID)).toBe(second);
+    expect(manager.activeEntities.has('id1')).toBe(false);
+    expect(manager.activeEntities.has('id2')).toBe(true);
+  });
+
+  it('clears primary mapping when last instance is removed', () => {
+    manager.createEntityInstance(DEF_ID, 'only');
+    expect(manager.getPrimaryInstanceByDefinitionId(DEF_ID)).toBeDefined();
+    manager.removeEntityInstance('only');
+    expect(manager.getPrimaryInstanceByDefinitionId(DEF_ID)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Summary: Fixes removal logic so that when a primary entity instance is deleted, another existing instance of the same definition becomes the new primary. Added regression tests.

Changes Made:
- update `removeEntityInstance` to select a replacement primary instance
- add test suite covering primary instance reassignment and removal

Testing Done:
- [x] Code formatted `npx prettier --write tests/entities/entityManager.primaryInstanceReassignment.test.js src/entities/entityManager.js`
- [x] Lint passes `npx eslint src/entities/entityManager.js tests/entities/entityManager.primaryInstanceReassignment.test.js --fix`
- [x] Root tests pass (coverage thresholds ignored)
- [x] Proxy tests pass (coverage thresholds ignored)


------
https://chatgpt.com/codex/tasks/task_e_684c9199a6188331b1f30bfdc5c402be