### PR TITLE
[Agent] Implement MATH operation handler

### DIFF
--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -31,7 +31,8 @@
             "ADD_PERCEPTION_LOG_ENTRY",
             "HAS_COMPONENT",
             "QUERY_ENTITIES",
-            "MODIFY_ARRAY_FIELD"
+            "MODIFY_ARRAY_FIELD",
+            "MATH"
           ]
         },
         "comment": {
@@ -340,6 +341,12 @@
             "properties": {
               "parameters": { "$ref": "#/$defs/ModifyArrayFieldParameters" }
             }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "MATH" } } },
+          "then": {
+            "properties": { "parameters": { "$ref": "#/$defs/MathParameters" } }
           }
         }
       ]
@@ -741,6 +748,46 @@
           "then": { "required": ["value"] }
         }
       ]
+    },
+    "MathParameters": {
+      "type": "object",
+      "description": "Parameters for the MATH operation. Performs a calculation and stores the result.",
+      "properties": {
+        "result_variable": { "type": "string", "minLength": 1 },
+        "expression": { "$ref": "#/$defs/MathExpression" }
+      },
+      "required": ["result_variable", "expression"]
+    },
+    "MathOperand": {
+      "description": "An operand for a math expression. Can be a number, a variable reference, or a nested expression.",
+      "oneOf": [
+        { "type": "number" },
+        {
+          "type": "object",
+          "properties": { "var": { "type": "string" } },
+          "required": ["var"],
+          "additionalProperties": false
+        },
+        { "$ref": "#/$defs/MathExpression" }
+      ]
+    },
+    "MathExpression": {
+      "type": "object",
+      "description": "A recursive mathematical expression.",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": ["add", "subtract", "multiply", "divide", "modulo"]
+        },
+        "operands": {
+          "type": "array",
+          "description": "An array of two operands for the operation.",
+          "items": { "$ref": "#/$defs/MathOperand" },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "required": ["operator", "operands"]
     }
   }
 }

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -32,6 +32,7 @@ import AddPerceptionLogEntryHandler from '../../logic/operationHandlers/addPerce
 import QueryEntitiesHandler from '../../logic/operationHandlers/queryEntitiesHandler.js';
 import HasComponentHandler from '../../logic/operationHandlers/hasComponentHandler';
 import ModifyArrayFieldHandler from '../../logic/operationHandlers/modifyArrayFieldHandler';
+import MathHandler from '../../logic/operationHandlers/mathHandler.js';
 
 /**
  * Registers all interpreter-layer services in the DI container.
@@ -194,6 +195,17 @@ export function registerInterpreters(container) {
           logger: c.resolve(tokens.ILogger),
         }),
     ],
+    [
+      tokens.MathHandler,
+      MathHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          jsonLogicEvaluationService: c.resolve(
+            tokens.JsonLogicEvaluationService
+          ),
+        }),
+    ],
   ];
 
   for (const [token, ctor, factory] of handlerFactories) {
@@ -249,6 +261,7 @@ export function registerInterpreters(container) {
       'MODIFY_ARRAY_FIELD',
       bind(tokens.ModifyArrayFieldHandler)
     );
+    registry.register('MATH', bind(tokens.MathHandler));
 
     return registry;
   });

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -261,6 +261,7 @@ export const tokens = freeze({
   QueryEntitiesHandler: 'QueryEntitiesHandler',
   HasComponentHandler: 'HasComponentHandler',
   ModifyArrayFieldHandler: 'ModifyArrayFieldHandler',
+  MathHandler: 'MathHandler',
 
   // --- Actions ---
   TurnActionChoicePipeline: 'TurnActionChoicePipeline',

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -1,0 +1,169 @@
+/**
+ * @file Implements the MATH operation handler which evaluates mathematical expressions.
+ */
+
+import jsonLogic from 'json-logic-js';
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../jsonLogicEvaluationService.js').default} JsonLogicEvaluationService */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+
+/**
+ * @typedef {object} MathExpression
+ * @property {string} operator
+ * @property {Array<number|object|MathExpression>} operands
+ */
+
+/**
+ * @class MathHandler
+ * @description Evaluates a recursive math expression and stores the numeric result in a context variable.
+ */
+class MathHandler {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {JsonLogicEvaluationService} */
+  #jsonLogicEvaluationService;
+
+  /**
+   * @param {object} deps
+   * @param {ILogger} deps.logger - Logging service.
+   * @param {JsonLogicEvaluationService} deps.jsonLogicEvaluationService - Service providing json-logic configuration.
+   */
+  constructor({ logger, jsonLogicEvaluationService }) {
+    if (!logger || typeof logger.warn !== 'function') {
+      throw new Error('MathHandler requires a valid ILogger instance.');
+    }
+    if (!jsonLogicEvaluationService) {
+      throw new Error('MathHandler requires JsonLogicEvaluationService.');
+    }
+    this.#logger = logger;
+    this.#jsonLogicEvaluationService = jsonLogicEvaluationService;
+  }
+
+  /**
+   * Execute the MATH operation.
+   *
+   * @param {{result_variable:string, expression:MathExpression}|null|undefined} params
+   * @param {ExecutionContext} executionContext
+   */
+  execute(params, executionContext) {
+    const log = executionContext?.logger ?? this.#logger;
+    if (!params || typeof params !== 'object') {
+      log.warn('MATH: parameters object missing or invalid.', { params });
+      return;
+    }
+    const { result_variable, expression } = params;
+    if (typeof result_variable !== 'string' || !result_variable.trim()) {
+      log.warn('MATH: "result_variable" must be a non-empty string.');
+      return;
+    }
+    if (!expression || typeof expression !== 'object') {
+      log.warn('MATH: "expression" must be an object.');
+      return;
+    }
+
+    const value = this.#evaluate(
+      expression,
+      executionContext.evaluationContext
+    );
+    const finalNumber =
+      typeof value === 'number' && !Number.isNaN(value) ? value : null;
+    if (finalNumber === null) {
+      log.warn('MATH: expression did not resolve to a numeric result.');
+    }
+    try {
+      if (executionContext?.evaluationContext?.context) {
+        executionContext.evaluationContext.context[result_variable.trim()] =
+          finalNumber;
+      } else {
+        log.error(
+          'MATH: evaluationContext.context not available to store result.'
+        );
+      }
+    } catch (e) {
+      log.error('MATH: Failed to store result_variable.', e);
+    }
+  }
+
+  /**
+   * Recursively evaluate a MathExpression.
+   *
+   * @private
+   * @param {MathExpression} expr
+   * @param {object} ctx
+   * @returns {number}
+   */
+  #evaluate(expr, ctx) {
+    if (!expr || typeof expr !== 'object') return NaN;
+    const { operator, operands } = expr;
+    if (!Array.isArray(operands) || operands.length !== 2) return NaN;
+    const left = this.#resolveOperand(operands[0], ctx);
+    const right = this.#resolveOperand(operands[1], ctx);
+    if (
+      typeof left !== 'number' ||
+      typeof right !== 'number' ||
+      Number.isNaN(left) ||
+      Number.isNaN(right)
+    ) {
+      this.#logger.warn('MATH: operands must resolve to numbers.', {
+        left,
+        right,
+      });
+      return NaN;
+    }
+    switch (operator) {
+      case 'add':
+        return left + right;
+      case 'subtract':
+        return left - right;
+      case 'multiply':
+        return left * right;
+      case 'divide':
+        if (right === 0) {
+          this.#logger.warn('MATH: Division by zero.');
+          return NaN;
+        }
+        return left / right;
+      case 'modulo':
+        if (right === 0) {
+          this.#logger.warn('MATH: Modulo by zero.');
+          return NaN;
+        }
+        return left % right;
+      default:
+        this.#logger.warn(`MATH: Unknown operator '${operator}'.`);
+        return NaN;
+    }
+  }
+
+  /**
+   * Resolve an operand which may be a number, var reference or nested expression.
+   *
+   * @private
+   * @param {number|object} operand
+   * @param {object} ctx
+   * @returns {number}
+   */
+  #resolveOperand(operand, ctx) {
+    if (typeof operand === 'number') return operand;
+    if (operand && typeof operand === 'object') {
+      if (Object.prototype.hasOwnProperty.call(operand, 'var')) {
+        try {
+          const raw = jsonLogic.apply({ var: operand.var }, ctx);
+          const num = Number(raw);
+          return Number.isNaN(num) ? NaN : num;
+        } catch (e) {
+          this.#logger.error('MATH: Error resolving variable operand.', e);
+          return NaN;
+        }
+      }
+      if (operand.operator) {
+        return this.#evaluate(operand, ctx);
+      }
+    }
+    this.#logger.warn('MATH: Invalid operand encountered.', { operand });
+    return NaN;
+  }
+}
+
+export default MathHandler;

