### PR TITLE
[Agent] Modularize ProcessingCommandState helpers

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -1,0 +1,66 @@
+/**
+ * @file Helper to safely retrieve services from ITurnContext implementations.
+ */
+
+/**
+ * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ */
+
+import { handleProcessingException } from './handleProcessingException.js';
+
+/**
+ * Safely obtains a service from the turn context.
+ *
+ * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ITurnContext} turnCtx - Current turn context.
+ * @param {string} methodName - Method name on ITurnContext used to retrieve the service.
+ * @param {string} serviceNameForLog - Label for logging when retrieval fails.
+ * @param {string} actorIdForLog - Actor ID for logging context.
+ * @returns {Promise<*>} The requested service instance or `null` if unavailable.
+ */
+export async function getServiceFromContext(
+  state,
+  turnCtx,
+  methodName,
+  serviceNameForLog,
+  actorIdForLog
+) {
+  if (!turnCtx || typeof turnCtx.getLogger !== 'function') {
+    console.error(
+      `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceNameForLog}, actor ${actorIdForLog}.`
+    );
+    if (state._isProcessing) {
+      state._isProcessing = false;
+    }
+    return null;
+  }
+  const logger = turnCtx.getLogger();
+  try {
+    if (typeof turnCtx[methodName] !== 'function') {
+      throw new Error(
+        `Method turnCtx.${methodName}() does not exist or is not a function.`
+      );
+    }
+    const service = turnCtx[methodName]();
+    if (!service) {
+      throw new Error(
+        `Method turnCtx.${methodName}() returned null or undefined.`
+      );
+    }
+    return service;
+  } catch (error) {
+    const errorMsg = `${state.getStateName()}: Failed to retrieve ${serviceNameForLog} for actor ${actorIdForLog}. Error: ${error.message}`;
+    logger.error(errorMsg, error);
+    const serviceError = new Error(errorMsg);
+    await handleProcessingException(
+      state,
+      turnCtx,
+      serviceError,
+      actorIdForLog
+    );
+    return null;
+  }
+}
+
+export default getServiceFromContext;

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -1,0 +1,143 @@
+/**
+ * @file Helper for processing command exceptions and cleanup logic.
+ */
+
+/**
+ * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../constants/eventIds.js';
+import { TurnIdleState } from '../turnIdleState.js';
+
+/**
+ * Handles exceptions that occur during command processing.
+ *
+ * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ITurnContext} turnCtx - Current turn context.
+ * @param {Error} error - Error being handled.
+ * @param {string} [actorIdContext] - Actor ID for logging context.
+ * @param {boolean} [shouldEndTurn] - Whether the turn should be ended.
+ * @returns {Promise<void>} Resolves when handling completes.
+ */
+export async function handleProcessingException(
+  state,
+  turnCtx,
+  error,
+  actorIdContext = 'UnknownActor',
+  shouldEndTurn = true
+) {
+  const wasProcessing = state._isProcessing;
+  state._isProcessing = false;
+
+  let logger = console;
+  let currentActorIdForLog = actorIdContext;
+
+  if (turnCtx && typeof turnCtx.getLogger === 'function') {
+    logger = turnCtx.getLogger();
+    currentActorIdForLog = turnCtx.getActor?.()?.id ?? actorIdContext;
+  } else {
+    console.error(
+      `${state.getStateName()}: Critical error - turnCtx is invalid in #handleProcessingException. Using console for logging. Actor context for this error: ${currentActorIdForLog}`
+    );
+  }
+
+  logger.error(
+    `${state.getStateName()}: Error during command processing for actor ${currentActorIdForLog} (wasProcessing: ${wasProcessing}): ${error.message}`,
+    error
+  );
+
+  /** @type {ISafeEventDispatcher | undefined} */
+  let systemErrorDispatcher;
+  if (turnCtx && typeof turnCtx.getSafeEventDispatcher === 'function') {
+    systemErrorDispatcher = turnCtx.getSafeEventDispatcher();
+  } else if (
+    state._handler &&
+    typeof state._handler.safeEventDispatcher === 'object' &&
+    state._handler.safeEventDispatcher !== null &&
+    typeof state._handler.safeEventDispatcher.dispatch === 'function'
+  ) {
+    logger.warn(
+      `${state.getStateName()}: SafeEventDispatcher not found on TurnContext for actor ${currentActorIdForLog}. Attempting to use this._handler.safeEventDispatcher.`
+    );
+    systemErrorDispatcher = state._handler.safeEventDispatcher;
+  }
+
+  if (systemErrorDispatcher) {
+    try {
+      await systemErrorDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+        message: `System error in ${state.getStateName()} for actor ${currentActorIdForLog}: ${error.message}`,
+        details: {
+          raw: `OriginalError: ${error.name} - ${error.message}`,
+          stack: error.stack,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (dispatchError) {
+      logger.error(
+        `${state.getStateName()}: Unexpected error dispatching SYSTEM_ERROR_OCCURRED_ID via SafeEventDispatcher for ${currentActorIdForLog}: ${dispatchError.message}`,
+        dispatchError
+      );
+    }
+  } else {
+    logger.warn(
+      `${state.getStateName()}: SafeEventDispatcher not available for actor ${currentActorIdForLog}. Cannot dispatch system error event.`
+    );
+  }
+
+  if (shouldEndTurn) {
+    if (turnCtx && typeof turnCtx.endTurn === 'function') {
+      logger.debug(
+        `${state.getStateName()}: Ending turn (no valid actor or error state) due to processing exception.`
+      );
+      try {
+        await turnCtx.endTurn(error);
+      } catch (endTurnError) {
+        logger.error(
+          `${state.getStateName()}: Error calling turnCtx.endTurn(): ${endTurnError.message}`,
+          endTurnError
+        );
+        if (
+          state._handler?._resetTurnStateAndResources &&
+          state._handler?._transitionToState
+        ) {
+          logger.warn(
+            `${state.getStateName()}: Resetting handler due to failure in turnCtx.endTurn().`
+          );
+          await state._handler._resetTurnStateAndResources(
+            `exception-endTurn-failed-${state.getStateName()}`
+          );
+          await state._handler._transitionToState(
+            new TurnIdleState(state._handler)
+          );
+        }
+      }
+    } else {
+      logger.warn(
+        `${state.getStateName()}: Cannot call turnCtx.endTurn(); ITurnContext or its endTurn method is unavailable.`
+      );
+      if (
+        state._handler?._resetTurnStateAndResources &&
+        state._handler?._transitionToState
+      ) {
+        await state._handler._resetTurnStateAndResources(
+          `exception-no-context-end-${state.getStateName()}`
+        );
+        await state._handler._transitionToState(
+          new TurnIdleState(state._handler)
+        );
+      } else {
+        logger.error(
+          `${state.getStateName()}: CRITICAL - Cannot end turn OR reset handler. System may be unstable.`
+        );
+      }
+    }
+  } else {
+    logger.debug(
+      `${state.getStateName()}: #handleProcessingException called with shouldEndTurn=false for actor ${currentActorIdForLog}.`
+    );
+  }
+}
+
+export default handleProcessingException;

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -1,0 +1,182 @@
+/**
+ * @file Utility for ProcessingCommandState that handles command processing logic.
+ */
+
+/**
+ * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../entities/entity.js').default} Entity
+ * @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
+ */
+
+import TurnDirectiveStrategyResolver from '../../strategies/turnDirectiveStrategyResolver.js';
+import { getServiceFromContext } from './getServiceFromContext.js';
+import { handleProcessingException } from './handleProcessingException.js';
+
+/**
+ * Executes the main command processing workflow.
+ *
+ * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ITurnContext} turnCtx - Current turn context.
+ * @param {Entity} actor - Actor executing the command.
+ * @param {ITurnAction} turnAction - Action to process.
+ * @returns {Promise<void>} Resolves when processing completes.
+ */
+export async function processCommandInternal(
+  state,
+  turnCtx,
+  actor,
+  turnAction
+) {
+  const logger = turnCtx.getLogger();
+  const actorId = actor.id;
+
+  try {
+    const commandProcessor = await getServiceFromContext(
+      state,
+      turnCtx,
+      'getCommandProcessor',
+      'ICommandProcessor',
+      actorId
+    );
+    if (!commandProcessor) {
+      return; // Error handled by getServiceFromContext
+    }
+
+    logger.debug(
+      `${state.getStateName()}: Invoking commandProcessor.dispatchAction() for actor ${actorId}, actionId: ${turnAction.actionDefinitionId}.`
+    );
+
+    const { success, errorResult } = await commandProcessor.dispatchAction(
+      actor,
+      turnAction
+    );
+
+    if (!state._isProcessing) {
+      logger.warn(
+        `${state.getStateName()}: Processing flag became false after commandProcessor.dispatchAction() for ${actorId}. Aborting further processing.`
+      );
+      return;
+    }
+
+    const activeTurnCtx = state._getTurnContext();
+    if (
+      !activeTurnCtx ||
+      typeof activeTurnCtx.getActor !== 'function' ||
+      activeTurnCtx.getActor()?.id !== actorId
+    ) {
+      logger.warn(
+        `${state.getStateName()}: Context is invalid, has changed, or actor mismatch after commandProcessor.dispatchAction() for ${actorId}. Current context actor: ${activeTurnCtx?.getActor?.()?.id ?? 'N/A'}. Aborting further processing.`
+      );
+      const contextForException =
+        activeTurnCtx && typeof activeTurnCtx.getActor === 'function'
+          ? activeTurnCtx
+          : turnCtx;
+      await handleProcessingException(
+        state,
+        contextForException,
+        new Error('Context invalid/changed after action dispatch.'),
+        actorId,
+        false
+      );
+      return;
+    }
+
+    const commandResultForInterpreter = {
+      success: success,
+      turnEnded: !success,
+      originalInput: turnAction.commandString || turnAction.actionDefinitionId,
+      actionResult: { actionId: turnAction.actionDefinitionId },
+      error: success ? undefined : errorResult?.error,
+      internalError: success ? undefined : errorResult?.internalError,
+    };
+
+    logger.debug(
+      `${state.getStateName()}: Action dispatch completed for actor ${actorId}. Result success: ${commandResultForInterpreter.success}.`
+    );
+
+    const outcomeInterpreter = await getServiceFromContext(
+      state,
+      activeTurnCtx,
+      'getCommandOutcomeInterpreter',
+      'ICommandOutcomeInterpreter',
+      actorId
+    );
+    if (!outcomeInterpreter) {
+      return; // Error handled by getServiceFromContext
+    }
+
+    const directiveType = await outcomeInterpreter.interpret(
+      commandResultForInterpreter,
+      activeTurnCtx
+    );
+    logger.debug(
+      `${state.getStateName()}: Actor ${actorId} - Dispatch result interpreted to directive: ${directiveType}`
+    );
+
+    const directiveStrategy =
+      TurnDirectiveStrategyResolver.resolveStrategy(directiveType);
+    if (!directiveStrategy) {
+      const errorMsg = `${state.getStateName()}: Could not resolve ITurnDirectiveStrategy for directive '${directiveType}' (actor ${actorId}).`;
+      logger.error(errorMsg);
+      await handleProcessingException(
+        state,
+        activeTurnCtx,
+        new Error(errorMsg),
+        actorId
+      );
+      return;
+    }
+    logger.debug(
+      `${state.getStateName()}: Actor ${actorId} - Resolved strategy ${directiveStrategy.constructor.name} for directive ${directiveType}.`
+    );
+
+    await directiveStrategy.execute(
+      activeTurnCtx,
+      directiveType,
+      commandResultForInterpreter
+    );
+    logger.debug(
+      `${state.getStateName()}: Actor ${actorId} - Directive strategy ${directiveStrategy.constructor.name} executed.`
+    );
+
+    if (state._isProcessing && state._handler._currentState === state) {
+      logger.debug(
+        `${state.getStateName()}: Directive strategy executed for ${actorId}, state remains ${state.getStateName()}. Processing complete for this state instance.`
+      );
+      state._isProcessing = false;
+    } else if (state._isProcessing) {
+      logger.debug(
+        `${state.getStateName()}: Directive strategy executed for ${actorId}, but state changed from ${state.getStateName()} to ${state._handler._currentState?.getStateName() ?? 'Unknown'}. Processing considered complete for previous state instance.`
+      );
+      state._isProcessing = false;
+    }
+  } catch (error) {
+    const errorHandlingCtx = state._getTurnContext() ?? turnCtx;
+    const actorIdForHandler = errorHandlingCtx?.getActor?.()?.id ?? actorId;
+    const processingError =
+      error instanceof Error
+        ? error
+        : new Error(String(error.message || error));
+    if (!(error instanceof Error) && error.stack) {
+      processingError.stack = error.stack;
+    }
+    await handleProcessingException(
+      state,
+      errorHandlingCtx || turnCtx,
+      processingError,
+      actorIdForHandler
+    );
+  } finally {
+    if (state._isProcessing && state._handler._currentState === state) {
+      const finalLogger =
+        state._getTurnContext()?.getLogger() ?? turnCtx.getLogger();
+      finalLogger.warn(
+        `${state.getStateName()}: _isProcessing was unexpectedly true at the end of _processCommandInternal for ${actorId}. Forcing to false.`
+      );
+      state._isProcessing = false;
+    }
+  }
+}
+
+export default processCommandInternal;


### PR DESCRIPTION
## Summary
- move command processing helpers to `src/turns/states/helpers`
- delegate `ProcessingCommandState` private methods to new helpers

## Testing Done
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684d99b349848331b16d047a41c7d0a9