### PR TITLE
[Agent] add actor location helper

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -15,6 +15,7 @@ import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
 import { validateDependency } from '../utils/validationUtils.js';
 import { getAvailableExits } from '../utils/locationUtils.js';
+import { getActorLocation } from '../utils/actorLocationUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 export class ActionDiscoveryService extends IActionDiscoveryService {
@@ -111,21 +112,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     /** @type {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]} */
     const validActions = [];
 
-    /* ── Resolve actor location (entity preferred, id as fallback) ───────── */
-    let currentLocation = null;
-    try {
-      const pos = this.#entityManager.getComponentData(
-        actorEntity.id,
-        'core:position'
-      );
-      if (pos && typeof pos.locationId === 'string' && pos.locationId) {
-        currentLocation =
-          this.#entityManager.getEntityInstance(pos.locationId) ??
-          pos.locationId;
-      }
-    } catch {
-      /* ignore – currentLocation remains null */
-    }
+    /* ── Resolve actor location via utility ───────── */
+    let currentLocation = getActorLocation(actorEntity.id, this.#entityManager);
     const locIdForLog =
       typeof currentLocation === 'string'
         ? currentLocation

--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -10,11 +10,11 @@
 /** @typedef {import('../../logic/defs.js').JsonLogicEvaluationContext} JsonLogicEvaluationContext */
 
 // --- FIX: Import necessary functions and constants ---
-import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
-import { validateDependency } from '../../utils/validationUtils.js';
 import { getExitByDirection } from '../../utils/locationUtils.js';
+import { getActorLocation } from '../../utils/actorLocationUtils.js';
 import { createComponentAccessor } from '../../logic/contextAssembler.js';
 
+import { validateDependency } from '../../utils/validationUtils.js';
 /**
  * @class ActionValidationContextBuilder
  * @description Service dedicated to constructing the data context object used
@@ -146,17 +146,13 @@ export class ActionValidationContextBuilder {
         );
       }
     } else if (targetContext.type === 'direction' && targetContext.direction) {
-      const actorPositionData = this.#entityManager.getComponentData(
-        actor.id,
-        POSITION_COMPONENT_ID
-      );
-      const actorLocationId = actorPositionData?.locationId;
+      const actorLocation = getActorLocation(actor.id, this.#entityManager);
       let targetBlockerValue = undefined;
       let targetExitDetailsValue = null;
 
-      if (actorLocationId) {
+      if (actorLocation) {
         const matchedExit = getExitByDirection(
-          actorLocationId,
+          actorLocation,
           targetContext.direction,
           this.#entityManager,
           this.#logger

--- a/src/utils/actorLocationUtils.js
+++ b/src/utils/actorLocationUtils.js
@@ -1,0 +1,43 @@
+/**
+ * @module actorLocationUtils
+ * @description Helper utilities to retrieve an actor's current location.
+ */
+
+/** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../entities/entity.js').default} Entity */
+
+import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
+
+/**
+ * Retrieves the current location for the given actor entity.
+ *
+ * It looks up the actor's `core:position` component and resolves the
+ * referenced `locationId` to an entity instance if possible.
+ *
+ * @param {string} entityId - The instance ID of the actor.
+ * @param {IEntityManager} entityManager - Manager used to access component data.
+ * @returns {Entity | string | null} The location entity if found, otherwise the
+ * locationId string, or `null` when unavailable.
+ */
+export function getActorLocation(entityId, entityManager) {
+  if (!entityId || typeof entityId !== 'string') return null;
+  if (!entityManager || typeof entityManager.getComponentData !== 'function') {
+    return null;
+  }
+
+  try {
+    const pos = entityManager.getComponentData(entityId, POSITION_COMPONENT_ID);
+    if (pos && typeof pos.locationId === 'string' && pos.locationId) {
+      const locationEntity =
+        typeof entityManager.getEntityInstance === 'function'
+          ? entityManager.getEntityInstance(pos.locationId)
+          : null;
+      return locationEntity ?? pos.locationId;
+    }
+  } catch {
+    /* ignored */
+  }
+  return null;
+}
+
+export default getActorLocation;

--- a/tests/utils/actorLocationUtils.test.js
+++ b/tests/utils/actorLocationUtils.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { getActorLocation } from '../../src/utils/actorLocationUtils.js';
+
+/** @typedef {import('../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+/**
+ * Simple mock entity class
+ *
+ * @param id
+ */
+function createMockEntity(id) {
+  return { id };
+}
+
+describe('getActorLocation', () => {
+  /** @type {jest.Mocked<IEntityManager>} */
+  let mockEntityManager;
+
+  beforeEach(() => {
+    mockEntityManager = {
+      getComponentData: jest.fn(),
+      getEntityInstance: jest.fn(),
+    };
+  });
+
+  it('returns entity instance when locationId resolves to entity', () => {
+    const locEntity = createMockEntity('loc1');
+    mockEntityManager.getComponentData.mockReturnValue({ locationId: 'loc1' });
+    mockEntityManager.getEntityInstance.mockReturnValue(locEntity);
+
+    const result = getActorLocation('actor1', mockEntityManager);
+    expect(result).toBe(locEntity);
+  });
+
+  it('returns locationId string when entity lookup fails', () => {
+    mockEntityManager.getComponentData.mockReturnValue({ locationId: 'loc1' });
+    mockEntityManager.getEntityInstance.mockReturnValue(undefined);
+
+    const result = getActorLocation('actor1', mockEntityManager);
+    expect(result).toBe('loc1');
+  });
+
+  it('returns null when position component missing or invalid', () => {
+    mockEntityManager.getComponentData.mockReturnValue(undefined);
+    const result = getActorLocation('actor1', mockEntityManager);
+    expect(result).toBeNull();
+
+    mockEntityManager.getComponentData.mockReturnValue({ locationId: '' });
+    expect(getActorLocation('actor1', mockEntityManager)).toBeNull();
+  });
+
+  it('returns null when parameters are invalid', () => {
+    expect(getActorLocation(null, mockEntityManager)).toBeNull();
+    expect(getActorLocation('actor1', null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary: Added `getActorLocation` helper for fetching actor location from its position component. Refactored `ActionDiscoveryService` and `ActionValidationContextBuilder` to use this shared utility. Included dedicated unit tests for the helper.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: known repo-wide issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684d824f52e88331acb6ed896a3ca3d0