### PR TITLE
[Agent] fix payload forwarding in human turn handler

### DIFF
--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -328,7 +328,7 @@ class HumanTurnHandler extends BaseTurnHandler {
         this._currentState &&
         typeof this._currentState.handleTurnEndedEvent === 'function'
       ) {
-        await this._currentState.handleTurnEndedEvent(this, payload);
+        await this._currentState.handleTurnEndedEvent(this, eventPayload);
       } else {
         this._logger.error(
           `${this.constructor.name}: No current state or state cannot handle turn ended event during no-context scenario.`
@@ -352,7 +352,7 @@ class HumanTurnHandler extends BaseTurnHandler {
       return;
     }
 
-    await this._currentState.handleTurnEndedEvent(this, payload);
+    await this._currentState.handleTurnEndedEvent(this, eventPayload);
   }
 }
 

--- a/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
@@ -101,12 +101,12 @@ describe('HumanTurnHandler method delegation', () => {
       endTurn: jest.fn(),
     });
 
-    const payload = { payload: { entityId: actor.id } };
-    await handler.handleTurnEndedEvent(payload);
+    const event = { payload: { entityId: actor.id } };
+    await handler.handleTurnEndedEvent(event);
 
     expect(mockState.handleTurnEndedEvent).toHaveBeenCalledWith(
       handler,
-      payload
+      event.payload
     );
   });
 });

--- a/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
+++ b/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
@@ -1,0 +1,89 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import HumanTurnHandler from '../../../src/turns/handlers/humanTurnHandler.js';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+
+/** Basic dependency mocks */
+let deps;
+let mockLogger;
+let mockTurnStateFactory;
+let mockCommandProcessor;
+let mockTurnEndPort;
+let mockPromptCoordinator;
+let mockCommandOutcomeInterpreter;
+let mockSafeEventDispatcher;
+let mockChoicePipeline;
+let mockHumanDecisionProvider;
+let mockTurnActionFactory;
+
+beforeEach(() => {
+  mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  mockTurnStateFactory = {
+    createInitialState: jest.fn().mockReturnValue({ stateName: 'Init' }),
+  };
+  mockCommandProcessor = {};
+  mockTurnEndPort = {};
+  mockPromptCoordinator = {};
+  mockCommandOutcomeInterpreter = {};
+  mockSafeEventDispatcher = {};
+  mockChoicePipeline = {};
+  mockHumanDecisionProvider = {};
+  mockTurnActionFactory = {};
+
+  deps = {
+    logger: mockLogger,
+    turnStateFactory: mockTurnStateFactory,
+    commandProcessor: mockCommandProcessor,
+    turnEndPort: mockTurnEndPort,
+    promptCoordinator: mockPromptCoordinator,
+    commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
+    safeEventDispatcher: mockSafeEventDispatcher,
+    choicePipeline: mockChoicePipeline,
+    humanDecisionProvider: mockHumanDecisionProvider,
+    turnActionFactory: mockTurnActionFactory,
+  };
+
+  jest
+    .spyOn(BaseTurnHandler.prototype, '_setInitialState')
+    .mockImplementation(function (state) {
+      this._currentState = state;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('HumanTurnHandler.handleTurnEndedEvent payload extraction', () => {
+  it('passes only the payload object to the current state', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const mockState = {
+      getStateName: () => 'state',
+      handleTurnEndedEvent: jest.fn(),
+    };
+    handler._currentState = mockState;
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue({
+      getActor: () => ({ id: 'a1' }),
+      endTurn: jest.fn(),
+    });
+
+    const event = { payload: { entityId: 'a1', success: true } };
+    await handler.handleTurnEndedEvent(event);
+
+    expect(mockState.handleTurnEndedEvent).toHaveBeenCalledWith(
+      handler,
+      event.payload
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fix `handleTurnEndedEvent` to forward only the event payload
- update delegation test accordingly
- add explicit test verifying payload extraction

## Testing Done
- `npx jest --runInBand --silent`
- `npm run test --silent` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_684d1ab344a0833181a267eb8c3c074f