### PR TITLE
[Agent] Extract context builder helpers

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -10,10 +10,12 @@
 /** @typedef {import('../../logic/defs.js').JsonLogicEvaluationContext} JsonLogicEvaluationContext */
 
 // --- FIX: Import necessary functions and constants ---
-import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
 import { validateDependency } from '../../utils/validationUtils.js';
-import { getExitByDirection } from '../../utils/locationUtils.js';
-import { createComponentAccessor } from '../../logic/contextAssembler.js';
+import {
+  buildActorContext,
+  buildDirectionContext,
+  buildEntityTargetContext,
+} from './contextBuilders.js';
 
 /**
  * @class ActionValidationContextBuilder
@@ -111,14 +113,11 @@ export class ActionValidationContextBuilder {
     );
 
     // --- 2. Build Actor Context ---
-    const actorContext = {
-      id: actor.id,
-      components: createComponentAccessor(
-        actor.id,
-        this.#entityManager,
-        this.#logger
-      ),
-    };
+    const actorContext = buildActorContext(
+      actor.id,
+      this.#entityManager,
+      this.#logger
+    );
 
     // --- 3. Build Target Context (handles different target types) ---
     let targetContextForEval = null;
@@ -128,53 +127,23 @@ export class ActionValidationContextBuilder {
         targetContext.entityId
       );
       if (targetEntityInstance) {
-        targetContextForEval = {
-          type: 'entity',
-          id: targetContext.entityId,
-          direction: null,
-          components: createComponentAccessor(
-            targetContext.entityId,
-            this.#entityManager,
-            this.#logger
-          ),
-          blocker: undefined,
-          exitDetails: null,
-        };
+        targetContextForEval = buildEntityTargetContext(
+          targetContext.entityId,
+          this.#entityManager,
+          this.#logger
+        );
       } else {
         this.#logger.warn(
           `ActionValidationContextBuilder: Target entity '${targetContext.entityId}' not found for action '${actionDefinition.id}'. Context will have null target entity data.`
         );
       }
     } else if (targetContext.type === 'direction' && targetContext.direction) {
-      const actorPositionData = this.#entityManager.getComponentData(
+      targetContextForEval = buildDirectionContext(
         actor.id,
-        POSITION_COMPONENT_ID
+        targetContext.direction,
+        this.#entityManager,
+        this.#logger
       );
-      const actorLocationId = actorPositionData?.locationId;
-      let targetBlockerValue = undefined;
-      let targetExitDetailsValue = null;
-
-      if (actorLocationId) {
-        const matchedExit = getExitByDirection(
-          actorLocationId,
-          targetContext.direction,
-          this.#entityManager,
-          this.#logger
-        );
-        if (matchedExit) {
-          targetExitDetailsValue = matchedExit;
-          targetBlockerValue = matchedExit.blocker ?? null;
-        }
-      }
-
-      targetContextForEval = {
-        type: 'direction',
-        id: null,
-        direction: targetContext.direction,
-        components: null, // A direction has no components
-        blocker: targetBlockerValue,
-        exitDetails: targetExitDetailsValue,
-      };
     }
 
     // --- 4. Assemble Final Context ---

--- a/src/actions/validation/contextBuilders.js
+++ b/src/actions/validation/contextBuilders.js
@@ -1,0 +1,87 @@
+// src/actions/validation/contextBuilders.js
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entityManager.js').default} EntityManager */
+
+import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
+import { getExitByDirection } from '../../utils/locationUtils.js';
+import { createComponentAccessor } from '../../logic/contextAssembler.js';
+
+/**
+ * @description Build the actor portion of an action validation context.
+ * @param {string} entityId - ID of the actor entity.
+ * @param {EntityManager} entityManager - Manager to access components.
+ * @param {ILogger} logger - Logger instance.
+ * @returns {{id: string, components: object}} Actor context object.
+ */
+export function buildActorContext(entityId, entityManager, logger) {
+  return {
+    id: entityId,
+    components: createComponentAccessor(entityId, entityManager, logger),
+  };
+}
+
+/**
+ * @description Build the target portion when targeting another entity.
+ * @param {string} entityId - ID of the target entity.
+ * @param {EntityManager} entityManager - Manager to access components.
+ * @param {ILogger} logger - Logger instance.
+ * @returns {{type: 'entity', id: string, direction: null, components: object, blocker: undefined, exitDetails: null}}
+ *   Target context for an entity.
+ */
+export function buildEntityTargetContext(entityId, entityManager, logger) {
+  return {
+    type: 'entity',
+    id: entityId,
+    direction: null,
+    components: createComponentAccessor(entityId, entityManager, logger),
+    blocker: undefined,
+    exitDetails: null,
+  };
+}
+
+/**
+ * @description Build the target portion when targeting a direction.
+ * @param {string} actorId - ID of the actor performing the action.
+ * @param {string} direction - Direction keyword.
+ * @param {EntityManager} entityManager - Manager to access components.
+ * @param {ILogger} logger - Logger instance.
+ * @returns {{type: 'direction', id: null, direction: string, components: null, blocker: any, exitDetails: any}}
+ *   Target context for a direction.
+ */
+export function buildDirectionContext(
+  actorId,
+  direction,
+  entityManager,
+  logger
+) {
+  const actorPositionData = entityManager.getComponentData(
+    actorId,
+    POSITION_COMPONENT_ID
+  );
+  const actorLocationId = actorPositionData?.locationId;
+  let targetBlockerValue = undefined;
+  let targetExitDetailsValue = null;
+
+  if (actorLocationId) {
+    const matchedExit = getExitByDirection(
+      actorLocationId,
+      direction,
+      entityManager,
+      logger
+    );
+    if (matchedExit) {
+      targetExitDetailsValue = matchedExit;
+      targetBlockerValue = matchedExit.blocker ?? null;
+    }
+  }
+
+  return {
+    type: 'direction',
+    id: null,
+    direction,
+    components: null,
+    blocker: targetBlockerValue,
+    exitDetails: targetExitDetailsValue,
+  };
+}

