### PR TITLE
[Agent] unify map management with MapManager

### DIFF
--- a/src/utils/mapManager.js
+++ b/src/utils/mapManager.js
@@ -1,0 +1,125 @@
+// src/utils/mapManager.js
+
+/**
+ * @class MapManager
+ * @description
+ * Generic helper for managing an internal Map with basic add, get,
+ * remove, and presence-check operations. Provides static ID validation
+ * and allows subclasses to customise how invalid IDs are handled.
+ */
+class MapManager {
+  /**
+   * Initializes the internal Map storage.
+   */
+  constructor() {
+    /**
+     * Internal storage map.
+     * @type {Map<string, any>}
+     */
+    this.items = new Map();
+  }
+
+  /**
+   * Determine if a value is a non-empty string ID.
+   *
+   * @param {any} id
+   * @returns {boolean}
+   */
+  static isValidId(id) {
+    return typeof id === 'string' && id.trim() !== '';
+  }
+
+  /**
+   * Hook called when an invalid ID is encountered. Subclasses may override
+   * to customise behaviour (e.g., logging instead of throwing).
+   *
+   * @protected
+   * @param {any} id
+   * @param {string} operation
+   */
+  onInvalidId(id, operation) {
+    throw new Error(
+      `${this.constructor.name}.${operation}: Invalid id '${id}'.`
+    );
+  }
+
+  /**
+   * Add or overwrite a value for the given ID.
+   *
+   * @param {string} id
+   * @param {any} value
+   */
+  add(id, value) {
+    if (!MapManager.isValidId(id)) {
+      this.onInvalidId(id, 'add');
+      return;
+    }
+    this.items.set(id, value);
+  }
+
+  /**
+   * Retrieve a value by its ID.
+   *
+   * @param {string} id
+   * @returns {any}
+   */
+  get(id) {
+    if (!MapManager.isValidId(id)) {
+      this.onInvalidId(id, 'get');
+      return undefined;
+    }
+    return this.items.get(id);
+  }
+
+  /**
+   * Check if the map contains the given ID.
+   *
+   * @param {string} id
+   * @returns {boolean}
+   */
+  has(id) {
+    if (!MapManager.isValidId(id)) {
+      this.onInvalidId(id, 'has');
+      return false;
+    }
+    return this.items.has(id);
+  }
+
+  /**
+   * Remove an entry by ID.
+   *
+   * @param {string} id
+   * @returns {boolean}
+   */
+  remove(id) {
+    if (!MapManager.isValidId(id)) {
+      this.onInvalidId(id, 'remove');
+      return false;
+    }
+    return this.items.delete(id);
+  }
+
+  /** @returns {IterableIterator<string>} */
+  keys() {
+    return this.items.keys();
+  }
+
+  /** @returns {IterableIterator<any>} */
+  values() {
+    return this.items.values();
+  }
+
+  /** @returns {IterableIterator<[string, any]>} */
+  entries() {
+    return this.items.entries();
+  }
+
+  /**
+   * Remove all entries from the map.
+   */
+  clear() {
+    this.items.clear();
+  }
+}
+
+export default MapManager;

--- a/src/utils/silentMapManager.js
+++ b/src/utils/silentMapManager.js
@@ -1,0 +1,17 @@
+// src/utils/silentMapManager.js
+
+import MapManager from './mapManager.js';
+
+/**
+ * @class SilentMapManager
+ * @description MapManager variant that ignores invalid IDs
+ * instead of throwing errors.
+ */
+class SilentMapManager extends MapManager {
+  /** @override */
+  onInvalidId() {
+    // deliberately no-op
+  }
+}
+
+export default SilentMapManager;


### PR DESCRIPTION
## Summary
- introduce `MapManager` and `SilentMapManager` helpers
- refactor `Entity` to extend `MapManager`
- refactor `EntityManager` to use `SilentMapManager`
- refactor `SpatialIndexManager` to extend `MapManager`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_684d74b985f48331b906125146ec49b8