### PR TITLE
[Agent] dispatch DISPLAY_ERROR_ID in GetNameHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -149,6 +149,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -151,7 +151,11 @@ function init(entities) {
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
-    GET_NAME: new GetNameHandler({ entityManager, logger }),
+    GET_NAME: new GetNameHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in `GetNameHandler`
- emit `core:display_error` instead of logging errors
- inject dispatcher via DI and update dismiss rule test

## Testing Done
- `npm run format`
- `npm run lint` *(fails: existing repo lint issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e577164e083319a47461a33710700