### PR TITLE
[Agent] use SafeEventDispatcher for has component errors

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -186,6 +186,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -136,7 +136,11 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
+    HAS_COMPONENT: new HasComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -67,8 +67,14 @@ function init(entities) {
   operationRegistry = new OperationRegistry({ logger });
   entityManager = new SimpleEntityManager(entities);
 
+  const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+
   const handlers = {
-    HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
+    HAS_COMPONENT: new HasComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -103,7 +103,11 @@ describe('core_handle_follow rule integration', () => {
         logger,
         entityManager,
       }),
-      HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
+      HAS_COMPONENT: new HasComponentHandler({
+        entityManager,
+        logger,
+        safeEventDispatcher: safeDispatcher,
+      }),
       QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
       ADD_COMPONENT: new AddComponentHandler({
         entityManager,

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -148,8 +148,14 @@ function init(entities) {
   entityManager = new SimpleEntityManager(entities);
   worldContext = new SimpleWorldContext(entityManager, logger);
 
+  const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+
   const handlers = {
-    HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
+    HAS_COMPONENT: new HasComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     SET_VARIABLE: new SetVariableHandler({ logger }),

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -131,7 +131,11 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    HAS_COMPONENT: new HasComponentHandler({ entityManager, logger }),
+    HAS_COMPONENT: new HasComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),


### PR DESCRIPTION
## Summary
- use `SafeEventDispatcher` in `HasComponentHandler`
- propagate dependency via interpreter registrations
- update tests and integrations for new dispatcher behavior

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684d5c8670688331abaff632bc139c39