### PR TITLE
[Test] guardrail overflow integration

### DIFF
--- a/src/constants/core.js
+++ b/src/constants/core.js
@@ -1,2 +1,6 @@
 export const CORE_MOD_ID = 'core';
-export const MAX_AVAILABLE_ACTIONS_PER_TURN = 30000;
+// Allow tests or specialized builds to override the default cap via an
+// environment variable. This keeps heavy loops short for test suites.
+const parsedMax = parseInt(process.env.MAX_AVAILABLE_ACTIONS_PER_TURN, 10);
+export const MAX_AVAILABLE_ACTIONS_PER_TURN =
+  Number.isInteger(parsedMax) && parsedMax > 0 ? parsedMax : 30000;

--- a/tests/integration/guardrailIndexOverflow.integration.test.js
+++ b/tests/integration/guardrailIndexOverflow.integration.test.js
@@ -1,0 +1,56 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import { AvailableActionsProvider } from '../../src/data/providers/availableActionsProvider.js';
+import { ActionIndexingService } from '../../src/turns/services/actionIndexingService.js';
+import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../src/constants/core.js';
+
+/**
+ * Integration test for overflow guardrails across ActionIndexingService and
+ * AvailableActionsProvider.
+ */
+describe('Guardrail – index overflow', () => {
+  let provider;
+  let discoverySvc;
+  let entityManager;
+  let logger;
+  let actor;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    discoverySvc = { getValidActions: jest.fn() };
+    entityManager = { getEntityInstance: jest.fn().mockResolvedValue(null) };
+    const indexingService = new ActionIndexingService(logger);
+    provider = new AvailableActionsProvider({
+      actionDiscoveryService: discoverySvc,
+      actionIndexingService: indexingService,
+      entityManager,
+    });
+    actor = {
+      id: 'actor-overflow',
+      getComponentData: jest.fn().mockReturnValue({}),
+    };
+  });
+
+  it('caps overflow and logs matching warnings', async () => {
+    const discovered = Array.from({ length: 40000 }, (_, i) => ({
+      id: `action-${i}`,
+      command: `cmd-${i}`,
+      params: {},
+      description: `desc-${i}`,
+    }));
+    discoverySvc.getValidActions.mockResolvedValue(discovered);
+
+    const turnContext = { game: { worldId: 'world', turn: 1 } };
+    const result = await provider.get(actor, turnContext, logger);
+
+    expect(result.length).toBe(MAX_AVAILABLE_ACTIONS_PER_TURN);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    const [serviceWarn, providerWarn] = logger.warn.mock.calls.map((c) => c[0]);
+    expect(serviceWarn).toContain(`actor \"${actor.id}\" truncated`);
+    expect(providerWarn).toContain(`[Overflow] actor=${actor.id}`);
+  });
+});


### PR DESCRIPTION
Summary: Add integration test for action indexing overflow and allow MAX_AVAILABLE_ACTIONS_PER_TURN override via env variable.

Changes Made:
- Added env-based override logic in `src/constants/core.js`.
- Created `tests/integration/guardrailIndexOverflow.integration.test.js` to feed 40k actions and verify warnings from both services.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root; fails due to existing issues)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684c9e71156483318fb0117558d1202d