### PR TITLE
[Agent] dispatch error event in LocationRenderer

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -143,7 +143,7 @@ export function registerUI(
     return new LocationRenderer({
       logger: resolvedLogger,
       documentContext: docContext,
-      validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       domElementFactory: c.resolve(tokens.DomElementFactory),
       entityManager: c.resolve(tokens.IEntityManager),
       entityDisplayDataProvider: c.resolve(tokens.EntityDisplayDataProvider),

--- a/tests/config/registrations/uiRegistrations.test.js
+++ b/tests/config/registrations/uiRegistrations.test.js
@@ -46,7 +46,7 @@ describe('registerUI', () => {
               warn: jest.fn(),
               error: jest.fn(),
             };
-          case tokens.IValidatedEventDispatcher:
+          case tokens.ISafeEventDispatcher:
             return { subscribe: jest.fn(), dispatch: jest.fn() };
           // For any other resolved dependency, return a generic mock function.
           default:


### PR DESCRIPTION
## Summary
- propagate UI errors via events in `LocationRenderer`
- require SafeEventDispatcher in UI registration for LocationRenderer
- adjust unit tests for new event dispatch behavior

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684db66b51a88331abb986ef42e84734