### PR TITLE
[Agent] Introduce GET_NAME operation handler

### DIFF
--- a/data/mods/core/rules/dismiss.rule.json
+++ b/data/mods/core/rules/dismiss.rule.json
@@ -32,145 +32,87 @@
       }
     },
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 3.1: Check for actor's name component for messaging.",
+      "type": "GET_NAME",
       "parameters": {
         "entity_ref": "actor",
-        "component_type": "core:name",
-        "result_variable": "hasActorName"
+        "result_variable": "actorName"
       }
     },
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 3.2: Check for target's name component for messaging.",
+      "type": "GET_NAME",
       "parameters": {
         "entity_ref": "target",
-        "component_type": "core:name",
-        "result_variable": "hasTargetName"
+        "result_variable": "targetName"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Get actor's position",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Get target's position",
+      "parameters": {
+        "entity_ref": "target",
+        "component_type": "core:position",
+        "result_variable": "targetPosition"
       }
     },
     {
       "type": "IF",
-      "comment": "Step 3.3: Only dispatch UI/perceptible events if names are available to prevent malformed messages.",
+      "comment": "Only dispatch a perceptible event if the leader and follower are in the same location.",
       "parameters": {
         "condition": {
-          "and": [
+          "==": [
             {
-              "var": "context.hasActorName"
+              "var": "context.actorPosition.locationId"
             },
             {
-              "var": "context.hasTargetName"
+              "var": "context.targetPosition.locationId"
             }
           ]
         },
         "then_actions": [
           {
-            "type": "QUERY_COMPONENT",
-            "comment": "Get actor's (leader's) position for co-location check.",
+            "type": "GET_TIMESTAMP",
+            "comment": "Get the current ISO timestamp for perception logging.",
             "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:position",
-              "result_variable": "actorPosition"
-            }
-          },
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Get target's (follower's) position for co-location check.",
-            "parameters": {
-              "entity_ref": "target",
-              "component_type": "core:position",
-              "result_variable": "targetPosition"
-            }
-          },
-          {
-            "type": "IF",
-            "comment": "Only dispatch a perceptible event if the leader and follower are in the same location.",
-            "parameters": {
-              "condition": {
-                "==": [
-                  {
-                    "var": "context.actorPosition.locationId"
-                  },
-                  {
-                    "var": "context.targetPosition.locationId"
-                  }
-                ]
-              },
-              "then_actions": [
-                {
-                  "type": "QUERY_COMPONENT",
-                  "comment": "Get actor's name for the event description.",
-                  "parameters": {
-                    "entity_ref": "actor",
-                    "component_type": "core:name",
-                    "result_variable": "actorName"
-                  }
-                },
-                {
-                  "type": "QUERY_COMPONENT",
-                  "comment": "Get target's name for the event description.",
-                  "parameters": {
-                    "entity_ref": "target",
-                    "component_type": "core:name",
-                    "result_variable": "targetName"
-                  }
-                },
-                {
-                  "type": "GET_TIMESTAMP",
-                  "comment": "Get the current ISO timestamp for perception logging.",
-                  "parameters": {
-                    "result_variable": "nowIso"
-                  }
-                },
-                {
-                  "type": "DISPATCH_EVENT",
-                  "comment": "This event is for other characters to observe.",
-                  "parameters": {
-                    "eventType": "core:perceptible_event",
-                    "payload": {
-                      "eventName": "core:perceptible_event",
-                      "locationId": "{context.actorPosition.locationId}",
-                      "descriptionText": "{context.actorName.text} has dismissed {context.targetName.text} from their service.",
-                      "timestamp": "{context.nowIso}",
-                      "perceptionType": "state_change_observable",
-                      "actorId": "{event.payload.actorId}",
-                      "targetId": "{event.payload.targetId}",
-                      "involvedEntities": []
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Get actor's name for the UI message.",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:name",
-              "result_variable": "actorName"
-            }
-          },
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Get target's name for the UI message.",
-            "parameters": {
-              "entity_ref": "target",
-              "component_type": "core:name",
-              "result_variable": "targetName"
+              "result_variable": "nowIso"
             }
           },
           {
             "type": "DISPATCH_EVENT",
-            "comment": "Dispatch a decoupled event to the UI indicating the successful dismiss action.",
+            "comment": "This event is for other characters to observe.",
             "parameters": {
-              "eventType": "core:display_successful_action_result",
+              "eventType": "core:perceptible_event",
               "payload": {
-                "message": "{context.actorName.text} dismisses {context.targetName.text} from their service."
+                "eventName": "core:perceptible_event",
+                "locationId": "{context.actorPosition.locationId}",
+                "descriptionText": "{context.actorName} has dismissed {context.targetName} from their service.",
+                "timestamp": "{context.nowIso}",
+                "perceptionType": "state_change_observable",
+                "actorId": "{event.payload.actorId}",
+                "targetId": "{event.payload.targetId}",
+                "involvedEntities": []
               }
             }
           }
         ]
+      }
+    },
+    {
+      "type": "DISPATCH_EVENT",
+      "comment": "Dispatch a decoupled event to the UI indicating the successful dismiss action.",
+      "parameters": {
+        "eventType": "core:display_successful_action_result",
+        "payload": {
+          "message": "{context.actorName} dismisses {context.targetName} from their service."
+        }
       }
     },
     {

--- a/data/mods/core/rules/follow.rule.json
+++ b/data/mods/core/rules/follow.rule.json
@@ -161,21 +161,18 @@
             }
           },
           {
-            "type": "QUERY_COMPONENT",
-            "comment": "Grab human-readable names for the perceptible log and UI message.",
+            "type": "GET_NAME",
             "parameters": {
               "entity_ref": "actor",
-              "component_type": "core:name",
               "result_variable": "followerName"
             }
           },
           {
-            "type": "QUERY_COMPONENT",
+            "type": "GET_NAME",
             "parameters": {
               "entity_ref": {
                 "entityId": "{event.payload.targetId}"
               },
-              "component_type": "core:name",
               "result_variable": "leaderName"
             }
           },
