### PR TITLE
[Agent] dispatch error event in perception log provider

### DIFF
--- a/src/data/providers/perceptionLogProvider.js
+++ b/src/data/providers/perceptionLogProvider.js
@@ -6,6 +6,7 @@
 import { IPerceptionLogProvider } from '../../interfaces/IPerceptionLogProvider.js';
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DEFAULT_FALLBACK_EVENT_DESCRIPTION_RAW } from '../../constants/textDefaults.js';
+import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -14,8 +15,11 @@ import { DEFAULT_FALLBACK_EVENT_DESCRIPTION_RAW } from '../../constants/textDefa
 export class PerceptionLogProvider extends IPerceptionLogProvider {
   /**
    * @override
+   * @param {Entity} actor
+   * @param {ILogger} logger
+   * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher
    */
-  async get(actor, logger) {
+  async get(actor, logger, dispatcher) {
     logger.debug(
       `PerceptionLogProvider: Retrieving perception log for actor ${actor.id}`
     );
@@ -39,10 +43,10 @@ export class PerceptionLogProvider extends IPerceptionLogProvider {
         }
       }
     } catch (perceptionError) {
-      logger.error(
-        `PerceptionLogProvider: Error retrieving perception log for ${actor.id}: ${perceptionError.message}`,
-        { error: perceptionError }
-      );
+      dispatcher?.dispatch(DISPLAY_ERROR_ID, {
+        message: `PerceptionLogProvider: Error retrieving perception log for ${actor.id}: ${perceptionError.message}`,
+        details: { error: perceptionError },
+      });
     }
     return perceptionLogDto;
   }

--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -316,6 +316,7 @@ export function registerAI(container) {
       actorDataExtractor: c.resolve(tokens.IActorDataExtractor),
       locationSummaryProvider: c.resolve(tokens.ILocationSummaryProvider),
       perceptionLogProvider: c.resolve(tokens.IPerceptionLogProvider),
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
     });
   });
   logger.debug(

--- a/src/interfaces/IPerceptionLogProvider.js
+++ b/src/interfaces/IPerceptionLogProvider.js
@@ -17,9 +17,13 @@ export class IPerceptionLogProvider {
    *
    * @param {Entity} actor - The AI-controlled entity.
    * @param {ILogger} logger - An instance of the logger.
+   * @param {import('./ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher -
+   * Safe dispatcher for DISPLAY_ERROR_ID events.
    * @returns {Promise<AIPerceptionLogEntryDTO[]>} A promise that resolves to an array of perception log entries.
    */
-  async get(actor, logger) {
-    throw new Error("Method 'get(actor, logger)' must be implemented.");
+  async get(actor, logger, dispatcher) {
+    throw new Error(
+      "Method 'get(actor, logger, dispatcher)' must be implemented."
+    );
   }
 }

--- a/src/turns/services/AIGameStateProvider.js
+++ b/src/turns/services/AIGameStateProvider.js
@@ -24,6 +24,7 @@ export class AIGameStateProvider extends IAIGameStateProvider {
   #actorDataExtractor;
   #locationSummaryProvider;
   #perceptionLogProvider;
+  #safeEventDispatcher;
 
   /**
    * @param {object} dependencies
@@ -31,18 +32,21 @@ export class AIGameStateProvider extends IAIGameStateProvider {
    * @param {IActorDataExtractor} dependencies.actorDataExtractor
    * @param {ILocationSummaryProvider} dependencies.locationSummaryProvider
    * @param {IPerceptionLogProvider} dependencies.perceptionLogProvider
+   * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dependencies.safeEventDispatcher
    */
   constructor({
     actorStateProvider,
     actorDataExtractor,
     locationSummaryProvider,
     perceptionLogProvider,
+    safeEventDispatcher,
   }) {
     super();
     this.#actorStateProvider = actorStateProvider;
     this.#actorDataExtractor = actorDataExtractor;
     this.#locationSummaryProvider = locationSummaryProvider;
     this.#perceptionLogProvider = perceptionLogProvider;
+    this.#safeEventDispatcher = safeEventDispatcher;
   }
 
   /**
@@ -66,7 +70,11 @@ export class AIGameStateProvider extends IAIGameStateProvider {
     const actorState = this.#actorStateProvider.build(actor, logger);
     const actorPromptData =
       this.#actorDataExtractor.extractPromptData(actorState);
-    const perceptionLog = await this.#perceptionLogProvider.get(actor, logger);
+    const perceptionLog = await this.#perceptionLogProvider.get(
+      actor,
+      logger,
+      this.#safeEventDispatcher
+    );
     const locationSummary = await this.#locationSummaryProvider.build(
       actor,
       logger

--- a/tests/turns/services/AIGameStateProvider.basic.test.js
+++ b/tests/turns/services/AIGameStateProvider.basic.test.js
@@ -7,6 +7,7 @@ describe('AIGameStateProvider', () => {
   let mockActorDataExtractor;
   let mockLocationSummaryProvider;
   let mockPerceptionLogProvider;
+  let mockSafeEventDispatcher;
   let provider;
   let mockActor;
   let mockTurnContext;
@@ -18,6 +19,7 @@ describe('AIGameStateProvider', () => {
     mockActorDataExtractor = { extractPromptData: jest.fn() };
     mockLocationSummaryProvider = { build: jest.fn() };
     mockPerceptionLogProvider = { get: jest.fn() };
+    mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     // Instantiate the provider with mocked dependencies
     provider = new AIGameStateProvider({
@@ -25,6 +27,7 @@ describe('AIGameStateProvider', () => {
       actorDataExtractor: mockActorDataExtractor,
       locationSummaryProvider: mockLocationSummaryProvider,
       perceptionLogProvider: mockPerceptionLogProvider,
+      safeEventDispatcher: mockSafeEventDispatcher,
     });
 
     // Setup common test data
@@ -73,7 +76,8 @@ describe('AIGameStateProvider', () => {
     );
     expect(mockPerceptionLogProvider.get).toHaveBeenCalledWith(
       mockActor,
-      mockLogger
+      mockLogger,
+      mockSafeEventDispatcher
     );
   });
 

--- a/tests/turns/services/AIGameStateProvider.bugFixes.test.js
+++ b/tests/turns/services/AIGameStateProvider.bugFixes.test.js
@@ -109,12 +109,14 @@ describe('AIGameStateProvider', () => {
       entityManager,
       summaryProvider: entitySummaryProvider,
     });
+    const safeEventDispatcher = { dispatch: jest.fn() };
 
     provider = new AIGameStateProvider({
       actorStateProvider,
       actorDataExtractor,
       locationSummaryProvider,
       perceptionLogProvider,
+      safeEventDispatcher,
     });
 
     const minimalLocationEntity = new MockEntity('loc1', {


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in PerceptionLogProvider
- pass dispatcher through AIGameStateProvider and DI
- update provider integration tests for new dispatcher argument

## Testing Done
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' imported from eslint.config.mjs)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e6f5320f88331815118cd866c2ac1