### PR TITLE
[Agent] use SafeEventDispatcher for MathHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -209,9 +209,7 @@ export function registerInterpreters(container) {
       (c, Handler) =>
         new Handler({
           logger: c.resolve(tokens.ILogger),
-          jsonLogicEvaluationService: c.resolve(
-            tokens.JsonLogicEvaluationService
-          ),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
   ];

--- a/tests/logic/operationHandlers/mathHandler.test.js
+++ b/tests/logic/operationHandlers/mathHandler.test.js
@@ -8,6 +8,7 @@ import MathHandler from '../../../src/logic/operationHandlers/mathHandler.js';
 describe('MathHandler', () => {
   let handler;
   let logger;
+  let safeEventDispatcher;
   let execCtx;
 
   beforeEach(() => {
@@ -16,7 +17,11 @@ describe('MathHandler', () => {
       error: jest.fn(),
       debug: jest.fn(),
     };
-    handler = new MathHandler({ logger, jsonLogicEvaluationService: {} });
+    safeEventDispatcher = { dispatch: jest.fn() };
+    handler = new MathHandler({
+      logger,
+      safeEventDispatcher,
+    });
     execCtx = {
       evaluationContext: {
         context: { a: 10, b: 2, c: 'foo' },


### PR DESCRIPTION
Summary: Replace error logging in MathHandler with dispatching the core:display_error event. Updated DI registration and tests to inject SafeEventDispatcher.

Changes Made:
- Added SafeEventDispatcher dependency to MathHandler and removed unused JsonLogicEvaluationService
- Dispatched DISPLAY_ERROR_ID instead of logger.error calls in MathHandler
- Updated DI registration for MathHandler
- Adjusted unit tests for new constructor

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684d71f40fd88331a48004ca54f66063