### PR TITLE
[Agent] Add END_TURN operation handler

### DIFF
--- a/data/mods/core/rules/dismiss.rule.json
+++ b/data/mods/core/rules/dismiss.rule.json
@@ -174,14 +174,11 @@
       }
     },
     {
-      "type": "DISPATCH_EVENT",
+      "type": "END_TURN",
       "comment": "Step 4: Signal to the Turn Manager that the actor's turn is over.",
       "parameters": {
-        "eventType": "core:turn_ended",
-        "payload": {
-          "entityId": "{event.payload.actorId}",
-          "success": true
-        }
+        "entityId": "{event.payload.actorId}",
+        "success": true
       }
     }
   ]

--- a/data/mods/core/rules/follow.rule.json
+++ b/data/mods/core/rules/follow.rule.json
@@ -40,14 +40,11 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "END_TURN",
             "comment": "Signal to the Turn Manager that the actor's turn is over (and was unsuccessful).",
             "parameters": {
-              "eventType": "core:turn_ended",
-              "payload": {
-                "entityId": "{event.payload.actorId}",
-                "success": false
-              }
+              "entityId": "{event.payload.actorId}",
+              "success": false
             }
           }
         ]
@@ -223,14 +220,11 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "END_TURN",
             "comment": "Dispatch an event to indicate the actor's turn has ended after successful follow attempt.",
             "parameters": {
-              "eventType": "core:turn_ended",
-              "payload": {
-                "entityId": "{event.payload.actorId}",
-                "success": true
-              }
+              "entityId": "{event.payload.actorId}",
+              "success": true
             }
           }
         ]

--- a/data/mods/core/rules/go.rule.json
+++ b/data/mods/core/rules/go.rule.json
@@ -209,14 +209,11 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "END_TURN",
                   "comment": "End the turn successfully.",
                   "parameters": {
-                    "eventType": "core:turn_ended",
-                    "payload": {
-                      "entityId": "{event.payload.actorId}",
-                      "success": true
-                    }
+                    "entityId": "{event.payload.actorId}",
+                    "success": true
                   }
                 }
               ],
@@ -232,16 +229,13 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "END_TURN",
                   "comment": "End the turn after a failed move.",
                   "parameters": {
-                    "eventType": "core:turn_ended",
-                    "payload": {
-                      "entityId": "{event.payload.actorId}",
-                      "success": false,
-                      "error": {
-                        "message": "Failed to move: No valid target location could be determined."
-                      }
+                    "entityId": "{event.payload.actorId}",
+                    "success": false,
+                    "error": {
+                      "message": "Failed to move: No valid target location could be determined."
                     }
                   }
                 }
@@ -251,16 +245,13 @@
         ],
         "else_actions": [
           {
-            "type": "DISPATCH_EVENT",
+            "type": "END_TURN",
             "comment": "Action failed because actor is missing required components.",
             "parameters": {
-              "eventType": "core:turn_ended",
-              "payload": {
-                "entityId": "{event.payload.actorId}",
-                "success": false,
-                "error": {
-                  "message": "Actor is missing required components for movement."
-                }
+              "entityId": "{event.payload.actorId}",
+              "success": false,
+              "error": {
+                "message": "Actor is missing required components for movement."
               }
             }
           }

--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -142,14 +142,11 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "END_TURN",
             "comment": "Signal to the Turn Manager that the actor's turn is over.",
             "parameters": {
-              "eventType": "core:turn_ended",
-              "payload": {
-                "entityId": "{event.payload.actorId}",
-                "success": true
-              }
+              "entityId": "{event.payload.actorId}",
+              "success": true
             }
           }
         ],
@@ -165,14 +162,11 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "END_TURN",
             "comment": "End the turn unsuccessfully.",
             "parameters": {
-              "eventType": "core:turn_ended",
-              "payload": {
-                "entityId": "{event.payload.actorId}",
-                "success": false
-              }
+              "entityId": "{event.payload.actorId}",
+              "success": false
             }
           }
         ]

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -19,6 +19,7 @@
             "ADD_COMPONENT",
             "REMOVE_COMPONENT",
             "DISPATCH_EVENT",
+            "END_TURN",
             "IF",
             "FOR_EACH",
             "LOG",
@@ -137,6 +138,20 @@
               "parameters": {
                 "$ref": "#/$defs/DispatchEventParameters"
               }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "END_TURN" }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": { "$ref": "#/$defs/EndTurnParameters" }
             },
             "required": ["parameters"]
           }
