### PR TITLE
[Agent] Fix AITurnHandler test suite

### DIFF
--- a/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
+++ b/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
@@ -52,8 +52,8 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
       lifecycle: 'singletonFactory',
     });
 
-    // Stub out ITurnContextFactory so AITurnHandler constructor passes
-    container.register(tokens.ITurnContextFactory, () => ({}), {
+    // Stub out TurnContextBuilder so AITurnHandler constructor passes
+    container.register(tokens.TurnContextBuilder, () => ({}), {
       lifecycle: 'singletonFactory',
     });
 
@@ -148,15 +148,15 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
           logger: c.resolve(tokens.ILogger),
           turnStateFactory: c.resolve(tokens.ITurnStateFactory),
           turnEndPort: c.resolve(tokens.ITurnEndPort),
-          aiPlayerStrategyFactory: c.resolve(tokens.IAIPlayerStrategyFactory),
-          // turnContextFactory intentionally omitted
+          strategyFactory: c.resolve(tokens.IAIPlayerStrategyFactory),
+          // turnContextBuilder intentionally omitted
         }),
       { lifecycle: 'transient' }
     );
 
     // Act & Assert
     expect(() => brokenContainer.resolve(tokens.AITurnHandler)).toThrow(
-      'AITurnHandler: Invalid ITurnContextFactory'
+      'GenericTurnHandler: turnContextBuilder is required'
     );
   });
 });

