### PR TITLE
[Agent] Validate dependencies via utilities

### DIFF
--- a/src/logic/contextAssembler.js
+++ b/src/logic/contextAssembler.js
@@ -10,6 +10,9 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 
+import { ensureValidLogger } from '../utils/loggerUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
+
 /** @typedef {string | number | null | undefined} EntityId */
 
 /**
@@ -158,25 +161,15 @@ export function createJsonLogicContext(
       "createJsonLogicContext: Missing or invalid 'event' object."
     );
   }
-  if (
-    !entityManager ||
-    typeof entityManager.getComponentData !== 'function' ||
-    typeof entityManager.getEntityInstance !== 'function'
-  ) {
-    throw new Error(
-      "createJsonLogicContext: Missing or invalid 'entityManager' instance."
-    );
-  }
-  if (
-    !logger ||
-    typeof logger.debug !== 'function' ||
-    typeof logger.warn !== 'function' ||
-    typeof logger.error !== 'function'
-  ) {
-    throw new Error(
-      "createJsonLogicContext: Missing or invalid 'logger' instance."
-    );
-  }
+  validateDependency(logger, 'logger', console, {
+    requiredMethods: ['debug', 'warn', 'error', 'info'],
+  });
+  const effectiveLogger = ensureValidLogger(logger, 'createJsonLogicContext');
+  validateDependency(entityManager, 'entityManager', effectiveLogger, {
+    requiredMethods: ['getComponentData', 'getEntityInstance', 'hasComponent'],
+  });
+
+  logger = effectiveLogger;
 
   logger.debug(
     `Creating JsonLogicEvaluationContext for event type [${event.type}]. ActorID: [${actorId ?? 'None'}], TargetID: [${targetId ?? 'None'}]`

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -1,5 +1,7 @@
 // src/logic/jsonLogicEvaluationService.js
 import jsonLogic from 'json-logic-js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 
 // -----------------------------------------------------------------------------
 // Ensure the alias "not" behaves the same as the built‑in "!" operator.
@@ -46,16 +48,10 @@ class JsonLogicEvaluationService {
    * @throws {Error} If required dependencies are missing or invalid.
    */
   constructor({ logger }) {
-    if (
-      !logger ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      throw new Error(
-        'JsonLogicEvaluationService requires a valid ILogger instance.'
-      );
-    }
-    this.#logger = logger;
+    validateDependency(logger, 'logger', console, {
+      requiredMethods: ['info', 'warn', 'error', 'debug'],
+    });
+    this.#logger = ensureValidLogger(logger, 'JsonLogicEvaluationService');
     this.#logger.debug('JsonLogicEvaluationService initialized.');
   }
 

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -4,6 +4,8 @@
 
 /** @typedef {import('./defs.js').OperationHandler}           OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+import { ensureValidLogger } from '../utils/loggerUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 
 class OperationRegistry {
   /** @type {Map<string, OperationHandler>} */ #registry = new Map();
@@ -17,9 +19,14 @@ class OperationRegistry {
    *        • new OperationRegistry()
    */
   constructor(arg = null) {
-    this.#logger =
+    const maybeLogger =
       arg && typeof arg === 'object' && 'logger' in arg ? arg.logger : arg;
-
+    if (maybeLogger) {
+      validateDependency(maybeLogger, 'logger', console, {
+        requiredMethods: ['info', 'warn', 'error', 'debug'],
+      });
+    }
+    this.#logger = ensureValidLogger(maybeLogger, 'OperationRegistry');
     this.#log('info', 'OperationRegistry initialized.');
   }
 

--- a/tests/logic/contextAssembler.more.test.js
+++ b/tests/logic/contextAssembler.more.test.js
@@ -709,9 +709,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
     test('should throw error if entityManager is missing or invalid', () => {
       expect(() =>
         createJsonLogicContext(baseEvent, actorId, targetId, null, mockLogger)
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
-      );
+      ).toThrow('Missing required dependency: entityManager.');
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -721,7 +719,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
           mockLogger
         )
       ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
+        "Invalid or missing method 'getEntityInstance' on dependency 'entityManager'."
       );
       expect(() =>
         createJsonLogicContext(
@@ -732,7 +730,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
           mockLogger
         )
       ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
+        "Invalid or missing method 'getComponentData' on dependency 'entityManager'."
       );
       expect(() =>
         createJsonLogicContext(
@@ -746,7 +744,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
           mockLogger
         )
       ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
+        "Invalid or missing method 'getEntityInstance' on dependency 'entityManager'."
       );
     });
 
@@ -759,9 +757,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
           mockEntityManager,
           null
         )
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'logger' instance."
-      );
+      ).toThrow('Missing required dependency: logger.');
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -773,9 +769,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
             error: jest.fn(),
           }
         )
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'logger' instance."
-      );
+      ).toThrow("Invalid or missing method 'debug' on dependency 'logger'.");
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -788,9 +782,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
             error: jest.fn(),
           }
         )
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'logger' instance."
-      );
+      ).toThrow("Invalid or missing method 'debug' on dependency 'logger'.");
     });
   });
 });

