### PR TITLE
[Agent] Add prefixed logger wrapper and update services

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -15,6 +15,7 @@ import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
 import { validateDependency } from '../utils/validationUtils.js';
 import { getAvailableExits } from '../utils/locationUtils.js';
+import { createPrefixedLogger } from '../utils/loggerUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 export class ActionDiscoveryService extends IActionDiscoveryService {
@@ -49,7 +50,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     validateDependency(logger, 'ActionDiscoveryService: logger', console, {
       requiredMethods: ['debug', 'warn', 'error'],
     });
-    this.#logger = logger;
+    this.#logger = createPrefixedLogger(logger, 'ActionDiscoveryService: ');
 
     validateDependency(
       gameDataRepository,

--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -14,6 +14,7 @@ import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
 import { validateDependency } from '../../utils/validationUtils.js';
 import { getExitByDirection } from '../../utils/locationUtils.js';
 import { createComponentAccessor } from '../../logic/contextAssembler.js';
+import { createPrefixedLogger } from '../../utils/loggerUtils.js';
 
 /**
  * @class ActionValidationContextBuilder
@@ -41,7 +42,10 @@ export class ActionValidationContextBuilder {
           requiredMethods: ['debug', 'error', 'warn'],
         }
       );
-      this.#logger = logger;
+      this.#logger = createPrefixedLogger(
+        logger,
+        'ActionValidationContextBuilder: '
+      );
     } catch (e) {
       const errorMsg = `ActionValidationContextBuilder Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       console.error(errorMsg);

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -12,6 +12,7 @@
 import { ActionTargetContext } from '../../models/actionTargetContext.js';
 import { PrerequisiteEvaluationService } from './prerequisiteEvaluationService.js';
 import { validateDependency } from '../../utils/validationUtils.js';
+import { createPrefixedLogger } from '../../utils/loggerUtils.js';
 // --- Refactor-AVS-3.4: Remove dependency ---
 // REMOVED: import { ActionValidationContextBuilder } from './actionValidationContextBuilder.js';
 // --- End Refactor-AVS-3.4 ---
@@ -55,7 +56,7 @@ export class ActionValidationService {
       validateDependency(logger, 'ActionValidationService: logger', console, {
         requiredMethods: ['debug', 'error', 'info'],
       });
-      this.#logger = logger;
+      this.#logger = createPrefixedLogger(logger, 'ActionValidationService: ');
     } catch (e) {
       const errorMsg = `ActionValidationService Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       // eslint-disable-next-line no-console

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -1,6 +1,7 @@
 // src/actions/validation/prerequisiteEvaluationService.js
 
 import { validateDependency } from '../../utils/validationUtils.js';
+import { createPrefixedLogger } from '../../utils/loggerUtils.js';
 
 /* type-only imports */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -53,7 +54,10 @@ export class PrerequisiteEvaluationService {
           requiredMethods: ['debug', 'error', 'warn', 'info'],
         }
       );
