### PR TITLE
[Agent] dispatch error event from HttpConfigurationProvider

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -174,7 +174,11 @@ export function registerAI(container) {
   );
   r.singletonFactory(
     tokens.IConfigurationProvider,
-    (c) => new HttpConfigurationProvider({ logger: c.resolve(tokens.ILogger) })
+    (c) =>
+      new HttpConfigurationProvider({
+        logger: c.resolve(tokens.ILogger),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+      })
   );
 
   r.singletonFactory(tokens.LLMConfigService, (c) => {


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in HttpConfigurationProvider
- fire DISPLAY_ERROR_ID for HTTP configuration errors
- inject dispatcher for HttpConfigurationProvider in ai registrations
- update tests for error event dispatching

## Testing Done
- `npm run format`
- `npx eslint src/configuration/httpConfigurationProvider.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e6f5320f88331815118cd866c2ac1