### PR TITLE
[Agent] add constructor tests for persistence services

### DIFF
--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -1,0 +1,39 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
+
+/**
+ *
+ */
+function makeDeps() {
+  return {
+    logger: { debug: jest.fn(), error: jest.fn() },
+    saveLoadService: {},
+    entityManager: {},
+    dataRegistry: {},
+    playtimeTracker: {},
+    container: {},
+  };
+}
+
+describe('GamePersistenceService constructor validation', () => {
+  const required = [
+    'logger',
+    'saveLoadService',
+    'entityManager',
+    'dataRegistry',
+    'playtimeTracker',
+    'container',
+  ];
+
+  test.each(required)('throws if %s is missing', (prop) => {
+    const deps = makeDeps();
+    delete deps[prop];
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    expect(() => new GamePersistenceService(deps)).toThrow();
+    const calledSpy = prop === 'logger' ? consoleSpy : deps.logger.error;
+    expect(calledSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/services/saveLoadService.constructor.test.js
+++ b/tests/services/saveLoadService.constructor.test.js
@@ -1,0 +1,32 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import SaveLoadService from '../../src/persistence/saveLoadService.js';
+
+/**
+ *
+ */
+function makeDeps() {
+  return {
+    logger: { debug: jest.fn(), error: jest.fn() },
+    storageProvider: {
+      writeFileAtomically: jest.fn(),
+      listFiles: jest.fn(),
+      readFile: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+    },
+  };
+}
+
+describe('SaveLoadService constructor validation', () => {
+  test('throws if logger missing', () => {
+    const deps = makeDeps();
+    expect(
+      () => new SaveLoadService({ storageProvider: deps.storageProvider })
+    ).toThrow();
+  });
+
+  test('throws if storageProvider missing', () => {
+    const deps = makeDeps();
+    expect(() => new SaveLoadService({ logger: deps.logger })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering constructor error paths for `GamePersistenceService`
- add tests covering constructor error paths for `SaveLoadService`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e783937f88331b5da19e4366f6d6a