### PR TITLE
[Agent] dispatch error events instead of logging

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -395,6 +395,7 @@ export function registerAI(container) {
       new LLMDecisionProvider({
         llmChooser: c.resolve(tokens.ILLMChooser),
         logger: c.resolve(tokens.ILogger),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
   logger.debug(

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -112,6 +112,7 @@ export function registerTurnLifecycle(container) {
       new HumanDecisionProvider({
         promptCoordinator: c.resolve(tokens.IPromptCoordinator),
         logger: c.resolve(tokens.ILogger),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
 

--- a/src/turns/providers/humanDecisionProvider.js
+++ b/src/turns/providers/humanDecisionProvider.js
@@ -6,6 +6,8 @@
 import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
 import { assertValidActionIndex } from '../../utils/validationUtils.js';
 
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
 /**
  * @class HumanDecisionProvider
  * @augments ITurnDecisionProvider
@@ -18,11 +20,14 @@ export class HumanDecisionProvider extends ITurnDecisionProvider {
    * @param {object} deps
    * @param {import('../../interfaces/IPromptCoordinator').IPromptCoordinator} deps.promptCoordinator
    * @param {import('../../interfaces/coreServices').ILogger} deps.logger
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
    */
-  constructor({ promptCoordinator, logger }) {
+  constructor({ promptCoordinator, logger, safeEventDispatcher }) {
     super();
     this.promptCoordinator = promptCoordinator;
     this.logger = logger;
+    /** @type {ISafeEventDispatcher} */
+    this.safeEventDispatcher = safeEventDispatcher;
   }
 
   /**
@@ -59,6 +64,7 @@ export class HumanDecisionProvider extends ITurnDecisionProvider {
       actions.length,
       'HumanDecisionProvider',
       actor.id,
+      this.safeEventDispatcher,
       this.logger,
       { promptResult: promptRes }
     );

--- a/src/turns/providers/llmDecisionProvider.js
+++ b/src/turns/providers/llmDecisionProvider.js
@@ -5,6 +5,8 @@
 import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
 import { assertValidActionIndex } from '../../utils/validationUtils.js';
 
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
 /**
  * @class LLMDecisionProvider
  * @augments ITurnDecisionProvider
@@ -16,14 +18,17 @@ export class LLMDecisionProvider extends ITurnDecisionProvider {
    * @param {{
    *  llmChooser: import('../../turns/ports/ILLMChooser').ILLMChooser,
    *  logger: import('../../interfaces/coreServices').ILogger
+   *  safeEventDispatcher: ISafeEventDispatcher
    * }} deps
    */
-  constructor({ llmChooser, logger }) {
+  constructor({ llmChooser, logger, safeEventDispatcher }) {
     super();
     /** @protected @type {import('../../turns/ports/ILLMChooser').ILLMChooser} */
     this.llmChooser = llmChooser;
     /** @protected @type {import('../../interfaces/coreServices').ILogger} */
     this.logger = logger;
+    /** @protected @type {ISafeEventDispatcher} */
+    this.safeEventDispatcher = safeEventDispatcher;
   }
 
   /**
@@ -48,6 +53,7 @@ export class LLMDecisionProvider extends ITurnDecisionProvider {
       actions.length,
       'LLMDecisionProvider',
       actor.id,
+      this.safeEventDispatcher,
       this.logger,
       { llmResult: { index, speech, thoughts, notes } }
     );

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -1,4 +1,5 @@
 // src/utils/validationUtils.js
+import { safeDispatchError } from './safeDispatchError.js';
 /**
  * Validates a dependency instance, checking for its existence and, optionally,
  * required methods or if it's expected to be a function.
@@ -64,6 +65,7 @@ export function validateDependency(
  * @param {number} actionsLength
  * @param {string} providerName
  * @param {string} actorId
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher
  * @param {import('../interfaces/coreServices.js').ILogger} logger
  * @param {object} [debugData]
  * @throws {Error} If the index is invalid or out of range.
@@ -73,11 +75,13 @@ export function assertValidActionIndex(
   actionsLength,
   providerName,
   actorId,
+  dispatcher,
   logger,
   debugData = {}
 ) {
   if (!Number.isInteger(chosenIndex)) {
-    logger.error(
+    safeDispatchError(
+      dispatcher,
       `${providerName}: Did not receive a valid integer 'chosenIndex' for actor ${actorId}.`,
       debugData
     );
@@ -85,7 +89,8 @@ export function assertValidActionIndex(
   }
 
   if (chosenIndex < 1 || chosenIndex > actionsLength) {
-    logger.error(
+    safeDispatchError(
+      dispatcher,
       `${providerName}: invalid chosenIndex (${chosenIndex}) for actor ${actorId}.`,
       { ...debugData, actionsCount: actionsLength }
     );

--- a/tests/integration/aiDecisionFlow.test.js
+++ b/tests/integration/aiDecisionFlow.test.js
@@ -56,6 +56,7 @@ describe('Integration – AI decision flow', () => {
         new LLMDecisionProvider({
           llmChooser: c.resolve(tokens.ILLMChooser),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: { dispatch: jest.fn() },
         })
     );
     r.singletonFactory(

--- a/tests/integration/humanAiTurnParity.integration.test.js
+++ b/tests/integration/humanAiTurnParity.integration.test.js
@@ -57,13 +57,19 @@ describe('Integration – Human and AI turn parity', () => {
     const promptCoordinator = {
       prompt: jest.fn().mockResolvedValue({ chosenIndex: 1 }),
     };
+    const dispatcher = { dispatch: jest.fn() };
     const humanProvider = new HumanDecisionProvider({
       promptCoordinator,
       logger,
+      safeEventDispatcher: dispatcher,
     });
 
     const llmChooser = { choose: jest.fn().mockResolvedValue({ index: 1 }) };
-    const aiProvider = new LLMDecisionProvider({ llmChooser, logger });
+    const aiProvider = new LLMDecisionProvider({
+      llmChooser,
+      logger,
+      safeEventDispatcher: dispatcher,
+    });
 
     const humanStrategy = new GenericTurnStrategy({
       choicePipeline: pipeline,

--- a/tests/integration/humanDecisionFlow.test.js
+++ b/tests/integration/humanDecisionFlow.test.js
@@ -76,6 +76,7 @@ describe('Integration – Human decision flow', () => {
         new HumanDecisionProvider({
           promptCoordinator: c.resolve(tokens.IPromptCoordinator),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: { dispatch: jest.fn() },
         })
     );
     r.singletonFactory(

--- a/tests/turns/providers/humanDecisionProvider.indexUse.test.js
+++ b/tests/turns/providers/humanDecisionProvider.indexUse.test.js
@@ -15,6 +15,8 @@ const mockLogger = {
   debug: jest.fn(),
 };
 
+const mockDispatcher = { dispatch: jest.fn() };
+
 // Test setup
 describe('HumanDecisionProvider', () => {
   let humanDecisionProvider;
@@ -30,6 +32,7 @@ describe('HumanDecisionProvider', () => {
       promptCoordinator: mockPromptCoordinator,
       actionIndexingService: {}, // Not used in the corrected implementation
       logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
     });
 
     mockActor = { id: 'player-1' };

--- a/tests/turns/providers/llmDecisionProvider.test.js
+++ b/tests/turns/providers/llmDecisionProvider.test.js
@@ -1,5 +1,6 @@
 import { jest, describe, expect } from '@jest/globals';
 import { LLMDecisionProvider } from '../../../src/turns/providers/llmDecisionProvider.js';
+import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
 
 const mockLogger = {
   error: jest.fn(),
@@ -7,6 +8,8 @@ const mockLogger = {
   info: jest.fn(),
   debug: jest.fn(),
 };
+
+const mockDispatcher = { dispatch: jest.fn() };
 
 describe('LLMDecisionProvider', () => {
   it('should delegate to llmChooser.choose and map result correctly', async () => {
@@ -17,6 +20,7 @@ describe('LLMDecisionProvider', () => {
     const provider = new LLMDecisionProvider({
       llmChooser: mockChooser,
       logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
     });
 
     // Act
@@ -47,12 +51,16 @@ describe('LLMDecisionProvider', () => {
     const provider = new LLMDecisionProvider({
       llmChooser: mockChooser,
       logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
     });
 
     await expect(
       provider.decide('actor', 'context', ['a'], null)
     ).rejects.toThrow('Could not resolve the chosen action to a valid index.');
-    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.any(Object)
+    );
   });
 
   it('should throw if index is out of range', async () => {
@@ -60,6 +68,7 @@ describe('LLMDecisionProvider', () => {
     const provider = new LLMDecisionProvider({
       llmChooser: mockChooser,
       logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
     });
 
     await expect(


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in assertValidActionIndex
- inject SafeEventDispatcher into decision providers
- update DI registries for new dependencies
- adjust tests for dispatch assertions

## Testing
- `npm run lint` *(fails: jsdoc/require-returns etc.)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df9add47883318ad865eb7485e6ba