### PR TITLE
[Agent] Add safe error dispatch utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,8 +361,11 @@ Quick reference for and, or, and not/!, including edge-cases and examples.
 **Full JSON Logic Usage Guide ➜ docs/json-logic/json-logic-usage.md**  
 Complete operator list, context explanation, and many ready-made patterns.
 
-**Mod Manifest Loader Usage ➜ docs/mods/modManifestLoader.md**  
+**Mod Manifest Loader Usage ➜ docs/mods/modManifestLoader.md**
 How to use the ModManifestLoader service and handle potential errors.
+
+**Display Error Event Payload ➜ docs/events/display_error_payload.md**
+Overview of the payload structure emitted when dispatching `core:display_error` events.
 
 ### License
 

--- a/docs/events/display_error_payload.md
+++ b/docs/events/display_error_payload.md
@@ -1,0 +1,15 @@
+# Display Error Event Payload
+
+The `core:display_error` event communicates user-facing errors to the UI layer. Payloads dispatched via `safeDispatchError` follow this structure:
+
+```json
+{
+  "message": "<human readable message>",
+  "details": { "<optional additional fields>": "..." }
+}
+```
+
+- `message` is a short text explaining the error.
+- `details` is an object with arbitrary diagnostic information intended for logs or debugging tools.
+
+The `safeDispatchError` utility validates the dispatcher before emitting the event, ensuring consistent formatting across the codebase.

--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -18,6 +18,7 @@ import { getAvailableExits } from '../utils/locationUtils.js';
 import { createPrefixedLogger } from '../utils/loggerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
+import { safeDispatchError } from '../utils/safeDispatchError.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 export class ActionDiscoveryService extends IActionDiscoveryService {
@@ -250,6 +251,11 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
         this.#logger.error(
           `Error processing action ${actionDef.id} for actor ${actorEntity.id}:`,
           err
+        );
+        safeDispatchError(
+          this.#safeEventDispatcher,
+          `ActionDiscoveryService: Error processing action ${actionDef.id} for actor ${actorEntity.id}.`,
+          { error: err.message }
         );
       }
     }

--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -10,6 +10,7 @@
 // --- Dependency Imports ---
 import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { safeDispatchError } from '../utils/safeDispatchError.js';
 
 /**
  * Formats a validated action and target into a user-facing command string.
@@ -41,35 +42,36 @@ export function formatActionCommand(
 
   // --- 1. Input Validation ---
   if (!actionDefinition || !actionDefinition.template) {
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-      message:
-        'formatActionCommand: Invalid or missing actionDefinition or template.',
-      details: { actionDefinition },
-    });
+    safeDispatchError(
+      safeEventDispatcher,
+      'formatActionCommand: Invalid or missing actionDefinition or template.',
+      { actionDefinition }
+    );
     return null;
   }
   if (!validatedTargetContext) {
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-      message:
-        'formatActionCommand: Invalid or missing validatedTargetContext.',
-      details: { validatedTargetContext },
-    });
+    safeDispatchError(
+      safeEventDispatcher,
+      'formatActionCommand: Invalid or missing validatedTargetContext.',
+      { validatedTargetContext }
+    );
     return null;
   }
   if (!entityManager || typeof entityManager.getEntityInstance !== 'function') {
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-      message: 'formatActionCommand: Invalid or missing entityManager.',
-      details: { entityManager },
-    });
+    safeDispatchError(
+      safeEventDispatcher,
+      'formatActionCommand: Invalid or missing entityManager.',
+      { entityManager }
+    );
     throw new Error(
       'formatActionCommand requires a valid EntityManager instance.'
     );
   }
   if (typeof getEntityDisplayName !== 'function') {
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-      message:
-        'formatActionCommand: getEntityDisplayName utility function is not available.',
-    });
+    safeDispatchError(
+      safeEventDispatcher,
+      'formatActionCommand: getEntityDisplayName utility function is not available.'
+    );
     throw new Error(
       'formatActionCommand requires the getEntityDisplayName utility function.'
     );
@@ -160,10 +162,11 @@ export function formatActionCommand(
         break;
     }
   } catch (error) {
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-      message: `formatActionCommand: Error during placeholder substitution for action ${actionDefinition.id}:`,
-      details: { error: error.message, stack: error.stack },
-    });
+    safeDispatchError(
+      safeEventDispatcher,
+      `formatActionCommand: Error during placeholder substitution for action ${actionDefinition.id}:`,
+      { error: error.message, stack: error.stack }
+    );
     return null; // Return null on processing error
   }
 

--- a/src/utils/safeDispatchError.js
+++ b/src/utils/safeDispatchError.js
@@ -1,0 +1,33 @@
+// src/utils/safeDispatchError.js
+
+/**
+ * @file Utility to safely dispatch a standardized error event using an
+ * ISafeEventDispatcher.
+ */
+
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
+import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { validateDependency } from './validationUtils.js';
+
+/**
+ * @description
+ * Sends a `core:display_error` event with a consistent payload structure.
+ * The dispatcher is validated before dispatching.
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
+ * @param {string} message - Human readable error message.
+ * @param {object} [details] - Additional structured details for debugging.
+ * @throws {Error} If the dispatcher is missing or invalid.
+ * @returns {void}
+ * @example
+ * safeDispatchError(safeEventDispatcher, 'Invalid action', { id: 'bad-action' });
+ */
+export function safeDispatchError(dispatcher, message, details = {}) {
+  validateDependency(dispatcher, 'safeDispatchError: dispatcher', console, {
+    requiredMethods: ['dispatch'],
+  });
+
+  dispatcher.dispatch(DISPLAY_ERROR_ID, { message, details });
+}
+
+// --- FILE END ---

--- a/tests/utils/safeDispatchError.test.js
+++ b/tests/utils/safeDispatchError.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { safeDispatchError } from '../../src/utils/safeDispatchError.js';
+import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+
+describe('safeDispatchError', () => {
+  it('dispatches the display error event', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    safeDispatchError(dispatcher, 'boom', { a: 1 });
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+      message: 'boom',
+      details: { a: 1 },
+    });
+  });
+
+  it('throws if dispatcher is invalid', () => {
+    expect(() => safeDispatchError({}, 'oops')).toThrow(
+      "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `safeDispatchError` for consistent error payload dispatch
- use `safeDispatchError` in `actionFormatter` and `actionDiscoveryService`
- document display error payload structure
- test the new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684dd0c7631483319cd1a9573af5ea63