### PR TITLE
[Agent] fix undefined typedef in humanTurnHandler

### DIFF
--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -13,6 +13,7 @@ import { GenericTurnStrategy } from '../strategies/genericTurnStrategy.js';
 /** @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState */
 /** @typedef {import('../interfaces/ITurnStateFactory.js').ITurnStateFactory} ITurnStateFactory */
 /** @typedef {import('../pipeline/turnActionChoicePipeline.js').TurnActionChoicePipeline} TurnActionChoicePipeline */
+/** @typedef {import('../../interfaces/IPromptCoordinator.js').IPromptCoordinator} IPromptCoordinator */
 
 /** @typedef {import('../interfaces/ITurnDecisionProvider.js').ITurnDecisionProvider} IHumanDecisionProvider */
 /** @typedef {import('../ports/ITurnActionFactory.js').ITurnActionFactory} ITurnActionFactory */

--- a/tests/turns/handlers/humanTurnHandler.jsdoc.test.js
+++ b/tests/turns/handlers/humanTurnHandler.jsdoc.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+
+/**
+ * Ensures that humanTurnHandler.js declares the IPromptCoordinator typedef.
+ */
+describe('humanTurnHandler JSDoc', () => {
+  it('includes IPromptCoordinator typedef', () => {
+    const contents = fs.readFileSync(
+      'src/turns/handlers/humanTurnHandler.js',
+      'utf8'
+    );
+    expect(contents).toMatch(
+      /import\('\.\.\/\.\.\/interfaces\/IPromptCoordinator\.js'\)\.IPromptCoordinator/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add missing IPromptCoordinator typedef in `humanTurnHandler`
- test presence of typedef in `humanTurnHandler`

## Testing
- `npm run test` *(fails coverage)*
- `cd llm-proxy-server && npm run test` *(fails coverage)*

------
https://chatgpt.com/codex/tasks/task_e_684d39f80338833189a646d041eedddc