--- a/tests/actions/contextBuilders.test.js
+++ b/tests/actions/contextBuilders.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import {
+  buildActorContext,
+  buildDirectionContext,
+  buildEntityTargetContext,
+} from '../../src/actions/validation/contextBuilders.js';
+
+jest.mock('../../src/logic/contextAssembler.js', () => ({
+  createComponentAccessor: jest.fn((id) => ({ accessorFor: id })),
+}));
+
+jest.mock('../../src/utils/locationUtils.js', () => ({
+  getExitByDirection: jest.fn(),
+}));
+
+import { createComponentAccessor } from '../../src/logic/contextAssembler.js';
+import { getExitByDirection } from '../../src/utils/locationUtils.js';
+
+const mockEntityManager = {
+  getComponentData: jest.fn(),
+};
+const mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('contextBuilders', () => {
+  describe('buildActorContext', () => {
+    it('returns id and component accessor', () => {
+      const result = buildActorContext('actor1', mockEntityManager, mockLogger);
+      expect(result).toEqual({
+        id: 'actor1',
+        components: { accessorFor: 'actor1' },
+      });
+      expect(createComponentAccessor).toHaveBeenCalledWith(
+        'actor1',
+        mockEntityManager,
+        mockLogger
+      );
+    });
+  });
+
+  describe('buildEntityTargetContext', () => {
+    it('returns expected structure', () => {
+      const result = buildEntityTargetContext(
+        'target1',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({
+        type: 'entity',
+        id: 'target1',
+        direction: null,
+        components: { accessorFor: 'target1' },
+        blocker: undefined,
+        exitDetails: null,
+      });
+      expect(createComponentAccessor).toHaveBeenCalledWith(
+        'target1',
+        mockEntityManager,
+        mockLogger
+      );
+    });
+  });
+
+  describe('buildDirectionContext', () => {
+    it('uses exit data when available', () => {
+      mockEntityManager.getComponentData.mockReturnValue({
+        locationId: 'loc1',
+      });
+      const exitObj = { blocker: 'door', some: 'data' };
+      getExitByDirection.mockReturnValue(exitObj);
+      const result = buildDirectionContext(
+        'actor1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(getExitByDirection).toHaveBeenCalledWith(
+        'loc1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({
+        type: 'direction',
+        id: null,
+        direction: 'north',
+        components: null,
+        blocker: 'door',
+        exitDetails: exitObj,
+      });
+    });
+
+    it('handles missing exit data', () => {
+      mockEntityManager.getComponentData.mockReturnValue({
+        locationId: 'loc1',
+      });
+      getExitByDirection.mockReturnValue(null);
+      const result = buildDirectionContext(
+        'actor1',
+        'south',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({
+        type: 'direction',
+        id: null,
+        direction: 'south',
+        components: null,
+        blocker: undefined,
+        exitDetails: null,
+      });
+    });
+  });
+});

--- a/tests/logic/createActionValidationContext.test.js
+++ b/tests/logic/createActionValidationContext.test.js
@@ -325,9 +325,12 @@ describe('Unit Test: createActionValidationContext', () => {
       expect(mockEntityManager.getEntityInstance).not.toHaveBeenCalled();
       // Updated expectation based on revised logic
       expect(context.target).toEqual({
+        type: 'direction',
         id: null,
-        direction: direction,
+        direction,
         components: null,
+        blocker: undefined,
+        exitDetails: null,
       });
       expect(createComponentAccessor).toHaveBeenCalledTimes(1); // Only actor
       expect(createComponentAccessor).toHaveBeenCalledWith(

--- a/tests/services/actionValidationService.prerequisites.test.js
+++ b/tests/services/actionValidationService.prerequisites.test.js
@@ -345,9 +345,12 @@ describe('Unit Test: createActionValidationContext', () => {
       // Verify target represents the direction
       // (Based on the *updated* logic in createActionValidationContext)
       expect(context.target).toEqual({
+        type: 'direction',
         id: null,
-        direction: direction,
+        direction,
         components: null,
+        blocker: undefined,
+        exitDetails: null,
       });
       // Accessor only called for actor
       expect(createComponentAccessor).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Summary: Introduced reusable action context helpers and updated validation context builders to use them. Added corresponding unit tests and adjusted existing expectations.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: many existing repo issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684d8271f0888331836dc5f85b4a78dd