### PR TITLE
[Agent] Additional game persistence tests

### DIFF
--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -71,11 +71,29 @@ describe('GamePersistenceService additional coverage', () => {
       ]);
     });
 
+    it('captures core mod version when present', () => {
+      dataRegistry.getAll.mockReturnValue([{ id: 'core', version: '1.2.3' }]);
+      const result = service.captureCurrentGameState('World');
+      expect(result.modManifest.activeMods).toEqual([
+        { modId: 'core', version: '1.2.3' },
+      ]);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it('warns and defaults title when world name missing', () => {
       dataRegistry.getAll.mockReturnValue([]);
       const result = service.captureCurrentGameState();
       expect(logger.warn).toHaveBeenCalled();
       expect(result.metadata.gameTitle).toBe('Unknown Game');
+    });
+
+    it('falls back to unknown version when manifest undefined', () => {
+      dataRegistry.getAll.mockReturnValue(undefined);
+      const result = service.captureCurrentGameState('World');
+      expect(result.modManifest.activeMods).toEqual([
+        { modId: 'core', version: 'unknown_fallback' },
+      ]);
+      expect(logger.warn).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- extend gamePersistenceService tests with core version and undefined manifest cases

## Testing Done
- `npm run format`
- `npm run lint` *(fails: cannot find module 'globals')*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684e86f888008331b3c145654e83e229