### PR TITLE
[Feat] Dispatch display error in notes module

### DIFF
--- a/src/ai/notesPersistenceListener.js
+++ b/src/ai/notesPersistenceListener.js
@@ -2,6 +2,8 @@
 
 import { persistNotes } from './notesPersistenceHook.js';
 
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
 /**
  * Consumes ACTION_DECIDED_ID and merges generated notes into the
  * actor’s notes component.
@@ -10,12 +12,15 @@ export class NotesPersistenceListener {
   /**
    * @param {{
    *   logger: import('../interfaces/coreServices.js').ILogger,
-   *   entityManager: import('../interfaces/IEntityManager.js').IEntityManager
+   *   entityManager: import('../interfaces/IEntityManager.js').IEntityManager,
+   *   dispatcher: ISafeEventDispatcher
    * }} deps
    */
-  constructor({ logger, entityManager }) {
+  constructor({ logger, entityManager, dispatcher }) {
     this.logger = logger;
     this.entityManager = entityManager;
+    /** @type {ISafeEventDispatcher} */
+    this.dispatcher = dispatcher;
   }
 
   /**
@@ -42,7 +47,12 @@ export class NotesPersistenceListener {
           extractedData.notes
         )}`
       );
-      persistNotes({ notes: extractedData.notes }, actorEntity, this.logger);
+      persistNotes(
+        { notes: extractedData.notes },
+        actorEntity,
+        this.logger,
+        this.dispatcher
+      );
     } else {
       this.logger.warn(
         `NotesPersistenceListener: entity not found for actor ${actorId}`

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -224,6 +224,7 @@ class InitializationService extends IInitializationService {
       const notesListener = new NotesPersistenceListener({
         logger: this.#logger,
         entityManager,
+        dispatcher,
       });
       dispatcher.subscribe(
         ACTION_DECIDED_ID,

--- a/tests/ai/notesPersistenceListener.test.js
+++ b/tests/ai/notesPersistenceListener.test.js
@@ -11,6 +11,7 @@ jest.mock('../../src/ai/notesPersistenceHook.js', () => ({
 describe('NotesPersistenceListener', () => {
   let logger;
   let entityManager;
+  let dispatcher;
   let listener;
 
   beforeEach(() => {
@@ -20,8 +21,13 @@ describe('NotesPersistenceListener', () => {
       error: jest.fn(),
       debug: jest.fn(),
     };
+    dispatcher = { dispatch: jest.fn() };
     entityManager = { getEntityInstance: jest.fn() };
-    listener = new NotesPersistenceListener({ logger, entityManager });
+    listener = new NotesPersistenceListener({
+      logger,
+      entityManager,
+      dispatcher,
+    });
     persistNotes.mockClear();
   });
 
@@ -40,7 +46,8 @@ describe('NotesPersistenceListener', () => {
     expect(persistNotes).toHaveBeenCalledWith(
       { notes: ['note'] },
       actorEntity,
-      logger
+      logger,
+      dispatcher
     );
   });
 


### PR DESCRIPTION
Summary: Replaced logger.error calls in notes persistence with dispatches of `DISPLAY_ERROR_ID`, ensuring errors are reported via events. Notes persistence logic and listener now accept `SafeEventDispatcher`, and InitializationService injects the dispatcher. Updated associated tests.

Changes Made:
- Added dispatcher parameter and error event dispatching in `persistNotes`
- Updated `NotesPersistenceListener` to require dispatcher and pass it to `persistNotes`
- Injected dispatcher when creating `NotesPersistenceListener` in InitializationService
- Adjusted tests for new dispatcher behavior

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint run (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684dac72cd1c8331985e0486ba0b21f0