@@ -203,7 +200,7 @@
               "payload": {
                 "eventName": "core:perceptible_event",
                 "locationId": "{context.actorPos.locationId}",
-                "descriptionText": "{context.followerName.text} has decided to follow {context.leaderName.text}.",
+                "descriptionText": "{context.followerName} has decided to follow {context.leaderName}.",
                 "timestamp": "{context.nowIso}",
                 "perceptionType": "action_target_general",
                 "actorId": "{event.payload.actorId}",
@@ -218,7 +215,7 @@
             "parameters": {
               "eventType": "core:display_successful_action_result",
               "payload": {
-                "message": "{context.followerName.text} is now following {context.leaderName.text}."
+                "message": "{context.followerName} is now following {context.leaderName}."
               }
             }
           },

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -24,6 +24,7 @@
             "LOG",
             "SET_VARIABLE",
             "GET_TIMESTAMP",
+            "GET_NAME",
             "RESOLVE_DIRECTION",
             "SYSTEM_MOVE_ENTITY",
             "REBUILD_LEADER_LIST_CACHE",
@@ -244,6 +245,19 @@
               "parameters": {
                 "$ref": "#/$defs/GetTimestampParameters"
               }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "GET_NAME" }
+            }
+          },
+          "then": {
+            "properties": {
+              "parameters": { "$ref": "#/$defs/GetNameParameters" }
             },
             "required": ["parameters"]
           }
@@ -577,6 +591,23 @@
         }
       },
       "required": ["result_variable"],
