### PR TITLE
[Agent] ensure primitive components are persisted

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -177,7 +177,9 @@ class GamePersistenceService extends IGamePersistenceService {
         // Only add the component to the save file if it still has data.
         // For example, if a notes component only had an empty `notes` array
         // and that key was deleted, the component object might now be empty.
-        if (Object.keys(dataToSave).length > 0) {
+        if (dataToSave !== null && typeof dataToSave !== 'object') {
+          components[componentTypeId] = dataToSave;
+        } else if (Object.keys(dataToSave).length > 0) {
           components[componentTypeId] = dataToSave;
         } else {
           this.#logger.debug(

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -95,6 +95,16 @@ describe('GamePersistenceService additional coverage', () => {
       ]);
       expect(logger.warn).toHaveBeenCalled();
     });
+
+    it('preserves primitive component data', () => {
+      const entity = makeEntity('e2', 'core:item', { count: 7 });
+      entityManager.activeEntities.set('e2', entity);
+      dataRegistry.getAll.mockReturnValue([]);
+
+      const result = service.captureCurrentGameState('World');
+      const components = result.gameState.entities[0].components;
+      expect(components.count).toBe(7);
+    });
   });
 
   describe('saveGame', () => {


### PR DESCRIPTION
## Summary
- store primitive component data when capturing game state
- add test to confirm primitives are saved unchanged

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684e8ed7a8d4833185a69cca0c0cab4f