### PR TITLE
[Agent] Restore operation schema usage

### DIFF
--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -80,7 +80,6 @@
       "set_title.event.json",
       "update_available_actions.event.json",
       "entity_moved.event.json"
-    ],
-    "operations": []
+    ]
   }
 }

--- a/data/mods/isekai/mod.manifest.json
+++ b/data/mods/isekai/mod.manifest.json
@@ -12,7 +12,6 @@
     "locations": ["adventurers_guild.location.json", "town.location.json"],
     "actions": [],
     "rules": [],
-    "events": [],
-    "operations": []
+    "events": []
   }
 }

--- a/data/onee/mod.manifest.json
+++ b/data/onee/mod.manifest.json
@@ -12,7 +12,6 @@
     "locations": ["living_room.location.json"],
     "actions": [],
     "rules": [],
-    "events": [],
-    "operations": []
+    "events": []
   }
 }

--- a/data/schemas/mod.manifest.schema.json
+++ b/data/schemas/mod.manifest.schema.json
@@ -79,9 +79,6 @@
         "locations": {
           "$ref": "#/definitions/contentFileList"
         },
-        "operations": {
-          "$ref": "#/definitions/contentFileList"
-        },
         "rules": {
           "$ref": "#/definitions/contentFileList"
         }


### PR DESCRIPTION
Summary: Reintroduced `operation.schema.json` in the static configuration after removing operations from mod manifests. Updated related unit test expectations so that rule validation continues to function.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(existing errors from repository remain)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start` (terminated)


------
https://chatgpt.com/codex/tasks/task_e_684e5eabed648331b2be73cc9c4ac2f1