### PR TITLE
[Agent] use dispatcher for location errors

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -159,6 +159,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
           const exits = getAvailableExits(
             currentLocation,
             this.#entityManager,
+            this.#safeEventDispatcher,
             this.#logger
           );
           this.#logger.debug(

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -57,11 +57,7 @@ function _getExitsComponentData(
           !!entityManager &&
           typeof entityManager.getEntityInstance === 'function',
       };
-      if (dispatcher) {
-        safeDispatchError(dispatcher, message, details);
-      } else {
-        log.error(message, details);
-      }
+      safeDispatchError(dispatcher, message, details);
 
       return null;
     }

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -246,6 +246,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
     expect(mockGetAvailableExits).toHaveBeenCalledWith(
       mockAdventurersGuildLocation,
       mockEntityManager,
+      mockSafeEventDispatcher,
       expect.objectContaining({
         debug: expect.any(Function),
         info: expect.any(Function),


### PR DESCRIPTION
## Summary
- dispatch DISPLAY_ERROR_ID events from locationUtils instead of logger.error
- ensure ActionDiscoveryService passes SafeEventDispatcher to getAvailableExits
- fix test for updated getAvailableExits call

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e90aa55f0833197a73386c5a919f5