### PR TITLE
[Agent] fix helper import paths

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -4,7 +4,7 @@
 
 /**
  * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
- * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  */
 
 import { handleProcessingException } from './handleProcessingException.js';

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -4,8 +4,8 @@
 
 /**
  * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
- * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
- * @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */
 
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../constants/eventIds.js';

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -4,9 +4,9 @@
 
 /**
  * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
- * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
- * @typedef {import('../../entities/entity.js').default} Entity
- * @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
+ * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../../entities/entity.js').default} Entity
+ * @typedef {import('../../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
  */
 
 import TurnDirectiveStrategyResolver from '../../strategies/turnDirectiveStrategyResolver.js';


### PR DESCRIPTION
## Summary
- fix relative paths for turn helpers

## Testing
- `npm run format`
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm run test`
- `npm install && npm run format && npm run lint && npm run test` in `llm-proxy-server`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684db71387088331b1c009378b9aec1c