### PR TITLE
[Agent] Add helper for safe component retrieval

### DIFF
--- a/src/utils/actorLocationUtils.js
+++ b/src/utils/actorLocationUtils.js
@@ -8,7 +8,7 @@
 
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 import { isNonEmptyString } from './textUtils.js';
-import { isValidEntityManager } from './entityValidationUtils.js';
+import { getComponentFromManager } from './componentAccessUtils.js';
 
 /**
  * Retrieves the current location for the given actor entity.
@@ -22,22 +22,17 @@ import { isValidEntityManager } from './entityValidationUtils.js';
  * locationId string, or `null` when unavailable.
  */
 export function getActorLocation(entityId, entityManager) {
-  if (!isNonEmptyString(entityId)) return null;
-  if (!isValidEntityManager(entityManager)) {
-    return null;
-  }
-
-  try {
-    const pos = entityManager.getComponentData(entityId, POSITION_COMPONENT_ID);
-    if (pos && isNonEmptyString(pos.locationId)) {
-      const locationEntity =
-        typeof entityManager.getEntityInstance === 'function'
-          ? entityManager.getEntityInstance(pos.locationId)
-          : null;
-      return locationEntity ?? pos.locationId;
-    }
-  } catch {
-    /* ignored */
+  const pos = getComponentFromManager(
+    entityId,
+    POSITION_COMPONENT_ID,
+    entityManager
+  );
+  if (pos && isNonEmptyString(pos.locationId)) {
+    const locationEntity =
+      typeof entityManager?.getEntityInstance === 'function'
+        ? entityManager.getEntityInstance(pos.locationId)
+        : null;
+    return locationEntity ?? pos.locationId;
   }
   return null;
 }

--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -32,4 +32,40 @@ export function getComponent(entity, componentId) {
   }
 }
 
+/** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+/**
+ * Safely retrieves component data for an entity via an EntityManager.
+ *
+ * The function validates the entity ID, component ID and entity manager
+ * before attempting to access the data. Any errors thrown during the
+ * lookup are caught and `null` is returned.
+ *
+ * @param {string} entityId - The ID of the entity instance to query.
+ * @param {string} componentId - The component type ID to retrieve.
+ * @param {IEntityManager} entityManager - Manager used to access component data.
+ * @returns {any | null} The component data if available, otherwise `null`.
+ */
+export function getComponentFromManager(entityId, componentId, entityManager) {
+  if (
+    typeof entityId !== 'string' ||
+    entityId.trim() === '' ||
+    typeof componentId !== 'string' ||
+    componentId.trim() === ''
+  ) {
+    return null;
+  }
+
+  if (!entityManager || typeof entityManager.getComponentData !== 'function') {
+    return null;
+  }
+
+  try {
+    const data = entityManager.getComponentData(entityId, componentId);
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // --- FILE END ---

--- a/tests/utils/componentAccessUtils.test.js
+++ b/tests/utils/componentAccessUtils.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { getComponent } from '../../src/utils/componentAccessUtils.js';
+import {
+  getComponent,
+  getComponentFromManager,
+} from '../../src/utils/componentAccessUtils.js';
 
 class MockEntity {
   constructor(data = {}) {
@@ -44,5 +47,45 @@ describe('getComponent', () => {
       },
     };
     expect(getComponent(ent, 'foo')).toBeNull();
+  });
+});
+
+class MockManager {
+  constructor(data = new Map()) {
+    this._data = data;
+  }
+
+  getComponentData(entityId, componentId) {
+    const comps = this._data.get(entityId);
+    return comps ? comps[componentId] : undefined;
+  }
+}
+
+describe('getComponentFromManager', () => {
+  it('returns component data when present', () => {
+    const map = new Map([['e1', { foo: { a: 1 } }]]);
+    const mgr = new MockManager(map);
+    expect(getComponentFromManager('e1', 'foo', mgr)).toEqual({ a: 1 });
+  });
+
+  it('returns null when component missing', () => {
+    const mgr = new MockManager();
+    expect(getComponentFromManager('e1', 'foo', mgr)).toBeNull();
+  });
+
+  it('returns null for invalid parameters', () => {
+    const mgr = new MockManager();
+    expect(getComponentFromManager('', 'foo', mgr)).toBeNull();
+    expect(getComponentFromManager('e1', '', mgr)).toBeNull();
+    expect(getComponentFromManager('e1', 'foo', null)).toBeNull();
+  });
+
+  it('returns null when getComponentData throws', () => {
+    const mgr = {
+      getComponentData() {
+        throw new Error('boom');
+      },
+    };
+    expect(getComponentFromManager('e1', 'foo', mgr)).toBeNull();
   });
 });


### PR DESCRIPTION
Summary: Implemented `getComponentFromManager` to safely fetch component data via an entity manager. Updated `getActorLocation` to use the new helper and added comprehensive unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on changed files `npx eslint src/utils/actorLocationUtils.js src/utils/componentAccessUtils.js tests/utils/componentAccessUtils.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684de10b6d448331849f279cf98f84a2