### PR TITLE
[Agent] dispatch error via safe dispatcher

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -125,7 +125,7 @@ export function registerUI(
       new InputStateController({
         logger: c.resolve(tokens.ILogger),
         documentContext: c.resolve(tokens.IDocumentContext),
-        validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         inputElement: c.resolve(tokens.inputElement),
       })
   );

--- a/src/domUI/inputStateController.js
+++ b/src/domUI/inputStateController.js
@@ -1,10 +1,11 @@
 // src/domUI/inputStateController.js
 import { RendererBase } from './rendererBase.js';
+import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
  * @typedef {import('../interfaces/IDocumentContext.js').IDocumentContext} IDocumentContext
- * @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */
 
 /**
@@ -32,29 +33,34 @@ export class InputStateController extends RendererBase {
    * @param {object} deps - Dependencies object.
    * @param {ILogger} deps.logger - The logger instance.
    * @param {IDocumentContext} deps.documentContext - The document context (not directly used but part of RendererBase).
-   * @param {IValidatedEventDispatcher} deps.validatedEventDispatcher - The event dispatcher.
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher - The event dispatcher.
    * @param {HTMLElement | null} deps.inputElement - The specific input element to manage. Must be an HTMLInputElement.
    * @throws {Error} If dependencies are invalid or inputElement is not a valid HTMLInputElement.
    */
-  constructor({
-    logger,
-    documentContext,
-    validatedEventDispatcher,
-    inputElement,
-  }) {
+  constructor({ logger, documentContext, safeEventDispatcher, inputElement }) {
     // Pass base dependencies to RendererBase constructor
-    super({ logger, documentContext, validatedEventDispatcher });
+    super({
+      logger,
+      documentContext,
+      validatedEventDispatcher: safeEventDispatcher,
+    });
 
     // --- Validate specific inputElement dependency ---
     if (!inputElement || inputElement.nodeType !== 1) {
       const errMsg = `${this._logPrefix} 'inputElement' dependency is missing or not a valid DOM element.`;
-      this.logger.error(errMsg);
+      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: errMsg,
+        details: { inputElement },
+      });
       throw new Error(errMsg);
     }
     // Check specifically if it's an INPUT element
     if (inputElement.tagName !== 'INPUT') {
       const errMsg = `${this._logPrefix} 'inputElement' must be an HTMLInputElement (<input>), but received '${inputElement.tagName}'.`;
-      this.logger.error(errMsg, { element: inputElement });
+      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: errMsg,
+        details: { element: inputElement },
+      });
       throw new Error(errMsg);
     }
 
@@ -179,9 +185,11 @@ export class InputStateController extends RendererBase {
    */
   setEnabled(enabled, placeholderText = '') {
     if (!this.#inputElement) {
-      this.logger.error(
-        `${this._logPrefix} Cannot set input state, internal #inputElement reference is missing.`
-      );
+      const errMsg = `${this._logPrefix} Cannot set input state, internal #inputElement reference is missing.`;
+      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: errMsg,
+        details: { element: this.#inputElement },
+      });
       return;
     }
 


### PR DESCRIPTION
Summary:
- inject SafeEventDispatcher into InputStateController
- dispatch DISPLAY_ERROR_ID instead of logger.error
- update DI registration and unit tests

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 543 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e7caf2c1083319e27531a949d2303