### PR TITLE
[Agent] Emit display_error in QueryEntitiesHandler

### DIFF
--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -167,6 +167,7 @@ function init(entities) {
       entityManager,
       logger,
       jsonLogicEvaluationService: jsonLogic,
+      safeEventDispatcher: eventBus,
     }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `QueryEntitiesHandler`
- emit `core:display_error` instead of logging when the result context is missing
- adapt unit and integration tests for the new dependency
- add test for error dispatch when context storage fails

## Testing Done
- `npm run format`
- `npx eslint src/logic/operationHandlers/queryEntitiesHandler.js tests/logic/operationHandlers/queryEntitiesHandler.test.js tests/integration/rules/followAutoMoveRule.integration.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684da063e1f48331b212e06aef120ae0