### PR TITLE
[Agent] dispatch display_error instead of logger.error

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -193,6 +193,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -131,7 +131,11 @@ function init(entities) {
 
   const handlers = {
     REMOVE_COMPONENT: new RemoveComponentHandler({ entityManager, logger }),
-    MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({ entityManager, logger }),
+    MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
@@ -172,6 +176,7 @@ let jsonLogic;
 let interpreter;
 let events;
 let listener;
+let safeDispatcher;
 
 describe('core_handle_dismiss rule integration', () => {
   beforeEach(() => {
@@ -194,6 +199,8 @@ describe('core_handle_dismiss rule integration', () => {
       }),
       listenerCount: jest.fn().mockReturnValue(1),
     };
+
+    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([dismissRule]),

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -113,6 +113,7 @@ describe('core_handle_follow rule integration', () => {
       MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({
         entityManager,
         logger,
+        safeEventDispatcher: safeDispatcher,
       }),
       DISPATCH_EVENT: new DispatchEventHandler({
         dispatcher: eventBus,

--- a/tests/logic/operationHandlers/modifyArrayFieldHandler.test.js
+++ b/tests/logic/operationHandlers/modifyArrayFieldHandler.test.js
@@ -46,6 +46,7 @@ describe('ModifyArrayFieldHandler', () => {
   let mockLogger;
   let handler;
   let mockExecutionContext;
+  let mockDispatcher;
 
   const ENTITY_ID = 'ent_player';
   const COMPONENT_TYPE = 'core:inventory';
@@ -53,9 +54,11 @@ describe('ModifyArrayFieldHandler', () => {
   beforeEach(() => {
     mockEntityManager = makeMockEntityManager();
     mockLogger = makeMockLogger();
+    mockDispatcher = { dispatch: jest.fn() };
     handler = new ModifyArrayFieldHandler({
       entityManager: mockEntityManager,
       logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
     });
     mockExecutionContext = {
       evaluationContext: {
@@ -73,14 +76,24 @@ describe('ModifyArrayFieldHandler', () => {
 
   describe('Setup & Validation', () => {
     test("constructor should throw an error if 'entityManager' dependency is missing", () => {
-      expect(() => new ModifyArrayFieldHandler({ logger: mockLogger })).toThrow(
+      expect(
+        () =>
+          new ModifyArrayFieldHandler({
+            logger: mockLogger,
+            safeEventDispatcher: mockDispatcher,
+          })
+      ).toThrow(
         "Dependency 'IEntityManager' with getComponentData and addComponent methods is required."
       );
     });
 
     test("constructor should throw an error if 'logger' dependency is missing", () => {
       expect(
-        () => new ModifyArrayFieldHandler({ entityManager: mockEntityManager })
+        () =>
+          new ModifyArrayFieldHandler({
+            entityManager: mockEntityManager,
+            safeEventDispatcher: mockDispatcher,
+          })
       ).toThrow("Dependency 'ILogger' with a 'warn' method is required.");
     });
 
@@ -92,6 +105,7 @@ describe('ModifyArrayFieldHandler', () => {
           new ModifyArrayFieldHandler({
             entityManager: malformedEntityManager,
             logger: mockLogger,
+            safeEventDispatcher: mockDispatcher,
           })
       ).toThrow();
       expect(
@@ -99,6 +113,7 @@ describe('ModifyArrayFieldHandler', () => {
           new ModifyArrayFieldHandler({
             entityManager: mockEntityManager,
             logger: malformedLogger,
+            safeEventDispatcher: mockDispatcher,
           })
       ).toThrow();
     });


### PR DESCRIPTION
## Summary
- inject `ISafeEventDispatcher` into `ModifyArrayFieldHandler`
- dispatch `core:display_error` when component updates fail
- adjust DI registration for `ModifyArrayFieldHandler`
- update affected unit and integration tests
- fix follow rule integration tests to supply dispatcher

## Testing
- `npm run lint`
- `npm run test` *(fails coverage threshold)*
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test` *(fails coverage threshold)*

------
https://chatgpt.com/codex/tasks/task_e_684d3f136798833180c1fead82741224