### PR TITLE
[Agent] dispatch display error event

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -9,6 +9,7 @@
 /** @typedef {import('./actionFormatter.js').formatActionCommand} formatActionCommandFn */
 /** @typedef {import('./actionTypes.js').ActionContext} ActionContext */
 /** @typedef {import('../logging/consoleLogger.js').default} ILogger */
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
@@ -23,6 +24,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   #formatActionCommandFn;
   #getEntityIdsForScopesFn;
   #logger;
+  #safeEventDispatcher;
 
   /**
    * @param {object} deps
@@ -32,6 +34,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
    * @param {ILogger}            deps.logger
    * @param {formatActionCommandFn} deps.formatActionCommandFn
    * @param {getEntityIdsForScopesFn} deps.getEntityIdsForScopesFn
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
    */
   constructor({
     gameDataRepository,
@@ -40,6 +43,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     logger,
     formatActionCommandFn,
     getEntityIdsForScopesFn,
+    safeEventDispatcher,
   }) {
     super();
     validateDependency(logger, 'ActionDiscoveryService: logger', console, {
@@ -77,12 +81,19 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       this.#logger,
       { isFunction: true }
     );
+    validateDependency(
+      safeEventDispatcher,
+      'ActionDiscoveryService: safeEventDispatcher',
+      this.#logger,
+      { requiredMethods: ['dispatch'] }
+    );
 
     this.#gameDataRepository = gameDataRepository;
     this.#entityManager = entityManager;
     this.#actionValidationService = actionValidationService;
     this.#formatActionCommandFn = formatActionCommandFn;
     this.#getEntityIdsForScopesFn = getEntityIdsForScopesFn;
+    this.#safeEventDispatcher = safeEventDispatcher;
 
     this.#logger.debug('ActionDiscoveryService initialised.');
   }
@@ -142,7 +153,11 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
               actionDef,
               targetCtx,
               this.#entityManager,
-              { logger: this.#logger, debug: true }
+              {
+                logger: this.#logger,
+                debug: true,
+                safeEventDispatcher: this.#safeEventDispatcher,
+              }
             );
             if (cmd !== null) {
               validActions.push({
@@ -187,7 +202,11 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
                 actionDef,
                 targetCtx,
                 this.#entityManager,
-                { logger: this.#logger, debug: true }
+                {
+                  logger: this.#logger,
+                  debug: true,
+                  safeEventDispatcher: this.#safeEventDispatcher,
+                }
               );
               if (cmd !== null) {
                 validActions.push({
@@ -218,7 +237,11 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
                 actionDef,
                 targetCtx,
                 this.#entityManager,
-                { logger: this.#logger, debug: true }
+                {
+                  logger: this.#logger,
+                  debug: true,
+                  safeEventDispatcher: this.#safeEventDispatcher,
+                }
               );
               if (cmd !== null) {
                 validActions.push({

--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -57,6 +57,7 @@ export function registerCommandAndAction(container) {
         logger: c.resolve(tokens.ILogger),
         formatActionCommandFn: formatActionCommand,
         getEntityIdsForScopesFn: getEntityIdsForScopes,
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
   logger.debug(

--- a/tests/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/actions/actionDiscoveryService.actionId.test.js
@@ -25,6 +25,7 @@ describe('ActionDiscoveryService params exposure', () => {
     const formatActionCommandFn = () => 'attack rat123';
     const getEntityIdsForScopesFn = () => new Set(['rat123']);
     const logger = { debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    const safeEventDispatcher = { dispatch: jest.fn() };
 
     service = new ActionDiscoveryService({
       gameDataRepository: gameDataRepo,
@@ -33,6 +34,7 @@ describe('ActionDiscoveryService params exposure', () => {
       formatActionCommandFn,
       getEntityIdsForScopesFn,
       logger,
+      safeEventDispatcher,
     });
   });
 

--- a/tests/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -54,6 +54,8 @@ describe('ActionDiscoveryService – directional discovery', () => {
 
   const getEntityIdsForScopesFn = () => [];
 
+  const safeEventDispatcher = { dispatch: jest.fn() };
+
   const service = new ActionDiscoveryService({
     gameDataRepository,
     entityManager,
@@ -61,6 +63,7 @@ describe('ActionDiscoveryService – directional discovery', () => {
     logger,
     formatActionCommandFn,
     getEntityIdsForScopesFn,
+    safeEventDispatcher,
   });
 
   /** Bare-bones actor / context objects */

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -47,6 +47,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   let mockGetEntityIdsForScopesFn;
   let mockGetAvailableExits;
   let availableExits;
+  let mockSafeEventDispatcher;
 
   const HERO_DEFINITION_ID = 'isekai:hero';
   const GUILD_DEFINITION_ID = 'isekai:adventurers_guild';
@@ -98,6 +99,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
     mockFormatActionCommandFn = formatActionCommandFn;
     mockGetEntityIdsForScopesFn = getEntityIdsForScopesFn;
     mockGetAvailableExits = getAvailableExits;
+    mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockHeroEntity = new Entity(HERO_INSTANCE_ID, HERO_DEFINITION_ID);
     Object.entries(heroEntityDefinitionData.components).forEach(
@@ -209,6 +211,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       logger: mockLogger,
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
+      safeEventDispatcher: mockSafeEventDispatcher,
     });
   });
 

--- a/tests/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/actions/actionDiscoverySystem.wait.test.js
@@ -56,6 +56,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   let mockLocationEntity;
   /** @type {ActionContext} */
   let mockActionContext;
+  let mockSafeEventDispatcher;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -71,6 +72,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
 
     mockFormatActionCommandFn = formatActionCommandFn;
     mockGetEntityIdsForScopesFn = getEntityIdsForScopesFn;
+    mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockActorEntity = new Entity(ACTOR_INSTANCE_ID, DUMMY_DEFINITION_ID);
     mockLocationEntity = new Entity(LOCATION_INSTANCE_ID, DUMMY_DEFINITION_ID);
@@ -116,6 +118,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
       logger: mockLogger,
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
+      safeEventDispatcher: mockSafeEventDispatcher,
     });
   });
 

--- a/tests/actions/actionFormatter.additional.test.js
+++ b/tests/actions/actionFormatter.additional.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import { formatActionCommand } from '../../src/actions/actionFormatter.js';
+import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
 
 jest.mock('../../src/utils/entityUtils.js', () => ({
   getEntityDisplayName: jest.fn(),
@@ -15,10 +16,12 @@ const createMockLogger = () => ({
 describe('formatActionCommand additional cases', () => {
   let entityManager;
   let logger;
+  let dispatcher;
 
   beforeEach(() => {
     entityManager = { getEntityInstance: jest.fn() };
     logger = createMockLogger();
+    dispatcher = { dispatch: jest.fn() };
     jest.clearAllMocks();
   });
 
@@ -28,6 +31,7 @@ describe('formatActionCommand additional cases', () => {
 
     const result = formatActionCommand(actionDef, context, entityManager, {
       logger,
+      safeEventDispatcher: dispatcher,
     });
 
     expect(result).toBeNull();
@@ -42,6 +46,7 @@ describe('formatActionCommand additional cases', () => {
 
     const result = formatActionCommand(actionDef, context, entityManager, {
       logger,
+      safeEventDispatcher: dispatcher,
     });
 
     expect(result).toBeNull();
@@ -59,6 +64,7 @@ describe('formatActionCommand additional cases', () => {
 
     const result = formatActionCommand(actionDef, context, entityManager, {
       logger,
+      safeEventDispatcher: dispatcher,
     });
 
     expect(result).toBe('wait {target} {direction}');
@@ -76,12 +82,15 @@ describe('formatActionCommand additional cases', () => {
 
     const result = formatActionCommand(actionDef, context, entityManager, {
       logger,
+      safeEventDispatcher: dispatcher,
     });
 
     expect(result).toBeNull();
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('placeholder substitution'),
-      expect.any(Error)
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('placeholder substitution'),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `formatActionCommand` and emit `core:display_error`
- wire dispatcher through `ActionDiscoveryService`
- register dispatcher in DI
- update relevant tests

## Testing
- `npm run lint` *(fails: many existing warnings and errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684d63f47d48833185f9fe784251eaef