### PR TITLE
[Agent] Fix missing method references in player handler

### DIFF
--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -275,7 +275,7 @@ class HumanTurnHandler extends BaseTurnHandler {
 
     if (
       !this._currentState ||
-      typeof this._currentStatehandleSubmittedCommand !== 'function'
+      typeof this._currentState.handleSubmittedCommand !== 'function'
     ) {
       const err = `${this.constructor.name}: handleSubmittedCommand called, but current state ${this._currentState?.getStateName()} cannot handle it.`;
       this._logger.error(err);
@@ -300,7 +300,7 @@ class HumanTurnHandler extends BaseTurnHandler {
       );
       if (
         this._currentState &&
-        typeof this._currentStatehandleTurnEndedEvent === 'function'
+        typeof this._currentState.handleTurnEndedEvent === 'function'
       ) {
         await this._currentState.handleTurnEndedEvent(this, payload);
       } else {

--- a/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
@@ -1,0 +1,112 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import HumanTurnHandler from '../../../src/turns/handlers/humanTurnHandler.js';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+
+// reusing constructor setup from existing tests
+
+describe('HumanTurnHandler method delegation', () => {
+  let deps;
+  let mockLogger;
+  let mockTurnStateFactory;
+  let mockCommandProcessor;
+  let mockTurnEndPort;
+  let mockPromptCoordinator;
+  let mockCommandOutcomeInterpreter;
+  let mockSafeEventDispatcher;
+  let mockChoicePipeline;
+  let mockHumanDecisionProvider;
+  let mockTurnActionFactory;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    mockTurnStateFactory = {
+      createInitialState: jest.fn().mockReturnValue({ stateName: 'Init' }),
+    };
+    mockCommandProcessor = {};
+    mockTurnEndPort = {};
+    mockPromptCoordinator = {};
+    mockCommandOutcomeInterpreter = {};
+    mockSafeEventDispatcher = {};
+    mockChoicePipeline = {};
+    mockHumanDecisionProvider = {};
+    mockTurnActionFactory = {};
+
+    deps = {
+      logger: mockLogger,
+      turnStateFactory: mockTurnStateFactory,
+      commandProcessor: mockCommandProcessor,
+      turnEndPort: mockTurnEndPort,
+      promptCoordinator: mockPromptCoordinator,
+      commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
+      safeEventDispatcher: mockSafeEventDispatcher,
+      choicePipeline: mockChoicePipeline,
+      humanDecisionProvider: mockHumanDecisionProvider,
+      turnActionFactory: mockTurnActionFactory,
+    };
+    jest
+      .spyOn(BaseTurnHandler.prototype, '_setInitialState')
+      .mockImplementation(function (state) {
+        this._currentState = state;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('delegates handleSubmittedCommand to current state', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const actor = { id: 'a1' };
+    const mockState = {
+      getStateName: () => 'state',
+      handleSubmittedCommand: jest.fn(),
+    };
+    handler._currentState = mockState;
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue({
+      getActor: () => actor,
+      endTurn: jest.fn(),
+    });
+
+    await handler.handleSubmittedCommand('look', actor);
+
+    expect(mockState.handleSubmittedCommand).toHaveBeenCalledWith(
+      handler,
+      'look',
+      actor
+    );
+  });
+
+  it('delegates handleTurnEndedEvent to current state', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const actor = { id: 'a2' };
+    const mockState = {
+      getStateName: () => 'state',
+      handleTurnEndedEvent: jest.fn(),
+    };
+    handler._currentState = mockState;
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue({
+      getActor: () => actor,
+      endTurn: jest.fn(),
+    });
+
+    const payload = { payload: { entityId: actor.id } };
+    await handler.handleTurnEndedEvent(payload);
+
+    expect(mockState.handleTurnEndedEvent).toHaveBeenCalledWith(
+      handler,
+      payload
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fix typos referencing state methods in `HumanTurnHandler`
- add regression tests verifying delegation to state methods

## Testing Done
- `npm run lint` *(fails: 568 errors, 1625 warnings)*
- `npm run format`
- `npm test`
- `cd llm-proxy-server && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca9a05dc48331b01844837dd959af