### PR TITLE
[Agent] validate actor id in handleSubmittedCommand

### DIFF
--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -268,7 +268,11 @@ class HumanTurnHandler extends BaseTurnHandler {
     this._assertHandlerActive();
     const currentContext = this.getTurnContext();
 
-    if (!actorEntity || typeof actorEntity.id === 'undefined') {
+    if (
+      !actorEntity ||
+      typeof actorEntity.id !== 'string' ||
+      actorEntity.id.trim() === ''
+    ) {
       const errMsg = `${this.constructor.name}: handleSubmittedCommand called without valid actorEntity.`;
       this._logger.error(errMsg);
       if (currentContext && typeof currentContext.endTurn === 'function') {

--- a/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
+++ b/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
@@ -111,4 +111,51 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
     await promise;
     expect(resolved).toBe(true);
   });
+
+  it('ends the turn when actorEntity has invalid id and no context', async () => {
+    const handler = new HumanTurnHandler(deps);
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue(null);
+
+    const endSpy = jest
+      .spyOn(handler, '_handleTurnEnd')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      handler.handleSubmittedCommand('look', { id: '' })
+    ).resolves.toBeUndefined();
+
+    expect(endSpy).toHaveBeenCalledTimes(1);
+    const errorArg = endSpy.mock.calls[0][1];
+    expect(errorArg).toBeInstanceOf(Error);
+    expect(errorArg.message).toBe('Actor missing in handleSubmittedCommand');
+  });
+
+  it('awaits endTurn when actorEntity has invalid id and context exists', async () => {
+    const handler = new HumanTurnHandler(deps);
+    let resolveEnd;
+    const endPromise = new Promise((res) => {
+      resolveEnd = res;
+    });
+    const mockCtx = {
+      getActor: () => ({ id: 'actor1' }),
+      endTurn: jest.fn(() => endPromise),
+    };
+    jest.spyOn(handler, 'getTurnContext').mockReturnValue(mockCtx);
+
+    const promise = handler.handleSubmittedCommand('look', { id: 123 });
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(mockCtx.endTurn).toHaveBeenCalledWith(
+      new Error('Actor missing in handleSubmittedCommand')
+    );
+
+    resolveEnd();
+    await promise;
+    expect(resolved).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure actorEntity.id is a non-empty string in `handleSubmittedCommand`
- test invalid id cases in `humanTurnHandler.invalidActor.test.js`

## Testing
- `npm run test:single tests/turns/handlers/humanTurnHandler.invalidActor.test.js`
- `cd llm-proxy-server && npx jest`


------
https://chatgpt.com/codex/tasks/task_e_684d338a409483319ed85b179520b318