### PR TITLE
[Agent] Replace logger.error with error events

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -238,7 +238,7 @@ export function registerUI(
       new ProcessingIndicatorController({
         logger: c.resolve(tokens.ILogger),
         documentContext: c.resolve(tokens.IDocumentContext),
-        validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
       })
   );

--- a/tests/domUI/processingIndicatorController.test.js
+++ b/tests/domUI/processingIndicatorController.test.js
@@ -61,7 +61,7 @@ describe('ProcessingIndicatorController', () => {
     controller = new ProcessingIndicatorController({
       logger,
       documentContext: docContext,
-      validatedEventDispatcher: ved,
+      safeEventDispatcher: ved,
       domElementFactory,
     });
   });

--- a/tests/utils/loggerInitUsage.test.js
+++ b/tests/utils/loggerInitUsage.test.js
@@ -12,6 +12,7 @@ const mockLogger = {
  * @param modulePath
  * @param ctorArgs
  * @param expectedName
+ * @param expectOptional
  */
 function setup(modulePath, ctorArgs, expectedName, expectOptional = false) {
   jest.resetModules();


### PR DESCRIPTION
## Summary
- use ISafeEventDispatcher in ProcessingIndicatorController
- emit DISPLAY_ERROR_ID instead of calling `logger.error`
- update DI setup to inject SafeEventDispatcher
- adjust related tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 541 errors, 1759 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e88a694308331b113314040369c2c