### PR TITLE
[Agent] fix dependency-cruiser issues

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -7,7 +7,7 @@
 /** @typedef {import('../events/eventBus.js').default} EventBus */ // Assuming EventBus might be an interface or a concrete type used directly
 /** @typedef {import('../constants/eventIds.js').ATTEMPT_ACTION_ID} ATTEMPT_ACTION_ID */
 // --- ADDED Import for ActionTargetContext ---
-/** @typedef {import('../models/ActionTargetContext.js').ActionTargetContext} ActionTargetContext */
+/** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 // --- ADDED Import for ActionDefinition (used in ActionAttemptPseudoEvent) ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */ // Added for ActionContext
 /** @typedef {import('../interfaces/IWorldContext.js').IWorldContext} IWorldContext */ // Added for ActionContext

--- a/src/turns/pipeline/turnActionChoicePipeline.js
+++ b/src/turns/pipeline/turnActionChoicePipeline.js
@@ -29,7 +29,8 @@ export class TurnActionChoicePipeline {
 
   /**
    * Discovers, indexes, and returns a list of action choices for an actor's turn.
-   * @param {import('../../models/entity.js').Entity} actor - The entity whose actions we’re building choices for.
+   *
+   * @param {import('../../entities/entity.js').Entity} actor - The entity whose actions we’re building choices for.
    * @param {ITurnContext} context - The current turn context.
    * @returns {Promise<import('../dtos/actionComposite.js').ActionComposite[]>} Deduped, capped, 1-based indexed action list.
    */

--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
+ * @typedef {import('../../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  */
 

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
+ * @typedef {import('../../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
+ * @typedef {import('../../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../../entities/entity.js').default} Entity
  * @typedef {import('../../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction


### PR DESCRIPTION
Summary: fix unresolved JSDoc import paths triggering dependency-cruiser errors.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: existing repo issues)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0bfc2748331949190e81a5bb93c