### PR TITLE
[Fix] validate actor id in humanTurnHandler

### DIFF
--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -118,9 +118,10 @@ class HumanTurnHandler extends BaseTurnHandler {
   async startTurn(actor) {
     super._assertHandlerActive();
 
-    if (!actor) {
-      this._logger.error('HumanTurnHandler.startTurn: actor is required.');
-      throw new Error('HumanTurnHandler.startTurn: actor is required.');
+    if (!actor || typeof actor.id !== 'string' || actor.id.trim() === '') {
+      const errMsg = `${this.constructor.name}.startTurn: actor is required and must have a valid id.`;
+      this._logger.error(errMsg);
+      throw new Error(errMsg);
     }
     this._setCurrentActorInternal(actor);
 

--- a/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
@@ -1,0 +1,85 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import HumanTurnHandler from '../../../src/turns/handlers/humanTurnHandler.js';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+
+let deps;
+let mockLogger;
+let mockTurnStateFactory;
+let mockCommandProcessor;
+let mockTurnEndPort;
+let mockPromptCoordinator;
+let mockCommandOutcomeInterpreter;
+let mockSafeEventDispatcher;
+let mockChoicePipeline;
+let mockHumanDecisionProvider;
+let mockTurnActionFactory;
+
+beforeEach(() => {
+  mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  mockTurnStateFactory = {
+    createInitialState: jest.fn().mockReturnValue({ stateName: 'Init' }),
+  };
+  mockCommandProcessor = {};
+  mockTurnEndPort = {};
+  mockPromptCoordinator = {};
+  mockCommandOutcomeInterpreter = {};
+  mockSafeEventDispatcher = {};
+  mockChoicePipeline = {};
+  mockHumanDecisionProvider = {};
+  mockTurnActionFactory = {};
+
+  deps = {
+    logger: mockLogger,
+    turnStateFactory: mockTurnStateFactory,
+    commandProcessor: mockCommandProcessor,
+    turnEndPort: mockTurnEndPort,
+    promptCoordinator: mockPromptCoordinator,
+    commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
+    safeEventDispatcher: mockSafeEventDispatcher,
+    choicePipeline: mockChoicePipeline,
+    humanDecisionProvider: mockHumanDecisionProvider,
+    turnActionFactory: mockTurnActionFactory,
+  };
+
+  jest
+    .spyOn(BaseTurnHandler.prototype, '_setInitialState')
+    .mockImplementation(function (state) {
+      this._currentState = state;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('HumanTurnHandler.startTurn validation', () => {
+  it('throws when actor is null or lacks a valid id', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const errorMsg =
+      'HumanTurnHandler.startTurn: actor is required and must have a valid id.';
+    await expect(handler.startTurn(null)).rejects.toThrow(errorMsg);
+    await expect(handler.startTurn({})).rejects.toThrow(errorMsg);
+    await expect(handler.startTurn({ id: ' ' })).rejects.toThrow(errorMsg);
+  });
+
+  it('does not throw for a valid actor', async () => {
+    const handler = new HumanTurnHandler(deps);
+    const actor = { id: 'actor1' };
+    const state = { startTurn: jest.fn() };
+    handler._currentState = state;
+    await expect(handler.startTurn(actor)).resolves.toBeUndefined();
+    expect(state.startTurn).toHaveBeenCalledWith(handler, actor);
+  });
+});


### PR DESCRIPTION
Summary: Added validation in `startTurn` to ensure the actor has a valid id. Added a new Jest test to verify invalid actors cause errors and valid ones proceed.

Changes Made:
- Updated `startTurn` in `HumanTurnHandler` to check for a non-empty `actor.id`.
- Created `humanTurnHandler.startTurn.validation.test.js` for test coverage.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified files (`npx eslint src/turns/handlers/humanTurnHandler.js tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)


------
https://chatgpt.com/codex/tasks/task_e_684d26f8f84883318a50c2c172947535