### PR TITLE
[Feat] Refactor decision providers

### DIFF
--- a/src/turns/providers/abstractDecisionProvider.js
+++ b/src/turns/providers/abstractDecisionProvider.js
@@ -1,0 +1,82 @@
+/**
+ * @module AbstractDecisionProvider
+ */
+
+import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
+import { assertValidActionIndex } from '../../utils/validationUtils.js';
+
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
+/**
+ * @abstract
+ * @class AbstractDecisionProvider
+ * @augments ITurnDecisionProvider
+ * @description
+ * Provides shared logic for decision providers that select an action index.
+ */
+export class AbstractDecisionProvider extends ITurnDecisionProvider {
+  /**
+   * Base constructor for decision providers.
+   *
+   * @param {object} deps - Constructor dependencies
+   * @param {import('../../interfaces/coreServices').ILogger} deps.logger - Logger for error reporting
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Event dispatcher for validation errors
+   */
+  constructor({ logger, safeEventDispatcher }) {
+    super();
+    /** @protected */
+    this.logger = logger;
+    /** @protected @type {ISafeEventDispatcher} */
+    this.safeEventDispatcher = safeEventDispatcher;
+  }
+
+  /**
+   * Subclasses must implement action selection logic.
+   *
+   * @abstract
+   * @protected
+   * @param {import('../../entities/entity.js').default} _actor - Acting entity
+   * @param {import('../interfaces/ITurnContext.js').ITurnContext} _context - Turn context
+   * @param {import('../dtos/actionComposite.js').ActionComposite[]} _actions - Indexed action list
+   * @param {AbortSignal} [_abortSignal] - Optional cancellation signal
+   * @returns {Promise<{ index: number, speech?: string|null, thoughts?: string|null, notes?: string[]|null }>} Selected action information
+   */
+  async choose(_actor, _context, _actions, _abortSignal) {
+    throw new Error('abstract');
+  }
+
+  /**
+   * @override
+   * @async
+   * @param {import('../../entities/entity.js').default} actor - Acting entity
+   * @param {import('../interfaces/ITurnContext.js').ITurnContext} context - Turn context
+   * @param {import('../dtos/actionComposite.js').ActionComposite[]} actions - Indexed action list
+   * @param {AbortSignal} [abortSignal] - Optional cancellation signal
+   * @returns {Promise<import('../interfaces/ITurnDecisionProvider.js').ITurnDecisionResult>} Finalized decision result
+   */
+  async decide(actor, context, actions, abortSignal) {
+    const { index, speech, thoughts, notes } = await this.choose(
+      actor,
+      context,
+      actions,
+      abortSignal
+    );
+
+    assertValidActionIndex(
+      index,
+      actions.length,
+      this.constructor.name,
+      actor.id,
+      this.safeEventDispatcher,
+      this.logger,
+      { result: { index, speech, thoughts, notes } }
+    );
+
+    return {
+      chosenIndex: index,
+      speech: speech ?? null,
+      thoughts: thoughts ?? null,
+      notes: notes ?? null,
+    };
+  }
+}

--- a/src/turns/providers/llmDecisionProvider.js
+++ b/src/turns/providers/llmDecisionProvider.js
@@ -2,67 +2,51 @@
  * @module LLMDecisionProvider
  */
 
-import { ITurnDecisionProvider } from '../interfaces/ITurnDecisionProvider.js';
-import { assertValidActionIndex } from '../../utils/validationUtils.js';
+import { AbstractDecisionProvider } from './abstractDecisionProvider.js';
 
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
  * @class LLMDecisionProvider
- * @augments ITurnDecisionProvider
+ * @augments AbstractDecisionProvider
  * @description
  *  Decision provider that delegates to an LLM chooser implementation.
  */
-export class LLMDecisionProvider extends ITurnDecisionProvider {
+export class LLMDecisionProvider extends AbstractDecisionProvider {
   /**
+   * Creates a new LLMDecisionProvider.
+   *
    * @param {{
    *  llmChooser: import('../../turns/ports/ILLMChooser').ILLMChooser,
-   *  logger: import('../../interfaces/coreServices').ILogger
+   *  logger: import('../../interfaces/coreServices').ILogger,
    *  safeEventDispatcher: ISafeEventDispatcher
-   * }} deps
+   * }} deps - Constructor dependencies
    */
   constructor({ llmChooser, logger, safeEventDispatcher }) {
-    super();
+    super({ logger, safeEventDispatcher });
     /** @protected @type {import('../../turns/ports/ILLMChooser').ILLMChooser} */
     this.llmChooser = llmChooser;
-    /** @protected @type {import('../../interfaces/coreServices').ILogger} */
-    this.logger = logger;
-    /** @protected @type {ISafeEventDispatcher} */
-    this.safeEventDispatcher = safeEventDispatcher;
   }
 
   /**
-   * @override
+   * Delegates decision making to an LLM chooser.
+   *
    * @async
-   * @param {import('../../entities/entity.js').default} actor
-   * @param {import('../interfaces/ITurnContext.js').ITurnContext} context
-   * @param {import('../dtos/actionComposite.js').ActionComposite[]} actions
-   * @param {AbortSignal} [abortSignal]
-   * @returns {Promise<import('../../turns/interfaces/ITurnDecisionProvider').ITurnDecisionResult>}
+   * @protected
+   * @override
+   * @param {import('../../entities/entity.js').default} actor - Acting entity
+   * @param {import('../interfaces/ITurnContext.js').ITurnContext} context - Turn context
+   * @param {import('../dtos/actionComposite.js').ActionComposite[]} actions - Indexed action list
+   * @param {AbortSignal} [abortSignal] - Optional cancellation signal
+   * @returns {Promise<{ index: number, speech?: string|null, thoughts?: string|null, notes?: string[]|null }>} Result selected by the LLM
    */
-  async decide(actor, context, actions, abortSignal) {
+  async choose(actor, context, actions, abortSignal) {
     const { index, speech, thoughts, notes } = await this.llmChooser.choose({
       actor,
       context,
       actions,
       abortSignal,
     });
-
-    assertValidActionIndex(
-      index,
-      actions.length,
-      'LLMDecisionProvider',
-      actor.id,
-      this.safeEventDispatcher,
-      this.logger,
-      { llmResult: { index, speech, thoughts, notes } }
-    );
-
-    return {
-      chosenIndex: index,
-      speech,
-      thoughts,
-      notes,
-    };
+    return { index, speech, thoughts, notes };
   }
 }


### PR DESCRIPTION
Summary: Introduces an abstract base for decision providers to centralize validation and result shaping.

Changes Made:
- Added `AbstractDecisionProvider` with common `decide` logic
- Updated `HumanDecisionProvider` and `LLMDecisionProvider` to extend the new base and implement `choose`
- Improved JSDoc comments across the updated files

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` – fails due to unrelated existing issues)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684e548f7ea08331ac4c2d6111e57c28