### PR TITLE
[Agent] Implement QUERY_COMPONENT_OPTIONAL operation

### DIFF
--- a/data/mods/core/rules/entity_speech.rule.json
+++ b/data/mods/core/rules/entity_speech.rule.json
@@ -5,21 +5,21 @@
   "event_type": "core:entity_spoke",
   "actions": [
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 1.1: Check if the speaker has a name.",
+      "type": "QUERY_COMPONENT_OPTIONAL",
+      "comment": "Step 1.1: Attempt to get the speaker's name component.",
       "parameters": {
         "entity_ref": "actor",
         "component_type": "core:name",
-        "result_variable": "hasName"
+        "result_variable": "speakerNameComponent"
       }
     },
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 1.2: Check if the speaker has a position.",
+      "type": "QUERY_COMPONENT_OPTIONAL",
+      "comment": "Step 1.2: Attempt to get the speaker's position component.",
       "parameters": {
         "entity_ref": "actor",
         "component_type": "core:position",
-        "result_variable": "hasPosition"
+        "result_variable": "speakerPositionComponent"
       }
     },
     {
@@ -28,33 +28,11 @@
       "parameters": {
         "condition": {
           "and": [
-            {
-              "var": "context.hasName"
-            },
-            {
-              "var": "context.hasPosition"
-            }
+            { "var": "context.speakerNameComponent" },
+            { "var": "context.speakerPositionComponent" }
           ]
         },
         "then_actions": [
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Fetch the name component of the entity that spoke (actor is event.payload.entityId).",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:name",
-              "result_variable": "speakerNameComponent"
-            }
-          },
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Fetch the position component of the entity that spoke to get their locationId.",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:position",
-              "result_variable": "speakerPositionComponent"
-            }
-          },
           {
             "type": "GET_TIMESTAMP",
             "comment": "Get the current ISO timestamp for perception logging.",

--- a/data/mods/core/rules/go.rule.json
+++ b/data/mods/core/rules/go.rule.json
@@ -13,21 +13,21 @@
   },
   "actions": [
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 1.1: Check if the actor has a name for messaging.",
+      "type": "QUERY_COMPONENT_OPTIONAL",
+      "comment": "Step 1.1: Attempt to fetch the actor's name component.",
       "parameters": {
         "entity_ref": "actor",
         "component_type": "core:name",
-        "result_variable": "actorHasName"
+        "result_variable": "actorNameComponent"
       }
     },
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 1.2: Check if the actor has a position, which is required for movement.",
+      "type": "QUERY_COMPONENT_OPTIONAL",
+      "comment": "Step 1.2: Attempt to fetch the actor's position component.",
       "parameters": {
         "entity_ref": "actor",
         "component_type": "core:position",
-        "result_variable": "actorHasPosition"
+        "result_variable": "actorPositionComponentPreMove"
       }
     },
     {
@@ -36,33 +36,11 @@
       "parameters": {
         "condition": {
           "and": [
-            {
-              "var": "context.actorHasName"
-            },
-            {
-              "var": "context.actorHasPosition"
-            }
+            { "var": "context.actorNameComponent" },
+            { "var": "context.actorPositionComponentPreMove" }
           ]
         },
         "then_actions": [
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Fetch the actor's name for messaging.",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:name",
-              "result_variable": "actorNameComponent"
-            }
-          },
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Fetch the actor's current position (pre-move).",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:position",
-              "result_variable": "actorPositionComponentPreMove"
-            }
-          },
           {
             "type": "QUERY_COMPONENT",
             "comment": "Fetch the name of the current location (pre-move).",

--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -13,31 +13,20 @@
   },
   "actions": [
     {
-      "type": "HAS_COMPONENT",
-      "comment": "Step 1: Check if the actor is actually following anyone. This is a critical guard.",
+      "type": "QUERY_COMPONENT_OPTIONAL",
+      "comment": "Step 1: Attempt to get the actor's core:following component.",
       "parameters": {
         "entity_ref": "actor",
         "component_type": "core:following",
-        "result_variable": "isCurrentlyFollowing"
+        "result_variable": "oldFollowingData"
       }
     },
     {
       "type": "IF",
       "comment": "Step 2: Proceed only if the actor has the 'core:following' component.",
       "parameters": {
-        "condition": {
-          "var": "context.isCurrentlyFollowing"
-        },
+        "condition": { "var": "context.oldFollowingData" },
         "then_actions": [
-          {
-            "type": "QUERY_COMPONENT",
-            "comment": "Get the current leader's ID for later use before removing the component.",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:following",
-              "result_variable": "oldFollowingData"
-            }
-          },
           {
             "type": "REMOVE_COMPONENT",
             "comment": "Authoritatively remove the following relationship from the actor.",

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -15,6 +15,7 @@
           "description": "Required. The identifier determining the type of operation and the expected structure of the 'parameters' object.",
           "enum": [
             "QUERY_COMPONENT",
+            "QUERY_COMPONENT_OPTIONAL",
             "MODIFY_COMPONENT",
             "ADD_COMPONENT",
             "REMOVE_COMPONENT",
@@ -68,6 +69,22 @@
             "properties": {
               "parameters": {
                 "$ref": "#/$defs/QueryComponentParameters"
+              }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "QUERY_COMPONENT_OPTIONAL" }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "$ref": "#/$defs/QueryComponentOptionalParameters"
               }
             },
             "required": ["parameters"]
@@ -462,6 +479,25 @@
     "QueryComponentParameters": {
       "type": "object",
       "description": "Parameters for the QUERY_COMPONENT operation.",
+      "properties": {
+        "entity_ref": {
+          "$ref": "./common.schema.json#/definitions/entityReference"
+        },
+        "component_type": {
+          "$ref": "./common.schema.json#/definitions/namespacedId"
+        },
+        "result_variable": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S(.*\\S)?$"
+        }
+      },
+      "required": ["entity_ref", "component_type", "result_variable"],
+      "additionalProperties": false
+    },
+    "QueryComponentOptionalParameters": {
+      "type": "object",
+      "description": "Parameters for the QUERY_COMPONENT_OPTIONAL operation.",
       "properties": {
         "entity_ref": {
           "$ref": "./common.schema.json#/definitions/entityReference"

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -22,6 +22,7 @@ import LogHandler from '../../logic/operationHandlers/logHandler.js';
 import ModifyComponentHandler from '../../logic/operationHandlers/modifyComponentHandler.js';
 import AddComponentHandler from '../../logic/operationHandlers/addComponentHandler.js';
 import QueryComponentHandler from '../../logic/operationHandlers/queryComponentHandler.js';
+import QueryComponentOptionalHandler from '../../logic/operationHandlers/queryComponentOptionalHandler.js';
 import RemoveComponentHandler from '../../logic/operationHandlers/removeComponentHandler.js';
 import SetVariableHandler from '../../logic/operationHandlers/setVariableHandler.js';
 import EndTurnHandler from '../../logic/operationHandlers/endTurnHandler.js';
@@ -118,6 +119,15 @@ export function registerInterpreters(container) {
     [
       tokens.QueryComponentHandler,
       QueryComponentHandler,
+      (c, Handler) =>
+        new Handler({
+          entityManager: c.resolve(tokens.IEntityManager),
+          logger: c.resolve(tokens.ILogger),
+        }),
+    ],
+    [
+      tokens.QueryComponentOptionalHandler,
+      QueryComponentOptionalHandler,
       (c, Handler) =>
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
@@ -286,6 +296,10 @@ export function registerInterpreters(container) {
     registry.register('ADD_COMPONENT', bind(tokens.AddComponentHandler));
     registry.register('REMOVE_COMPONENT', bind(tokens.RemoveComponentHandler));
     registry.register('QUERY_COMPONENT', bind(tokens.QueryComponentHandler));
+    registry.register(
+      'QUERY_COMPONENT_OPTIONAL',
+      bind(tokens.QueryComponentOptionalHandler)
+    );
     registry.register('QUERY_ENTITIES', bind(tokens.QueryEntitiesHandler));
     registry.register('SET_VARIABLE', bind(tokens.SetVariableHandler));
     registry.register('END_TURN', bind(tokens.EndTurnHandler));

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -123,6 +123,7 @@ import { freeze } from '../utils/objectUtils';
  * @property {DiToken} AddComponentHandler - Token for the 'ADD_COMPONENT' operation handler.
  * @property {DiToken} RemoveComponentHandler - Token for the 'REMOVE_COMPONENT' operation handler.
  * @property {DiToken} QueryComponentHandler - Token for the 'QUERY_COMPONENT' operation handler.
+ * @property {DiToken} QueryComponentOptionalHandler - Token for the 'QUERY_COMPONENT_OPTIONAL' operation handler.
  * @property {DiToken} SetVariableHandler - Token for the 'SET_VARIABLE' operation handler.
  * @property {DiToken} EndTurnHandler - Token for the 'END_TURN' operation handler.
  *
@@ -250,6 +251,7 @@ export const tokens = freeze({
   AddComponentHandler: 'AddComponentHandler',
   RemoveComponentHandler: 'RemoveComponentHandler',
   QueryComponentHandler: 'QueryComponentHandler',
+  QueryComponentOptionalHandler: 'QueryComponentOptionalHandler',
   SetVariableHandler: 'SetVariableHandler',
   EndTurnHandler: 'EndTurnHandler',
   SystemMoveEntityHandler: 'SystemMoveEntityHandler',

--- a/src/logic/operationHandlers/queryComponentOptionalHandler.js
+++ b/src/logic/operationHandlers/queryComponentOptionalHandler.js
@@ -1,0 +1,188 @@
+// src/logic/operationHandlers/queryComponentOptionalHandler.js
+
+/**
+ * @file Operation handler that queries a component but stores `null` if the
+ * component is missing instead of `undefined`.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../defs.js').OperationHandler} OperationHandler */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../defs.js').OperationParams} OperationParams */
+import { resolveEntityId } from '../../utils/entityRefUtils.js';
+/**
+ * @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject
+ */
+
+/**
+ * @typedef {object} QueryComponentOptionalParams
+ * @property {'actor'|'target'|string|EntityRefObject} entity_ref
+ * @property {string} component_type
+ * @property {string} result_variable
+ */
+
+import storeResult from '../../utils/contextVariableUtils.js';
+
+class QueryComponentOptionalHandler {
+  #entityManager;
+  #logger;
+
+  constructor({ entityManager, logger }) {
+    if (
+      !entityManager ||
+      typeof entityManager.getComponentData !== 'function'
+    ) {
+      throw new Error(
+        'QueryComponentOptionalHandler requires a valid EntityManager instance with a getComponentData method.'
+      );
+    }
+    if (
+      !logger ||
+      typeof logger.error !== 'function' ||
+      typeof logger.warn !== 'function' ||
+      typeof logger.debug !== 'function'
+    ) {
+      throw new Error(
+        'QueryComponentOptionalHandler requires a valid ILogger instance.'
+      );
+    }
+    this.#entityManager = entityManager;
+    this.#logger = logger;
+  }
+
+  /**
+   * Execute the QUERY_COMPONENT_OPTIONAL operation.
+   *
+   * @param {QueryComponentOptionalParams|null|undefined} params
+   * @param {ExecutionContext} executionContext
+   */
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
+
+    if (!params || typeof params !== 'object') {
+      logger.error(
+        'QueryComponentOptionalHandler: Missing or invalid parameters object.',
+        { params }
+      );
+      return;
+    }
+
+    if (
+      !executionContext?.evaluationContext?.context ||
+      typeof executionContext.evaluationContext.context !== 'object'
+    ) {
+      logger.error(
+        'QueryComponentOptionalHandler: executionContext.evaluationContext.context is missing or invalid. Cannot store result.',
+        { executionContext }
+      );
+      return;
+    }
+
+    const { entity_ref, component_type, result_variable } = params;
+
+    if (!entity_ref) {
+      logger.error(
+        'QueryComponentOptionalHandler: Missing required "entity_ref" parameter.',
+        { params }
+      );
+      return;
+    }
+    if (typeof component_type !== 'string' || !component_type.trim()) {
+      logger.error(
+        'QueryComponentOptionalHandler: Missing or invalid required "component_type" parameter (must be non-empty string).',
+        { params }
+      );
+      return;
+    }
+    const trimmedComponentType = component_type.trim();
+
+    if (typeof result_variable !== 'string' || !result_variable.trim()) {
+      logger.error(
+        'QueryComponentOptionalHandler: Missing or invalid required "result_variable" parameter (must be non-empty string).',
+        { params }
+      );
+      return;
+    }
+    const trimmedResultVar = result_variable.trim();
+
+    const entityId = resolveEntityId(entity_ref, executionContext);
+    if (!entityId) {
+      logger.error(
+        'QueryComponentOptionalHandler: Could not resolve entity id from entity_ref.',
+        { entityRef: entity_ref }
+      );
+      return;
+    }
+
+    if (
+      typeof entity_ref === 'string' &&
+      entity_ref.trim() &&
+      entity_ref.trim() !== 'actor' &&
+      entity_ref.trim() !== 'target'
+    ) {
+      logger.debug(
+        `QueryComponentOptionalHandler: Interpreting entity_ref string "${entity_ref.trim()}" as a direct entity ID.`
+      );
+    }
+
+    logger.debug(
+      `QueryComponentOptionalHandler: Attempting to query component "${trimmedComponentType}" from entity "${entityId}". Storing result in context variable "${trimmedResultVar}".`
+    );
+
+    try {
+      const result = this.#entityManager.getComponentData(
+        entityId,
+        trimmedComponentType
+      );
+      const valueToStore = result === undefined ? null : result;
+      storeResult(
+        trimmedResultVar,
+        valueToStore,
+        executionContext,
+        undefined,
+        logger
+      );
+
+      if (result !== undefined) {
+        const resultString =
+          result === null
+            ? 'null'
+            : typeof result === 'object'
+              ? JSON.stringify(result)
+              : result;
+        logger.debug(
+          `QueryComponentOptionalHandler: Successfully queried component "${trimmedComponentType}" from entity "${entityId}". Result stored in "${trimmedResultVar}": ${resultString}`
+        );
+      } else {
+        logger.debug(
+          `QueryComponentOptionalHandler: Component "${trimmedComponentType}" not found on entity "${entityId}". Stored 'null' in "${trimmedResultVar}".`
+        );
+      }
+    } catch (error) {
+      logger.error(
+        `QueryComponentOptionalHandler: Error during EntityManager.getComponentData for component "${trimmedComponentType}" on entity "${entityId}".`,
+        {
+          error: error.message,
+          stack: error.stack,
+          params,
+          resolvedEntityId: entityId,
+        }
+      );
+      const stored = storeResult(
+        trimmedResultVar,
+        null,
+        executionContext,
+        undefined,
+        logger
+      );
+      if (stored) {
+        logger.warn(
+          `QueryComponentOptionalHandler: Stored 'null' in "${trimmedResultVar}" due to EntityManager error.`
+        );
+      }
+    }
+  }
+}
+
+export default QueryComponentOptionalHandler;

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -13,8 +13,7 @@ import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
-import HasComponentHandler from '../../../src/logic/operationHandlers/hasComponentHandler.js';
-import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
+import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
@@ -71,12 +70,10 @@ function init(entities) {
   const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
   const handlers = {
-    HAS_COMPONENT: new HasComponentHandler({
+    QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
-      safeEventDispatcher: safeDispatcher,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     DISPATCH_SPEECH: new DispatchSpeechHandler({

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -13,8 +13,7 @@ import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
-import HasComponentHandler from '../../../src/logic/operationHandlers/hasComponentHandler.js';
-import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
+import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
 import ResolveDirectionHandler from '../../../src/logic/operationHandlers/resolveDirectionHandler.js';
@@ -152,12 +151,10 @@ function init(entities) {
   const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
   const handlers = {
-    HAS_COMPONENT: new HasComponentHandler({
+    QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
-      safeEventDispatcher: safeDispatcher,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     SET_VARIABLE: new SetVariableHandler({ logger }),
     RESOLVE_DIRECTION: new ResolveDirectionHandler({

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -15,8 +15,7 @@ import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import RemoveComponentHandler from '../../../src/logic/operationHandlers/removeComponentHandler.js';
 import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modifyArrayFieldHandler.js';
-import HasComponentHandler from '../../../src/logic/operationHandlers/hasComponentHandler.js';
-import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
+import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
@@ -139,12 +138,10 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    HAS_COMPONENT: new HasComponentHandler({
+    QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
-      safeEventDispatcher: safeDispatcher,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),

--- a/tests/logic/operationHandlers/queryComponentOptionalHandler.test.js
+++ b/tests/logic/operationHandlers/queryComponentOptionalHandler.test.js
@@ -1,0 +1,123 @@
+// src/tests/logic/operationHandlers/queryComponentOptionalHandler.test.js
+
+/**
+ * @jest-environment node
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
+
+/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../../src/entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../../../src/logic/defs.js').ExecutionContext} ExecutionContext */
+
+const mockEntityManager = { getComponentData: jest.fn() };
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const baseCtx = {
+  event: { type: 'TEST', payload: {} },
+  actor: { id: 'actor1' },
+  target: { id: 'target1' },
+  logger: mockLogger,
+  evaluationContext: {
+    actor: { id: 'actor1' },
+    target: { id: 'target1' },
+    context: {},
+  },
+};
+
+const ctx = (overrides = {}) => ({
+  ...baseCtx,
+  evaluationContext: {
+    ...baseCtx.evaluationContext,
+    context: { ...baseCtx.evaluationContext.context },
+    ...(overrides.evaluationContext || {}),
+  },
+  ...overrides,
+});
+
+describe('QueryComponentOptionalHandler', () => {
+  /** @type {QueryComponentOptionalHandler} */
+  let handler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new QueryComponentOptionalHandler({
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+    });
+  });
+
+  test('constructor throws with invalid deps', () => {
+    expect(
+      () => new QueryComponentOptionalHandler({ logger: mockLogger })
+    ).toThrow(/EntityManager/);
+    expect(
+      () =>
+        new QueryComponentOptionalHandler({
+          entityManager: {},
+          logger: mockLogger,
+        })
+    ).toThrow(/getComponentData/);
+    expect(
+      () =>
+        new QueryComponentOptionalHandler({ entityManager: mockEntityManager })
+    ).toThrow(/ILogger/);
+  });
+
+  test('stores component data when present', () => {
+    const params = {
+      entity_ref: 'actor',
+      component_type: 'core:test',
+      result_variable: 'data',
+    };
+    const c = ctx();
+    const result = { foo: 'bar' };
+    mockEntityManager.getComponentData.mockReturnValue(result);
+    handler.execute(params, c);
+    expect(mockEntityManager.getComponentData).toHaveBeenCalledWith(
+      'actor1',
+      'core:test'
+    );
+    expect(c.evaluationContext.context.data).toEqual(result);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  test('stores null when component missing', () => {
+    const params = {
+      entity_ref: 'actor',
+      component_type: 'core:missing',
+      result_variable: 'maybe',
+    };
+    const c = ctx();
+    mockEntityManager.getComponentData.mockReturnValue(undefined);
+    handler.execute(params, c);
+    expect(c.evaluationContext.context.maybe).toBeNull();
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Stored 'null'")
+    );
+  });
+
+  test('uses execution context logger if provided', () => {
+    const customLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    const params = {
+      entity_ref: 'actor',
+      component_type: 'core:test',
+      result_variable: 'data',
+    };
+    const c = ctx({ logger: customLogger });
+    mockEntityManager.getComponentData.mockReturnValue({});
+    handler.execute(params, c);
+    expect(customLogger.debug).toHaveBeenCalled();
+    expect(mockLogger.debug).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Introduces an optional component query operation and updates rules/tests accordingly.

Changes Made:
- Added `QUERY_COMPONENT_OPTIONAL` type to schema and registry.
- Implemented new handler `queryComponentOptionalHandler`.
- Updated dependency injection to register the handler.
- Simplified `go`, `stop_following`, and `entity_speech` rules using the new operation.
- Updated related integration tests and added unit tests for the handler.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684e6abc6f1c833198c72508e4c25db3