### PR TITLE
[Agent] centralize entity ref resolution

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -13,6 +13,7 @@
 /** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */ // Reuse definition
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * Parameters accepted by {@link AddComponentHandler#execute}.
@@ -69,35 +70,6 @@ class AddComponentHandler {
   }
 
   /**
-   * Resolves entity_ref -> entityId or null.
-   * (Copied directly from ModifyComponentHandler as the logic is identical)
-   *
-   * @private
-   * @param {AddComponentOperationParams['entity_ref']} ref - The entity reference from parameters.
-   * @param {ExecutionContext} ctx - The execution context.
-   * @returns {string | null} The resolved entity ID or null.
-   */
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t; // Assume direct ID
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
-
-  /**
    * Executes the ADD_COMPONENT operation.
    * Adds a new component instance (or replaces an existing one) on the specified entity.
    *
@@ -138,7 +110,7 @@ class AddComponentHandler {
     const trimmedComponentType = component_type.trim();
 
     // 2. Resolve Entity ID
-    const entityId = this.#resolveEntityId(entity_ref, executionContext);
+    const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
       log.warn(`ADD_COMPONENT: Could not resolve entity id from entity_ref.`, {
         entity_ref,

--- a/src/logic/operationHandlers/hasComponentHandler.js
+++ b/src/logic/operationHandlers/hasComponentHandler.js
@@ -12,6 +12,7 @@
 /** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * Parameters accepted by {@link HasComponentHandler#execute}.
@@ -72,25 +73,6 @@ class HasComponentHandler {
    * @param {ExecutionContext} ctx - The execution context.
    * @returns {string | null} The resolved entity ID or null.
    */
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t; // Assume direct ID
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
 
   /**
    * Executes the HAS_COMPONENT operation.
@@ -131,7 +113,7 @@ class HasComponentHandler {
     const trimmedComponentType = component_type.trim();
 
     // 2. Resolve Entity ID
-    const entityId = this.#resolveEntityId(entity_ref, executionContext);
+    const entityId = resolveEntityId(entity_ref, executionContext);
 
     // 3. Perform check and store result
     let result = false; // Default to false

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -12,6 +12,7 @@
 import resolvePath from '../../utils/resolvePath.js';
 import { cloneDeep } from 'lodash';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * @class ModifyArrayFieldHandler
@@ -58,35 +59,6 @@ class ModifyArrayFieldHandler {
   }
 
   /**
-   * Resolves entity_ref -> entityId or null.
-   * (Copied from other handlers as this is the established pattern).
-   *
-   * @private
-   * @param {string|'actor'|'target'|EntityRefObject} ref - The entity reference from parameters.
-   * @param {ExecutionContext} ctx - The execution context.
-   * @returns {string | null} The resolved entity ID or null.
-   */
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t; // Assume direct ID
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
-
-  /**
    * Executes the array modification operation.
    *
    * @param {object} params - The parameters for the operation.
@@ -101,7 +73,7 @@ class ModifyArrayFieldHandler {
   execute(params, executionContext) {
     const log = executionContext?.logger ?? this.#logger;
     // 1. Resolve Entity ID
-    const entityId = this.#resolveEntityId(params.entity_ref, executionContext);
+    const entityId = resolveEntityId(params.entity_ref, executionContext);
     if (!entityId) {
       log.warn(
         `MODIFY_ARRAY_FIELD: Could not resolve entity_ref: ${JSON.stringify(

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -11,6 +11,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * @typedef {object} EntityRefObject
@@ -81,26 +82,6 @@ class ModifyComponentHandler {
     this.#dispatcher = safeEventDispatcher;
   }
 
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t;
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
-
   /**
    * Executes a MODIFY_COMPONENT operation (mode = "set" only).
    *
@@ -142,7 +123,7 @@ class ModifyComponentHandler {
     }
 
     // ── resolve entity ─────────────────────────────────────────────
-    const entityId = this.#resolveEntityId(entity_ref, execCtx);
+    const entityId = resolveEntityId(entity_ref, execCtx);
     if (!entityId) {
       log.warn('MODIFY_COMPONENT: could not resolve entity id.', {
         entity_ref,

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -6,6 +6,7 @@
 /** @typedef {import('../defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../defs.js').OperationParams} OperationParams */
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject
@@ -43,67 +44,6 @@ class QueryComponentHandler {
     }
     this.#entityManager = entityManager;
     this.#logger = logger;
-  }
-
-  #resolveEntityId(entityRef, executionContext, logger) {
-    const actorId = executionContext?.evaluationContext?.actor?.id;
-    const targetId = executionContext?.evaluationContext?.target?.id;
-
-    if (typeof entityRef === 'string') {
-      const trimmedRef = entityRef.trim();
-      if (!trimmedRef) {
-        logger.error(
-          'QueryComponentHandler: Invalid empty string provided for entity_ref.',
-          { entityRef }
-        );
-        return null;
-      }
-
-      if (trimmedRef === 'actor') {
-        if (!actorId) {
-          logger.error(
-            "QueryComponentHandler: Cannot resolve 'actor' entity ID. Actor missing or has no ID in evaluationContext.actor.",
-            { evalContextActor: executionContext?.evaluationContext?.actor }
-          );
-          return null;
-        }
-        return actorId;
-      } else if (trimmedRef === 'target') {
-        if (!targetId) {
-          logger.error(
-            "QueryComponentHandler: Cannot resolve 'target' entity ID. Target missing or has no ID in evaluationContext.target.",
-            { evalContextTarget: executionContext?.evaluationContext?.target }
-          );
-          return null;
-        }
-        return targetId;
-      } else {
-        logger.debug(
-          `QueryComponentHandler: Interpreting entity_ref string "${trimmedRef}" as a direct entity ID.`
-        );
-        return trimmedRef;
-      }
-    } else if (
-      typeof entityRef === 'object' &&
-      entityRef !== null &&
-      typeof entityRef.entityId === 'string'
-    ) {
-      const trimmedId = entityRef.entityId.trim();
-      if (!trimmedId) {
-        logger.error(
-          'QueryComponentHandler: Invalid entity_ref object: entityId property is empty or whitespace.',
-          { entityRef }
-        );
-        return null;
-      }
-      return trimmedId;
-    } else {
-      logger.error(
-        'QueryComponentHandler: Invalid entity_ref parameter. Must be "actor", "target", a non-empty entity ID string, or an object like { entityId: "..." }.',
-        { entityRef }
-      );
-      return null;
-    }
   }
 
   execute(params, executionContext) {
@@ -156,14 +96,65 @@ class QueryComponentHandler {
     }
     const trimmedResultVariable = result_variable.trim();
 
-    const entityId = this.#resolveEntityId(
-      entity_ref,
-      executionContext,
-      logger
-    );
+    const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
-      // Error already logged by #resolveEntityId
+      if (typeof entity_ref === 'string') {
+        const trimmedRef = entity_ref.trim();
+        if (!trimmedRef) {
+          logger.error(
+            'QueryComponentHandler: Invalid empty string provided for entity_ref.',
+            { entityRef: entity_ref }
+          );
+        } else if (trimmedRef === 'actor') {
+          logger.error(
+            "QueryComponentHandler: Cannot resolve 'actor' entity ID. Actor missing or has no ID in evaluationContext.actor.",
+            { evalContextActor: executionContext?.evaluationContext?.actor }
+          );
+        } else if (trimmedRef === 'target') {
+          logger.error(
+            "QueryComponentHandler: Cannot resolve 'target' entity ID. Target missing or has no ID in evaluationContext.target.",
+            { evalContextTarget: executionContext?.evaluationContext?.target }
+          );
+        } else {
+          logger.error(
+            'QueryComponentHandler: Invalid entity_ref parameter. Must be "actor", "target", a non-empty entity ID string, or an object like { entityId: "..." }.',
+            { entityRef: entity_ref }
+          );
+        }
+      } else if (
+        entity_ref &&
+        typeof entity_ref === 'object' &&
+        typeof entity_ref.entityId === 'string'
+      ) {
+        if (!entity_ref.entityId.trim()) {
+          logger.error(
+            'QueryComponentHandler: Invalid entity_ref object: entityId property is empty or whitespace.',
+            { entityRef: entity_ref }
+          );
+        } else {
+          logger.error(
+            'QueryComponentHandler: Invalid entity_ref parameter. Must be "actor", "target", a non-empty entity ID string, or an object like { entityId: "..." }.',
+            { entityRef: entity_ref }
+          );
+        }
+      } else {
+        logger.error(
+          'QueryComponentHandler: Invalid entity_ref parameter. Must be "actor", "target", a non-empty entity ID string, or an object like { entityId: "..." }.',
+          { entityRef: entity_ref }
+        );
+      }
       return;
