### PR TITLE
[Agent] add entity validation helpers

### DIFF
--- a/src/utils/actorLocationUtils.js
+++ b/src/utils/actorLocationUtils.js
@@ -8,6 +8,7 @@
 
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 import { isNonEmptyString } from './textUtils.js';
+import { isValidEntityManager } from './entityValidationUtils.js';
 
 /**
  * Retrieves the current location for the given actor entity.
@@ -22,7 +23,7 @@ import { isNonEmptyString } from './textUtils.js';
  */
 export function getActorLocation(entityId, entityManager) {
   if (!isNonEmptyString(entityId)) return null;
-  if (!entityManager || typeof entityManager.getComponentData !== 'function') {
+  if (!isValidEntityManager(entityManager)) {
     return null;
   }
 

--- a/src/utils/entityUtils.js
+++ b/src/utils/entityUtils.js
@@ -1,6 +1,7 @@
 // src/utils/entityUtils.js
 
 import { NAME_COMPONENT_ID } from '../constants/componentIds.js';
+import { isValidEntity } from './entityValidationUtils.js';
 
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../interfaces/ILogger.js').ILogger} ILogger */
@@ -23,7 +24,7 @@ export function getEntityDisplayName(
   fallbackString = 'unknown entity',
   logger
 ) {
-  if (!entity || typeof entity.getComponentData !== 'function') {
+  if (!isValidEntity(entity)) {
     const entityId = entity && typeof entity.id === 'string' ? entity.id : null;
     logger?.debug(
       `getEntityDisplayName: Received invalid or non-entity object (ID: ${

--- a/src/utils/entityValidationUtils.js
+++ b/src/utils/entityValidationUtils.js
@@ -1,0 +1,34 @@
+// src/utils/entityValidationUtils.js
+
+/**
+ * @file Utility functions to validate Entity and EntityManager objects.
+ */
+
+/** @typedef {import('../entities/entity.js').default} Entity */
+/** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+/**
+ * @description Checks whether a value appears to be a valid Entity.
+ * A valid Entity must expose a `getComponentData` method.
+ * @param {any} entity - The value to test.
+ * @returns {boolean} `true` if the object exposes `getComponentData`, otherwise `false`.
+ */
+export function isValidEntity(entity) {
+  return !!entity && typeof entity.getComponentData === 'function';
+}
+
+/**
+ * @description Checks whether a value appears to be a valid EntityManager.
+ * It must expose both `getEntityInstance` and `getComponentData` methods.
+ * @param {any} manager - The value to test.
+ * @returns {boolean} `true` if both methods are present, otherwise `false`.
+ */
+export function isValidEntityManager(manager) {
+  return (
+    !!manager &&
+    typeof manager.getEntityInstance === 'function' &&
+    typeof manager.getComponentData === 'function'
+  );
+}
+
+// --- FILE END ---

--- a/src/utils/followUtils.js
+++ b/src/utils/followUtils.js
@@ -8,6 +8,7 @@
  */
 
 import { FOLLOWING_COMPONENT_ID } from '../constants/componentIds.js';
+import { isValidEntityManager } from './entityValidationUtils.js';
 
 /**
  * @description
@@ -33,7 +34,11 @@ export function wouldCreateCycle(
   prospectiveLeaderId,
   entityManager
 ) {
-  if (!prospectiveFollowerId || !prospectiveLeaderId || !entityManager) {
+  if (
+    !prospectiveFollowerId ||
+    !prospectiveLeaderId ||
+    !isValidEntityManager(entityManager)
+  ) {
     // Cannot perform check without required IDs and entity manager.
     return false;
   }

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -3,6 +3,10 @@
 import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
 import { isNonEmptyString } from './textUtils.js';
 import { ensureValidLogger } from './loggerUtils.js';
+import {
+  isValidEntityManager,
+  isValidEntity,
+} from './entityValidationUtils.js';
 
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
@@ -33,10 +37,7 @@ function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
   let locationEntity = locationEntityOrId;
 
   if (typeof locationEntityOrId === 'string') {
-    if (
-      !entityManager ||
-      typeof entityManager.getEntityInstance !== 'function'
-    ) {
+    if (!isValidEntityManager(entityManager)) {
       log.error(
         "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid."
       );
@@ -45,10 +46,7 @@ function _getExitsComponentData(locationEntityOrId, entityManager, logger) {
     locationEntity = entityManager.getEntityInstance(locationEntityOrId);
   }
 
-  if (
-    !locationEntity ||
-    typeof locationEntity.getComponentData !== 'function'
-  ) {
+  if (!isValidEntity(locationEntity)) {
     const id =
       typeof locationEntityOrId === 'string'
         ? locationEntityOrId

--- a/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
+++ b/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
@@ -48,6 +48,7 @@ const makeMockEntityManager = () => ({
   // Add other methods to satisfy the interface if needed, even if they do nothing.
   getEntityDefinition: jest.fn(),
   validate: jest.fn(),
+  getComponentData: jest.fn(),
 });
 
 describe('CheckFollowCycleHandler', () => {

--- a/tests/utils/entityValidationUtils.test.js
+++ b/tests/utils/entityValidationUtils.test.js
@@ -1,0 +1,46 @@
+// tests/utils/entityValidationUtils.test.js
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  isValidEntity,
+  isValidEntityManager,
+} from '../../src/utils/entityValidationUtils.js';
+
+describe('isValidEntity', () => {
+  it('returns true for an object with getComponentData function', () => {
+    const entity = { getComponentData: () => {} };
+    expect(isValidEntity(entity)).toBe(true);
+  });
+
+  it('returns false for null or undefined', () => {
+    expect(isValidEntity(null)).toBe(false);
+    expect(isValidEntity(undefined)).toBe(false);
+  });
+
+  it('returns false when getComponentData is missing', () => {
+    const entity = { id: 'e1' };
+    expect(isValidEntity(entity)).toBe(false);
+  });
+});
+
+describe('isValidEntityManager', () => {
+  it('returns true when required methods exist', () => {
+    const manager = {
+      getEntityInstance: () => {},
+      getComponentData: () => {},
+    };
+    expect(isValidEntityManager(manager)).toBe(true);
+  });
+
+  it('returns false when any required method is missing', () => {
+    const missingGetInstance = { getComponentData: () => {} };
+    const missingGetComponent = { getEntityInstance: () => {} };
+    expect(isValidEntityManager(missingGetInstance)).toBe(false);
+    expect(isValidEntityManager(missingGetComponent)).toBe(false);
+  });
+
+  it('returns false for null or undefined', () => {
+    expect(isValidEntityManager(null)).toBe(false);
+    expect(isValidEntityManager(undefined)).toBe(false);
+  });
+});

--- a/tests/utils/locationUtils.test.js
+++ b/tests/utils/locationUtils.test.js
@@ -47,6 +47,7 @@ describe('locationUtils', () => {
 
     mockEntityManager = {
       getEntityInstance: jest.fn(),
+      getComponentData: jest.fn(),
     };
   });
 


### PR DESCRIPTION
Summary: Centralized entity and entity manager validation in `entityValidationUtils`. Updated utilities to use these helpers and adjusted tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on changed files `npx eslint ... --fix`
- [x] Root tests `npm run test` *(coverage threshold failures ignored)*
- [x] Proxy tests `cd llm-proxy-server && npm run test` *(coverage threshold failures ignored)*

------
https://chatgpt.com/codex/tasks/task_e_684daf66ac008331b1a103d17b6bb968