### PR TITLE
[Agent] simplify state classes

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -17,14 +17,6 @@ import { ACTION_DECIDED_ID } from '../../constants/eventIds';
  * ● All other errors cause the turn to end with an error.
  */
 export class AwaitingActorDecisionState extends AbstractTurnState {
-  constructor(handler) {
-    super(handler);
-  }
-
-  getStateName() {
-    return 'AwaitingActorDecisionState';
-  }
-
   get name() {
     return this.getStateName();
   }

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -45,9 +45,6 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
   #awaitingActionId = 'unknown-action';
 
   //─────────────────────────────────────────────────────────────────────────────
-  getStateName() {
-    return 'AwaitingExternalTurnEndState';
-  }
 
   //─────────────────────────────────────────────────────────────────────────────
   async enterState(handler, prev) {

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -50,11 +50,6 @@ export class ProcessingCommandState extends AbstractTurnState {
     );
   }
 
-  /** @override */
-  getStateName() {
-    return 'ProcessingCommandState';
-  }
-
   /**
    * @override
    * @param {BaseTurnHandler} handler

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -40,10 +40,6 @@ export class TurnEndingState extends AbstractTurnState {
     );
   }
 
-  getStateName() {
-    return 'TurnEndingState';
-  }
-
   /* ────────────────────────────────────────────────────────────────── */
   /** @override */
   async enterState(handler, previousState) {

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -16,20 +16,6 @@ import { AbstractTurnState } from './abstractTurnState.js';
  * @augments AbstractTurnState_Base
  */
 export class TurnIdleState extends AbstractTurnState {
-  /**
-   * Creates an instance of TurnIdleState.
-   *
-   * @param {BaseTurnHandler} handler - The BaseTurnHandler instance that manages this state.
-   */
-  constructor(handler) {
-    super(handler);
-  }
-
-  /** @override */
-  getStateName() {
-    return 'TurnIdleState';
-  }
-
   /** @override */
   async enterState(handler, previousState) {
     await super.enterState(handler, previousState);


### PR DESCRIPTION
Summary: Removed redundant constructors and getStateName overrides from several turn states to rely on AbstractTurnState defaults.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684d999000148331ad24c3fca60d54f5