### PR TITLE
[Agent] dispatch error via event

### DIFF
--- a/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
+++ b/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../interfaces/IWorldContext.js').IWorldContext} IWorldContext */
 /** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
@@ -36,7 +37,10 @@ export function registerWorldAndEntity(container) {
     (c) =>
       new WorldContext(
         /** @type {IEntityManager} */ (c.resolve(tokens.IEntityManager)),
-        /** @type {ILogger} */ (c.resolve(tokens.ILogger))
+        /** @type {ILogger} */ (c.resolve(tokens.ILogger)),
+        /** @type {ISafeEventDispatcher} */ (
+          c.resolve(tokens.ISafeEventDispatcher)
+        )
       )
   );
   logger.debug(

--- a/tests/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
@@ -40,6 +40,9 @@ describe('registerWorldAndEntity', () => {
     // Pre-register required tokens
     container.register(tokens.ILogger, () => mockLogger);
     container.register(tokens.IEntityManager, () => mockEntityManager);
+    container.register(tokens.ISafeEventDispatcher, () => ({
+      dispatch: jest.fn().mockResolvedValue(true),
+    }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Summary: 
- replace `logger.error` usage in `WorldContext` with `core:display_error` event dispatching
- inject `ISafeEventDispatcher` into `WorldContext` via DI
- update DI registration and related tests
- adjust unit tests for new event dispatch behavior

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 543 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e77274eec833194a2ce0f18ea1c16