### PR TITLE
[Agent] Add DISPATCH_SPEECH operation

### DIFF
--- a/data/mods/core/rules/entity_speech.rule.json
+++ b/data/mods/core/rules/entity_speech.rule.json
@@ -83,109 +83,14 @@
             }
           },
           {
-            "type": "IF",
-            "comment": "Check if hidden metadata (thoughts OR notes) is present and dispatch core:display_speech accordingly.",
+            "type": "DISPATCH_SPEECH",
+            "comment": "Dispatch core:display_speech event.",
             "parameters": {
-              "condition": {
-                "or": [
-                  {
-                    "!!": {
-                      "var": "event.payload.thoughts"
-                    }
-                  },
-                  {
-                    "!!": {
-                      "var": "event.payload.notes"
-                    }
-                  }
-                ]
-              },
-              "then_actions": [
-                {
-                  "type": "IF",
-                  "comment": "Branch logic based on which fields (thoughts, notes) are present to avoid placeholder warnings.",
-                  "parameters": {
-                    "condition": {
-                      "!!": {
-                        "var": "event.payload.thoughts"
-                      }
-                    },
-                    "then_actions": [
-                      {
-                        "type": "IF",
-                        "comment": "Thoughts exist, now check for notes.",
-                        "parameters": {
-                          "condition": {
-                            "!!": {
-                              "var": "event.payload.notes"
-                            }
-                          },
-                          "then_actions": [
-                            {
-                              "type": "DISPATCH_EVENT",
-                              "comment": "Dispatch with BOTH thoughts and notes.",
-                              "parameters": {
-                                "eventType": "core:display_speech",
-                                "payload": {
-                                  "entityId": "{event.payload.entityId}",
-                                  "speechContent": "{event.payload.speechContent}",
-                                  "thoughts": "{event.payload.thoughts}",
-                                  "notes": "{event.payload.notes}",
-                                  "allowHtml": false
-                                }
-                              }
-                            }
-                          ],
-                          "else_actions": [
-                            {
-                              "type": "DISPATCH_EVENT",
-                              "comment": "Dispatch with ONLY thoughts.",
-                              "parameters": {
-                                "eventType": "core:display_speech",
-                                "payload": {
-                                  "entityId": "{event.payload.entityId}",
-                                  "speechContent": "{event.payload.speechContent}",
-                                  "thoughts": "{event.payload.thoughts}",
-                                  "allowHtml": false
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "else_actions": [
-                      {
-                        "type": "DISPATCH_EVENT",
-                        "comment": "Dispatch with ONLY notes (since the parent condition requires either thoughts or notes to be present).",
-                        "parameters": {
-                          "eventType": "core:display_speech",
-                          "payload": {
-                            "entityId": "{event.payload.entityId}",
-                            "speechContent": "{event.payload.speechContent}",
-                            "notes": "{event.payload.notes}",
-                            "allowHtml": false
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              ],
-              "else_actions": [
-                {
-                  "type": "DISPATCH_EVENT",
-                  "comment": "Dispatch speech WITHOUT thoughts and notes.",
-                  "parameters": {
-                    "eventType": "core:display_speech",
-                    "payload": {
-                      "entityId": "{event.payload.entityId}",
-                      "speechContent": "{event.payload.speechContent}",
-                      "allowHtml": false
-                    }
-                  }
-                }
-              ]
+              "entity_id": "{event.payload.entityId}",
+              "speech_content": "{event.payload.speechContent}",
+              "thoughts": "{event.payload.thoughts}",
+              "notes": "{event.payload.notes}",
+              "allow_html": false
             }
           }
         ]

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -19,6 +19,7 @@
             "ADD_COMPONENT",
             "REMOVE_COMPONENT",
             "DISPATCH_EVENT",
+            "DISPATCH_SPEECH",
             "END_TURN",
             "IF",
             "FOR_EACH",
@@ -140,6 +141,20 @@
               "parameters": {
                 "$ref": "#/$defs/DispatchEventParameters"
               }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "DISPATCH_SPEECH" }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": { "$ref": "#/$defs/DispatchSpeechParameters" }
             },
             "required": ["parameters"]
           }
@@ -532,6 +547,33 @@
         }
       },
       "required": ["eventType"],
+      "additionalProperties": false
+    },
+    "DispatchSpeechParameters": {
+      "type": "object",
+      "description": "Parameters for the DISPATCH_SPEECH operation. Emits core:display_speech.",
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "speech_content": {
+          "type": "string",
+          "minLength": 1
+        },
+        "thoughts": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allow_html": {
+          "type": "boolean"
+        }
+      },
+      "required": ["entity_id", "speech_content"],
       "additionalProperties": false
     },
     "EndTurnParameters": {

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -17,6 +17,7 @@ import CommandOutcomeInterpreter from '../../commands/interpreters/commandOutcom
 
 // operation handlers
 import DispatchEventHandler from '../../logic/operationHandlers/dispatchEventHandler.js';
+import DispatchSpeechHandler from '../../logic/operationHandlers/dispatchSpeechHandler.js';
 import LogHandler from '../../logic/operationHandlers/logHandler.js';
 import ModifyComponentHandler from '../../logic/operationHandlers/modifyComponentHandler.js';
 import AddComponentHandler from '../../logic/operationHandlers/addComponentHandler.js';
@@ -64,6 +65,15 @@ export function registerInterpreters(container) {
     [
       tokens.DispatchEventHandler,
       DispatchEventHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          dispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        }),
+    ],
+    [
+      tokens.DispatchSpeechHandler,
+      DispatchSpeechHandler,
       (c, Handler) =>
         new Handler({
           logger: c.resolve(tokens.ILogger),
@@ -270,6 +280,7 @@ export function registerInterpreters(container) {
         c.resolve(tkn).execute(...args);
 
     registry.register('DISPATCH_EVENT', bind(tokens.DispatchEventHandler));
+    registry.register('DISPATCH_SPEECH', bind(tokens.DispatchSpeechHandler));
     registry.register('LOG', bind(tokens.LogHandler));
     registry.register('MODIFY_COMPONENT', bind(tokens.ModifyComponentHandler));
     registry.register('ADD_COMPONENT', bind(tokens.AddComponentHandler));

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -244,6 +244,7 @@ export const tokens = freeze({
 
   // Operation Handlers (Registered within Interpreter bundle)
   DispatchEventHandler: 'DispatchEventHandler',
+  DispatchSpeechHandler: 'DispatchSpeechHandler',
   LogHandler: 'LogHandler',
   ModifyComponentHandler: 'ModifyComponentHandler',
   AddComponentHandler: 'AddComponentHandler',

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -1,0 +1,95 @@
+/**
+ * @file Handler to dispatch the core:display_speech event.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../../events/eventBus.js').default} EventBus */
+
+import { DISPLAY_SPEECH_ID } from '../../constants/eventIds.js';
+
+/**
+ * Parameters accepted by {@link DispatchSpeechHandler#execute}.
+ *
+ * @typedef {object} DispatchSpeechParams
+ * @property {string} entity_id       - ID of the entity that spoke.
+ * @property {string} speech_content  - Content of the speech.
+ * @property {string=} thoughts       - Optional inner thoughts.
+ * @property {string=} notes          - Optional notes.
+ * @property {boolean=} allow_html    - Whether speech_content is HTML.
+ */
+
+class DispatchSpeechHandler {
+  /** @type {ValidatedEventDispatcher | EventBus} */
+  #dispatcher;
+  /** @type {ILogger} */
+  #logger;
+
+  /**
+   * @param {object} deps
+   * @param {ValidatedEventDispatcher|EventBus} deps.dispatcher - Dispatcher used to emit the event.
+   * @param {ILogger} deps.logger - Logger instance.
+   */
+  constructor({ dispatcher, logger }) {
+    if (!dispatcher || typeof dispatcher.dispatch !== 'function') {
+      throw new Error(
+        'DispatchSpeechHandler requires a dispatcher with a dispatch method.'
+      );
+    }
+    if (!logger || typeof logger.debug !== 'function') {
+      throw new Error(
+        'DispatchSpeechHandler requires a valid ILogger instance.'
+      );
+    }
+    this.#dispatcher = dispatcher;
+    this.#logger = logger;
+  }
+
+  /**
+   * Construct payload and dispatch {@link DISPLAY_SPEECH_ID}.
+   *
+   * @param {DispatchSpeechParams|null|undefined} params - Resolved parameters.
+   * @param {ExecutionContext} _ctx - Execution context (unused).
+   */
+  execute(params, _ctx) {
+    if (
+      !params ||
+      typeof params.entity_id !== 'string' ||
+      !params.entity_id.trim() ||
+      typeof params.speech_content !== 'string'
+    ) {
+      this.#logger.error('DISPATCH_SPEECH: invalid parameters.', { params });
+      return;
+    }
+
+    const payload = {
+      entityId: params.entity_id.trim(),
+      speechContent: params.speech_content,
+    };
+
+    if (params.allow_html !== undefined) {
+      payload.allowHtml = Boolean(params.allow_html);
+    }
+    if (typeof params.thoughts === 'string') {
+      payload.thoughts = params.thoughts;
+    }
+    if (typeof params.notes === 'string') {
+      payload.notes = params.notes;
+    }
+
+    this.#logger.debug('DISPATCH_SPEECH: dispatching display_speech', {
+      payload,
+    });
+    try {
+      this.#dispatcher.dispatch(DISPLAY_SPEECH_ID, payload);
+    } catch (err) {
+      this.#logger.error(
+        'DISPATCH_SPEECH: Error dispatching display_speech.',
+        err
+      );
+    }
+  }
+}
+
+export default DispatchSpeechHandler;

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -17,6 +17,7 @@ import HasComponentHandler from '../../../src/logic/operationHandlers/hasCompone
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
 import {
   NAME_COMPONENT_ID,
   POSITION_COMPONENT_ID,
@@ -78,6 +79,10 @@ function init(entities) {
     QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+    DISPATCH_SPEECH: new DispatchSpeechHandler({
+      dispatcher: eventBus,
+      logger,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
+import { DISPLAY_SPEECH_ID } from '../../../src/constants/eventIds.js';
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+const makeDispatcher = () => ({ dispatch: jest.fn() });
+
+describe('DispatchSpeechHandler', () => {
+  let logger;
+  let dispatcher;
+  let handler;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    dispatcher = makeDispatcher();
+    handler = new DispatchSpeechHandler({ dispatcher, logger });
+    jest.clearAllMocks();
+  });
+
+  test('constructor throws with invalid deps', () => {
+    expect(() => new DispatchSpeechHandler({ logger })).toThrow();
+    expect(() => new DispatchSpeechHandler({ dispatcher })).toThrow();
+  });
+
+  const base = { entity_id: 'e1', speech_content: 'hi' };
+  const combos = [
+    ['no optional params', {}, {}],
+    ['allow_html true', { allow_html: true }, { allowHtml: true }],
+    ['allow_html false', { allow_html: false }, { allowHtml: false }],
+    ['thoughts only', { thoughts: 't' }, { thoughts: 't' }],
+    ['notes only', { notes: 'n' }, { notes: 'n' }],
+    [
+      'thoughts and notes',
+      { thoughts: 't', notes: 'n' },
+      { thoughts: 't', notes: 'n' },
+    ],
+    [
+      'thoughts + allow_html',
+      { thoughts: 't', allow_html: true },
+      { thoughts: 't', allowHtml: true },
+    ],
+    [
+      'notes + allow_html',
+      { notes: 'n', allow_html: false },
+      { notes: 'n', allowHtml: false },
+    ],
+    [
+      'thoughts + notes + allow_html',
+      { thoughts: 't', notes: 'n', allow_html: true },
+      { thoughts: 't', notes: 'n', allowHtml: true },
+    ],
+  ];
+
+  test.each(combos)('dispatch payload %s', (_desc, extras, expectedExtras) => {
+    const params = { ...base, ...extras };
+    const expected = {
+      entityId: base.entity_id,
+      speechContent: base.speech_content,
+      ...expectedExtras,
+    };
+    handler.execute(params, {});
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_SPEECH_ID,
+      expected
+    );
+  });
+});


### PR DESCRIPTION
Summary: Introduces a new DISPATCH_SPEECH operation to simplify speech dispatching. Adds handler, updates schema and rule, and registers the handler. Comprehensive unit tests cover all optional parameter combinations and integration tests updated.

Changes Made:
- Added DISPATCH_SPEECH type in operation schema with new parameters.
- Implemented dispatchSpeechHandler to build and send core:display_speech events.
- Registered handler within DI and replaced complex IF logic in entity_speech.rule.json.
- Added unit tests for handler and updated integration tests for new operation.

Testing Done:
- [x] Code formatted (`npm run format` on modified files)
- [ ] Lint passes (`npm run lint` in root and proxy) *(fails: 540 errors)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation



------
https://chatgpt.com/codex/tasks/task_e_684e5d7bdf10833193c564f9acfa9c17