### PR TITLE
[Agent] use safeDispatchError in utilities

### DIFF
--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -1,7 +1,7 @@
 // src/utils/contextVariableUtils.js
 
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 import { getPrefixedLogger } from './loggerUtils.js';
+import { safeDispatchError } from './safeDispatchError.js';
 
 /**
  * Safely stores a value into `execCtx.evaluationContext.context`. If the context
@@ -26,11 +26,8 @@ export function storeResult(variableName, value, execCtx, dispatcher, logger) {
   if (!hasContext) {
     const message =
       'storeResult: evaluationContext.context is missing; cannot store result';
-    if (dispatcher?.dispatch) {
-      dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message,
-        details: { variableName },
-      });
+    if (dispatcher) {
+      safeDispatchError(dispatcher, message, { variableName });
     } else {
       log.error(message, { variableName });
     }
@@ -41,11 +38,16 @@ export function storeResult(variableName, value, execCtx, dispatcher, logger) {
     execCtx.evaluationContext.context[variableName] = value;
     return true;
   } catch (e) {
-    if (dispatcher?.dispatch) {
-      dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `storeResult: Failed to write variable "${variableName}"`,
-        details: { variableName, error: e.message, stack: e.stack },
-      });
+    if (dispatcher) {
+      safeDispatchError(
+        dispatcher,
+        `storeResult: Failed to write variable "${variableName}"`,
+        {
+          variableName,
+          error: e.message,
+          stack: e.stack,
+        }
+      );
     } else {
       log.error(`storeResult: Failed to write variable "${variableName}"`, {
         variableName,

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -1,7 +1,7 @@
 // src/utils/locationUtils.js
 
 import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { safeDispatchError } from './safeDispatchError.js';
 import { isNonEmptyString } from './textUtils.js';
 import { getPrefixedLogger } from './loggerUtils.js';
 import {
@@ -46,19 +46,22 @@ function _getExitsComponentData(
 
   if (typeof locationEntityOrId === 'string') {
     if (!isValidEntityManager(entityManager)) {
-      dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message:
-          "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid.",
-        details: {
-          locationId:
-            typeof locationEntityOrId === 'string'
-              ? locationEntityOrId
-              : locationEntityOrId?.id,
-          entityManagerValid:
-            !!entityManager &&
-            typeof entityManager.getEntityInstance === 'function',
-        },
-      });
+      const message =
+        "_getExitsComponentData: EntityManager is required when passing location ID, but it's invalid.";
+      const details = {
+        locationId:
+          typeof locationEntityOrId === 'string'
+            ? locationEntityOrId
+            : locationEntityOrId?.id,
+        entityManagerValid:
+          !!entityManager &&
+          typeof entityManager.getEntityInstance === 'function',
+      };
+      if (dispatcher) {
+        safeDispatchError(dispatcher, message, details);
+      } else {
+        log.error(message, details);
+      }
 
       return null;
     }


### PR DESCRIPTION
Summary: Refactored contextVariableUtils and locationUtils to use safeDispatchError for consistent error dispatching.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684de830711483318c8c254dc0310571