@@ -489,6 +504,24 @@
         }
       },
       "required": ["eventType"],
+      "additionalProperties": false
+    },
+    "EndTurnParameters": {
+      "type": "object",
+      "description": "Parameters for the END_TURN operation, dispatching core:turn_ended.",
+      "properties": {
+        "entityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "object"
+        }
+      },
+      "required": ["entityId", "success"],
       "additionalProperties": false
     },
     "IfParameters": {

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -23,6 +23,7 @@ import AddComponentHandler from '../../logic/operationHandlers/addComponentHandl
 import QueryComponentHandler from '../../logic/operationHandlers/queryComponentHandler.js';
 import RemoveComponentHandler from '../../logic/operationHandlers/removeComponentHandler.js';
 import SetVariableHandler from '../../logic/operationHandlers/setVariableHandler.js';
+import EndTurnHandler from '../../logic/operationHandlers/endTurnHandler.js';
 import SystemMoveEntityHandler from '../../logic/operationHandlers/systemMoveEntityHandler.js';
 import GetTimestampHandler from '../../logic/operationHandlers/getTimestampHandler.js';
 import ResolveDirectionHandler from '../../logic/operationHandlers/resolveDirectionHandler.js';
@@ -115,6 +116,15 @@ export function registerInterpreters(container) {
       tokens.SetVariableHandler,
       SetVariableHandler,
       (c, Handler) => new Handler({ logger: c.resolve(tokens.ILogger) }),
+    ],
+    [
+      tokens.EndTurnHandler,
+      EndTurnHandler,
+      (c, Handler) =>
+        new Handler({
+          dispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+          logger: c.resolve(tokens.ILogger),
+        }),
     ],
     [
       tokens.SystemMoveEntityHandler,
@@ -244,6 +254,7 @@ export function registerInterpreters(container) {
     registry.register('QUERY_COMPONENT', bind(tokens.QueryComponentHandler));
     registry.register('QUERY_ENTITIES', bind(tokens.QueryEntitiesHandler));
     registry.register('SET_VARIABLE', bind(tokens.SetVariableHandler));
+    registry.register('END_TURN', bind(tokens.EndTurnHandler));
     registry.register(
       'SYSTEM_MOVE_ENTITY',
       bind(tokens.SystemMoveEntityHandler)

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -124,6 +124,7 @@ import { freeze } from '../utils/objectUtils';
  * @property {DiToken} RemoveComponentHandler - Token for the 'REMOVE_COMPONENT' operation handler.
  * @property {DiToken} QueryComponentHandler - Token for the 'QUERY_COMPONENT' operation handler.
  * @property {DiToken} SetVariableHandler - Token for the 'SET_VARIABLE' operation handler.
+ * @property {DiToken} EndTurnHandler - Token for the 'END_TURN' operation handler.
  *
  * // ***** ADDITIONS FOR PROMPTBUILDER REFACTORING START *****
  * @property {DiToken} IConfigurationProvider - Token for the LLM configuration provider interface.
@@ -249,6 +250,7 @@ export const tokens = freeze({
   RemoveComponentHandler: 'RemoveComponentHandler',
   QueryComponentHandler: 'QueryComponentHandler',
   SetVariableHandler: 'SetVariableHandler',
+  EndTurnHandler: 'EndTurnHandler',
   SystemMoveEntityHandler: 'SystemMoveEntityHandler',
   GetTimestampHandler: 'GetTimestampHandler',
   ResolveDirectionHandler: 'ResolveDirectionHandler',

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -1,0 +1,84 @@
+/**
+ * @file Handler that dispatches the core:turn_ended event with a payload
+ * describing the outcome of an entity's turn.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../../events/eventBus.js').default} EventBus */
+
+import { TURN_ENDED_ID } from '../../constants/eventIds.js';
+
+/**
+ * Parameters for {@link EndTurnHandler#execute}.
+ *
+ * @typedef {object} EndTurnParameters
+ * @property {string} entityId - ID of the entity whose turn ended.
+ * @property {boolean} success - Whether the turn completed successfully.
+ * @property {object=} error - Optional error information.
+ */
+
+class EndTurnHandler {
+  /** @type {ValidatedEventDispatcher|EventBus} */
+  #dispatcher;
+  /** @type {ILogger} */
+  #logger;
+
+  /**
+   * @param {object} deps
+   * @param {ValidatedEventDispatcher|EventBus} deps.dispatcher - Event dispatcher.
+   * @param {ILogger} deps.logger - Logger instance.
+   */
+  constructor({ dispatcher, logger }) {
+    if (!dispatcher || typeof dispatcher.dispatch !== 'function') {
+      throw new Error(
+        'EndTurnHandler requires a dispatcher with a dispatch method.'
+      );
+    }
+    if (!logger || typeof logger.debug !== 'function') {
+      throw new Error('EndTurnHandler requires a valid ILogger instance.');
+    }
+    this.#dispatcher = dispatcher;
+    this.#logger = logger;
+  }
+
+  /**
+   * Dispatch the core:turn_ended event.
+   *
+   * @param {EndTurnParameters} params - Resolved parameters.
+   * @param {ExecutionContext} _executionContext - Execution context (unused).
+   */
+  execute(params, _executionContext) {
+    if (
+      !params ||
+      typeof params.entityId !== 'string' ||
+      !params.entityId.trim()
+    ) {
+      this.#logger.error('END_TURN: Invalid or missing "entityId" parameter.');
+      return;
+    }
+
+    const payload = {
+      entityId: params.entityId.trim(),
+      success: Boolean(params.success),
+    };
+
+    if (params.error !== undefined) {
+      payload.error = params.error;
+    }
+
+    this.#logger.debug(
+      `END_TURN: dispatching ${TURN_ENDED_ID} for ${payload.entityId} with success=${payload.success}`,
+      { payload }
+    );
+
+    try {
+      this.#dispatcher.dispatch(TURN_ENDED_ID, payload);
+    } catch (err) {
+      this.#logger.error('END_TURN: Error dispatching turn ended event.', err);
+    }
+  }
+}
+
+export default EndTurnHandler;

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -20,6 +20,7 @@ import HasComponentHandler from '../../../src/logic/operationHandlers/hasCompone
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -147,6 +148,7 @@ function init(entities) {
     }),
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
   };
 

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -21,6 +21,7 @@ import AddComponentHandler from '../../../src/logic/operationHandlers/addCompone
 import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modifyArrayFieldHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -124,6 +125,7 @@ describe('core_handle_follow rule integration', () => {
         dispatcher: eventBus,
         logger,
       }),
+      END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
       GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     };
 

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -20,6 +20,7 @@ import SetVariableHandler from '../../../src/logic/operationHandlers/setVariable
 import ResolveDirectionHandler from '../../../src/logic/operationHandlers/resolveDirectionHandler.js';
 import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   NAME_COMPONENT_ID,
   POSITION_COMPONENT_ID,
@@ -169,6 +170,7 @@ function init(entities) {
       safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -19,6 +19,7 @@ import HasComponentHandler from '../../../src/logic/operationHandlers/hasCompone
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -140,6 +141,7 @@ function init(entities) {
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/logic/operationHandlers/endTurnHandler.test.js
+++ b/tests/logic/operationHandlers/endTurnHandler.test.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
+import { TURN_ENDED_ID } from '../../../src/constants/eventIds.js';
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+});
+
+const makeDispatcher = () => ({ dispatch: jest.fn() });
+
+describe('EndTurnHandler', () => {
+  let logger;
+  let dispatcher;
+  let handler;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    dispatcher = makeDispatcher();
+    handler = new EndTurnHandler({ dispatcher, logger });
+  });
+
+  test('constructor throws with invalid dependencies', () => {
+    expect(() => new EndTurnHandler({ logger })).toThrow();
+    expect(() => new EndTurnHandler({ dispatcher })).toThrow();
+  });
+
+  test('execute dispatches core:turn_ended with provided payload', () => {
+    const params = { entityId: 'e1', success: true };
+    handler.execute(params, {});
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(TURN_ENDED_ID, params);
+  });
+
+  test('execute includes optional error field when provided', () => {
+    const params = { entityId: 'e2', success: false, error: { msg: 'oops' } };
+    handler.execute(params, {});
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(TURN_ENDED_ID, params);
+  });
+
+  test('execute logs error and does not dispatch when entityId is invalid', () => {
+    handler.execute({ entityId: '   ', success: true }, {});
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'END_TURN: Invalid or missing "entityId" parameter.'
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added a new END_TURN operation handler to dispatch `core:turn_ended` with configurable payload. Updated operation schema and dependency injection to register the handler. Modified follow, go, dismiss, and stop_following rules to use END_TURN. Updated related integration tests.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684dfb6513f083319bc70e5daa9ef608