### PR TITLE
[Agent] Add SaveLoadService test for missing directory helper

### DIFF
--- a/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, jest } from '@jest/globals';
+import SaveLoadService from '../../src/persistence/saveLoadService.js';
+import { webcrypto } from 'crypto';
+
+beforeAll(() => {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+  Object.defineProperty(global, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+});
+
+/**
+ *
+ */
+function makeDeps() {
+  return {
+    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    storageProvider: {
+      listFiles: jest.fn(),
+      readFile: jest.fn(),
+      writeFileAtomically: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      // intentionally no ensureDirectoryExists
+    },
+  };
+}
+
+describe('SaveLoadService without ensureDirectoryExists', () => {
+  it('saves successfully when directory helper is absent', async () => {
+    const { logger, storageProvider } = makeDeps();
+    const service = new SaveLoadService({ logger, storageProvider });
+
+    storageProvider.writeFileAtomically.mockResolvedValue({ success: true });
+
+    const obj = {
+      metadata: {},
+      modManifest: {},
+      gameState: {},
+      integrityChecks: {},
+    };
+
+    const res = await service.saveManualGame('Slot', obj);
+
+    expect(res.success).toBe(true);
+    expect(storageProvider.writeFileAtomically).toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Added a new Jest test verifying that SaveLoadService saves correctly when the storageProvider lacks `ensureDirectoryExists`.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` (fails due to existing repo issues)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684e8ece1c988331892d22562f6ce99a