### PR TITLE
[Agent] dispatch display error instead of logger

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -99,6 +99,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -130,7 +130,11 @@ function init(entities) {
   entityManager = new SimpleEntityManager(entities);
 
   const handlers = {
-    REMOVE_COMPONENT: new RemoveComponentHandler({ entityManager, logger }),
+    REMOVE_COMPONENT: new RemoveComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({
       entityManager,
       logger,

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -125,6 +125,7 @@ function init(entities) {
     REMOVE_COMPONENT: new RemoveComponentHandler({
       entityManager,
       logger,
+      safeEventDispatcher: safeDispatcher,
     }),
     MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({
       entityManager,

--- a/tests/integration/rules/turnEndedRule.integration.test.js
+++ b/tests/integration/rules/turnEndedRule.integration.test.js
@@ -98,6 +98,7 @@ function init(entities) {
     REMOVE_COMPONENT: new RemoveComponentHandler({
       entityManager,
       logger,
+      safeEventDispatcher: safeDispatcher,
     }),
   };
 
@@ -135,6 +136,7 @@ let jsonLogic;
 let interpreter;
 let events;
 let listener;
+let safeDispatcher;
 
 describe('turn_ended rule integration', () => {
   beforeEach(() => {
@@ -146,6 +148,7 @@ describe('turn_ended rule integration', () => {
     };
 
     events = [];
+    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
     eventBus = {
       subscribe: jest.fn((ev, l) => {
         if (ev === '*') listener = l;


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `RemoveComponentHandler`
- dispatch `DISPLAY_ERROR_ID` instead of logging errors
- wire up SafeEventDispatcher for RemoveComponentHandler in registrations
- update unit test for RemoveComponentHandler
- update integration tests to pass SafeEventDispatcher

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684da9bc14b08331b3ee795b6e32154f