### PR TITLE
[Agent] Extract generic strategy DI helper

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -96,12 +96,10 @@ import {
 } from '../../prompting/assembling/indexedChoicesAssembler.js';
 import { AssemblerRegistry } from '../../prompting/assemblerRegistry.js';
 import * as ConditionEvaluator from '../../prompting/elementConditionEvaluator.js';
-import { GenericStrategyFactory } from '../../turns/factories/genericStrategyFactory.js';
-import { TurnActionFactory } from '../../turns/factories/turnActionFactory.js';
 import { LLMChooser } from '../../turns/adapters/llmChooser.js';
 import { ActionIndexerAdapter } from '../../turns/adapters/actionIndexerAdapter.js';
-import { TurnActionChoicePipeline } from '../../turns/pipeline/turnActionChoicePipeline.js';
 import { LLMDecisionProvider } from '../../turns/providers/llmDecisionProvider.js';
+import { registerGenericStrategy } from './registerGenericStrategy.js';
 
 /**
  * Registers AI, LLM, and Prompting services.
@@ -355,15 +353,6 @@ export function registerAI(container) {
     (c) => new ActionIndexerAdapter(c.resolve(tokens.ActionIndexingService))
   );
 
-  r.singletonFactory(
-    tokens.TurnActionChoicePipeline,
-    (c) =>
-      new TurnActionChoicePipeline({
-        availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
-        logger: c.resolve(tokens.ILogger),
-      })
-  );
-
   r.singletonFactory(tokens.IAIPromptPipeline, (c) => {
     return new AIPromptPipeline({
       llmAdapter: c.resolve(tokens.LLMAdapter),
@@ -402,24 +391,10 @@ export function registerAI(container) {
     `AI Systems Registration: Registered ${tokens.ILLMDecisionProvider}.`
   );
 
-  // 3) Turn-action factory
-  r.singletonFactory(tokens.ITurnActionFactory, () => new TurnActionFactory());
-
-  // 4) AI-player‐strategy factory
-  r.singletonFactory(
-    tokens.AIStrategyFactory,
-    (c) =>
-      new GenericStrategyFactory({
-        choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
-        decisionProvider: c.resolve(tokens.ILLMDecisionProvider),
-        turnActionFactory: c.resolve(tokens.ITurnActionFactory),
-        logger: c.resolve(tokens.ILogger),
-        fallbackFactory: c.resolve(tokens.IAIFallbackActionFactory),
-      })
-  );
-
-  logger.debug(
-    `AI Systems Registration: Registered ${tokens.AIStrategyFactory} factory.`
+  registerGenericStrategy(
+    container,
+    tokens.ILLMDecisionProvider,
+    tokens.AIStrategyFactory
   );
 
   // --- AI TURN HANDLER (MODIFIED) ---

--- a/src/dependencyInjection/registrations/registerGenericStrategy.js
+++ b/src/dependencyInjection/registrations/registerGenericStrategy.js
@@ -1,0 +1,77 @@
+// src/dependencyInjection/registrations/registerGenericStrategy.js
+/**
+ * @file Helper for registering the GenericStrategyFactory and its prerequisites.
+ */
+
+/** @typedef {import('../appContainer.js').default} AppContainer */
+/** @typedef {import('../tokens.js').DiToken} DiToken */
+
+import { tokens } from '../tokens.js';
+import { Registrar } from '../registrarHelpers.js';
+import { TurnActionChoicePipeline } from '../../turns/pipeline/turnActionChoicePipeline.js';
+import { TurnActionFactory } from '../../turns/factories/turnActionFactory.js';
+import { GenericStrategyFactory } from '../../turns/factories/genericStrategyFactory.js';
+
+/**
+ * Registers the {@link GenericStrategyFactory} and supporting services if needed.
+ *
+ * @param {AppContainer} container - The DI container.
+ * @param {DiToken} decisionProviderToken - Token for the decision provider.
+ * @param {DiToken} strategyFactoryToken - Token for the resulting strategy factory.
+ * @returns {void}
+ */
+export function registerGenericStrategy(
+  container,
+  decisionProviderToken,
+  strategyFactoryToken
+) {
+  const r = new Registrar(container);
+  const logger = container.resolve(tokens.ILogger);
+  logger.debug(
+    `[registerGenericStrategy] Starting for ${String(strategyFactoryToken)}...`
+  );
+
+  if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
+    r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
+      return new TurnActionChoicePipeline({
+        availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
+        logger: c.resolve(tokens.ILogger),
+      });
+    });
+    logger.debug(
+      `[registerGenericStrategy] Registered ${tokens.TurnActionChoicePipeline}.`
+    );
+  }
+
+  if (!container.isRegistered(tokens.ITurnActionFactory)) {
+    r.singletonFactory(
+      tokens.ITurnActionFactory,
+      () => new TurnActionFactory()
+    );
+    logger.debug(
+      `[registerGenericStrategy] Registered ${tokens.ITurnActionFactory}.`
+    );
+  }
+
+  if (!container.isRegistered(strategyFactoryToken)) {
+    r.singletonFactory(strategyFactoryToken, (c) => {
+      const opts = {
+        choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
+        decisionProvider: c.resolve(decisionProviderToken),
+        turnActionFactory: c.resolve(tokens.ITurnActionFactory),
+        logger: c.resolve(tokens.ILogger),
+      };
+      if (c.isRegistered(tokens.IAIFallbackActionFactory)) {
+        opts.fallbackFactory = c.resolve(tokens.IAIFallbackActionFactory);
+      }
+      return new GenericStrategyFactory(opts);
+    });
+    logger.debug(
+      `[registerGenericStrategy] Registered ${String(strategyFactoryToken)}.`
+    );
+  }
+
+  logger.debug(
+    `[registerGenericStrategy] Completed for ${String(strategyFactoryToken)}.`
+  );
+}


### PR DESCRIPTION
## Summary
- add `registerGenericStrategy` to consolidate strategy setup
- use helper in AI and turn lifecycle registrations

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c3a4bf88331a3715c2b0b043cdc