### PR TITLE
[Agent] dispatch errors in location utils

### DIFF
--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -1,6 +1,7 @@
 // src/utils/locationUtils.js
 
 import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
+import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 import { isNonEmptyString } from './textUtils.js';
 import { ensureValidLogger } from './loggerUtils.js';
 
@@ -26,9 +27,16 @@ import { ensureValidLogger } from './loggerUtils.js';
  * @param {Entity | string} locationEntityOrId - Entity instance or ID to check.
  * @param {IEntityManager} entityManager - Used to fetch the entity when an ID is provided.
  * @param {ILogger} [logger] - Optional logger for debug messages.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher -
+ * Safe dispatcher for error events.
  * @returns {ExitData[] | null} Array of exit objects or null when unavailable.
  */
-function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
+function _getExitsComponentData(
+  locationEntityOrId,
+  entityManager,
+  logger,
+  dispatcher
+) {
   const log = ensureValidLogger(logger, 'locationUtils');
   let locationEntity = locationEntityOrId;
 
@@ -37,9 +45,19 @@ function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
       !entityManager ||
       typeof entityManager.getEntityInstance !== 'function'
     ) {
-      log.error(
-        "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid."
-      );
+      dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message:
+          "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid.",
+        details: {
+          locationId:
+            typeof locationEntityOrId === 'string'
+              ? locationEntityOrId
+              : locationEntityOrId?.id,
+          entityManagerValid:
+            !!entityManager &&
+            typeof entityManager.getEntityInstance === 'function',
+        },
+      });
       return null;
     }
     locationEntity = entityManager.getEntityInstance(locationEntityOrId);
@@ -76,13 +94,16 @@ function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
  * @param {string} directionName - Direction to search for.
  * @param {IEntityManager} entityManager - Manager used to fetch the entity.
  * @param {ILogger} [logger] - Optional logger for diagnostics.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher -
+ * Safe dispatcher for error events.
  * @returns {ExitData | null} The exit data if found, otherwise null.
  */
 export function getExitByDirection(
   locationEntityOrId,
   directionName,
   entityManager,
-  logger
+  logger,
+  dispatcher
 ) {
   const log = ensureValidLogger(logger, 'locationUtils');
   if (!isNonEmptyString(directionName)) {
@@ -93,7 +114,8 @@ export function getExitByDirection(
   const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,
-    log
+    log,
+    dispatcher
   );
   if (!exitsData || exitsData.length === 0) {
     return null;
@@ -137,15 +159,23 @@ export function getExitByDirection(
  *
  * @param {Entity | string} locationEntityOrId - Location entity or its ID.
  * @param {IEntityManager} entityManager - Manager used to fetch the entity.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher -
+ * Safe dispatcher for error events.
  * @param {ILogger} [logger] - Optional logger for diagnostics.
  * @returns {ExitData[]} Array of valid exit objects.
  */
-export function getAvailableExits(locationEntityOrId, entityManager, logger) {
+export function getAvailableExits(
+  locationEntityOrId,
+  entityManager,
+  dispatcher,
+  logger
+) {
   const log = ensureValidLogger(logger, 'locationUtils');
   const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,
-    log
+    log,
+    dispatcher
   );
   if (!exitsData || exitsData.length === 0) {
     return [];

--- a/tests/utils/locationUtils.test.js
+++ b/tests/utils/locationUtils.test.js
@@ -38,6 +38,7 @@ function createMockLocation(id, exitsData) {
 describe('locationUtils', () => {
   /** @type {IEntityManager} */
   let mockEntityManager;
+  let mockDispatcher;
 
   beforeEach(() => {
     mockLogger.info.mockReset();
@@ -48,6 +49,7 @@ describe('locationUtils', () => {
     mockEntityManager = {
       getEntityInstance: jest.fn(),
     };
+    mockDispatcher = { dispatch: jest.fn() };
   });
 
   describe('getExitByDirection', () => {
@@ -63,7 +65,8 @@ describe('locationUtils', () => {
         'loc1',
         'north',
         mockEntityManager,
-        mockLogger
+        mockLogger,
+        mockDispatcher
       );
 
       expect(result).toEqual({ direction: 'North', target: 'loc2' }); // CHANGED targetLocationId to target
@@ -79,7 +82,8 @@ describe('locationUtils', () => {
         'loc1',
         'west',
         mockEntityManager,
-        mockLogger
+        mockLogger,
+        mockDispatcher
       );
 
       expect(result).toBeNull();
@@ -93,7 +97,8 @@ describe('locationUtils', () => {
         'loc1',
         'north',
         mockEntityManager,
-        mockLogger
+        mockLogger,
+        mockDispatcher
       );
 
       expect(result).toBeNull();
@@ -106,7 +111,8 @@ describe('locationUtils', () => {
         'missing',
         'north',
         mockEntityManager,
-        mockLogger
+        mockLogger,
+        mockDispatcher
       );
 
       expect(result).toBeNull();
@@ -123,7 +129,8 @@ describe('locationUtils', () => {
         'loc1',
         'north',
         mockEntityManager,
-        mockLogger
+        mockLogger,
+        mockDispatcher
       );
 
       expect(result).toBeNull();
@@ -142,7 +149,12 @@ describe('locationUtils', () => {
       const location = createMockLocation('loc1', exits);
       mockEntityManager.getEntityInstance.mockReturnValue(location);
 
-      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+      const result = getAvailableExits(
+        'loc1',
+        mockEntityManager,
+        mockDispatcher,
+        mockLogger
+      );
 
       expect(result).toEqual([
         { direction: 'north', target: 'loc2' }, // CHANGED targetLocationId to target
@@ -155,7 +167,12 @@ describe('locationUtils', () => {
       const location = createMockLocation('loc1', null);
       mockEntityManager.getEntityInstance.mockReturnValue(location);
 
-      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+      const result = getAvailableExits(
+        'loc1',
+        mockEntityManager,
+        mockDispatcher,
+        mockLogger
+      );
 
       expect(result).toEqual([]);
     });
@@ -163,7 +180,12 @@ describe('locationUtils', () => {
     it('should return empty array when location not found', () => {
       mockEntityManager.getEntityInstance.mockReturnValue(undefined);
 
-      const result = getAvailableExits('loc1', mockEntityManager, mockLogger);
+      const result = getAvailableExits(
+        'loc1',
+        mockEntityManager,
+        mockDispatcher,
+        mockLogger
+      );
 
       expect(result).toEqual([]);
     });


### PR DESCRIPTION
## Summary
- update locationUtils to dispatch `core:display_error`
- adjust tests for new dispatcher dependency

## Testing Done
- `npm run format`
- `npm run lint` *(fails: jsdoc/require-returns, jest/no-commented-out-tests, etc.)*
- `npm test` *(passes but coverage thresholds not met)*
- `cd llm-proxy-server && npm test` *(passes but coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_684daea9ff948331a20b7ab3713b30cb