### PR TITLE
[Agent] replace logger.error with event dispatch

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -79,6 +79,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/coreHandlers.integration.test.js
+++ b/tests/integration/coreHandlers.integration.test.js
@@ -128,7 +128,11 @@ describe('T‑07: enemy_damaged ➜ enemy_dead chained rules', () => {
 
     // ---- Handlers we actually need -----------------------------------------
     // MODIFY_COMPONENT – use the real handler so we truly mutate the component
-    const modHandler = new ModifyComponentHandler({ entityManager, logger });
+    const modHandler = new ModifyComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
+    });
     opRegistry.register(
       'MODIFY_COMPONENT',
       modHandler.execute.bind(modHandler)

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -157,7 +157,11 @@ function init(entities) {
       worldContext,
       logger,
     }),
-    MODIFY_COMPONENT: new ModifyComponentHandler({ entityManager, logger }),
+    MODIFY_COMPONENT: new ModifyComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
   };
 

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -153,6 +153,7 @@ describe('Sequential Action Execution – Success Path', () => {
     const realModifyHandler = new ModifyComponentHandler({
       entityManager,
       logger,
+      safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
     });
 
     modifyHandlerSpy = jest.fn((params, rawEvalCtx) => {

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -124,7 +124,11 @@ describe('Sequential Action Execution – Error Path', () => {
     opRegistry.register('FAILING_ACTION', failingHandlerMock);
 
     // MODIFY_COMPONENT — real handler wrapped to spy (should never be hit)
-    const realMod = new ModifyComponentHandler({ entityManager, logger });
+    const realMod = new ModifyComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
+    });
     skippedModifyHandlerMock = jest.fn((p, ctx) =>
       realMod.execute(
         p,


### PR DESCRIPTION
## Summary
- dispatch DISPLAY_ERROR_ID from ModifyComponentHandler instead of logging
- inject SafeEventDispatcher into ModifyComponentHandler
- pass dispatcher through interpreter registrations
- update integration and unit tests for new dependency

## Testing
- `npm run test` (fails: coverage threshold)
- `cd llm-proxy-server && npm run test` (fails: coverage threshold)


------
https://chatgpt.com/codex/tasks/task_e_684d52429270833194a04a83fc93da52