### PR TITLE
[Agent] dispatch error via SafeEventDispatcher

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -147,6 +147,7 @@ export function registerInterpreters(container) {
         new Handler({
           logger: c.resolve(tokens.ILogger),
           entityManager: c.resolve(tokens.IEntityManager),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -162,6 +162,7 @@ function init(entities) {
     REBUILD_LEADER_LIST_CACHE: new RebuildLeaderListCacheHandler({
       logger,
       entityManager,
+      safeEventDispatcher: eventBus,
     }),
     QUERY_ENTITIES: new QueryEntitiesHandler({
       entityManager,


### PR DESCRIPTION
## Summary
- send DISPLAY_ERROR_ID events in RebuildLeaderListCacheHandler instead of logging
- inject SafeEventDispatcher into RebuildLeaderListCacheHandler
- register SafeEventDispatcher with handler in interpreter registrations
- update integration and unit tests to expect error events

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 546 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684dd911ac848331a2dcd5c1cdfef8b5