### PR TITLE
[Fix] enforce active checks when destroying

### DIFF
--- a/src/turns/handlers/baseTurnHandler.js
+++ b/src/turns/handlers/baseTurnHandler.js
@@ -222,15 +222,15 @@ export class BaseTurnHandler {
   /* ───────────────────────────── LIVENESS CHECKS ──────────────────────── */
 
   _assertHandlerActive() {
-    if (this._isDestroyed && !this._isDestroying) {
+    if (this._isDestroyed || this._isDestroying) {
       throw new Error(
-        `${this.constructor.name}: Operation invoked after handler was destroyed.`
+        `${this.constructor.name}: Operation invoked while handler is destroying or has been destroyed.`
       );
     }
   }
 
   _assertHandlerActiveUnlessDestroying(fromDestroy) {
-    if (!fromDestroy && !this._isDestroying) {
+    if (!fromDestroy) {
       this._assertHandlerActive();
     }
   }

--- a/tests/turns/handlers/baseTurnHandler.livenessCheck.test.js
+++ b/tests/turns/handlers/baseTurnHandler.livenessCheck.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js';
+import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js';
+import { TurnEndingState } from '../../../src/turns/states/turnEndingState.js';
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  createChild: jest.fn(() => mockLogger),
+};
+
+const mockTurnStateFactory = {
+  createIdleState: jest.fn((h) => new TurnIdleState(h)),
+  createEndingState: jest.fn((h, actorId, err) => {
+    const state = new TurnEndingState(h, actorId, err);
+    jest.spyOn(state, 'enterState').mockResolvedValue(undefined);
+    jest.spyOn(state, 'exitState').mockResolvedValue(undefined);
+    return state;
+  }),
+  createAwaitingInputState: jest.fn(),
+  createProcessingCommandState: jest.fn(),
+  createAwaitingExternalTurnEndState: jest.fn(),
+};
+
+class SimpleHandler extends BaseTurnHandler {
+  constructor(opts) {
+    super(opts);
+    this._setInitialState(mockTurnStateFactory.createIdleState(this));
+  }
+
+  async startTurn() {
+    this._assertHandlerActive();
+    return 'started';
+  }
+}
+
+describe('BaseTurnHandler liveness checks', () => {
+  it('startTurn throws when handler is destroying', async () => {
+    const handler = new SimpleHandler({
+      logger: mockLogger,
+      turnStateFactory: mockTurnStateFactory,
+    });
+    handler._isDestroying = true;
+    await expect(handler.startTurn({ id: 'A' })).rejects.toThrow(
+      'destroying or'
+    );
+  });
+
+  it('_handleTurnEnd throws when called while destroying and not from destroy', async () => {
+    const handler = new SimpleHandler({
+      logger: mockLogger,
+      turnStateFactory: mockTurnStateFactory,
+    });
+    handler._isDestroying = true;
+    await expect(handler._handleTurnEnd('A')).rejects.toThrow('destroying or');
+  });
+
+  it('_handleTurnEnd does not throw when called from destroy', async () => {
+    const handler = new SimpleHandler({
+      logger: mockLogger,
+      turnStateFactory: mockTurnStateFactory,
+    });
+    handler._isDestroying = true;
+    await expect(
+      handler._handleTurnEnd('A', null, true)
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Summary: Improve BaseTurnHandler liveness logic by preventing operations while a handler is destroying. Added tests verifying startTurn and _handleTurnEnd throw unless invoked from destroy.

Changes Made:
- Updated `_assertHandlerActive` and `_assertHandlerActiveUnlessDestroying` to treat the destroying phase as inactive.
- Added `baseTurnHandler.livenessCheck.test.js` covering new behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on touched files (`npx eslint src/turns/handlers/baseTurnHandler.js tests/turns/handlers/baseTurnHandler.livenessCheck.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684d69ffd5d88331be1a3fae0eeea0dc