### PR TITLE
[Agent] unify logger handling

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -52,11 +52,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     safeEventDispatcher,
   }) {
     super();
-    this.#logger = initLogger('ActionDiscoveryService', logger, [
-      'debug',
-      'warn',
-      'error',
-    ]);
+    this.#logger = initLogger('ActionDiscoveryService', logger);
     validateServiceDeps('ActionDiscoveryService', this.#logger, {
       gameDataRepository: {
         value: gameDataRepository,

--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -38,11 +38,7 @@ export class ActionValidationContextBuilder {
   constructor({ entityManager, logger }) {
     // (Constructor remains the same)
     try {
-      this.#logger = initLogger('ActionValidationContextBuilder', logger, [
-        'debug',
-        'error',
-        'warn',
-      ]);
+      this.#logger = initLogger('ActionValidationContextBuilder', logger);
     } catch (e) {
       const errorMsg = `ActionValidationContextBuilder Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       console.error(errorMsg);

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -55,11 +55,7 @@ export class ActionValidationService {
   }) {
     // 1. Validate logger dependency first
     try {
-      this.#logger = initLogger('ActionValidationService', logger, [
-        'debug',
-        'error',
-        'info',
-      ]);
+      this.#logger = initLogger('ActionValidationService', logger);
     } catch (e) {
       const errorMsg = `ActionValidationService Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       // eslint-disable-next-line no-console

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -48,12 +48,7 @@ export class PrerequisiteEvaluationService {
     actionValidationContextBuilder,
   }) {
     try {
-      this.#logger = initLogger('PrerequisiteEvaluationService', logger, [
-        'debug',
-        'error',
-        'warn',
-        'info',
-      ]);
+      this.#logger = initLogger('PrerequisiteEvaluationService', logger);
     } catch (e) {
       const errorMsg = `PrerequisiteEvaluationService Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
       // eslint-disable-next-line no-console

--- a/src/utils/serviceInitializer.js
+++ b/src/utils/serviceInitializer.js
@@ -7,26 +7,19 @@
  * @property {boolean} [isFunction] - Whether the dependency should be a function.
  */
 
+import { ensureValidLogger, createPrefixedLogger } from './loggerUtils.js';
 import { validateDependency } from './validationUtils.js';
-import { createPrefixedLogger } from './loggerUtils.js';
 
 /**
  * Validates the provided logger and returns a prefixed logger instance.
  *
  * @param {string} serviceName - Name used for log prefix and error messages.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to validate.
- * @param {string[]} [loggerMethods] - Required logging methods.
  * @returns {import('../interfaces/coreServices.js').ILogger} Prefixed logger.
  */
-export function initLogger(
-  serviceName,
-  logger,
-  loggerMethods = ['debug', 'error', 'warn', 'info']
-) {
-  validateDependency(logger, `${serviceName}: logger`, console, {
-    requiredMethods: loggerMethods,
-  });
-  return createPrefixedLogger(logger, `${serviceName}: `);
+export function initLogger(serviceName, logger) {
+  const validLogger = ensureValidLogger(logger, serviceName);
+  return createPrefixedLogger(validLogger, `${serviceName}: `);
 }
 
 /**

--- a/tests/services/actionValidationContextBuilder.test.js
+++ b/tests/services/actionValidationContextBuilder.test.js
@@ -87,7 +87,7 @@ describe('ActionValidationContextBuilder', () => {
     );
   });
 
-  it('should throw an error if ILogger dependency is invalid', () => {
+  it('should fallback to console logger if ILogger dependency is invalid', () => {
     const validEntityManager = {
       getEntityInstance: jest.fn(),
       getComponentData: jest.fn(),
@@ -98,9 +98,7 @@ describe('ActionValidationContextBuilder', () => {
           entityManager: validEntityManager,
           logger: null,
         })
-    ).toThrow(
-      'ActionValidationContextBuilder Constructor: CRITICAL - Invalid or missing ILogger instance. Error: Missing required dependency: ActionValidationContextBuilder: logger.'
-    );
+    ).not.toThrow();
   });
 
   it('should successfully create an instance with valid dependencies', () => {


### PR DESCRIPTION
## Summary
- simplify logger initialization with `ensureValidLogger`
- update services to use new `initLogger` signature
- adjust unit tests for logger changes

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 539 errors, 1722 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684dea312cb08331a54f3a88560597fc