### PR TITLE
[Feat] centralize logger resolution

### DIFF
--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -82,33 +82,41 @@ export class AbstractTurnState extends ITurnState {
     return turnCtx;
   }
 
+  /**
+   * Resolves a logger using the provided context or handler.
+   *
+   * @protected
+   * @param {ITurnContext | null} turnCtx - The current ITurnContext, if any.
+   * @param {BaseTurnHandler} [handler] - Optional handler override.
+   * @returns {import('../../logging/consoleLogger.js').default | Console} The logger instance.
+   */
+  _resolveLogger(turnCtx, handler) {
+    if (turnCtx && typeof turnCtx.getLogger === 'function') {
+      try {
+        const l = turnCtx.getLogger();
+        if (l) return l;
+      } catch {
+        /* ignore */
+      }
+    }
+    const h = handler || this._handler;
+    if (h && typeof h.getLogger === 'function') {
+      try {
+        const l = h.getLogger();
+        if (l) return l;
+      } catch {
+        /* ignore */
+      }
+    }
+    return console;
+  }
+
   // --- Interface Methods with Default Implementations ---
 
   /** @override */
   async enterState(handler, previousState) {
     const turnCtx = this._getTurnContext();
-
-    // Robust logger resolution (similar to the updated exitState)
-    let resolvedLogger = turnCtx?.getLogger();
-    if (!resolvedLogger && handler && typeof handler.getLogger === 'function') {
-      try {
-        resolvedLogger = handler.getLogger();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (
-      !resolvedLogger &&
-      this._handler &&
-      typeof this._handler.getLogger === 'function'
-    ) {
-      try {
-        resolvedLogger = this._handler.getLogger();
-      } catch {
-        /* ignore */
-      }
-    }
-    const logger = resolvedLogger || console;
+    const logger = this._resolveLogger(turnCtx, handler);
 
     let actorIdForLog = 'N/A';
     if (turnCtx && typeof turnCtx.getActor === 'function') {
@@ -130,26 +138,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async exitState(handler, nextState) {
     const turnCtx = this._getTurnContext();
-    let resolvedLogger = turnCtx?.getLogger();
-    if (!resolvedLogger && handler && typeof handler.getLogger === 'function') {
-      try {
-        resolvedLogger = handler.getLogger();
-      } catch {
-        /* ignore */
-      }
-    }
-    if (
-      !resolvedLogger &&
-      this._handler &&
-      typeof this._handler.getLogger === 'function'
-    ) {
-      try {
-        resolvedLogger = this._handler.getLogger();
-      } catch {
-        /* ignore */
-      }
-    }
-    const logger = resolvedLogger || console;
+    const logger = this._resolveLogger(turnCtx, handler);
 
     let actorIdForLog = 'N/A';
     if (turnCtx && typeof turnCtx.getActor === 'function') {
@@ -171,7 +160,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async startTurn(handler, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ACTOR';
     const warningMessage = `Method 'startTurn(actorId: ${actorIdForLog})' called on state ${this.getStateName()} where it is not expected or handled.`;
     logger.warn(warningMessage);
@@ -183,7 +172,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleSubmittedCommand(handler, commandString, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const contextActorId = turnCtx?.getActor()?.id ?? 'NO_CONTEXT_ACTOR';
     const errorMessage = `Method 'handleSubmittedCommand(command: "${commandString}", entity: ${actorEntity?.id}, contextActor: ${contextActorId})' must be implemented by concrete state ${this.getStateName()}.`;
     logger.error(errorMessage);
@@ -193,7 +182,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleTurnEndedEvent(handler, payload) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const warningMessage = `Method 'handleTurnEndedEvent(payloadActorId: ${payload?.entityId})' called on state ${this.getStateName()} where it might not be expected or handled. Current context actor: ${turnCtx?.getActor()?.id ?? 'N/A'}.`;
     logger.warn(warningMessage);
   }
@@ -201,7 +190,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async processCommandResult(handler, actor, cmdProcResult, commandString) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();
     if (actor.id !== contextActor?.id) {
       logger.warn(
@@ -216,7 +205,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleDirective(handler, actor, directive, cmdProcResult) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();
     if (actor.id !== contextActor?.id) {
       logger.warn(

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -37,7 +37,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
 
     const turnContext = this._getTurnContext();
     if (!turnContext) {
-      const logger = this._handler?.getLogger?.() ?? console;
+      const logger = this._resolveLogger(null);
       logger.error(
         `${this.name}: Critical error - TurnContext is not available. Attempting to reset and idle.`
       );
@@ -171,10 +171,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   /* --------------------------------------------------------------------- */
   async exitState(handler, nextState) {
     await super.exitState(handler, nextState);
-    const l =
-      this._getTurnContext()?.getLogger?.() ??
-      this._handler?.getLogger?.() ??
-      console;
+    const l = this._resolveLogger(this._getTurnContext());
     l.debug(
       `${this.name}: ExitState cleanup (if any) specific to AwaitingActorDecisionState complete.`
     );
@@ -185,7 +182,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
     const turnContext = this._getTurnContext();
 
     if (!turnContext) {
-      const logger = this._handler?.getLogger?.() ?? console;
+      const logger = this._resolveLogger(null);
       const actorIdForLog = actorEntity?.id ?? 'unknown actor';
       logger.error(
         `${this.name}: handleSubmittedCommand (for actor ${actorIdForLog}, cmd: "${commandString}") called, but no ITurnContext. Forcing handler reset.`
@@ -221,8 +218,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   async handleTurnEndedEvent(handlerInstance, payload) {
     const handler = handlerInstance || this._handler;
     const turnContext = this._getTurnContext();
-    const logger =
-      turnContext?.getLogger?.() ?? handler?.getLogger?.() ?? console;
+    const logger = this._resolveLogger(turnContext, handler);
 
     if (!turnContext) {
       logger.warn(
@@ -254,8 +250,8 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   /* --------------------------------------------------------------------- */
   async destroy(handlerInstance) {
     const handler = handlerInstance || this._handler;
-    const logger = handler?.getLogger?.() ?? console;
     const turnContext = handler?.getTurnContext?.();
+    const logger = this._resolveLogger(turnContext, handler);
     const actorInCtx = turnContext?.getActor();
 
     if (turnContext) {

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -14,6 +14,8 @@ import { TurnIdleState } from './turnIdleState.js';
 
 import { TURN_ENDED_ID, DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
+/* global process */
+
 // ─── Config ────────────────────────────────────────────────────────────────────
 /**
  * Dev / prod switch without `import.meta`.
@@ -55,11 +57,9 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     await super.enterState(handler, prev);
 
     if (!ctx) {
-      handler
-        .getLogger()
-        .error(
-          `${this.getStateName()}: entered with no ITurnContext; aborting`
-        );
+      this._resolveLogger(null, handler).error(
+        `${this.getStateName()}: entered with no ITurnContext; aborting`
+      );
       await handler._transitionToState(new TurnIdleState(handler));
       return;
     }
@@ -164,12 +164,10 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     try {
       ctx.endTurn(err);
     } catch (e) {
-      handler
-        .getLogger()
-        .error(
-          `${this.getStateName()}: failed to end turn after timeout – ${e.message}`,
-          e
-        );
+      this._resolveLogger(ctx, handler).error(
+        `${this.getStateName()}: failed to end turn after timeout – ${e.message}`,
+        e
+      );
       handler._resetTurnStateAndResources('timeout-recovery');
       handler._transitionToState(new TurnIdleState(handler));
     }

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -44,7 +44,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this.#commandStringForLog =
       commandString || turnAction?.commandString || null;
 
-    const logger = this._handler?.getLogger() ?? console;
+    const logger = this._resolveLogger(null);
     logger.debug(
       `${this.getStateName()} constructed. Command string (arg): "${this.#commandStringForLog}". TurnAction ID (arg): ${turnAction ? `"${turnAction.actionDefinitionId}"` : 'null'}`
     );
@@ -64,7 +64,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     const turnCtx = this._getTurnContext();
 
     if (this._isProcessing) {
-      const logger = turnCtx?.getLogger() ?? this._handler.getLogger();
+      const logger = this._resolveLogger(turnCtx);
       logger.warn(
         `${this.getStateName()}: enterState called while already processing. Actor: ${turnCtx?.getActor()?.id ?? 'N/A'}. Aborting re-entry.`
       );
@@ -73,7 +73,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this._isProcessing = true;
 
     await super.enterState(this._handler, previousState);
-    const logger = turnCtx ? turnCtx.getLogger() : this._handler.getLogger();
+    const logger = this._resolveLogger(turnCtx);
 
     if (!turnCtx) {
       logger.error(
@@ -586,11 +586,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this._isProcessing = false;
 
     const turnCtx = this._getTurnContext();
-    const logger =
-      turnCtx?.getLogger() ??
-      handler?.getLogger() ??
-      this._handler?.getLogger() ??
-      console;
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorId = turnCtx?.getActor?.()?.id ?? 'N/A_on_exit';
 
     if (wasProcessing) {
@@ -607,11 +603,7 @@ export class ProcessingCommandState extends AbstractTurnState {
 
   async destroy(handler) {
     const turnCtx = this._getTurnContext(); // Get context before calling super, as super.destroy might clear it.
-    const logger =
-      turnCtx?.getLogger() ??
-      handler?.getLogger() ??
-      this._handler?.getLogger() ??
-      console;
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorId = turnCtx?.getActor?.()?.id ?? 'N/A_at_destroy';
 
     logger.debug(

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -20,7 +20,7 @@ export class TurnEndingState extends AbstractTurnState {
   constructor(handler, actorToEndId, turnError = null) {
     super(handler);
 
-    const log = handler.getLogger();
+    const log = this._resolveLogger(null, handler);
 
     if (!actorToEndId) {
       log.error('TurnEndingState Constructor: actorToEndId must be provided.');
@@ -48,7 +48,7 @@ export class TurnEndingState extends AbstractTurnState {
   /** @override */
   async enterState(handler, previousState) {
     const ctx = this._getTurnContext();
-    const logger = ctx ? ctx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(ctx, handler);
     const sameActor = ctx?.getActor()?.id === this.#actorToEndId;
     const success = this.#turnError === null;
 
@@ -107,19 +107,17 @@ export class TurnEndingState extends AbstractTurnState {
   /* ────────────────────────────────────────────────────────────────── */
   /** @override */
   async exitState(handler, nextState) {
-    handler
-      .getLogger()
-      .debug(
-        `TurnEndingState: Exiting for (intended) actor ${this.#actorToEndId}. ` +
-          `Transitioning to ${nextState?.getStateName() ?? 'None'}. ITurnContext should be null.`
-      );
+    this._resolveLogger(null, handler).debug(
+      `TurnEndingState: Exiting for (intended) actor ${this.#actorToEndId}. ` +
+        `Transitioning to ${nextState?.getStateName() ?? 'None'}. ITurnContext should be null.`
+    );
     await super.exitState(handler, nextState);
   }
 
   /* ────────────────────────────────────────────────────────────────── */
   /** @override */
   async destroy(handler) {
-    const logger = handler.getLogger();
+    const logger = this._resolveLogger(this._getTurnContext(), handler);
 
     logger.warn(
       `TurnEndingState: Handler destroyed while in TurnEndingState for actor ${this.#actorToEndId}.`

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -34,7 +34,7 @@ export class TurnIdleState extends AbstractTurnState {
   async enterState(handler, previousState) {
     await super.enterState(handler, previousState);
 
-    const logger = handler.getLogger();
+    const logger = this._resolveLogger(null, handler);
     logger.debug(
       `${this.getStateName()}: Ensuring clean state by calling handler._resetTurnStateAndResources().`
     );
@@ -52,7 +52,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async startTurn(handler, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
 
     const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ENTITY';
     logger.debug(
@@ -127,7 +127,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleSubmittedCommand(handler, commandString, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ENTITY';
     const message = `${this.getStateName()}: Command ('${commandString}') submitted by ${actorIdForLog} but no turn is active (handler is Idle).`;
     logger.warn(message);
@@ -137,7 +137,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleTurnEndedEvent(handler, payload) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const payloadActorId = payload?.entityId ?? 'UNKNOWN_ENTITY';
     const message = `${this.getStateName()}: handleTurnEndedEvent called (for ${payloadActorId}) but no turn is active (handler is Idle).`;
     logger.warn(message);
@@ -147,7 +147,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async processCommandResult(handler, actor, cmdProcResult, commandString) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorIdForLog = actor?.id ?? 'UNKNOWN_ENTITY';
     const message = `${this.getStateName()}: processCommandResult called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
@@ -162,7 +162,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleDirective(handler, actor, directive, cmdProcResult) {
     const turnCtx = this._getTurnContext();
-    const logger = turnCtx ? turnCtx.getLogger() : handler.getLogger();
+    const logger = this._resolveLogger(turnCtx, handler);
     const actorIdForLog = actor?.id ?? 'UNKNOWN_ENTITY';
     const message = `${this.getStateName()}: handleDirective called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
@@ -171,7 +171,7 @@ export class TurnIdleState extends AbstractTurnState {
 
   /** @override */
   async destroy(handler) {
-    const logger = handler.getLogger();
+    const logger = this._resolveLogger(this._getTurnContext(), handler);
     logger.debug(
       `${this.getStateName()}: BaseTurnHandler is being destroyed while in idle state.`
     );

--- a/tests/turns/states/turnEndingState.test.js
+++ b/tests/turns/states/turnEndingState.test.js
@@ -365,14 +365,14 @@ describe('TurnEndingState', () => {
       mockHandler._transitionToState.mockClear();
 
       await turnEndingState.destroy(mockHandler);
-      expect(mockSystemLogger.warn).toHaveBeenCalledWith(
+      expect(mockContextSpecificLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Handler destroyed while in TurnEndingState')
       );
     });
 
     it('should log a warning and call super.destroy()', async () => {
       await turnEndingState.destroy(mockHandler);
-      expect(mockSystemLogger.warn).toHaveBeenCalledWith(
+      expect(mockContextSpecificLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           `Handler destroyed while in TurnEndingState for actor ${actorId}.`
         )
@@ -389,7 +389,7 @@ describe('TurnEndingState', () => {
 
       await turnEndingState.destroy(mockHandler);
 
-      expect(mockSystemLogger.error).toHaveBeenCalledWith(
+      expect(mockContextSpecificLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Failed forced transition to TurnIdleState during destroy for actor ${actorId}: ${transitionError.message}`
         ),


### PR DESCRIPTION
Summary: Introduces helper `_resolveLogger` on `AbstractTurnState` to consistently obtain loggers. All turn state classes now call this method instead of duplicating logger lookup logic. Tests updated to reflect new behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_684d996f19d883319b6622225d81d56b