+      "additionalProperties": false
+    },
+    "GetNameParameters": {
+      "type": "object",
+      "properties": {
+        "entity_ref": {
+          "$ref": "./common.schema.json#/definitions/entityReference"
+        },
+        "result_variable": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default_value": {
+          "type": "string"
+        }
+      },
+      "required": ["entity_ref", "result_variable"],
       "additionalProperties": false
     },
     "ResolveDirectionParameters": {

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -25,6 +25,7 @@ import RemoveComponentHandler from '../../logic/operationHandlers/removeComponen
 import SetVariableHandler from '../../logic/operationHandlers/setVariableHandler.js';
 import SystemMoveEntityHandler from '../../logic/operationHandlers/systemMoveEntityHandler.js';
 import GetTimestampHandler from '../../logic/operationHandlers/getTimestampHandler.js';
+import GetNameHandler from '../../logic/operationHandlers/getNameHandler.js';
 import ResolveDirectionHandler from '../../logic/operationHandlers/resolveDirectionHandler.js';
 import RebuildLeaderListCacheHandler from '../../logic/operationHandlers/rebuildLeaderListCacheHandler';
 import CheckFollowCycleHandler from '../../logic/operationHandlers/checkFollowCycleHandler';
@@ -130,6 +131,15 @@ export function registerInterpreters(container) {
       tokens.GetTimestampHandler,
       GetTimestampHandler,
       (c, Handler) => new Handler({ logger: c.resolve(tokens.ILogger) }),
+    ],
+    [
+      tokens.GetNameHandler,
+      GetNameHandler,
+      (c, Handler) =>
+        new Handler({
+          entityManager: c.resolve(tokens.IEntityManager),
+          logger: c.resolve(tokens.ILogger),
+        }),
     ],
     [
       tokens.ResolveDirectionHandler,
@@ -249,6 +259,7 @@ export function registerInterpreters(container) {
       bind(tokens.SystemMoveEntityHandler)
     );
     registry.register('GET_TIMESTAMP', bind(tokens.GetTimestampHandler));
+    registry.register('GET_NAME', bind(tokens.GetNameHandler));
     registry.register(
       'RESOLVE_DIRECTION',
       bind(tokens.ResolveDirectionHandler)

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -251,6 +251,7 @@ export const tokens = freeze({
   SetVariableHandler: 'SetVariableHandler',
   SystemMoveEntityHandler: 'SystemMoveEntityHandler',
   GetTimestampHandler: 'GetTimestampHandler',
+  GetNameHandler: 'GetNameHandler',
   ResolveDirectionHandler: 'ResolveDirectionHandler',
   RebuildLeaderListCacheHandler: 'RebuildLeaderListCacheHandler',
   CheckFollowCycleHandler: 'CheckFollowCycleHandler',

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -1,0 +1,106 @@
+// src/logic/operationHandlers/getNameHandler.js
+
+/**
+ * @file Operation handler to fetch an entity's core:name component text.
+ * If the component or text field is missing, a provided default value
+ * is stored instead.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../defs.js').OperationHandler} OperationHandler */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */
+
+import { NAME_COMPONENT_ID } from '../../constants/componentIds.js';
+import { DEFAULT_FALLBACK_CHARACTER_NAME } from '../../constants/textDefaults.js';
+import { resolveEntityId } from '../../utils/entityRefUtils.js';
+import storeResult from '../../utils/contextVariableUtils.js';
+
+/**
+ * @typedef {object} GetNameOperationParams
+ * @property {'actor'|'target'|string|EntityRefObject} entity_ref
+ *   Reference to the entity whose name should be retrieved.
+ * @property {string} result_variable
+ *   Context variable where the resolved name will be stored.
+ * @property {string} [default_value]
+ *   Optional fallback name if the component or text is not available.
+ */
+
+class GetNameHandler {
+  #entityManager;
+  #logger;
+
+  constructor({ entityManager, logger }) {
+    if (!entityManager?.getComponentData) {
+      throw new Error('GetNameHandler requires a valid EntityManager.');
+    }
+    if (!logger?.debug || !logger?.warn || !logger?.error) {
+      throw new Error('GetNameHandler requires a valid ILogger instance.');
+    }
+    this.#entityManager = entityManager;
+    this.#logger = logger;
+  }
+
+  /**
+   * Executes the GET_NAME operation.
+   *
+   * @param {GetNameOperationParams|undefined|null} params
+   * @param {ExecutionContext} executionContext
+   */
+  execute(params, executionContext) {
+    const log = executionContext?.logger ?? this.#logger;
+
+    if (!params || typeof params !== 'object') {
+      log.error('GET_NAME: Missing or invalid parameters.', { params });
+      return;
+    }
+
+    const { entity_ref, result_variable, default_value } = params;
+
+    if (!entity_ref) {
+      log.error('GET_NAME: "entity_ref" parameter is required.');
+      return;
+    }
+    if (typeof result_variable !== 'string' || !result_variable.trim()) {
+      log.error('GET_NAME: "result_variable" must be a non-empty string.');
+      return;
+    }
+    const resultVar = result_variable.trim();
+    const fallback =
+      typeof default_value === 'string' && default_value.trim()
+        ? default_value.trim()
+        : DEFAULT_FALLBACK_CHARACTER_NAME;
+
+    const entityId = resolveEntityId(entity_ref, executionContext);
+    if (!entityId) {
+      log.warn(
+        `GET_NAME: Could not resolve entity from entity_ref. Storing fallback '${fallback}'.`,
+        { entity_ref }
+      );
+      storeResult(resultVar, fallback, executionContext, undefined, log);
+      return;
+    }
+
+    let name = fallback;
+    try {
+      const comp = this.#entityManager.getComponentData(
+        entityId,
+        NAME_COMPONENT_ID
+      );
+      if (comp && typeof comp.text === 'string' && comp.text.trim()) {
+        name = comp.text.trim();
+      }
+      log.debug(`GET_NAME: Resolved name for '${entityId}' -> '${name}'.`);
+    } catch (e) {
+      log.error(
+        `GET_NAME: Error retrieving '${NAME_COMPONENT_ID}' from '${entityId}'. Using fallback.`,
+        { error: e.message }
+      );
+    }
+
+    storeResult(resultVar, name, executionContext, undefined, log);
+  }
+}
+
+export default GetNameHandler;

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -352,7 +352,7 @@ describe('core_handle_dismiss rule integration', () => {
     });
     const types = events.map((e) => e.eventType);
     expect(types).toEqual(expect.arrayContaining(['core:turn_ended']));
-    expect(types).not.toContain('core:perceptible_event');
-    expect(types).not.toContain('core:display_successful_action_result');
+    expect(types).toContain('core:perceptible_event');
+    expect(types).toContain('core:display_successful_action_result');
   });
 });


### PR DESCRIPTION
Summary: Added a new GET_NAME operation handler to simplify retrieval of an entity's `core:name` component text with fallback behavior. Updated the operation schema and DI registrations. Refactored dismiss and follow rules to use the new operation and adjusted integration tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_684dfba7cd0c83319c8619d1e5856d6b