--- a/tests/logic/operationHandlers/mathHandler.test.js
+++ b/tests/logic/operationHandlers/mathHandler.test.js
@@ -1,0 +1,83 @@
+/**
+ * @file Tests for MathHandler.
+ */
+
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import MathHandler from '../../../src/logic/operationHandlers/mathHandler.js';
+
+describe('MathHandler', () => {
+  let handler;
+  let logger;
+  let execCtx;
+
+  beforeEach(() => {
+    logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    handler = new MathHandler({ logger, jsonLogicEvaluationService: {} });
+    execCtx = {
+      evaluationContext: {
+        context: { a: 10, b: 2, c: 'foo' },
+      },
+      logger,
+    };
+  });
+
+  test('performs addition with literals', () => {
+    const params = {
+      result_variable: 'res',
+      expression: { operator: 'add', operands: [1, 2] },
+    };
+    handler.execute(params, execCtx);
+    expect(execCtx.evaluationContext.context.res).toBe(3);
+  });
+
+  test('performs subtraction using context variables', () => {
+    const params = {
+      result_variable: 'res',
+      expression: {
+        operator: 'subtract',
+        operands: [{ var: 'context.a' }, { var: 'context.b' }],
+      },
+    };
+    handler.execute(params, execCtx);
+    expect(execCtx.evaluationContext.context.res).toBe(8);
+  });
+
+  test('handles nested expressions', () => {
+    const params = {
+      result_variable: 'res',
+      expression: {
+        operator: 'multiply',
+        operands: [{ operator: 'add', operands: [{ var: 'context.a' }, 2] }, 3],
+      },
+    };
+    handler.execute(params, execCtx);
+    expect(execCtx.evaluationContext.context.res).toBe(36);
+  });
+
+  test('division by zero stores null', () => {
+    const params = {
+      result_variable: 'res',
+      expression: { operator: 'divide', operands: [5, 0] },
+    };
+    handler.execute(params, execCtx);
+    expect(execCtx.evaluationContext.context.res).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('non-numeric operand results in null', () => {
+    const params = {
+      result_variable: 'res',
+      expression: {
+        operator: 'add',
+        operands: [{ var: 'context.c' }, 2],
+      },
+    };
+    handler.execute(params, execCtx);
+    expect(execCtx.evaluationContext.context.res).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Added new `MATH` operation allowing recursive mathematical expressions. Updated schema and DI registrations, created `MathHandler` with evaluation logic using json‑logic vars, and added comprehensive unit tests.

Testing Done:
- [x] Code formatted `npx prettier -w`
- [x] Lint run `npm run lint` *(fails due to existing repo issues)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca60014bc8331b207bb71658468ff