### PR TITLE
[Agent] add prefixed logger helper

### DIFF
--- a/src/utils/actorValidation.js
+++ b/src/utils/actorValidation.js
@@ -10,7 +10,7 @@
  */
 
 import { isNonEmptyString } from './textUtils.js';
-import { ensureValidLogger } from './loggerUtils.js';
+import { getPrefixedLogger } from './loggerUtils.js';
 
 /**
  * Throws an error if the provided actor is invalid.
@@ -26,7 +26,7 @@ export function assertValidActor(
   logger,
   contextName = 'UnknownContext'
 ) {
-  const log = ensureValidLogger(logger, 'ActorValidation');
+  const log = getPrefixedLogger(logger, '[ActorValidation] ');
   if (!actor || !isNonEmptyString(actor.id)) {
     const errMsg = `${contextName}: actor is required and must have a valid id.`;
     log.error(errMsg, { actor });

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -1,6 +1,6 @@
 // src/utils/apiUtils.js
 // --- FILE START ---
-import { ensureValidLogger } from './loggerUtils.js';
+import { getPrefixedLogger } from './loggerUtils.js';
 
 const RETRYABLE_HTTP_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
@@ -57,7 +57,7 @@ export async function Workspace_retry(
   maxDelayMs,
   logger
 ) {
-  const log = ensureValidLogger(logger, 'Workspace_retry');
+  const log = getPrefixedLogger(logger, '[Workspace_retry] ');
   // This internal recursive function handles the actual fetch attempts and retry logic.
   // It's called by Workspace_retry with the initial attempt number.
   /**

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -1,7 +1,7 @@
 // src/utils/contextVariableUtils.js
 
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
-import { ensureValidLogger } from './loggerUtils.js';
+import { getPrefixedLogger } from './loggerUtils.js';
 
 /**
  * Safely stores a value into `execCtx.evaluationContext.context`. If the context
@@ -17,7 +17,7 @@ import { ensureValidLogger } from './loggerUtils.js';
  * @returns {boolean} `true` if the value was stored successfully, otherwise `false`.
  */
 export function storeResult(variableName, value, execCtx, dispatcher, logger) {
-  const log = ensureValidLogger(logger, 'contextVariableUtils');
+  const log = getPrefixedLogger(logger, '[contextVariableUtils] ');
   const hasContext =
     execCtx?.evaluationContext &&
     typeof execCtx.evaluationContext.context === 'object' &&

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -3,7 +3,7 @@
 import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 import { isNonEmptyString } from './textUtils.js';
-import { ensureValidLogger } from './loggerUtils.js';
+import { getPrefixedLogger } from './loggerUtils.js';
 import {
   isValidEntityManager,
   isValidEntity,
@@ -41,7 +41,7 @@ function _getExitsComponentData(
   logger,
   dispatcher
 ) {
-  const log = ensureValidLogger(logger, 'locationUtils');
+  const log = getPrefixedLogger(logger, '[locationUtils] ');
   let locationEntity = locationEntityOrId;
 
   if (typeof locationEntityOrId === 'string') {
@@ -104,7 +104,7 @@ export function getExitByDirection(
   logger,
   dispatcher
 ) {
-  const log = ensureValidLogger(logger, 'locationUtils');
+  const log = getPrefixedLogger(logger, '[locationUtils] ');
   if (!isNonEmptyString(directionName)) {
     log.debug('getExitByDirection: Invalid or empty directionName provided.');
     return null;
@@ -169,7 +169,7 @@ export function getAvailableExits(
   dispatcher,
   logger
 ) {
-  const log = ensureValidLogger(logger, 'locationUtils');
+  const log = getPrefixedLogger(logger, '[locationUtils] ');
   const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -67,4 +67,18 @@ export function createPrefixedLogger(baseLogger, prefix) {
   };
 }
 
+/**
+ * @description Convenience wrapper that validates the provided logger and
+ * returns a new logger that automatically prefixes all messages. Useful for
+ * utilities that consistently tag their log output.
+ * @param {ILogger | undefined | null} logger - Logger instance to validate.
+ * @param {string} prefix - The prefix applied to each log message.
+ * @returns {ILogger} Logger instance that prepends `prefix` to each message.
+ */
+export function getPrefixedLogger(logger, prefix) {
+  const validLogger = ensureValidLogger(logger, prefix);
+  const effectivePrefix = prefix || '';
+  return createPrefixedLogger(validLogger, effectivePrefix);
+}
+
 // --- FILE END ---


### PR DESCRIPTION
Summary: introduce `getPrefixedLogger` helper wrapping `ensureValidLogger` and `createPrefixedLogger` to standardize logger setup. Updated several utility modules to use this new helper.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [ ] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684db68098288331bf572acf58b6675a