### PR TITLE
[Agent] Fix prompt coordinator action mapping

### DIFF
--- a/src/turns/prompting/promptCoordinator.js
+++ b/src/turns/prompting/promptCoordinator.js
@@ -134,17 +134,20 @@ class PromptCoordinator extends IPromptCoordinator {
         `Displaying ${indexedComposites.length} indexed choices to actor ${actor.id}.`
       );
 
-      // ************************** FIXED LINE **************************
-      // The bug was passing `indexedComposites` (ActionComposite[]) directly
-      // to a port expecting `DiscoveredActionInfo[]`. We now map it back
-      // to the expected format to respect the interface contract.
+      // ───── Transform composites back to the prompt schema ─────
+      // The prompt output port expects objects shaped according to the
+      // PLAYER_TURN_PROMPT event schema ({ index, actionId, commandString,
+      // params, description }). Previously this code forwarded the
+      // ActionComposite objects directly, which use different property names
+      // (actionId → id, commandString → command). That mismatch meant prompts
+      // failed schema validation. We now map the composites back to the
+      // expected property names.
       const actionsForPrompt = indexedComposites.map((comp) => ({
         index: comp.index,
-        id: comp.actionId,
-        name: comp.description, // Use description as the primary name for UI
-        command: comp.commandString,
-        description: comp.description,
+        actionId: comp.actionId,
+        commandString: comp.commandString,
         params: comp.params,
+        description: comp.description,
       }));
 
       await this.#promptOutputPort.prompt(actor.id, actionsForPrompt);

--- a/tests/turns/prompting/promptCoordinator.test.js
+++ b/tests/turns/prompting/promptCoordinator.test.js
@@ -148,11 +148,10 @@ describe('PromptCoordinator Integration Test', () => {
     const indexedComposites = indexerStub.indexActions.mock.results[0].value;
     const expectedActionsForPrompt = indexedComposites.map((comp) => ({
       index: comp.index,
-      id: comp.actionId,
-      name: comp.description,
-      command: comp.commandString,
-      description: comp.description,
+      actionId: comp.actionId,
+      commandString: comp.commandString,
       params: comp.params,
+      description: comp.description,
     }));
 
     expect(promptOutputPort.prompt).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary: Fixes action object mapping in PromptCoordinator so prompts use the schema with actionId/commandString. Updated integration test accordingly.

Testing Done:
- [x] Code formatted `npx prettier src/turns/prompting/promptCoordinator.js tests/turns/prompting/promptCoordinator.test.js --write`
- [x] Lint specific files `npx eslint src/turns/prompting/promptCoordinator.js tests/turns/prompting/promptCoordinator.test.js`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d3f32199083319f68a38de08475af