### PR TITLE
[Agent] replace logger.error with core error event

### DIFF
--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -174,7 +174,7 @@ function init(entities) {
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     SYSTEM_MOVE_ENTITY: new SystemMoveEntityHandler({
       entityManager,
-      dispatcher: eventBus,
+      safeEventDispatcher: eventBus,
       logger,
     }),
   };


### PR DESCRIPTION
Summary: Replaced logger-based error handling in `SystemMoveEntityHandler` with a safe event dispatch of `DISPLAY_ERROR_ID`. The handler now injects `ISafeEventDispatcher`, validates dependencies, and sends detailed error payloads. Updated integration and unit tests accordingly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` shows existing issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684da4b9da3883318a2962a3595face4