### PR TITLE
[Agent] delegate getEntityName to utility

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -7,6 +7,7 @@ import {
   POSITION_COMPONENT_ID,
   EXITS_COMPONENT_ID,
 } from '../constants/componentIds.js';
+import { getEntityDisplayName } from '../utils/entityUtils.js';
 
 /**
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
@@ -104,19 +105,7 @@ export class EntityDisplayDataProvider {
       return defaultName;
     }
 
-    const nameComponent = entity.getComponentData(NAME_COMPONENT_ID);
-    if (
-      nameComponent &&
-      typeof nameComponent.text === 'string' &&
-      nameComponent.text.trim() !== ''
-    ) {
-      return nameComponent.text;
-    }
-
-    this.#logger.debug(
-      `${this._logPrefix} getEntityName: Entity '${entityId}' found, but no valid NAME_COMPONENT_ID data. Returning entity ID as name.`
-    );
-    return entity.id || defaultName;
+    return getEntityDisplayName(entity, defaultName, this.#logger);
   }
 
   /**

--- a/tests/services/entityDisplayDataProvider.test.js
+++ b/tests/services/entityDisplayDataProvider.test.js
@@ -94,10 +94,8 @@ describe('EntityDisplayDataProvider', () => {
       };
       mockEntityManager.getEntityInstance.mockReturnValue(mockEntityNoNameComp);
       expect(service.getEntityName('npcNoNameComp')).toBe('npcNoNameComp');
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Entity 'npcNoNameComp' found, but no valid NAME_COMPONENT_ID data. Returning entity ID as name."
-        )
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "getEntityDisplayName: Entity 'npcNoNameComp' has no usable name from component or 'entity.name'. Falling back to entity ID."
       );
 
       const mockEntityEmptyName = {


### PR DESCRIPTION
## Summary
- expose getEntityDisplayName util in EntityDisplayDataProvider
- use getEntityDisplayName inside getEntityName
- update provider tests

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684d748dc0448331837b5cd3e6c7dabd