### PR TITLE
[Agent] add caching test and fix DI for actions

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -299,6 +299,7 @@ export function registerAI(container) {
     (c) =>
       new AvailableActionsProvider({
         actionDiscoveryService: c.resolve(tokens.IActionDiscoveryService),
+        actionIndexingService: c.resolve(tokens.ActionIndexingService),
         entityManager: c.resolve(tokens.IEntityManager),
       })
   );
@@ -358,8 +359,7 @@ export function registerAI(container) {
     tokens.TurnActionChoicePipeline,
     (c) =>
       new TurnActionChoicePipeline({
-        discoverySvc: c.resolve(tokens.IActionDiscoveryService),
-        indexer: c.resolve(tokens.IActionIndexer),
+        availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
         logger: c.resolve(tokens.ILogger),
       })
   );

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -45,15 +45,12 @@ export function registerTurnLifecycle(container) {
 
   // --- Also ensure the TurnActionChoicePipeline is registered if not already ---
   if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
-    r.singletonFactory(
-      tokens.TurnActionChoicePipeline,
-      (c) =>
-        new TurnActionChoicePipeline({
-          discoverySvc: c.resolve(tokens.IActionDiscoveryService),
-          indexer: c.resolve(tokens.IActionIndexer),
-          logger: c.resolve(tokens.ILogger),
-        })
-    );
+    r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
+      return new TurnActionChoicePipeline({
+        availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
+        logger: c.resolve(tokens.ILogger),
+      });
+    });
   }
 
   // ─────────────────── Turn-context factory ──────────────────

--- a/src/turns/handlers/aiTurnHandler.js
+++ b/src/turns/handlers/aiTurnHandler.js
@@ -1,5 +1,6 @@
 /**
- * @file This module contains the handler for turns for AI-controlled actors.
+ * @file Alias module exposing ActorTurnHandler as `AITurnHandler` for DI
+ * compatibility.
  * @see src/turns/handlers/aiTurnHandler.js
  */
 
@@ -8,20 +9,10 @@ import ActorTurnHandler from './actorTurnHandler.js';
 /**
  * @class AITurnHandler
  * @augments ActorTurnHandler
- * @description Thin wrapper that configures ActorTurnHandler for AI actors.
+ * @description Empty subclass retaining the original class name so that
+ * error messages and instanceof checks continue to work while delegating all
+ * behavior to {@link ActorTurnHandler}.
  */
-export class AITurnHandler extends ActorTurnHandler {
-  /**
-   * @param {object} deps
-   * @param {import('../../interfaces/coreServices.js').ILogger} deps.logger
-   * @param {import('../interfaces/ITurnStateFactory.js').ITurnStateFactory} deps.turnStateFactory
-   * @param {import('../ports/ITurnEndPort.js').ITurnEndPort} deps.turnEndPort
-   * @param {import('../interfaces/ITurnStrategyFactory.js').ITurnStrategyFactory} deps.strategyFactory
-   * @param {import('../builders/turnContextBuilder.js').TurnContextBuilder} deps.turnContextBuilder
-   */
-  constructor({ strategyFactory, ...rest }) {
-    super({ ...rest, strategyFactory });
-  }
-}
+export class AITurnHandler extends ActorTurnHandler {}
 
 export default AITurnHandler;

--- a/src/turns/handlers/humanTurnHandler.js
+++ b/src/turns/handlers/humanTurnHandler.js
@@ -1,5 +1,6 @@
 /**
- * @file This module is the main handler of a turn for a human character.
+ * @file Alias module exposing ActorTurnHandler as `HumanTurnHandler` for
+ * backward compatibility.
  * @see src/turns/handlers/humanTurnHandler.js
  */
 
@@ -10,21 +11,10 @@ import ActorTurnHandler from './actorTurnHandler.js';
 /**
  * @class HumanTurnHandler
  * @augments ActorTurnHandler
- * @description Thin wrapper that configures ActorTurnHandler for human players.
+ * @description Empty subclass preserving the original class name so that
+ * logs and instanceof checks remain consistent while delegating all
+ * behavior to {@link ActorTurnHandler}.
  */
