### PR TITLE
[Agent] Use lodash cloneDeep in EntityManager

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import { v4 as uuidv4 } from 'uuid';
+import { cloneDeep } from 'lodash';
 import Entity from './entity.js';
 import {
   ACTOR_COMPONENT_ID,
@@ -51,17 +52,6 @@ function validationSucceeded(rawResult) {
   if (rawResult === undefined || rawResult === null) return true;
   if (typeof rawResult === 'boolean') return rawResult;
   return !!rawResult.isValid;
-}
-
-/**
- * Deep clone an arbitrary JSON-compatible object.
- *
- * @private
- * @param {object} obj
- * @returns {object}
- */
-function cloneDeep(obj) {
-  return JSON.parse(JSON.stringify(obj));
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove local cloneDeep helper from EntityManager
- import cloneDeep from lodash

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2187 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `PORT=8081 npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684d747d7b648331a26d8492ce869350