### PR TITLE
[Agent] dispatch error event in StandardElementAssembler

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -193,7 +193,11 @@ export function registerAI(container) {
   );
   r.singletonFactory(
     tokens.StandardElementAssembler,
-    (c) => new StandardElementAssembler({ logger: c.resolve(tokens.ILogger) })
+    (c) =>
+      new StandardElementAssembler({
+        logger: c.resolve(tokens.ILogger),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+      })
   );
   r.singletonFactory(
     tokens.PerceptionLogAssembler,

--- a/tests/integration/promptBuilder.integration.test.js
+++ b/tests/integration/promptBuilder.integration.test.js
@@ -46,6 +46,7 @@ describe('PromptBuilder Integration Test', () => {
     placeholderResolver = new PlaceholderResolver(mockLogger);
     const standardAssembler = new StandardElementAssembler({
       logger: mockLogger,
+      safeEventDispatcher: { dispatch: jest.fn() },
     });
     const indexedChoicesAssembler = new IndexedChoicesAssembler({
       logger: mockLogger,


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `StandardElementAssembler`
- dispatch `DISPLAY_ERROR_ID` when required parameters are missing
- register `StandardElementAssembler` with SafeEventDispatcher
- update unit and integration tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684dee5acea08331af37aef74793f981