### PR TITLE
[Agent] replace dependency checks with validation utils

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -7,6 +7,8 @@ import {
   POSITION_COMPONENT_ID,
   EXITS_COMPONENT_ID,
 } from '../constants/componentIds.js';
+import { validateDependency } from '../utils/validationUtils.js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 
 /**
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
@@ -61,22 +63,20 @@ export class EntityDisplayDataProvider {
    * @param {ILogger} dependencies.logger - The logger instance.
    */
   constructor({ entityManager, logger }) {
-    if (
-      !entityManager ||
-      typeof entityManager.getEntityInstance !== 'function'
-    ) {
-      const errMsg = `${this._logPrefix} 'entityManager' dependency is missing or invalid.`;
-      (logger || console).error(errMsg);
-      throw new Error(errMsg);
-    }
-    if (!logger || typeof logger.debug !== 'function') {
-      const errMsg = `${this._logPrefix} 'logger' dependency is missing or invalid.`;
-      console.error(errMsg);
-      throw new Error(errMsg);
-    }
+    validateDependency(logger, 'logger', console, {
+      requiredMethods: ['info', 'warn', 'error', 'debug'],
+    });
+    const effectiveLogger = ensureValidLogger(
+      logger,
+      'EntityDisplayDataProvider'
+    );
+
+    validateDependency(entityManager, 'entityManager', effectiveLogger, {
+      requiredMethods: ['getEntityInstance'],
+    });
 
     this.#entityManager = entityManager;
-    this.#logger = logger;
+    this.#logger = effectiveLogger;
     this.#logger.debug(`${this._logPrefix} Service instantiated.`);
   }
 

--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -21,6 +21,8 @@ import {
   NOTES_COMPONENT_ID,
 } from '../constants/componentIds.js';
 import { IEntityManager } from '../interfaces/IEntityManager.js';
+import { validateDependency } from '../utils/validationUtils.js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 
 /* -------------------------------------------------------------------------- */
 /* Type-Hint Imports (JSDoc only – removed at runtime)                        */
@@ -78,22 +80,7 @@ function formatValidationErrors(rawResult) {
   return '(validator returned false)';
 }
 
-/**
- * Assert that an injected dependency exposes required methods.
- *
- * @private
- * @param {string} name
- * @param {object} instance
- * @param {string[]} methods
- */
-function assertInterface(name, instance, methods) {
-  const missing = methods.some((m) => typeof instance?.[m] !== 'function');
-  if (!instance || missing) {
-    throw new Error(
-      `EntityManager requires an ${name} instance with ${methods.join(', ')}.`
-    );
-  }
-}
+// assertInterface removed; using validateDependency instead
 
 /* -------------------------------------------------------------------------- */
 /* EntityManager Implementation                                               */
@@ -135,19 +122,33 @@ class EntityManager extends IEntityManager {
     super();
 
     /* ---------- dependency checks ---------- */
-    assertInterface('IDataRegistry', registry, ['getEntityDefinition']);
-    assertInterface('ISchemaValidator', validator, ['validate']);
-    assertInterface('ILogger', logger, ['info', 'error', 'warn', 'debug']);
-    assertInterface('ISpatialIndexManager', spatialIndexManager, [
-      'addEntity',
-      'removeEntity',
-      'updateEntityLocation',
-      'clearIndex',
-    ]);
+    validateDependency(logger, 'ILogger', console, {
+      requiredMethods: ['info', 'error', 'warn', 'debug'],
+    });
+    this.#logger = ensureValidLogger(logger, 'EntityManager');
+
+    validateDependency(registry, 'IDataRegistry', this.#logger, {
+      requiredMethods: ['getEntityDefinition'],
+    });
+    validateDependency(validator, 'ISchemaValidator', this.#logger, {
+      requiredMethods: ['validate'],
+    });
+    validateDependency(
+      spatialIndexManager,
+      'ISpatialIndexManager',
+      this.#logger,
+      {
+        requiredMethods: [
+          'addEntity',
+          'removeEntity',
+          'updateEntityLocation',
+          'clearIndex',
+        ],
+      }
+    );
 
     this.#registry = registry;
     this.#validator = validator;