--- a/tests/integration/turnHandlerResolution.integration.test.js
+++ b/tests/integration/turnHandlerResolution.integration.test.js
@@ -52,7 +52,7 @@ describe('T-08: AITurnHandler Resolution and Startup', () => {
   let mockTurnState;
   let mockAiPromptPipeline;
   let mockEntityManager;
-  let mockTurnContextFactory;
+  let mockTurnContextBuilder;
   let stubs;
   const AI_ACTOR_ID = 'ai-npc-1';
   let aiActor;
@@ -75,7 +75,7 @@ describe('T-08: AITurnHandler Resolution and Startup', () => {
     };
 
     mockEntityManager = { getEntityInstance: (id) => ({ id }) };
-    mockTurnContextFactory = { create: jest.fn() };
+    mockTurnContextBuilder = { build: jest.fn() };
 
     stubs = {
       logger,
@@ -96,10 +96,10 @@ describe('T-08: AITurnHandler Resolution and Startup', () => {
       promptBuilder: {},
       aiFallbackActionFactory: { create: jest.fn() },
       // stub strategy factory directly:
-      aiPlayerStrategyFactory: {
-        create: jest.fn(() => new StubAIPlayerStrategy(stubs)),
+      strategyFactory: {
+        createForHuman: jest.fn(() => new StubAIPlayerStrategy(stubs)),
       },
-      turnContextFactory: mockTurnContextFactory,
+      turnContextBuilder: mockTurnContextBuilder,
       gameStateProvider: {},
       promptContentProvider: {},
       llmResponseProcessor: { processResponse: jest.fn() },
@@ -141,9 +141,9 @@ describe('T-08: AITurnHandler Resolution and Startup', () => {
     await expect(handler.startTurn(aiActor)).resolves.not.toThrow();
 
     // 3. Verify key calls.
-    expect(mockTurnContextFactory.create).toHaveBeenCalledTimes(1);
-    expect(stubs.aiPlayerStrategyFactory.create).toHaveBeenCalledTimes(1);
-    expect(stubs.aiPlayerStrategyFactory.create).toHaveBeenCalled();
+    expect(mockTurnContextBuilder.build).toHaveBeenCalledTimes(1);
+    expect(stubs.strategyFactory.createForHuman).toHaveBeenCalledTimes(1);
+    expect(stubs.strategyFactory.createForHuman).toHaveBeenCalled();
     expect(mockTurnState.startTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/turns/handlers/aiTurnHandler.test.js
+++ b/tests/turns/handlers/aiTurnHandler.test.js
@@ -37,8 +37,8 @@ const mockAiStrategy = {
   decideAction: jest.fn(),
 };
 
-const mockAIPlayerStrategyFactory = {
-  create: jest.fn(() => mockAiStrategy),
+const mockStrategyFactory = {
+  createForHuman: jest.fn(() => mockAiStrategy),
 };
 
 const mockTurnContext = {
@@ -46,8 +46,8 @@ const mockTurnContext = {
   // Add other methods if they are called by the handler directly.
 };
 
-const mockTurnContextFactory = {
-  create: jest.fn(() => mockTurnContext),
+const mockTurnContextBuilder = {
+  build: jest.fn(() => mockTurnContext),
 };
 
 const mockActor = { id: 'ai-actor-1', name: 'Test AI' };
@@ -58,8 +58,8 @@ describe('AITurnHandler', () => {
     logger: mockLogger,
     turnStateFactory: mockTurnStateFactory,
     turnEndPort: mockTurnEndPort,
-    aiPlayerStrategyFactory: mockAIPlayerStrategyFactory,
-    turnContextFactory: mockTurnContextFactory,
+    strategyFactory: mockStrategyFactory,
+    turnContextBuilder: mockTurnContextBuilder,
   };
 
   beforeEach(() => {
@@ -90,21 +90,21 @@ describe('AITurnHandler', () => {
     it('should throw an error if the turnEndPort dependency is missing', () => {
       const deps = { ...dependencies, turnEndPort: undefined };
       expect(() => new AITurnHandler(deps)).toThrow(
-        'AITurnHandler: Invalid ITurnEndPort'
+        'GenericTurnHandler: turnEndPort is required'
       );
     });
 
-    it('should throw an error if the aiPlayerStrategyFactory is missing', () => {
-      const deps = { ...dependencies, aiPlayerStrategyFactory: undefined };
+    it('should throw an error if the strategyFactory is missing', () => {
+      const deps = { ...dependencies, strategyFactory: undefined };
       expect(() => new AITurnHandler(deps)).toThrow(
-        'AITurnHandler: Invalid IAIPlayerStrategyFactory'
+        'GenericTurnHandler: strategyFactory is required'
       );
     });
 
-    it('should throw an error if the turnContextFactory is missing', () => {
-      const deps = { ...dependencies, turnContextFactory: undefined };
+    it('should throw an error if the turnContextBuilder is missing', () => {
+      const deps = { ...dependencies, turnContextBuilder: undefined };
       expect(() => new AITurnHandler(deps)).toThrow(
-        'AITurnHandler: Invalid ITurnContextFactory'
+        'GenericTurnHandler: turnContextBuilder is required'
       );
     });
 
@@ -129,25 +129,26 @@ describe('AITurnHandler', () => {
       await expect(handler.startTurn({})).rejects.toThrow(expectedError);
     });
 
-    it('should call aiPlayerStrategyFactory.create to get a strategy', async () => {
+    it('should call strategyFactory.createForHuman to get a strategy', async () => {
       // Act
       await handler.startTurn(mockActor);
 
       // Assert
-      expect(mockAIPlayerStrategyFactory.create).toHaveBeenCalledTimes(1);
+      expect(mockStrategyFactory.createForHuman).toHaveBeenCalledTimes(1);
     });
 
-    it('should call turnContextFactory.create with the correct parameters', async () => {
+    it('should call turnContextBuilder.build with the correct parameters', async () => {
       // Act
       await handler.startTurn(mockActor);
 
       // Assert
-      expect(mockTurnContextFactory.create).toHaveBeenCalledTimes(1);
-      expect(mockTurnContextFactory.create).toHaveBeenCalledWith({
+      expect(mockTurnContextBuilder.build).toHaveBeenCalledTimes(1);
+      expect(mockTurnContextBuilder.build).toHaveBeenCalledWith({
         actor: mockActor,
         strategy: mockAiStrategy,
-        onEndTurnCallback: expect.any(Function),
-        handlerInstance: handler,
+        onEndTurn: expect.any(Function),
+        awaitFlagProvider: expect.any(Function),
+        setAwaitFlag: expect.any(Function),
       });
     });
 

--- a/tests/utils/contextVariableUtils.test.js
+++ b/tests/utils/contextVariableUtils.test.js
@@ -32,7 +32,12 @@ describe('storeResult', () => {
 
   test('logs error when dispatcher not provided', () => {
     const ctx = {};
-    const logger = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
     const success = storeResult('baz', 7, ctx, undefined, logger);
     expect(success).toBe(false);
     expect(logger.error).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- update AITurnHandler unit tests for new constructor
- adjust awaiting external event test to use new TurnContextBuilder stub
- update DI registration test and integration test for updated dependencies
- keep context utils test formatting tidy

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm run test` *(fails coverage thresholds)*
- `cd llm-proxy-server && npm run test` *(fails coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_684db1cbe3c083319b359bd6d7f4d436