### PR TITLE
[Agent] Fix HumanTurnHandler constructor tests

### DIFF
--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -26,7 +26,7 @@ import { TurnActionChoicePipeline } from '../../turns/pipeline/turnActionChoiceP
 import { HumanDecisionProvider } from '../../turns/providers/humanDecisionProvider';
 import { GenericTurnStrategyFactory } from '../../turns/factories/genericTurnStrategyFactory.js';
 import { TurnContextBuilder } from '../../turns/builders/turnContextBuilder.js';
-import { assertValidActor } from '../../utils/validation/actorValidation.js';
+import { assertValidActor } from '../../utils/actorValidation.js';
 
 /**
  * @param {import('../appContainer.js').default} container
@@ -134,7 +134,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ──────────────────── Validation Utils ─────────────────────
-  r.value(tokens.assertValidActor, assertValidActor);
+  r.singletonFactory(tokens.assertValidActor, () => assertValidActor);
 
   // ───────────────── Turn Context Builder ────────────────────
   r.transientFactory(

--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -123,7 +123,15 @@ class HumanTurnHandler extends BaseTurnHandler {
    * @param {Entity} actor
    */
   async startTurn(actor) {
+    this._logger.debug(
+      `${this.constructor.name}.startTurn called for actor ${actor?.id}.`
+    );
     super._assertHandlerActive();
+    if (!actor || typeof actor.id !== 'string' || actor.id.trim() === '') {
+      const errorMsg = `${this.constructor.name}.startTurn: actor is required and must have a valid id.`;
+      this._logger.error(errorMsg);
+      throw new Error(errorMsg);
+    }
     this._setCurrentActorInternal(actor);
 
     const humanStrategy = this.#turnStrategyFactory.createForHuman(actor.id);

--- a/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
+++ b/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
@@ -24,6 +24,7 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
   let mockTurnStrategyFactory;
+  let mockTurnContextBuilder;
 
   beforeEach(() => {
     mockLogger = {
@@ -46,6 +47,7 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
     mockTurnStrategyFactory = {
       createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
     };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     deps = {
       logger: mockLogger,
@@ -59,6 +61,7 @@ describe('HumanTurnHandler handleSubmittedCommand actor mismatch', () => {
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
       turnStrategyFactory: mockTurnStrategyFactory,
+      turnContextBuilder: mockTurnContextBuilder,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
@@ -24,6 +24,7 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
   let mockTurnStrategyFactory;
+  let mockTurnContextBuilder;
 
   beforeEach(() => {
     mockLogger = {
@@ -46,6 +47,7 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
     mockTurnStrategyFactory = {
       createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
     };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     deps = {
       logger: mockLogger,
@@ -59,6 +61,7 @@ describe('HumanTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
       turnStrategyFactory: mockTurnStrategyFactory,
+      turnContextBuilder: mockTurnContextBuilder,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
@@ -22,6 +22,7 @@ let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
 let mockTurnStrategyFactory;
+let mockTurnContextBuilder;
 
 beforeEach(() => {
   mockLogger = {
@@ -46,6 +47,21 @@ beforeEach(() => {
   mockTurnStrategyFactory = {
     createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
+  mockTurnContextBuilder = {
+    build: jest.fn(({ actor, setAwaitFlag }) => {
+      return {
+        getActor: () => actor,
+        awaitFlag: false,
+        setAwaitingExternalEvent(flag, id) {
+          this.awaitFlag = flag;
+          if (typeof setAwaitFlag === 'function') setAwaitFlag(flag, id);
+        },
+        isAwaitingExternalEvent() {
+          return this.awaitFlag === true;
+        },
+      };
+    }),
+  };
 
   deps = {
     logger: mockLogger,
@@ -59,6 +75,7 @@ beforeEach(() => {
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
     turnStrategyFactory: mockTurnStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
@@ -21,6 +21,7 @@ let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
 let mockTurnStrategyFactory;
+let mockTurnContextBuilder;
 
 beforeEach(() => {
   mockLogger = {
@@ -43,6 +44,7 @@ beforeEach(() => {
   mockTurnStrategyFactory = {
     createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
+  mockTurnContextBuilder = { build: jest.fn() };
 
   deps = {
     logger: mockLogger,
@@ -56,6 +58,7 @@ beforeEach(() => {
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
     turnStrategyFactory: mockTurnStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
+++ b/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
@@ -14,6 +14,7 @@ let deps;
 let mockLogger;
 let mockTurnStateFactory;
 let mockTurnStrategyFactory;
+let mockTurnContextBuilder;
 
 beforeEach(() => {
   mockLogger = {
@@ -28,6 +29,7 @@ beforeEach(() => {
   mockTurnStrategyFactory = {
     createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
+  mockTurnContextBuilder = { build: jest.fn() };
   deps = {
     logger: mockLogger,
     turnStateFactory: mockTurnStateFactory,
@@ -40,6 +42,7 @@ beforeEach(() => {
     humanDecisionProvider: {},
     turnActionFactory: {},
     turnStrategyFactory: mockTurnStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
   jest
     .spyOn(BaseTurnHandler.prototype, '_setInitialState')

--- a/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
+++ b/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
@@ -22,6 +22,7 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
   let mockTurnStrategyFactory;
+  let mockTurnContextBuilder;
 
   beforeEach(() => {
     mockLogger = {
@@ -44,6 +45,7 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
     mockTurnStrategyFactory = {
       createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
     };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     deps = {
       logger: mockLogger,
@@ -57,6 +59,7 @@ describe('HumanTurnHandler.handleSubmittedCommand with invalid actor', () => {
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
       turnStrategyFactory: mockTurnStrategyFactory,
+      turnContextBuilder: mockTurnContextBuilder,
     };
 
     jest

--- a/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
@@ -24,6 +24,7 @@ describe('HumanTurnHandler method delegation', () => {
   let mockHumanDecisionProvider;
   let mockTurnActionFactory;
   let mockTurnStrategyFactory;
+  let mockTurnContextBuilder;
 
   beforeEach(() => {
     mockLogger = {
@@ -46,6 +47,7 @@ describe('HumanTurnHandler method delegation', () => {
     mockTurnStrategyFactory = {
       createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
     };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     deps = {
       logger: mockLogger,
@@ -59,6 +61,7 @@ describe('HumanTurnHandler method delegation', () => {
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
       turnStrategyFactory: mockTurnStrategyFactory,
+      turnContextBuilder: mockTurnContextBuilder,
     };
     jest
       .spyOn(BaseTurnHandler.prototype, '_setInitialState')

--- a/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
@@ -21,6 +21,7 @@ let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
 let mockTurnStrategyFactory;
+let mockTurnContextBuilder;
 
 beforeEach(() => {
   mockLogger = {
@@ -43,6 +44,7 @@ beforeEach(() => {
   mockTurnStrategyFactory = {
     createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
+  mockTurnContextBuilder = { build: jest.fn() };
 
   deps = {
     logger: mockLogger,
@@ -56,6 +58,7 @@ beforeEach(() => {
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
     turnStrategyFactory: mockTurnStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
 
   jest

--- a/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
+++ b/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
@@ -22,6 +22,7 @@ let mockChoicePipeline;
 let mockHumanDecisionProvider;
 let mockTurnActionFactory;
 let mockTurnStrategyFactory;
+let mockTurnContextBuilder;
 
 beforeEach(() => {
   mockLogger = {
@@ -44,6 +45,7 @@ beforeEach(() => {
   mockTurnStrategyFactory = {
     createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
   };
+  mockTurnContextBuilder = { build: jest.fn() };
 
   deps = {
     logger: mockLogger,
@@ -57,6 +59,7 @@ beforeEach(() => {
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
     turnStrategyFactory: mockTurnStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
 
   jest

--- a/tests/turns/handlers/playerTurnHandler.fixes.test.js
+++ b/tests/turns/handlers/playerTurnHandler.fixes.test.js
@@ -21,6 +21,7 @@ describe('HumanTurnHandler Constructor', () => {
   let mockSafeEventDispatcher;
   let mockGameWorldAccess;
   let mockTurnStrategyFactory; // <-- Changed
+  let mockTurnContextBuilder;
   let mockInitialState;
   let setInitialStateSpy;
 
@@ -45,6 +46,7 @@ describe('HumanTurnHandler Constructor', () => {
     mockTurnStrategyFactory = {
       createForHuman: jest.fn(),
     };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     setInitialStateSpy = jest
       .spyOn(BaseTurnHandler.prototype, '_setInitialState')
@@ -67,6 +69,7 @@ describe('HumanTurnHandler Constructor', () => {
     promptCoordinator: mockPlayerPromptService,
     commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
     safeEventDispatcher: mockSafeEventDispatcher,
+    turnContextBuilder: mockTurnContextBuilder,
     turnStrategyFactory: mockTurnStrategyFactory, // <-- Changed
     gameWorldAccess: mockGameWorldAccess,
   });


### PR DESCRIPTION
Summary: fix broken import path and update tests for new HumanTurnHandler dependencies. Updated DI registration to provide assertValidActor correctly and adjusted state builder mocks.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint <files>`
- [ ] Root tests         `npm run test` *(fails: coverage thresholds)*
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

🚫 tests failing—needs human review
See attached logs for failing coverage thresholds.

------
https://chatgpt.com/codex/tasks/task_e_684d7c0d000c8331ae0df979344bcff4