-    this.#logger = logger;
     this.#spatialIndexManager = spatialIndexManager;
     this.#definitionToPrimaryInstanceMap = new Map();
 

--- a/tests/entities/entityManager.test.js
+++ b/tests/entities/entityManager.test.js
@@ -95,33 +95,37 @@ describe('EntityManager', () => {
     delete invalidSpatialMissingMethod.addEntity; // Example of a missing essential method
 
     it.each([
+      ['IDataRegistry', null, /Missing required dependency: IDataRegistry/],
       [
-        'IDataRegistry',
+        'ISchemaValidator',
         null,
-        /IDataRegistry instance with getEntityDefinition/,
+        /Missing required dependency: ISchemaValidator/,
       ],
-      ['ISchemaValidator', null, /ISchemaValidator instance with validate/],
-      ['ILogger', null, /ILogger instance/],
-      ['ISpatialIndexManager', null, /ISpatialIndexManager instance/],
+      ['ILogger', null, /Missing required dependency: ILogger/],
+      [
+        'ISpatialIndexManager',
+        null,
+        /Missing required dependency: ISpatialIndexManager/,
+      ],
       [
         'IDataRegistry (missing method)',
         invalidRegistryMissingMethod,
-        /IDataRegistry instance with getEntityDefinition/,
+        /Invalid or missing method 'getEntityDefinition' on dependency 'IDataRegistry'/,
       ],
       [
         'ISchemaValidator (missing method)',
         invalidValidatorMissingMethod,
-        /ISchemaValidator instance with validate/,
+        /Invalid or missing method 'validate' on dependency 'ISchemaValidator'/,
       ],
       [
         'ILogger (missing method)',
         invalidLoggerMissingMethod,
-        /ILogger instance/,
+        /Invalid or missing method 'error' on dependency 'ILogger'/,
       ],
       [
         'ISpatialIndexManager (missing method)',
         invalidSpatialMissingMethod,
-        /ISpatialIndexManager instance/,
+        /Invalid or missing method 'addEntity' on dependency 'ISpatialIndexManager'/,
       ],
     ])(
       'should throw an Error if %s is missing or invalid (%p)',

--- a/tests/services/entityDisplayDataProvider.test.js
+++ b/tests/services/entityDisplayDataProvider.test.js
@@ -37,28 +37,30 @@ describe('EntityDisplayDataProvider', () => {
     it('should throw an error if entityManager is missing or invalid', () => {
       expect(
         () => new EntityDisplayDataProvider({ logger: mockLogger })
-      ).toThrow("'entityManager' dependency is missing or invalid.");
+      ).toThrow('Missing required dependency: entityManager.');
       expect(
         () =>
           new EntityDisplayDataProvider({
             entityManager: {},
             logger: mockLogger,
           })
-      ).toThrow("'entityManager' dependency is missing or invalid.");
+      ).toThrow(
+        "Invalid or missing method 'getEntityInstance' on dependency 'entityManager'."
+      );
     });
 
     it('should throw an error if logger is missing or invalid', () => {
       expect(
         () =>
           new EntityDisplayDataProvider({ entityManager: mockEntityManager })
-      ).toThrow("'logger' dependency is missing or invalid.");
+      ).toThrow('Missing required dependency: logger.');
       expect(
         () =>
           new EntityDisplayDataProvider({
             entityManager: mockEntityManager,
             logger: {},
           })
-      ).toThrow("'logger' dependency is missing or invalid.");
+      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
     });
 
     it('should instantiate successfully with valid dependencies', () => {


### PR DESCRIPTION
## Summary
- use `validateDependency` and `ensureValidLogger`
- drop custom `assertInterface`
- update constructor tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2185 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684d745dc7708331b749efec0c3157c4