### PR TITLE
[Agent] use SafeEventDispatcher for turn end adapter

### DIFF
--- a/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
+++ b/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
@@ -11,7 +11,7 @@
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
 import { Registrar } from '../registrarHelpers.js';
-import { SHUTDOWNABLE } from '../tags.js';
+import { SHUTDOWNABLE as _SHUTDOWNABLE } from '../tags.js';
 
 // --- Adapter Imports ---
 import { EventBusPromptAdapter } from '../../turns/adapters/eventBusPromptAdapter.js';
@@ -62,21 +62,15 @@ export function registerEventBusAdapters(container) {
 
   // --- Register EventBusTurnEndAdapter ---
   registrar.singletonFactory(tokens.ITurnEndPort, (c) => {
-    // --- FIX: Check for registration before resolving optional dependencies. ---
     const safeDispatcher = c.isRegistered(tokens.ISafeEventDispatcher)
-      ? /** @type {ISafeEventDispatcher | null} */ (
+      ? /** @type {ISafeEventDispatcher} */ (
           c.resolve(tokens.ISafeEventDispatcher)
         )
       : null;
-    const validatedDispatcher = c.isRegistered(tokens.IValidatedEventDispatcher)
-      ? /** @type {IValidatedEventDispatcher | null} */ (
-          c.resolve(tokens.IValidatedEventDispatcher)
-        )
-      : null;
 
-    if (!safeDispatcher && !validatedDispatcher) {
+    if (!safeDispatcher) {
       logger.error(
-        `Adapter Registration: Failed to resolve either ${tokens.ISafeEventDispatcher} or ${tokens.IValidatedEventDispatcher} for ${tokens.ITurnEndPort}.`
+        `Adapter Registration: Failed to resolve ${tokens.ISafeEventDispatcher} for ${tokens.ITurnEndPort}.`
       );
       throw new Error(
         `Missing dispatcher dependency for EventBusTurnEndAdapter`
@@ -84,8 +78,7 @@ export function registerEventBusAdapters(container) {
     }
     return new EventBusTurnEndAdapter({
       safeEventDispatcher: safeDispatcher,
-      validatedEventDispatcher: validatedDispatcher,
-      logger: logger,
+      logger,
     });
   });
   logger.debug(

--- a/tests/dependencyInjection/registrations/eventBusAdapterRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/eventBusAdapterRegistrations.test.js
@@ -19,7 +19,6 @@ import { mock } from 'jest-mock-extended';
 import AppContainer from '../../../src/dependencyInjection/appContainer.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { registerEventBusAdapters } from '../../../src/dependencyInjection/registrations/eventBusAdapterRegistrations.js';
-import { SHUTDOWNABLE } from '../../../src/dependencyInjection/tags.js';
 
 // --- Concrete Class Imports for `instanceof` checks ---
 import { EventBusPromptAdapter } from '../../../src/turns/adapters/eventBusPromptAdapter.js';
@@ -28,7 +27,6 @@ import EventBusTurnEndAdapter from '../../../src/turns/adapters/eventBusTurnEndA
 describe('registerEventBusAdapters', () => {
   /** @type {AppContainer} */
   let container;
-  let registerSpy;
 
   // --- Mock External Dependencies ---
   const mockLogger = mock();
@@ -38,8 +36,6 @@ describe('registerEventBusAdapters', () => {
   beforeEach(() => {
     container = new AppContainer();
 
-    // Spy on the container's register method to check options later
-    registerSpy = jest.spyOn(container, 'register');
 
     // Register the logger, which is a common dependency for the registration module itself
     container.register(tokens.ILogger, () => mockLogger);
@@ -135,8 +131,8 @@ describe('registerEventBusAdapters', () => {
       expect(freshContainer.resolve(tokens.IPromptOutputPort)).toBe(instance);
     });
 
-    test('should throw during resolution if both dispatcher dependencies are missing', () => {
-      // Arrange: No dispatchers are registered
+    test('should throw during resolution if dispatcher dependency is missing', () => {
+      // Arrange: No dispatcher is registered
       registerEventBusAdapters(container);
 
       // Act & Assert
@@ -151,35 +147,11 @@ describe('registerEventBusAdapters', () => {
     const successCases = [
       {
         description:
-          'should resolve correctly when both dispatchers are present',
+          'should resolve correctly when ISafeEventDispatcher is present',
         setup: (c) => {
           c.register(
             tokens.ISafeEventDispatcher,
             () => mockSafeEventDispatcher
-          );
-          c.register(
-            tokens.IValidatedEventDispatcher,
-            () => mockValidatedEventDispatcher
-          );
-        },
-      },
-      {
-        description:
-          'should resolve correctly when only ISafeEventDispatcher is present',
-        setup: (c) => {
-          c.register(
-            tokens.ISafeEventDispatcher,
-            () => mockSafeEventDispatcher
-          );
-        },
-      },
-      {
-        description:
-          'should resolve correctly when only IValidatedEventDispatcher is present',
-        setup: (c) => {
-          c.register(
-            tokens.IValidatedEventDispatcher,
-            () => mockValidatedEventDispatcher
           );
         },
       },


### PR DESCRIPTION
## Summary
- refactor EventBusTurnEndAdapter to require SafeEventDispatcher
- emit `core:display_error` instead of logging errors
- update DI registration for EventBusTurnEndAdapter
- update associated unit tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 542 errors, 1720 warnings)*
- `npx eslint src/turns/adapters/eventBusTurnEndAdapter.js src/dependencyInjection/registrations/eventBusAdapterRegistrations.js tests/turns/adapters/eventBusTurnEndAdapter.test.js tests/dependencyInjection/registrations/eventBusAdapterRegistrations.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684de1b4c8d08331b8139de458271dc5