### PR TITLE
[Agent] Update HumanTurnHandler tests after refactor

### DIFF
--- a/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
+++ b/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
@@ -23,6 +23,7 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
   let mockChoicePipeline;
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
+  let mockTurnStrategyFactory;
 
   beforeEach(() => {
     mockLogger = {
@@ -42,6 +43,9 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
     mockChoicePipeline = {};
     mockHumanDecisionProvider = {};
     mockTurnActionFactory = {};
+    mockTurnStrategyFactory = {
+      createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+    };
 
     deps = {
       logger: mockLogger,
@@ -54,6 +58,7 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
+      turnStrategyFactory: mockTurnStrategyFactory,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
@@ -23,6 +23,7 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
   let mockChoicePipeline;
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
+  let mockTurnStrategyFactory;
 
   beforeEach(() => {
     mockLogger = {
@@ -42,6 +43,9 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
     mockChoicePipeline = {};
     mockHumanDecisionProvider = {};
     mockTurnActionFactory = {};
+    mockTurnStrategyFactory = {
+      createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+    };
 
     deps = {
       logger: mockLogger,
@@ -54,6 +58,7 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
+      turnStrategyFactory: mockTurnStrategyFactory,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
@@ -21,6 +21,7 @@ let mockSafeEventDispatcher;
 let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
+let mockTurnStrategyFactory;
 
 beforeEach(() => {
   mockLogger = {
@@ -42,6 +43,9 @@ beforeEach(() => {
   mockChoicePipeline = {};
   mockHumanDecisionProvider = {};
   mockTurnActionFactory = {};
+  mockTurnStrategyFactory = {
+    createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+  };
 
   deps = {
     logger: mockLogger,
@@ -54,6 +58,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
+    turnStrategyFactory: mockTurnStrategyFactory,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
@@ -20,6 +20,7 @@ let mockSafeEventDispatcher;
 let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
+let mockTurnStrategyFactory;
 
 beforeEach(() => {
   mockLogger = {
@@ -39,6 +40,9 @@ beforeEach(() => {
   mockChoicePipeline = {};
   mockHumanDecisionProvider = {};
   mockTurnActionFactory = {};
+  mockTurnStrategyFactory = {
+    createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+  };
 
   deps = {
     logger: mockLogger,
@@ -51,6 +55,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
+    turnStrategyFactory: mockTurnStrategyFactory,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
+++ b/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
@@ -13,6 +13,7 @@ import { BaseTurnHandler } from '../../../src/turns/handlers/baseTurnHandler.js'
 let deps;
 let mockLogger;
 let mockTurnStateFactory;
+let mockTurnStrategyFactory;
 
 beforeEach(() => {
   mockLogger = {
@@ -23,6 +24,9 @@ beforeEach(() => {
   };
   mockTurnStateFactory = {
     createInitialState: jest.fn().mockReturnValue({ stateName: 'init' }),
+  };
+  mockTurnStrategyFactory = {
+    createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
   deps = {
     logger: mockLogger,
@@ -35,6 +39,7 @@ beforeEach(() => {
     choicePipeline: {},
     humanDecisionProvider: {},
     turnActionFactory: {},
+    turnStrategyFactory: mockTurnStrategyFactory,
   };
   jest
     .spyOn(BaseTurnHandler.prototype, '_setInitialState')

--- a/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
+++ b/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
@@ -21,6 +21,7 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
   let mockChoicePipeline;
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
+  let mockTurnStrategyFactory;
 
   beforeEach(() => {
     mockLogger = {
@@ -40,6 +41,9 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
     mockChoicePipeline = {};
     mockHumanDecisionProvider = {};
     mockTurnActionFactory = {};
+    mockTurnStrategyFactory = {
+      createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+    };
 
     deps = {
       logger: mockLogger,
@@ -52,6 +56,7 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
+      turnStrategyFactory: mockTurnStrategyFactory,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
@@ -23,6 +23,7 @@ describe('HumanTurnHandler method delegation', () => {
   let mockChoicePipeline;
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
+  let mockTurnStrategyFactory;
 
   beforeEach(() => {
     mockLogger = {
@@ -42,6 +43,9 @@ describe('HumanTurnHandler method delegation', () => {
     mockChoicePipeline = {};
     mockHumanDecisionProvider = {};
     mockTurnActionFactory = {};
+    mockTurnStrategyFactory = {
+      createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+    };
 
     deps = {
       logger: mockLogger,
@@ -54,6 +58,7 @@ describe('HumanTurnHandler method delegation', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
+      turnStrategyFactory: mockTurnStrategyFactory,
     };
     jest
       .spyOn(BaseTurnHandler.prototype, '_setInitialState')

--- a/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
@@ -20,6 +20,7 @@ let mockSafeEventDispatcher;
 let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
+let mockTurnStrategyFactory;
 
 beforeEach(() => {
   mockLogger = {
@@ -39,6 +40,9 @@ beforeEach(() => {
   mockChoicePipeline = {};
   mockHumanDecisionProvider = {};
   mockTurnActionFactory = {};
+  mockTurnStrategyFactory = {
+    createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+  };
 
   deps = {
     logger: mockLogger,
@@ -51,6 +55,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
+    turnStrategyFactory: mockTurnStrategyFactory,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
+++ b/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
@@ -21,6 +21,7 @@ let mockSafeEventDispatcher;
 let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
+let mockTurnStrategyFactory;
 
 beforeEach(() => {
   mockLogger = {
@@ -40,6 +41,9 @@ beforeEach(() => {
   mockChoicePipeline = {};
   mockHumanDecisionProvider = {};
   mockTurnActionFactory = {};
+  mockTurnStrategyFactory = {
+    createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
+  };
 
   deps = {
     logger: mockLogger,
@@ -52,6 +56,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
+    turnStrategyFactory: mockTurnStrategyFactory,
   };
 
   jest


### PR DESCRIPTION
Summary: Updated several HumanTurnHandler test suites to provide the new `turnStrategyFactory` dependency required by the refactored constructor. Each mock now returns a minimal strategy with a `decideAction` method, allowing TurnContext creation. All root and proxy tests pass.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684d789ad57083319e07ea854f2e73df