### PR TITLE
[Test] Cover saveManualGame write failure

### DIFF
--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -275,6 +275,23 @@ describe('SaveLoadService edge cases', () => {
       expect(res.error).toMatch(/Not enough disk space/);
       expect(logger.error).toHaveBeenCalled();
     });
+
+    it('handles write failure rejection', async () => {
+      storageProvider.ensureDirectoryExists.mockResolvedValue();
+      storageProvider.writeFileAtomically.mockRejectedValue(
+        new Error('fs fail')
+      );
+      const obj = {
+        metadata: {},
+        modManifest: {},
+        gameState: {},
+        integrityChecks: {},
+      };
+      const res = await service.saveManualGame('Reject', obj);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/unexpected error/i);
+      expect(logger.error).toHaveBeenCalled();
+    });
   });
 
   describe('deleteManualSave branches', () => {


### PR DESCRIPTION
Summary: Adds regression test for SaveLoadService to ensure saveManualGame handles writeFileAtomically rejections gracefully.

Changes Made:
- Mocked writeFileAtomically to reject with an error in edge case suite
- Verified failure result and logger invocation

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [x] Lint passes (`npm run lint` in root)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_684e8ed33eec833197a38197026dd2ba