### PR TITLE
[Fix] remove circular deps in processing helpers

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  */
 
@@ -12,7 +12,7 @@ import { handleProcessingException } from './handleProcessingException.js';
 /**
  * Safely obtains a service from the turn context.
  *
- * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
  * @param {ITurnContext} turnCtx - Current turn context.
  * @param {string} methodName - Method name on ITurnContext used to retrieve the service.
  * @param {string} serviceNameForLog - Label for logging when retrieval fails.

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */
@@ -14,7 +14,7 @@ import { TurnIdleState } from '../turnIdleState.js';
 /**
  * Handles exceptions that occur during command processing.
  *
- * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
  * @param {ITurnContext} turnCtx - Current turn context.
  * @param {Error} error - Error being handled.
  * @param {string} [actorIdContext] - Actor ID for logging context.

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../processingCommandState.js').ProcessingCommandState} ProcessingCommandState
+ * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../../entities/entity.js').default} Entity
  * @typedef {import('../../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
@@ -16,7 +16,7 @@ import { handleProcessingException } from './handleProcessingException.js';
 /**
  * Executes the main command processing workflow.
  *
- * @param {ProcessingCommandState} state - Owning state instance.
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
  * @param {ITurnContext} turnCtx - Current turn context.
  * @param {Entity} actor - Actor executing the command.
  * @param {ITurnAction} turnAction - Action to process.

--- a/src/types/stateTypes.js
+++ b/src/types/stateTypes.js
@@ -1,0 +1,14 @@
+/**
+ * @file Generic type definitions for turn state helpers.
+ */
+
+/**
+ * @typedef {object} ProcessingCommandStateLike
+ * @description Minimal shape used by helper utilities for ProcessingCommandState.
+ * @property {boolean} _isProcessing - Indicates if command processing is active.
+ * @property {function(): string} getStateName - Retrieves the state's name for logging.
+ * @property {function(): import('../turns/interfaces/ITurnContext.js').ITurnContext | null} _getTurnContext - Gets the current turn context.
+ * @property {{ safeEventDispatcher?: any, _currentState?: any }} _handler - Owning handler reference.
+ */
+
+export {};


### PR DESCRIPTION
Summary: Breaks dependency cycle flagged by dependency-cruiser. Helper modules now reference a lightweight `ProcessingCommandStateLike` type instead of importing `ProcessingCommandState`.

Changes Made:
- added `src/types/stateTypes.js` with `ProcessingCommandStateLike`
- updated helper JSDoc to use new type

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` for changed files)
- [x] Root tests pass (`npm run test`) *(coverage thresholds ignored)*
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`) *(coverage thresholds ignored)*
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_684dbb075340833180c2f80e3f369cab