### PR TITLE
[Agent] unify actor validation

### DIFF
--- a/src/turns/handlers/aiTurnHandler.js
+++ b/src/turns/handlers/aiTurnHandler.js
@@ -15,6 +15,7 @@
  */
 
 import { BaseTurnHandler } from './baseTurnHandler.js';
+import { assertValidActor } from '../../utils/actorValidation.js';
 
 /**
  * @class AITurnHandler
@@ -90,11 +91,7 @@ export class AITurnHandler extends BaseTurnHandler {
       `${this.constructor.name}.startTurn called for AI actor ${actor?.id}.`
     );
     super._assertHandlerActive();
-    if (!actor || typeof actor.id !== 'string' || actor.id.trim() === '') {
-      const errorMsg = `${this.constructor.name}.startTurn: actor is required and must have a valid id.`;
-      this._logger.error(errorMsg);
-      throw new Error(errorMsg);
-    }
+    assertValidActor(actor, this._logger, `${this.constructor.name}.startTurn`);
     this._setCurrentActorInternal(actor);
     const aiStrategy = this.#aiPlayerStrategyFactory.create();
     const newTurnContext = this.#turnContextFactory.create({

--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -6,6 +6,7 @@
 import { BaseTurnHandler } from './baseTurnHandler.js';
 import { AwaitTurnEndState } from '../valueObjects/awaitTurnEndState.js';
 import { ActorMismatchError } from '../../errors/actorMismatchError.js';
+import { assertValidActor } from '../../utils/actorValidation.js';
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor */
@@ -202,11 +203,11 @@ class HumanTurnHandler extends BaseTurnHandler {
    * @throws {Error} If the actor is invalid.
    */
   _assertValidActor(actor, operationName) {
-    if (!actor || typeof actor.id !== 'string' || actor.id.trim() === '') {
-      const errorMsg = `${this.constructor.name}.${operationName}: actor is required and must have a valid id.`;
-      this._logger.error(errorMsg);
-      throw new Error(errorMsg);
-    }
+    assertValidActor(
+      actor,
+      this._logger,
+      `${this.constructor.name}.${operationName}`
+    );
   }
 
   /** @private */


### PR DESCRIPTION
Summary: centralize repeated actor validation by reusing assertValidActor in both AITurnHandler and HumanTurnHandler.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint (partial)     `npx eslint src/turns/handlers/aiTurnHandler.js src/turns/handlers/humanTurnHandler.js`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684daf8587fc83319e1a5edbf8c52864