### PR TITLE
[Agent] add getComponent helper

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -1,0 +1,35 @@
+// src/utils/componentAccessUtils.js
+
+/**
+ * @module componentAccessUtils
+ * @description Helper utilities for safely accessing component data on entities.
+ */
+
+/** @typedef {import('../entities/entity.js').default} Entity */
+
+/**
+ * Safely retrieves component data from an entity.
+ *
+ * @param {Entity | any} entity - The entity instance to query. Must expose a
+ *   `getComponentData` method.
+ * @param {string} componentId - The component type ID to retrieve.
+ * @returns {any | null} The component data if available, otherwise `null`.
+ */
+export function getComponent(entity, componentId) {
+  if (typeof componentId !== 'string' || componentId.trim() === '') {
+    return null;
+  }
+
+  if (!entity || typeof entity.getComponentData !== 'function') {
+    return null;
+  }
+
+  try {
+    const data = entity.getComponentData(componentId);
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// --- FILE END ---

--- a/tests/utils/componentAccessUtils.test.js
+++ b/tests/utils/componentAccessUtils.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+import { getComponent } from '../../src/utils/componentAccessUtils.js';
+
+class MockEntity {
+  constructor(data = {}) {
+    this._data = data;
+  }
+
+  getComponentData(id) {
+    if (id in this._data) {
+      return this._data[id];
+    }
+    return undefined;
+  }
+}
+
+describe('getComponent', () => {
+  it('returns component data when present', () => {
+    const ent = new MockEntity({ foo: { a: 1 } });
+    expect(getComponent(ent, 'foo')).toEqual({ a: 1 });
+  });
+
+  it('returns null when component missing', () => {
+    const ent = new MockEntity();
+    expect(getComponent(ent, 'foo')).toBeNull();
+  });
+
+  it('returns null for invalid entity', () => {
+    expect(getComponent(null, 'foo')).toBeNull();
+    expect(getComponent({}, 'foo')).toBeNull();
+  });
+
+  it('returns null for invalid componentId', () => {
+    const ent = new MockEntity({ foo: { a: 1 } });
+    expect(getComponent(ent, '')).toBeNull();
+    // @ts-ignore - purposely pass non-string
+    expect(getComponent(ent, null)).toBeNull();
+  });
+
+  it('returns null when getComponentData throws', () => {
+    const ent = {
+      getComponentData() {
+        throw new Error('boom');
+      },
+    };
+    expect(getComponent(ent, 'foo')).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary:
- add componentAccessUtils.getComponent to unify component fetching
- cover new helper with unit tests

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684dbe2a0ef88331876a13a82fada61a