### PR TITLE
[Agent] fix dependency cruiser warnings

### DIFF
--- a/src/domUI/helpers/buildSpeechMeta.js
+++ b/src/domUI/helpers/buildSpeechMeta.js
@@ -6,7 +6,7 @@ import { THOUGHT_SVG, NOTES_SVG } from '../icons.js';
 
 /**
  * @typedef {import('../domElementFactory.js').default} DomElementFactory
- * @typedef {import('../../../interfaces/IDocumentContext.js').IDocumentContext['document']} Document
+ * @typedef {import('../../interfaces/IDocumentContext.js').IDocumentContext['document']} Document
  */
 
 /**

--- a/src/domUI/speechBubbleRenderer.js
+++ b/src/domUI/speechBubbleRenderer.js
@@ -114,7 +114,7 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
    * Handles the DISPLAY_SPEECH_ID event.
    *
    * @private
-   * @param {import('../events/event.js').IEvent<DisplaySpeechPayload>} eventObject - The event object.
+   * @param {{type: string, payload: DisplaySpeechPayload}} eventObject - The event object.
    */
   #onDisplaySpeech(eventObject) {
     if (!eventObject || !eventObject.payload) {

--- a/src/utils/safeDispatchError.js
+++ b/src/utils/safeDispatchError.js
@@ -8,12 +8,11 @@
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
-import { validateDependency } from './validationUtils.js';
 
 /**
- * @description
  * Sends a `core:display_error` event with a consistent payload structure.
  * The dispatcher is validated before dispatching.
+ *
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
  * @param {string} message - Human readable error message.
  * @param {object} [details] - Additional structured details for debugging.
@@ -23,9 +22,13 @@ import { validateDependency } from './validationUtils.js';
  * safeDispatchError(safeEventDispatcher, 'Invalid action', { id: 'bad-action' });
  */
 export function safeDispatchError(dispatcher, message, details = {}) {
-  validateDependency(dispatcher, 'safeDispatchError: dispatcher', console, {
-    requiredMethods: ['dispatch'],
-  });
+  const hasDispatch = dispatcher && typeof dispatcher.dispatch === 'function';
+  if (!hasDispatch) {
+    const errorMsg =
+      "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'.";
+    console.error(errorMsg);
+    throw new Error(errorMsg);
+  }
 
   dispatcher.dispatch(DISPLAY_ERROR_ID, { message, details });
 }


### PR DESCRIPTION
Summary: Addressed dependency-cruiser issues by updating import paths and removing a circular dependency.

Changes Made:
- corrected IDocumentContext import path in buildSpeechMeta
- updated speechBubbleRenderer JSDoc to use a literal event object type
- removed validateDependency from safeDispatchError to break a circular import

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (started server with `npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_684e5be1ad248331ad0b827fd0c0e87c