--- a/tests/logic/contextAssembler.test.js
+++ b/tests/logic/contextAssembler.test.js
@@ -535,9 +535,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
     test('should throw error if entityManager is missing or invalid', () => {
       expect(() =>
         createJsonLogicContext(baseEvent, actorId, targetId, null, mockLogger)
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
-      );
+      ).toThrow('Missing required dependency: entityManager.');
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -547,7 +545,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
           mockLogger
         )
       ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
+        "Invalid or missing method 'getEntityInstance' on dependency 'entityManager'."
       );
       expect(() =>
         createJsonLogicContext(
@@ -558,7 +556,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
           mockLogger
         )
       ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'entityManager' instance."
+        "Invalid or missing method 'getComponentData' on dependency 'entityManager'."
       );
     });
 
@@ -571,9 +569,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
           mockEntityManager,
           null
         )
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'logger' instance."
-      );
+      ).toThrow('Missing required dependency: logger.');
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -582,9 +578,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
           mockEntityManager,
           { warn: jest.fn() }
         )
-      ).toThrow(
-        "createJsonLogicContext: Missing or invalid 'logger' instance."
-      );
+      ).toThrow("Invalid or missing method 'debug' on dependency 'logger'.");
     });
   });
 });

--- a/tests/logic/jsonLogicEvaluationService.test.js
+++ b/tests/logic/jsonLogicEvaluationService.test.js
@@ -102,8 +102,7 @@ describe('JsonLogicEvaluationService', () => {
     });
 
     test('should throw an error if logger dependency is missing or invalid', () => {
-      const expectedErrorMsg =
-        'JsonLogicEvaluationService requires a valid ILogger instance.';
+      const expectedErrorMsg = 'Missing required dependency: logger.';
       expect(() => new JsonLogicEvaluationService({})).toThrow(
         expectedErrorMsg
       );

--- a/tests/logic/operationInterpreter.test.js
+++ b/tests/logic/operationInterpreter.test.js
@@ -124,24 +124,26 @@ describe('OperationInterpreter', () => {
   test('constructor should throw if logger is missing or invalid', () => {
     expect(
       () => new OperationInterpreter({ operationRegistry: mockRegistry })
-    ).toThrow('ILogger');
+    ).toThrow('Missing required dependency: logger.');
     expect(
       () =>
         new OperationInterpreter({
           logger: {},
           operationRegistry: mockRegistry,
         })
-    ).toThrow('ILogger');
+    ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
   });
 
   test('constructor should throw if registry is missing or invalid', () => {
     expect(() => new OperationInterpreter({ logger: mockLogger })).toThrow(
-      'OperationRegistry'
+      'Missing required dependency: operationRegistry.'
     );
     expect(
       () =>
         new OperationInterpreter({ logger: mockLogger, operationRegistry: {} })
-    ).toThrow('OperationRegistry');
+    ).toThrow(
+      "Invalid or missing method 'getHandler' on dependency 'operationRegistry'."
+    );
   });
 
   test('constructor should initialize successfully with valid dependencies', () => {

--- a/tests/logic/operationRegistry.test.js
+++ b/tests/logic/operationRegistry.test.js
@@ -240,7 +240,10 @@ describe('OperationRegistry', () => {
       );
       // #log calls console.error internally before throwing
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'OperationRegistry: ',
+        expectedErrorMsg
+      );
       expect(mockLogger.error).not.toHaveBeenCalled(); // Ensure mock logger wasn't used
     });
 
@@ -261,11 +264,13 @@ describe('OperationRegistry', () => {
       // #log calls console.warn internally
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'OperationRegistry: ',
         `OperationRegistry: Overwriting existing handler for operation type "${operationType}".`
       );
       // #log also calls console.debug (or log fallback) for the registration itself
       expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
       expect(consoleDebugSpy).toHaveBeenCalledWith(
+        'OperationRegistry: ',
         `OperationRegistry: Registered handler for operation type "${operationType}".`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled(); // Ensure mock logger wasn't used
@@ -379,6 +384,7 @@ describe('OperationRegistry', () => {
       // Check the appropriate console spy (debug or log fallback)
       expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
       expect(consoleDebugSpy).toHaveBeenCalledWith(
+        'OperationRegistry: ',
         `OperationRegistry: No handler found for operation type "${unregisteredType}".`
       );
       expect(mockLogger.debug).not.toHaveBeenCalled();
@@ -395,6 +401,7 @@ describe('OperationRegistry', () => {
 
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'OperationRegistry: ',
         `OperationRegistry.getHandler: Received non-string operationType: ${typeof false}. Returning undefined.`
       );
       expect(mockLogger.warn).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary: Updated constructors in key logic modules to use ensureValidLogger and validateDependency utilities. Adjusted tests for new validation messages and logger prefix output. All project tests pass.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e5dd81ac88331a4e6eeea6e893752