### PR TITLE
[Agent] Add unified string validation helper

### DIFF
--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -6,6 +6,7 @@
 import NotesService from './notesService.js';
 import { NOTES_COMPONENT_ID } from '../constants/componentIds.js';
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
  * Persists the "notes" produced during an LLM turn into the actor's
@@ -42,7 +43,7 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
   // Filter out invalid notes before processing, dispatching errors for them.
   const validNotes = [];
   for (const noteText of notesArray) {
-    if (typeof noteText === 'string' && noteText.trim() !== '') {
+    if (isNonBlankString(noteText)) {
       validNotes.push(noteText);
     } else {
       dispatcher?.dispatch(DISPLAY_ERROR_ID, {

--- a/src/configuration/loggerConfigLoader.js
+++ b/src/configuration/loggerConfigLoader.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 
 import { Workspace_retry } from '../utils/apiUtils.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -91,10 +92,9 @@ export class LoggerConfigLoader {
    * JavaScript object representing the logger configuration, or an error object if loading/parsing fails.
    */
   async loadConfig(filePath) {
-    const path =
-      typeof filePath === 'string' && filePath.trim() !== ''
-        ? filePath.trim()
-        : this.#defaultConfigPath;
+    const path = isNonBlankString(filePath)
+      ? filePath.trim()
+      : this.#defaultConfigPath;
 
     // Use a safe way to log, as this.#logger could be console or a full ILogger
     const logInfo = (msg, ...args) =>

--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -10,6 +10,7 @@ import {
 import { validateDependency } from '../utils/validationUtils.js';
 import { ensureValidLogger } from '../utils/loggerUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
@@ -310,14 +311,12 @@ export class EntityDisplayDataProvider {
             );
             return null;
           }
-          const exitDescription =
-            typeof exit.direction === 'string' && exit.direction.trim()
-              ? exit.direction.trim()
-              : 'Unspecified Exit';
-          const exitTarget =
-            typeof exit.target === 'string' && exit.target.trim()
-              ? exit.target.trim()
-              : undefined;
+          const exitDescription = isNonBlankString(exit.direction)
+            ? exit.direction.trim()
+            : 'Unspecified Exit';
+          const exitTarget = isNonBlankString(exit.target)
+            ? exit.target.trim()
+            : undefined;
 
           return {
             description: exitDescription,
@@ -388,11 +387,9 @@ export class EntityDisplayDataProvider {
     // This path construction assumes a specific mod structure.
     // You might need to adjust this based on your actual asset loading strategy.
     const fullPath = `/data/mods/${modId}/${imagePath}`;
-    const altText =
-      typeof portraitComponent.altText === 'string' &&
-      portraitComponent.altText.trim()
-        ? portraitComponent.altText.trim()
-        : null; // Return null if altText is not provided or empty
+    const altText = isNonBlankString(portraitComponent.altText)
+      ? portraitComponent.altText.trim()
+      : null; // Return null if altText is not provided or empty
 
     this.#logger.debug(
       `${this._logPrefix} getLocationPortraitData: Constructed portrait path for location '${locationEntityId}': ${fullPath}`

--- a/src/entities/entityScopeService.js
+++ b/src/entities/entityScopeService.js
@@ -8,6 +8,7 @@ import {
   EXITS_COMPONENT_ID,
   LEADING_COMPONENT_ID,
 } from '../constants/componentIds.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('./entityManager.js').default} EntityManager */
@@ -66,7 +67,7 @@ function _createActorComponentScopeHandler(
       return new Set();
     }
 
-    return new Set(ids.filter((id) => typeof id === 'string' && id));
+    return new Set(ids.filter((id) => isNonBlankString(id)));
   };
 }
 

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -3,6 +3,7 @@
  * Rebuilds the 'core:leading' component for one or more leaders.
  * @see src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
  */
+import { isNonBlankString } from '../../utils/textUtils.js';
 class RebuildLeaderListCacheHandler {
   #logger;
   #entityManager;
@@ -45,9 +46,7 @@ class RebuildLeaderListCacheHandler {
       );
       return;
     }
-    const ids = [
-      ...new Set(leaderIds.filter((id) => typeof id === 'string' && id.trim())),
-    ];
+    const ids = [...new Set(leaderIds.filter((id) => isNonBlankString(id)))];
     if (ids.length === 0) {
       this.#logger.debug(
         '[RebuildLeaderListCacheHandler] leaderIds empty after filtering; skipping.'

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -52,13 +52,24 @@ export function snakeToCamel(str) {
 }
 
 /**
- * Checks if the provided value is a non-empty string after trimming.
+ * Checks if the provided value is a non-blank string.
+ * A non-blank string is a string containing characters other than whitespace.
  *
+ * @param {*} value - Value to validate.
+ * @returns {boolean} True if value is a non-blank string, otherwise false.
+ */
+export function isNonBlankString(value) {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * @deprecated Use `isNonBlankString` instead.
+ * Checks if the provided value is a non-empty string after trimming.
  * @param {*} value - Value to validate.
  * @returns {boolean} True if value is a non-empty string, otherwise false.
  */
 export function isNonEmptyString(value) {
-  return typeof value === 'string' && value.trim() !== '';
+  return isNonBlankString(value);
 }
 
 /**

--- a/tests/utils/textUtils.isNonBlankString.test.js
+++ b/tests/utils/textUtils.isNonBlankString.test.js
@@ -1,0 +1,22 @@
+import { describe, test, expect } from '@jest/globals';
+import { isNonBlankString } from '../../src/utils/textUtils.js';
+
+describe('isNonBlankString', () => {
+  test('returns true for a normal string', () => {
+    expect(isNonBlankString('hello')).toBe(true);
+  });
+
+  test('returns false for an empty string', () => {
+    expect(isNonBlankString('')).toBe(false);
+  });
+
+  test('returns false for whitespace only string', () => {
+    expect(isNonBlankString('   ')).toBe(false);
+  });
+
+  test('returns false for non-string values', () => {
+    expect(isNonBlankString(null)).toBe(false);
+    // @ts-ignore
+    expect(isNonBlankString(123)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `isNonBlankString` to text utilities and deprecate `isNonEmptyString`
- use the helper in notes persistence, logger config loader, and entity helpers
- update entity display provider exit and portrait parsing
- test the new `isNonBlankString` function

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 562 errors, 1708 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684dbe0782088331868c35438d253306