-class HumanTurnHandler extends ActorTurnHandler {
-  /**
-   * @param {object} deps
-   * @param {import('../../interfaces/coreServices.js').ILogger} deps.logger
-   * @param {import('../interfaces/ITurnStateFactory.js').ITurnStateFactory} deps.turnStateFactory
-   * @param {import('../ports/ITurnEndPort.js').ITurnEndPort} deps.turnEndPort
-   * @param {import('../interfaces/ITurnStrategyFactory.js').ITurnStrategyFactory} deps.turnStrategyFactory
-   * @param {import('../builders/turnContextBuilder.js').TurnContextBuilder} deps.turnContextBuilder
-   */
-  constructor({ turnStrategyFactory, ...rest }) {
-    super({ ...rest, turnStrategyFactory });
-  }
-}
+export class HumanTurnHandler extends ActorTurnHandler {}
 
 export default HumanTurnHandler;
-export { HumanTurnHandler };

--- a/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
@@ -112,6 +112,10 @@ describe('registerTurnLifecycle', () => {
     // register turn action factory for HumanTurnHandler
     mockTurnActionFactory = mock();
     container.register(tokens.ITurnActionFactory, () => mockTurnActionFactory);
+
+    container.register(tokens.IAvailableActionsProvider, () => ({
+      get: jest.fn().mockResolvedValue([]),
+    }));
   });
 
   afterEach(() => {

--- a/tests/integration/availableActionsProvider.integration.test.js
+++ b/tests/integration/availableActionsProvider.integration.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AvailableActionsProvider } from '../../src/data/providers/availableActionsProvider.js';
+import { ActionIndexingService } from '../../src/turns/services/actionIndexingService.js';
+import { TurnActionChoicePipeline } from '../../src/turns/pipeline/turnActionChoicePipeline.js';
+
+/**
+ * @class StubEntity
+ * @description Minimal entity used for tests. Provides an ID and a
+ *              getComponentData method returning a fake position component.
+ */
+class StubEntity {
+  /**
+   * @param {string} id - Unique identifier for the entity.
+   */
+  constructor(id) {
+    this.id = id;
+  }
+
+  /**
+   * @returns {{ locationId: null }} Position component stub.
+   */
+  getComponentData() {
+    return { locationId: null };
+  }
+}
+
+describe('Integration – AvailableActionsProvider caching', () => {
+  /** @type {import('../../src/interfaces/coreServices.js').ILogger} */
+  let logger;
+  let discoverySvc;
+  let indexingService;
+  let provider;
+  let entityManager;
+  let pipeline;
+  let actor;
+  let context;
+
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    discoverySvc = { getValidActions: jest.fn() };
+    indexingService = new ActionIndexingService({ logger });
+    entityManager = { getEntityInstance: jest.fn().mockResolvedValue(null) };
+
+    provider = new AvailableActionsProvider({
+      actionDiscoveryService: discoverySvc,
+      actionIndexingService: indexingService,
+      entityManager,
+    });
+
+    pipeline = new TurnActionChoicePipeline({
+      availableActionsProvider: provider,
+      logger,
+    });
+
+    actor = new StubEntity('actor');
+    context = { game: { turn: 1 }, getActor: () => actor };
+  });
+
+  it('reuses cached actions within a single turn', async () => {
+    const discovered = [{ id: 'core:wait', command: 'Wait', params: {} }];
+    discoverySvc.getValidActions.mockResolvedValue(discovered);
+
+    const first = await pipeline.buildChoices(actor, context);
+    const second = await pipeline.buildChoices(actor, context);
+
+    expect(first).toEqual(second);
+    expect(discoverySvc.getValidActions).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears cache when turn context changes', async () => {
+    discoverySvc.getValidActions.mockResolvedValue([
+      { id: 'core:wait', command: 'Wait', params: {} },
+    ]);
+
+    await pipeline.buildChoices(actor, context);
+    const newContext = { game: { turn: 2 }, getActor: () => actor };
+    await pipeline.buildChoices(actor, newContext);
+
+    expect(discoverySvc.getValidActions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/integration/humanAiTurnParity.integration.test.js
+++ b/tests/integration/humanAiTurnParity.integration.test.js
@@ -1,8 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { ACTION_DECIDED_ID } from '../../src/constants/eventIds.js';
 import { TurnActionChoicePipeline } from '../../src/turns/pipeline/turnActionChoicePipeline.js';
-import { ActionIndexingService } from '../../src/turns/services/actionIndexingService.js';
-import { ActionIndexerAdapter } from '../../src/turns/adapters/actionIndexerAdapter.js';
 import { GenericTurnStrategy } from '../../src/turns/strategies/genericTurnStrategy.js';
 import { HumanDecisionProvider } from '../../src/turns/providers/humanDecisionProvider.js';
 import { LLMDecisionProvider } from '../../src/turns/providers/llmDecisionProvider.js';
@@ -41,14 +39,18 @@ describe('Integration – Human and AI turn parity', () => {
         .mockResolvedValue([{ id: 'core:wait', command: 'Wait', params: {} }]),
     };
 
-    const indexingService = new ActionIndexingService({ logger });
-    const indexSpy = jest.spyOn(indexingService, 'indexActions');
+    const composite = {
+      index: 1,
+      actionId: 'core:wait',
+      commandString: 'Wait',
+      params: {},
+      description: 'Wait',
+    };
 
-    const indexer = new ActionIndexerAdapter(indexingService);
+    const provider = { get: jest.fn().mockResolvedValue([composite]) };
 
     const pipeline = new TurnActionChoicePipeline({
-      discoverySvc,
-      indexer,
+      availableActionsProvider: provider,
       logger,
     });
 
@@ -135,13 +137,14 @@ describe('Integration – Human and AI turn parity', () => {
       expect.objectContaining({ actorId: aiActor.id, actorType: 'ai' })
     );
 
-    expect(indexSpy).toHaveBeenCalledTimes(2);
-    expect(indexSpy).toHaveBeenNthCalledWith(
+    expect(provider.get).toHaveBeenCalledTimes(2);
+    expect(provider.get).toHaveBeenNthCalledWith(
       1,
-      humanActor.id,
-      expect.any(Array)
+      humanActor,
+      humanContext,
+      logger
     );
-    expect(indexSpy).toHaveBeenNthCalledWith(2, aiActor.id, expect.any(Array));
+    expect(provider.get).toHaveBeenNthCalledWith(2, aiActor, aiContext, logger);
 
     const humanEndState = {
       action: humanContext.getChosenAction(),

--- a/tests/integration/humanDecisionFlow.test.js
+++ b/tests/integration/humanDecisionFlow.test.js
@@ -27,11 +27,6 @@ describe('Integration – Human decision flow', () => {
       warn: jest.fn(),
       error: jest.fn(),
     };
-    const discoverySvc = {
-      getValidActions: jest
-        .fn()
-        .mockResolvedValue([{ id: 'core:wait', command: 'Wait', params: {} }]),
-    };
     const composite = {
       index: 1,
       id: 'core:wait',
@@ -40,32 +35,21 @@ describe('Integration – Human decision flow', () => {
       params: {},
       description: 'Wait',
     };
-    const actionIndexingService = {
-      indexActions: jest.fn().mockReturnValue([composite]),
-      resolve: jest.fn().mockReturnValue(composite),
-      beginTurn: jest.fn(),
-    };
+    const provider = { get: jest.fn().mockResolvedValue([composite]) };
     const promptCoordinator = {
       prompt: jest.fn().mockResolvedValue({ chosenIndex: 1, speech: 'Wait' }),
     };
 
     // Register all the mock instances
     r.instance(tokens.ILogger, logger);
-    r.instance(tokens.IActionDiscoveryService, discoverySvc);
-    r.instance(tokens.ActionIndexingService, actionIndexingService);
+    r.instance(tokens.IAvailableActionsProvider, provider);
     r.instance(tokens.IPromptCoordinator, promptCoordinator);
-
-    r.singletonFactory(
-      tokens.IActionIndexer,
-      (c) => new ActionIndexerAdapter(c.resolve(tokens.ActionIndexingService))
-    );
 
     r.singletonFactory(
       tokens.TurnActionChoicePipeline,
       (c) =>
         new TurnActionChoicePipeline({
-          discoverySvc: c.resolve(tokens.IActionDiscoveryService),
-          indexer: c.resolve(tokens.IActionIndexer),
+          availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
           logger: c.resolve(tokens.ILogger),
         })
     );
@@ -96,13 +80,7 @@ describe('Integration – Human decision flow', () => {
     const result = await strategy.decideAction(context);
 
     // Assertions
-    expect(discoverySvc.getValidActions).toHaveBeenCalledWith(actor, context);
-
-    // The ActionIndexerAdapter swaps arguments, so the mock for ActionIndexingService
-    // receives actorId first.
-    expect(actionIndexingService.indexActions).toHaveBeenCalledWith(actor.id, [
-      { id: 'core:wait', command: 'Wait', params: {} },
-    ]);
+    expect(provider.get).toHaveBeenCalledWith(actor, context, logger);
 
     // ─── PRIMARY FIX IS HERE ───
     // The HumanDecisionProvider now passes the indexed actions (composites)

--- a/tests/turns/pipeline/turnActionChoicePipeline.test.js
+++ b/tests/turns/pipeline/turnActionChoicePipeline.test.js
@@ -3,22 +3,22 @@ import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { TurnActionChoicePipeline } from '../../../src/turns/pipeline/turnActionChoicePipeline.js';
 
 describe('TurnActionChoicePipeline', () => {
-  let discoverySvc;
-  let indexer;
+  let provider;
   let logger;
   let pipeline;
 
   beforeEach(() => {
-    discoverySvc = { getValidActions: jest.fn() };
-    indexer = { index: jest.fn() };
+    provider = { get: jest.fn() };
     logger = { debug: jest.fn() };
-    pipeline = new TurnActionChoicePipeline({ discoverySvc, indexer, logger });
+    pipeline = new TurnActionChoicePipeline({
+      availableActionsProvider: provider,
+      logger,
+    });
   });
 
   test('buildChoices invokes discovery, indexing and returns the indexed array', async () => {
     const actor = { id: 'actor-1' };
     const context = {};
-    const rawActions = [{ id: 'act-1' }, { id: 'act-2' }];
     const indexedActions = [
       {
         index: 1,
@@ -29,23 +29,19 @@ describe('TurnActionChoicePipeline', () => {
       },
     ];
 
-    discoverySvc.getValidActions.mockResolvedValue(rawActions);
-    indexer.index.mockReturnValue(indexedActions);
+    provider.get.mockResolvedValue(indexedActions);
 
     const result = await pipeline.buildChoices(actor, context);
 
-    // discovery called correctly
-    expect(discoverySvc.getValidActions).toHaveBeenCalledWith(actor, context);
+    // provider called correctly
+    expect(provider.get).toHaveBeenCalledWith(actor, context, logger);
 
-    // indexing called with rawActions and actor.id
-    expect(indexer.index).toHaveBeenCalledWith(rawActions, actor.id);
-
-    // returns exactly the indexer’s output
+    // returns exactly the provider's output
     expect(result).toBe(indexedActions);
 
     // logging
     expect(logger.debug).toHaveBeenCalledWith(
-      `[ChoicePipeline] Discovering actions for ${actor.id}`
+      `[ChoicePipeline] Fetching actions for ${actor.id}`
     );
     expect(logger.debug).toHaveBeenCalledWith(
       `[ChoicePipeline] Actor ${actor.id}: ${indexedActions.length} choices ready`


### PR DESCRIPTION
Summary: Fixed DI registration for AvailableActionsProvider to pass ActionIndexingService and added an integration test verifying caching behavior in TurnActionChoicePipeline.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de85631a483318286f3e61e904ff2