### PR TITLE
[Fix] propagate awaiting event flag in turn context

### DIFF
--- a/src/turns/interfaces/ITurnContext.js
+++ b/src/turns/interfaces/ITurnContext.js
@@ -135,9 +135,10 @@ export class ITurnContext {
    * Sets the flag indicating the turn is paused awaiting an external event.
    *
    * @param {boolean} isAwaiting - True if the turn should pause, false otherwise.
+   * @param {string} [actorId] - Actor ID associated with the await flag.
    * @returns {void}
    */
-  setAwaitingExternalEvent(isAwaiting) {
+  setAwaitingExternalEvent(isAwaiting, actorId) {
     throw new Error("Method 'setAwaitingExternalEvent()' must be implemented.");
   }
 

--- a/tests/turns/handlers/aiTurnHandler.awaitingExternalEvent.test.js
+++ b/tests/turns/handlers/aiTurnHandler.awaitingExternalEvent.test.js
@@ -133,7 +133,7 @@ describe('TurnContext State Isolation', () => {
     const context1 = mockTurnContextFactory.create.mock.results[0].value;
 
     // Act: Set the "awaiting event" state ON THE CONTEXT ITSELF.
-    context1.setAwaitingExternalEvent(true);
+    context1.setAwaitingExternalEvent(true, aiActor1.id);
 
     // Assert: The state is correctly set on the first context.
     expect(context1.isAwaitingExternalEvent()).toBe(true);

--- a/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
@@ -1,0 +1,88 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import HumanTurnHandler from '../../../src/turns/handlers/humanTurnHandler.js';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+
+/** Sets up minimal dependency mocks */
+let deps;
+let mockLogger;
+let mockTurnStateFactory;
+let mockCommandProcessor;
+let mockTurnEndPort;
+let mockPromptCoordinator;
+let mockCommandOutcomeInterpreter;
+let mockSafeEventDispatcher;
+let mockChoicePipeline;
+let mockHumanDecisionProvider;
+let mockTurnActionFactory;
+
+beforeEach(() => {
+  mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  mockTurnStateFactory = {
+    createInitialState: jest
+      .fn()
+      .mockReturnValue({ stateName: 'Init', startTurn: jest.fn() }),
+  };
+  mockCommandProcessor = {};
+  mockTurnEndPort = {};
+  mockPromptCoordinator = {};
+  mockCommandOutcomeInterpreter = {};
+  mockSafeEventDispatcher = {};
+  mockChoicePipeline = {};
+  mockHumanDecisionProvider = {};
+  mockTurnActionFactory = {};
+
+  deps = {
+    logger: mockLogger,
+    turnStateFactory: mockTurnStateFactory,
+    commandProcessor: mockCommandProcessor,
+    turnEndPort: mockTurnEndPort,
+    promptCoordinator: mockPromptCoordinator,
+    commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
+    safeEventDispatcher: mockSafeEventDispatcher,
+    choicePipeline: mockChoicePipeline,
+    humanDecisionProvider: mockHumanDecisionProvider,
+    turnActionFactory: mockTurnActionFactory,
+  };
+
+  jest
+    .spyOn(BaseTurnHandler.prototype, '_setInitialState')
+    .mockImplementation(function (state) {
+      this._currentState = state;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('TurnContext awaiting external event flag propagation', () => {
+  it('forwards awaiting flag changes to the handler', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const actor = { id: 'actor1' };
+    const markSpy = jest.spyOn(handler, '_markAwaitingTurnEnd');
+
+    await handler.startTurn(actor);
+    const ctx = handler.getTurnContext();
+    expect(ctx).toBeTruthy();
+
+    ctx.setAwaitingExternalEvent(true, actor.id);
+    expect(markSpy).toHaveBeenLastCalledWith(true, actor.id);
+    expect(ctx.isAwaitingExternalEvent()).toBe(true);
+
+    ctx.setAwaitingExternalEvent(false, actor.id);
+    expect(markSpy).toHaveBeenLastCalledWith(false, actor.id);
+    expect(ctx.isAwaitingExternalEvent()).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary: Ensure `TurnContext` properly communicates awaiting-external-event state back to `HumanTurnHandler`. Constructor now accepts callbacks for getting/setting this flag and methods invoke them. Added unit test verifying flag propagation. Updated existing test and interface docs.

Testing Done:
- [ ] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` – fails with existing errors)
- [ ] Root tests pass (`npm test` – coverage threshold fails)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm test` – coverage threshold fails)


------
https://chatgpt.com/codex/tasks/task_e_684d0df8954c8331b132584dd55d8df2