### PR TITLE
[Agent] add SaveLoadService tests

### DIFF
--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import SaveLoadService from '../../src/persistence/saveLoadService.js';
+import { encode } from '@msgpack/msgpack';
+import pako from 'pako';
+import { webcrypto } from 'crypto';
+
+beforeAll(() => {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+  Object.defineProperty(global, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+});
+
+/**
+ *
+ */
+function makeDeps() {
+  return {
+    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    storageProvider: {
+      listFiles: jest.fn(),
+      readFile: jest.fn(),
+      writeFileAtomically: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      ensureDirectoryExists: jest.fn(),
+    },
+  };
+}
+
+describe('SaveLoadService additional coverage', () => {
+  let logger;
+  let storageProvider;
+  let service;
+
+  beforeEach(() => {
+    ({ logger, storageProvider } = makeDeps());
+    service = new SaveLoadService({ logger, storageProvider });
+  });
+
+  it('returns empty list when directory missing', async () => {
+    storageProvider.listFiles.mockRejectedValue(new Error('not found'));
+    const slots = await service.listManualSaveSlots();
+    expect(slots).toEqual([]);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('parses valid save metadata', async () => {
+    const obj = {
+      metadata: { saveName: 'Slot1', timestamp: 't', playtimeSeconds: 1 },
+      modManifest: {},
+      gameState: {},
+      integrityChecks: {},
+    };
+    const compressed = pako.gzip(encode(obj));
+    storageProvider.listFiles.mockResolvedValue(['manual_save_Slot1.sav']);
+    storageProvider.readFile.mockResolvedValue(compressed);
+
+    const slots = await service.listManualSaveSlots();
+    expect(slots).toEqual([
+      {
+        identifier: 'saves/manual_saves/manual_save_Slot1.sav',
+        saveName: 'Slot1',
+        timestamp: 't',
+        playtimeSeconds: 1,
+      },
+    ]);
+  });
+
+  it('loadGameData validates identifier', async () => {
+    const res = await service.loadGameData('');
+    expect(res.success).toBe(false);
+    expect(res.data).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('loadGameData returns data on success', async () => {
+    const obj = {
+      metadata: { saveName: 'Slot1', timestamp: 't', playtimeSeconds: 1 },
+      modManifest: {},
+      gameState: {},
+      integrityChecks: {},
+    };
+    const checksumBuffer = await webcrypto.subtle.digest(
+      'SHA-256',
+      encode(obj.gameState)
+    );
+    obj.integrityChecks.gameStateChecksum = Array.from(
+      new Uint8Array(checksumBuffer)
+    )
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    const compressed = pako.gzip(encode(obj));
+    storageProvider.readFile.mockResolvedValue(compressed);
+    const res = await service.loadGameData(
+      'saves/manual_saves/manual_save_Slot1.sav'
+    );
+    expect(res).toEqual({ success: true, data: obj, error: null });
+  });
+
+  it('saveManualGame validates name', async () => {
+    const res = await service.saveManualGame('', {});
+    expect(res.success).toBe(false);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('saveManualGame writes file when successful', async () => {
+    storageProvider.ensureDirectoryExists.mockResolvedValue();
+    storageProvider.writeFileAtomically.mockResolvedValue({ success: true });
+    const obj = {
+      metadata: {},
+      modManifest: {},
+      gameState: {},
+      integrityChecks: {},
+    };
+    const res = await service.saveManualGame('Test', obj);
+    expect(storageProvider.writeFileAtomically).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  it('deleteManualSave handles missing file', async () => {
+    storageProvider.fileExists.mockResolvedValue(false);
+    const res = await service.deleteManualSave('saves/manual_saves/x.sav');
+    expect(res.success).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('deleteManualSave removes file when present', async () => {
+    storageProvider.fileExists.mockResolvedValue(true);
+    storageProvider.deleteFile.mockResolvedValue({ success: true });
+    const res = await service.deleteManualSave('saves/manual_saves/x.sav');
+    expect(storageProvider.deleteFile).toHaveBeenCalledWith(
+      'saves/manual_saves/x.sav'
+    );
+    expect(res.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary: Added comprehensive tests for SaveLoadService covering listing, loading, saving, and deletion scenarios, ensuring Web Crypto availability during tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684e7ce0e924833190eee5652d12b78b