### PR TITLE
[Refactor] unify decision validation logic

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -388,7 +388,10 @@ export function registerAI(container) {
   r.singletonFactory(
     tokens.ILLMDecisionProvider,
     (c) =>
-      new LLMDecisionProvider({ llmChooser: c.resolve(tokens.ILLMChooser) })
+      new LLMDecisionProvider({
+        llmChooser: c.resolve(tokens.ILLMChooser),
+        logger: c.resolve(tokens.ILogger),
+      })
   );
   logger.debug(
     `AI Systems Registration: Registered ${tokens.ILLMDecisionProvider}.`

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -100,9 +100,6 @@ export function registerTurnLifecycle(container) {
         promptOutputPort: c.resolve(tokens.IPromptOutputPort),
         actionIndexingService: c.resolve(tokens.ActionIndexingService),
         playerTurnEvents: c.resolve(tokens.IPlayerTurnEvents),
-        // FIX: Provide the missing dependencies.
-        actionDiscoveryService: c.resolve(tokens.IActionDiscoveryService),
-        actionContextBuilder: c.resolve(tokens.ActionContextBuilder),
       })
   );
   logger.debug(

--- a/src/turns/prompting/promptCoordinator.js
+++ b/src/turns/prompting/promptCoordinator.js
@@ -9,9 +9,7 @@ import IPromptCoordinator from '../../interfaces/IPromptCoordinator';
 
 /**
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
- * @typedef {import('../../interfaces/IActionDiscoveryService.js').IActionDiscoveryService} IActionDiscoveryService
  * @typedef {import('../ports/IPromptOutputPort.js').IPromptOutputPort} IPromptOutputPort
- * @typedef {import('./actionContextBuilder.js').default} ActionContextBuilder
  * @typedef {import('../interfaces/IPlayerTurnEvents.js').IPlayerTurnEvents} IPlayerTurnEvents
  * @typedef {import('../services/actionIndexingService.js').ActionIndexingService} ActionIndexingService
  * @typedef {import('../../entities/entity.js').default} Entity
@@ -20,9 +18,7 @@ import IPromptCoordinator from '../../interfaces/IPromptCoordinator';
 /**
  * @typedef {object} PromptCoordinatorDependencies
  * @property {ILogger} logger
- * @property {IActionDiscoveryService} actionDiscoveryService
  * @property {IPromptOutputPort} promptOutputPort
- * @property {ActionContextBuilder} actionContextBuilder
  * @property {ActionIndexingService} actionIndexingService
  * @property {IPlayerTurnEvents} playerTurnEvents
  */

--- a/src/turns/providers/humanDecisionProvider.js
+++ b/src/turns/providers/humanDecisionProvider.js
@@ -4,10 +4,11 @@
  */
 
 import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
+import { assertValidActionIndex } from '../../utils/validationUtils.js';
 
 /**
  * @class HumanDecisionProvider
- * @extends ITurnDecisionProvider
+ * @augments ITurnDecisionProvider
  * @description
  * Orchestrates a human prompt to select an action and returns the chosen
  * index and any associated metadata (speech, thoughts).
@@ -53,27 +54,14 @@ export class HumanDecisionProvider extends ITurnDecisionProvider {
 
     const { chosenIndex, speech, thoughts, notes } = promptRes;
 
-    // FIX: Split validation into two separate checks to provide more accurate error messages.
-
-    // 1. First, validate that we received a proper integer index.
-    if (!Number.isInteger(chosenIndex)) {
-      this.logger.error(
-        `HumanDecisionProvider: Did not receive a valid integer 'chosenIndex' for actor ${actor.id}.`,
-        { promptResult: promptRes }
-      );
-      throw new Error('Could not resolve the chosen action to a valid index.');
-    }
-
-    // 2. Second, validate that the integer is within the bounds of the available actions.
-    if (chosenIndex < 1 || chosenIndex > actions.length) {
-      this.logger.error(
-        `HumanDecisionProvider: invalid chosenIndex (${chosenIndex}) for actor ${actor.id}.`,
-        { promptRes, actionsCount: actions.length }
-      );
-      throw new Error(
-        'Player chose an index that does not exist for this turn.'
-      );
-    }
+    assertValidActionIndex(
+      chosenIndex,
+      actions.length,
+      'HumanDecisionProvider',
+      actor.id,
+      this.logger,
+      { promptResult: promptRes }
+    );
 
     return {
       chosenIndex,

--- a/src/turns/providers/llmDecisionProvider.js
+++ b/src/turns/providers/llmDecisionProvider.js
@@ -3,21 +3,27 @@
  */
 
 import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
+import { assertValidActionIndex } from '../../utils/validationUtils.js';
 
 /**
  * @class LLMDecisionProvider
- * @extends ITurnDecisionProvider
+ * @augments ITurnDecisionProvider
  * @description
  *  Decision provider that delegates to an LLM chooser implementation.
  */
 export class LLMDecisionProvider extends ITurnDecisionProvider {
   /**
-   * @param {{ llmChooser: import('../../turns/ports/ILLMChooser').ILLMChooser }} deps
+   * @param {{
+   *  llmChooser: import('../../turns/ports/ILLMChooser').ILLMChooser,
+   *  logger: import('../../interfaces/coreServices').ILogger
+   * }} deps
    */
-  constructor({ llmChooser }) {
+  constructor({ llmChooser, logger }) {
     super();
     /** @protected @type {import('../../turns/ports/ILLMChooser').ILLMChooser} */
     this.llmChooser = llmChooser;
+    /** @protected @type {import('../../interfaces/coreServices').ILogger} */
+    this.logger = logger;
   }
 
   /**
@@ -36,6 +42,15 @@ export class LLMDecisionProvider extends ITurnDecisionProvider {
       actions,
       abortSignal,
     });
+
+    assertValidActionIndex(
+      index,
+      actions.length,
+      'LLMDecisionProvider',
+      actor.id,
+      this.logger,
+      { llmResult: { index, speech, thoughts, notes } }
+    );
 
     return {
       chosenIndex: index,

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -55,3 +55,40 @@ export function validateDependency(
     }
   }
 }
+
+/**
+ * Validates that a chosen action index is an integer within the
+ * bounds of the available actions.
+ *
+ * @param {number} chosenIndex
+ * @param {number} actionsLength
+ * @param {string} providerName
+ * @param {string} actorId
+ * @param {import('../interfaces/coreServices.js').ILogger} logger
+ * @param {object} [debugData]
+ * @throws {Error} If the index is invalid or out of range.
+ */
+export function assertValidActionIndex(
+  chosenIndex,
+  actionsLength,
+  providerName,
+  actorId,
+  logger,
+  debugData = {}
+) {
+  if (!Number.isInteger(chosenIndex)) {
+    logger.error(
+      `${providerName}: Did not receive a valid integer 'chosenIndex' for actor ${actorId}.`,
+      debugData
+    );
+    throw new Error('Could not resolve the chosen action to a valid index.');
+  }
+
+  if (chosenIndex < 1 || chosenIndex > actionsLength) {
+    logger.error(
+      `${providerName}: invalid chosenIndex (${chosenIndex}) for actor ${actorId}.`,
+      { ...debugData, actionsCount: actionsLength }
+    );
+    throw new Error('Player chose an index that does not exist for this turn.');
+  }
+}

--- a/tests/integration/aiDecisionFlow.test.js
+++ b/tests/integration/aiDecisionFlow.test.js
@@ -53,7 +53,10 @@ describe('Integration – AI decision flow', () => {
     r.transientFactory(
       tokens.ILLMDecisionProvider,
       (c) =>
-        new LLMDecisionProvider({ llmChooser: c.resolve(tokens.ILLMChooser) })
+        new LLMDecisionProvider({
+          llmChooser: c.resolve(tokens.ILLMChooser),
+          logger: c.resolve(tokens.ILogger),
+        })
     );
     r.singletonFactory(
       tokens.ITurnActionFactory,

--- a/tests/integration/humanAiTurnParity.integration.test.js
+++ b/tests/integration/humanAiTurnParity.integration.test.js
@@ -63,7 +63,7 @@ describe('Integration – Human and AI turn parity', () => {
     });
 
     const llmChooser = { choose: jest.fn().mockResolvedValue({ index: 1 }) };
-    const aiProvider = new LLMDecisionProvider({ llmChooser });
+    const aiProvider = new LLMDecisionProvider({ llmChooser, logger });
 
     const humanStrategy = new GenericTurnStrategy({
       choicePipeline: pipeline,

--- a/tests/turns/providers/llmDecisionProvider.test.js
+++ b/tests/turns/providers/llmDecisionProvider.test.js
@@ -1,13 +1,23 @@
 import { jest, describe, expect } from '@jest/globals';
 import { LLMDecisionProvider } from '../../../src/turns/providers/llmDecisionProvider.js';
 
+const mockLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
 describe('LLMDecisionProvider', () => {
   it('should delegate to llmChooser.choose and map result correctly', async () => {
     // Arrange
     const mockResult = { index: 2, speech: 'hi', thoughts: null, notes: null };
     const mockChooser = { choose: jest.fn().mockResolvedValue(mockResult) };
 
-    const provider = new LLMDecisionProvider({ llmChooser: mockChooser });
+    const provider = new LLMDecisionProvider({
+      llmChooser: mockChooser,
+      logger: mockLogger,
+    });
 
     // Act
     const decision = await provider.decide(
@@ -30,5 +40,32 @@ describe('LLMDecisionProvider', () => {
       thoughts: null,
       notes: null,
     });
+  });
+
+  it('should throw if chooser returns non-integer index', async () => {
+    const mockChooser = { choose: jest.fn().mockResolvedValue({ index: '1' }) };
+    const provider = new LLMDecisionProvider({
+      llmChooser: mockChooser,
+      logger: mockLogger,
+    });
+
+    await expect(
+      provider.decide('actor', 'context', ['a'], null)
+    ).rejects.toThrow('Could not resolve the chosen action to a valid index.');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('should throw if index is out of range', async () => {
+    const mockChooser = { choose: jest.fn().mockResolvedValue({ index: 3 }) };
+    const provider = new LLMDecisionProvider({
+      llmChooser: mockChooser,
+      logger: mockLogger,
+    });
+
+    await expect(
+      provider.decide('actor', 'context', ['a', 'b'], null)
+    ).rejects.toThrow(
+      'Player chose an index that does not exist for this turn.'
+    );
   });
 });


### PR DESCRIPTION
Summary: Streamlines prompting dependencies and consolidates decision index validation.

Changes Made:
- Removed unused dependencies from `PromptCoordinator` and DI registration.
- Added `assertValidActionIndex` utility for common index checks.
- Updated human and LLM decision providers to use new validator and accept logger (AI path).
- Adjusted DI registrations and relevant integration tests.
- Expanded LLMDecisionProvider tests to cover invalid index cases.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint executed (`npm run lint` & `cd llm-proxy-server && npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684de12e3f04833194dee78d3c4cd0ed