### PR TITLE
[Agent] dispatch display_error from validation util

### DIFF
--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -134,7 +134,16 @@ export function registerTurnLifecycle(container) {
   );
 
   // ──────────────────── Validation Utils ─────────────────────
-  r.singletonFactory(tokens.assertValidActor, () => assertValidActor);
+  r.singletonFactory(
+    tokens.assertValidActor,
+    (c) => (actor, logger, contextName) =>
+      assertValidActor(
+        actor,
+        logger,
+        contextName,
+        c.resolve(tokens.ISafeEventDispatcher)
+      )
+  );
 
   // ───────────────── Turn Context Builder ────────────────────
   r.transientFactory(

--- a/src/utils/actorValidation.js
+++ b/src/utils/actorValidation.js
@@ -7,10 +7,12 @@
 /**
  * @typedef {import('../entities/entity.js').default} Entity
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */
 
 import { isNonEmptyString } from './textUtils.js';
 import { getPrefixedLogger } from './loggerUtils.js';
+import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 
 /**
  * Throws an error if the provided actor is invalid.
@@ -19,17 +21,27 @@ import { getPrefixedLogger } from './loggerUtils.js';
  * @param {Entity} actor - The actor entity to validate.
  * @param {ILogger} [logger] - An optional logger instance for logging errors.
  * @param {string} [contextName] - The name of the calling context for improved error messages.
+ * @param {ISafeEventDispatcher} [safeEventDispatcher] - Dispatcher used to send DISPLAY_ERROR_ID events.
  * @throws {Error} If the actor is invalid.
  */
 export function assertValidActor(
   actor,
   logger,
-  contextName = 'UnknownContext'
+  contextName = 'UnknownContext',
+  safeEventDispatcher
 ) {
   const log = getPrefixedLogger(logger, '[ActorValidation] ');
   if (!actor || !isNonEmptyString(actor.id)) {
     const errMsg = `${contextName}: actor is required and must have a valid id.`;
-    log.error(errMsg, { actor });
+    const payload = {
+      message: errMsg,
+      details: { contextName, actorId: actor?.id ?? null, actor },
+    };
+    if (safeEventDispatcher?.dispatch) {
+      safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, payload);
+    } else {
+      log.warn(`${errMsg} - SafeEventDispatcher missing.`, { actor });
+    }
     throw new Error(errMsg);
   }
 }

--- a/tests/utils/actorValidation.test.js
+++ b/tests/utils/actorValidation.test.js
@@ -1,0 +1,53 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { assertValidActor } from '../../src/utils/actorValidation.js';
+import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+
+describe('assertValidActor', () => {
+  test('dispatches error and throws when actor invalid', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const badActor = { id: '' };
+    expect(() =>
+      assertValidActor(badActor, logger, 'TestCtx', dispatcher)
+    ).toThrow('TestCtx: actor is required and must have a valid id.');
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.any(String),
+        details: expect.objectContaining({ contextName: 'TestCtx' }),
+      })
+    );
+  });
+
+  test('falls back to logger.warn when dispatcher missing', () => {
+    const logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    expect(() => assertValidActor(null, logger, 'Ctx')).toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('does nothing when actor valid', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const actor = { id: 'a1' };
+    expect(() =>
+      assertValidActor(actor, logger, 'Ctx', dispatcher)
+    ).not.toThrow();
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Replaced error logging in `assertValidActor` with dispatching of the `core:display_error` event. Added SafeEventDispatcher injection in DI registration and created unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing repository issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684dc781d36c8331ac7fa62cf61295fd