### PR TITLE
[Agent] Replace hardcoded position ID

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -15,6 +15,7 @@ import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
 import { validateDependency } from '../utils/validationUtils.js';
 import { getAvailableExits } from '../utils/locationUtils.js';
+import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 export class ActionDiscoveryService extends IActionDiscoveryService {
@@ -116,7 +117,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     try {
       const pos = this.#entityManager.getComponentData(
         actorEntity.id,
-        'core:position'
+        POSITION_COMPONENT_ID
       );
       if (pos && typeof pos.locationId === 'string' && pos.locationId) {
         currentLocation =


### PR DESCRIPTION
Summary: Imported `POSITION_COMPONENT_ID` in `ActionDiscoveryService` and used it when retrieving an actor's position, improving maintainability.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (`npm run lint` – existing warnings)
- [x] Root tests `npm run test:single`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684d823c35c083319c974649e0d11de7