### PR TITLE
[Agent] ensure turn end is awaited

### DIFF
--- a/src/turns/context/turnContext.js
+++ b/src/turns/context/turnContext.js
@@ -161,7 +161,7 @@ export class TurnContext extends ITurnContext {
 
   /* ───────────────────────────── TURN ENDING ──────────────────────────── */
 
-  endTurn(errorOrNull = null) {
+  async endTurn(errorOrNull = null) {
     if (!this.#promptAbortController.signal.aborted) {
       this.#logger.debug(
         `TurnContext.endTurn: aborting prompt for actor ${this.#actor.id}.`
@@ -173,7 +173,7 @@ export class TurnContext extends ITurnContext {
     if (this.#handlerInstance?._isDestroyed === true) return;
 
     this.#decisionMeta = null;
-    this.#onEndTurnCallback(errorOrNull);
+    return this.#onEndTurnCallback(errorOrNull);
   }
 
   /* ───────────────────── AWAITING-EVENT FLAG MANAGEMENT ────────────────── */

--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -270,7 +270,7 @@ class HumanTurnHandler extends BaseTurnHandler {
       const errMsg = `${this.constructor.name}: handleSubmittedCommand actor mismatch or no context. Command for ${actorEntity.id}, context actor: ${currentContext?.getActor()?.id}.`;
       this._logger.error(errMsg);
       if (currentContext && typeof currentContext.endTurn === 'function') {
-        currentContext.endTurn(
+        await currentContext.endTurn(
           new Error('Actor mismatch in handleSubmittedCommand')
         );
       } else {
@@ -288,7 +288,7 @@ class HumanTurnHandler extends BaseTurnHandler {
     ) {
       const err = `${this.constructor.name}: handleSubmittedCommand called, but current state ${this._currentState?.getStateName()} cannot handle it.`;
       this._logger.error(err);
-      currentContext.endTurn(new Error(err));
+      await currentContext.endTurn(new Error(err));
       return;
     }
     await this._currentState.handleSubmittedCommand(
@@ -327,7 +327,7 @@ class HumanTurnHandler extends BaseTurnHandler {
       this._logger.error(
         `${this.constructor.name}: handleTurnEndedEvent called, but current state ${this._currentState?.getStateName()} cannot handle it.`
       );
-      currentContext.endTurn(
+      await currentContext.endTurn(
         new Error(
           `Current state ${this._currentState?.getStateName()} cannot handle turn ended event.`
         )

--- a/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
+++ b/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
@@ -1,0 +1,102 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import HumanTurnHandler from '../../../src/turns/handlers/humanTurnHandler.js';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+
+// New test verifying handleSubmittedCommand awaits endTurn on actor mismatch
+
+describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
+  let deps;
+  let mockLogger;
+  let mockTurnStateFactory;
+  let mockCommandProcessor;
+  let mockTurnEndPort;
+  let mockPromptCoordinator;
+  let mockCommandOutcomeInterpreter;
+  let mockSafeEventDispatcher;
+  let mockChoicePipeline;
+  let mockHumanDecisionProvider;
+  let mockTurnActionFactory;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    mockTurnStateFactory = {
+      createInitialState: jest.fn().mockReturnValue({ stateName: 'Init' }),
+    };
+    mockCommandProcessor = {};
+    mockTurnEndPort = {};
+    mockPromptCoordinator = {};
+    mockCommandOutcomeInterpreter = {};
+    mockSafeEventDispatcher = {};
+    mockChoicePipeline = {};
+    mockHumanDecisionProvider = {};
+    mockTurnActionFactory = {};
+
+    deps = {
+      logger: mockLogger,
+      turnStateFactory: mockTurnStateFactory,
+      commandProcessor: mockCommandProcessor,
+      turnEndPort: mockTurnEndPort,
+      promptCoordinator: mockPromptCoordinator,
+      commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
+      safeEventDispatcher: mockSafeEventDispatcher,
+      choicePipeline: mockChoicePipeline,
+      humanDecisionProvider: mockHumanDecisionProvider,
+      turnActionFactory: mockTurnActionFactory,
+    };
+
+    jest
+      .spyOn(BaseTurnHandler.prototype, '_setInitialState')
+      .mockImplementation(function (state) {
+        this._currentState = state;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('awaits endTurn when actor mismatches the active context', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const actorInContext = { id: 'actorA' };
+    const actorSubmitting = { id: 'actorB' };
+
+    let resolveEnd;
+    const endPromise = new Promise((res) => {
+      resolveEnd = res;
+    });
+
+    const mockCtx = {
+      getActor: () => actorInContext,
+      endTurn: jest.fn(() => endPromise),
+    };
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue(mockCtx);
+
+    const promise = handler.handleSubmittedCommand('look', actorSubmitting);
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(mockCtx.endTurn).toHaveBeenCalledWith(
+      new Error('Actor mismatch in handleSubmittedCommand')
+    );
+
+    resolveEnd();
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- return promise from `TurnContext.endTurn`
- wait for `endTurn` in `HumanTurnHandler`
- test awaiting turn end when actors mismatch

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2208 problems)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d13eec54c8331873d6b07490ea70c