+    }
+
+    if (
+      typeof entity_ref === 'string' &&
+      entity_ref.trim() &&
+      entity_ref.trim() !== 'actor' &&
+      entity_ref.trim() !== 'target'
+    ) {
+      logger.debug(
+        `QueryComponentHandler: Interpreting entity_ref string "${entity_ref.trim()}" as a direct entity ID.`
+      );
     }
 
     logger.debug(

--- a/src/logic/operationHandlers/removeComponentHandler.js
+++ b/src/logic/operationHandlers/removeComponentHandler.js
@@ -11,6 +11,7 @@
 /** @typedef {import('../defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */ // Reuse definition
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 /**
  * Parameters accepted by {@link RemoveComponentHandler#execute}.
@@ -66,25 +67,6 @@ class RemoveComponentHandler {
    * @param {ExecutionContext} ctx - The execution context.
    * @returns {string | null} The resolved entity ID or null.
    */
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t; // Assume direct ID
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
 
   /**
    * Executes the REMOVE_COMPONENT operation.
@@ -121,7 +103,7 @@ class RemoveComponentHandler {
     const trimmedComponentType = component_type.trim();
 
     // 2. Resolve Entity ID
-    const entityId = this.#resolveEntityId(entity_ref, executionContext);
+    const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
       log.warn(
         `REMOVE_COMPONENT: Could not resolve entity id from entity_ref.`,

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -9,6 +9,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher */
 /** @typedef {import('../defs.js').EntityRefObject} EntityRefObject */
+import resolveEntityId from '../../utils/entityRefUtils.js';
 
 class SystemMoveEntityHandler {
   #logger;
@@ -30,25 +31,6 @@ class SystemMoveEntityHandler {
    * @param {ExecutionContext} ctx - The execution context.
    * @returns {string | null} The resolved entity ID or null.
    */
-  #resolveEntityId(ref, ctx) {
-    const ec = ctx?.evaluationContext ?? {};
-    if (typeof ref === 'string') {
-      const t = ref.trim();
-      if (!t) return null;
-      if (t === 'actor') return ec.actor?.id ?? null;
-      if (t === 'target') return ec.target?.id ?? null;
-      return t; // Assume direct ID
-    }
-    if (
-      ref &&
-      typeof ref === 'object' &&
-      typeof ref.entityId === 'string' &&
-      ref.entityId.trim()
-    ) {
-      return ref.entityId.trim();
-    }
-    return null;
-  }
 
   /**
    * Executes the SYSTEM_MOVE_ENTITY operation.
@@ -74,7 +56,7 @@ class SystemMoveEntityHandler {
     }
 
     // 2. Resolve the entity ID
-    const entityId = this.#resolveEntityId(entity_ref, executionContext);
+    const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
       log.warn(`${opName}: Could not resolve entity_ref.`, { entity_ref });
       return;

--- a/src/utils/entityRefUtils.js
+++ b/src/utils/entityRefUtils.js
@@ -1,0 +1,37 @@
+/**
+ * @file Utility functions for entity reference resolution.
+ */
+
+/**
+ * Resolves an entity reference to a concrete entity ID.
+ * Supports string references 'actor' and 'target', direct ID strings,
+ * or objects shaped like `{ entityId: string }`.
+ *
+ * @param {'actor'|'target'|string|{entityId:string}|null|undefined} ref - The entity reference.
+ * @param {object} ctx - The execution context containing evaluationContext.
+ * @returns {string|null} The resolved entity ID, or null if it cannot be resolved.
+ */
+export function resolveEntityId(ref, ctx) {
+  const ec = ctx?.evaluationContext ?? {};
+
+  if (typeof ref === 'string') {
+    const t = ref.trim();
+    if (!t) return null;
+    if (t === 'actor') return ec.actor?.id ?? null;
+    if (t === 'target') return ec.target?.id ?? null;
+    return t; // assume direct ID string
+  }
+
+  if (
+    ref &&
+    typeof ref === 'object' &&
+    typeof ref.entityId === 'string' &&
+    ref.entityId.trim()
+  ) {
+    return ref.entityId.trim();
+  }
+
+  return null;
+}
+
+export default resolveEntityId;


### PR DESCRIPTION
## Summary
- add shared `resolveEntityId` util for resolving actor/target/entity refs
- update operation handlers to use the shared helper

## Testing Done
- [x] `npm run format`
- [ ] `npm run lint` *(fails: 561 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684d7ab3ef9883318344a3180f7f0c8b