-      this.#logger = logger;
+      this.#logger = createPrefixedLogger(
+        logger,
+        'PrerequisiteEvaluationService: '
+      );
     } catch (e) {
       const errorMsg = `PrerequisiteEvaluationService Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       // eslint-disable-next-line no-console

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -48,4 +48,23 @@ export function ensureValidLogger(
   return fallback;
 }
 
+/**
+ * Creates a logger that prepends a prefix to all messages before delegating
+ * to the provided base logger. Useful for tagging log output with a service
+ * identifier while keeping the original logger implementation.
+ *
+ * @param {ILogger} baseLogger - The logger to wrap.
+ * @param {string} prefix - Prefix to prepend to each logged message.
+ * @returns {ILogger} Logger wrapper with prefixed output methods.
+ */
+export function createPrefixedLogger(baseLogger, prefix) {
+  const safePrefix = prefix || '';
+  return {
+    debug: (msg, ...args) => baseLogger.debug(`${safePrefix}${msg}`, ...args),
+    info: (msg, ...args) => baseLogger.info(`${safePrefix}${msg}`, ...args),
+    warn: (msg, ...args) => baseLogger.warn(`${safePrefix}${msg}`, ...args),
+    error: (msg, ...args) => baseLogger.error(`${safePrefix}${msg}`, ...args),
+  };
+}
+
 // --- FILE END ---

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -246,11 +246,16 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
     expect(mockGetAvailableExits).toHaveBeenCalledWith(
       mockAdventurersGuildLocation,
       mockEntityManager,
-      mockLogger
+      expect.objectContaining({
+        debug: expect.any(Function),
+        info: expect.any(Function),
+        warn: expect.any(Function),
+        error: expect.any(Function),
+      })
     );
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `Found ${availableExits.length} available exits for location: ${GUILD_INSTANCE_ID} via getAvailableExits.`
+      `ActionDiscoveryService: Found ${availableExits.length} available exits for location: ${GUILD_INSTANCE_ID} via getAvailableExits.`
     );
 
     expect(mockGameDataRepo.getAllActionDefinitions).toHaveBeenCalledTimes(1);

--- a/tests/services/actionValidationContextBuilder.test.js
+++ b/tests/services/actionValidationContextBuilder.test.js
@@ -16,7 +16,7 @@ jest.mock('../../src/utils/locationUtils.js', () => ({
 }));
 
 jest.mock('../../src/logic/contextAssembler.js', () => ({
-  createComponentAccessor: jest.fn((entityId, entityManager, logger) => {
+  createComponentAccessor: jest.fn((entityId, entityManager) => {
     // Return a simple mock proxy for testing purposes
     return new Proxy(
       {},
@@ -159,12 +159,22 @@ describe('ActionValidationContextBuilder', () => {
         expect(createComponentAccessor).toHaveBeenCalledWith(
           actorId,
           mockEntityManager,
-          mockLogger
+          expect.objectContaining({
+            debug: expect.any(Function),
+            info: expect.any(Function),
+            warn: expect.any(Function),
+            error: expect.any(Function),
+          })
         );
         expect(createComponentAccessor).toHaveBeenCalledWith(
           targetId,
           mockEntityManager,
-          mockLogger
+          expect.objectContaining({
+            debug: expect.any(Function),
+            info: expect.any(Function),
+            warn: expect.any(Function),
+            error: expect.any(Function),
+          })
         );
       });
 

--- a/tests/services/actionValidationService.actorComponents.test.js
+++ b/tests/services/actionValidationService.actorComponents.test.js
@@ -4,16 +4,7 @@
  * @jest-environment node
  */
 
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-  test,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 // --- Service Under Test ---
 import { ActionValidationService } from '../../src/actions/validation/actionValidationService.js';
@@ -516,7 +507,7 @@ describe('ActionValidationService: Orchestration Logic', () => {
 
     // Check for the specific UNEXPECTED ERROR log from AVS's catch block
     expect(mockLogger.error).toHaveBeenCalledWith(
-      `Validation[${actionDefinition.id}]: UNEXPECTED ERROR during validation process for actor '${actor.id}': ${evaluationError.message}`,
+      `ActionValidationService: Validation[${actionDefinition.id}]: UNEXPECTED ERROR during validation process for actor '${actor.id}': ${evaluationError.message}`,
       expect.objectContaining({ error: evaluationError }) // Check the error object itself was logged
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(

--- a/tests/services/prerequisiteEvaluationService.test.js
+++ b/tests/services/prerequisiteEvaluationService.test.js
@@ -110,7 +110,7 @@ describe('PrerequisiteEvaluationService', () => {
     expect(result).toBe(true);
     expect(mockLogger.debug).toHaveBeenCalledTimes(1);
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `PrereqEval[${mockActionDefinition.id}]: → PASSED (No prerequisites to evaluate).`
+      `PrerequisiteEvaluationService: PrereqEval[${mockActionDefinition.id}]: → PASSED (No prerequisites to evaluate).`
     );
     expect(mockBuilderInstance.buildContext).not.toHaveBeenCalled();
     expect(mockJsonLogicServiceInstance.evaluate).not.toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe('PrerequisiteEvaluationService', () => {
     );
     // ... other evaluate calls
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `PrereqEval[${mockActionDefinition.id}]: Evaluation Context Built Successfully.`
+      `PrerequisiteEvaluationService: PrereqEval[${mockActionDefinition.id}]: Evaluation Context Built Successfully.`
     );
     // ... other log checks ...
     expect(mockLogger.error).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary: Implement logger wrapper for consistent service log prefixes and update relevant services and tests.

Changes Made:
- Added `createPrefixedLogger` utility to `loggerUtils`.
- Wrapped loggers in ActionDiscoveryService, ActionValidationService, PrerequisiteEvaluationService, and ActionValidationContextBuilder.
- Updated unit tests to reflect prefixed log output and new logger instances.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint <modified>`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684d828fbd148331a68238c6b59223b6