### PR TITLE
[Test] Add integration test for wait rule

### DIFF
--- a/tests/integration/rules/waitRule.integration.test.js
+++ b/tests/integration/rules/waitRule.integration.test.js
@@ -1,0 +1,198 @@
+/**
+ * @file Integration tests for wait.rule.json.
+ */
+
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import Ajv from 'ajv';
+import ruleSchema from '../../../data/schemas/rule.schema.json';
+import commonSchema from '../../../data/schemas/common.schema.json';
+import operationSchema from '../../../data/schemas/operation.schema.json';
+import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import waitRule from '../../../data/mods/core/rules/wait.rule.json';
+import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
+import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
+import OperationRegistry from '../../../src/logic/operationRegistry.js';
+import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
+import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
+import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import { NAME_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
+
+/**
+ * Simple entity manager used for integration tests.
+ * Provides just enough functionality for the handlers.
+ */
+class SimpleEntityManager {
+  /**
+   * Create the manager with the provided entities.
+   *
+   * @param {Array<{id:string,components:object}>} entities - initial entities
+   */
+  constructor(entities) {
+    this.entities = new Map();
+    for (const e of entities) {
+      this.entities.set(e.id, {
+        id: e.id,
+        components: { ...e.components },
+      });
+    }
+  }
+
+  /**
+   * Return an entity instance.
+   *
+   * @param {string} id - entity id
+   * @returns {object|undefined} entity object
+   */
+  getEntityInstance(id) {
+    return this.entities.get(id);
+  }
+
+  /**
+   * Retrieve component data.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   * @returns {any} component data or null
+   */
+  getComponentData(id, type) {
+    return this.entities.get(id)?.components[type] ?? null;
+  }
+
+  /**
+   * Determine if an entity has a component.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   * @returns {boolean} true if present
+   */
+  hasComponent(id, type) {
+    return Object.prototype.hasOwnProperty.call(
+      this.entities.get(id)?.components || {},
+      type
+    );
+  }
+}
+
+/**
+ * Helper to initialize the interpreter with a fresh entity manager.
+ *
+ * @param {Array<{id:string,components:object}>} entities - seed entities
+ */
+function init(entities) {
+  operationRegistry = new OperationRegistry({ logger });
+  entityManager = new SimpleEntityManager(entities);
+
+  const handlers = {
+    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
+    DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+  };
+
+  for (const [type, handler] of Object.entries(handlers)) {
+    operationRegistry.register(type, handler.execute.bind(handler));
+  }
+
+  operationInterpreter = new OperationInterpreter({
+    logger,
+    operationRegistry,
+  });
+
+  jsonLogic = new JsonLogicEvaluationService({ logger });
+
+  interpreter = new SystemLogicInterpreter({
+    logger,
+    eventBus,
+    dataRegistry,
+    jsonLogicEvaluationService: jsonLogic,
+    entityManager,
+    operationInterpreter,
+  });
+
+  listener = null;
+  interpreter.initialize();
+}
+
+let logger;
+let eventBus;
+let dataRegistry;
+let entityManager;
+let operationRegistry;
+let operationInterpreter;
+let jsonLogic;
+let interpreter;
+let events;
+let listener;
+
+describe('core_handle_wait rule integration', () => {
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    events = [];
+    eventBus = {
+      subscribe: jest.fn((ev, l) => {
+        if (ev === '*') listener = l;
+      }),
+      unsubscribe: jest.fn(),
+      dispatch: jest.fn((eventType, payload) => {
+        events.push({ eventType, payload });
+        return Promise.resolve();
+      }),
+      listenerCount: jest.fn().mockReturnValue(1),
+    };
+
+    dataRegistry = {
+      getAllSystemRules: jest.fn().mockReturnValue([waitRule]),
+    };
+
+    init([]);
+  });
+
+  it('validates wait.rule.json against schema', () => {
+    const ajv = new Ajv({ allErrors: true });
+    ajv.addSchema(
+      commonSchema,
+      'http://example.com/schemas/common.schema.json'
+    );
+    ajv.addSchema(
+      operationSchema,
+      'http://example.com/schemas/operation.schema.json'
+    );
+    ajv.addSchema(
+      jsonLogicSchema,
+      'http://example.com/schemas/json-logic.schema.json'
+    );
+    const valid = ajv.validate(ruleSchema, waitRule);
+    if (!valid) console.error(ajv.errors);
+    expect(valid).toBe(true);
+  });
+
+  it('queries actor name and dispatches turn_ended event', () => {
+    interpreter.shutdown();
+    init([
+      {
+        id: 'a1',
+        components: { [NAME_COMPONENT_ID]: { text: 'Hero' } },
+      },
+    ]);
+
+    const spy = jest.spyOn(entityManager, 'getComponentData');
+
+    listener({
+      type: ATTEMPT_ACTION_ID,
+      payload: { actorId: 'a1', actionId: 'core:wait', targetId: null },
+    });
+
+    expect(spy).toHaveBeenCalledWith('a1', NAME_COMPONENT_ID);
+    expect(events).toEqual([
+      {
+        eventType: 'core:turn_ended',
+        payload: { entityId: 'a1', success: true },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Summary: Added a new integration test covering `data/mods/core/rules/wait.rule.json`. The test validates the rule schema and ensures that waiting triggers a `core:turn_ended` event using real `QueryComponent` and `DispatchEvent` handlers.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified file (`npx eslint tests/integration/rules/waitRule.integration.test.js`)
- [x] Root tests pass (`npm run test`, ignoring coverage threshold failures)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`, ignoring coverage threshold failures)


------
https://chatgpt.com/codex/tasks/task_e_684d65ca83048331b9e7c38910db599a