### PR TITLE
[Agent] Allow hyphenated command verbs

### DIFF
--- a/data/schemas/action-definition.schema.json
+++ b/data/schemas/action-definition.schema.json
@@ -12,9 +12,9 @@
     },
     "commandVerb": {
       "type": "string",
-      "description": "Required. The single, canonical, lowercase command verb associated with this action (e.g., 'go', 'take', 'look', 'use'). Used for UI generation and potentially mapping. Should not contain spaces.",
+      "description": "Required. The single, canonical command verb associated with this action (e.g., 'go', 'take', 'look', 'use'). Used for UI generation and potentially mapping. Hyphenated and camelCase verbs are allowed, but spaces are not.",
       "minLength": 1,
-      "pattern": "^[a-z]+$",
+      "pattern": "^[A-Za-z-]+$",
       "examples": ["go", "take", "look", "inventory", "wait", "attack"]
     },
     "name": {

--- a/src/commands/commandParser.js
+++ b/src/commands/commandParser.js
@@ -94,7 +94,10 @@ class CommandParser extends ICommandParser {
     if (inputVerb !== null) {
       for (const actionDefinition of allActionDefinitions) {
         // Compare input verb with the canonical commandVerb from the definition
-        if (actionDefinition.commandVerb === inputVerb) {
+        if (
+          typeof actionDefinition.commandVerb === 'string' &&
+          actionDefinition.commandVerb.toLowerCase() === inputVerb
+        ) {
           matchedActionId = actionDefinition.id;
           matchedVerbLength = inputVerb.length; // Store length of the matched verb
           break; // Found the unique match based on commandVerb

--- a/tests/commands/commandParser.parse.verbMatching.test.js
+++ b/tests/commands/commandParser.parse.verbMatching.test.js
@@ -128,6 +128,64 @@ describe('CommandParser.parse() - Verb Matching & Case Sensitivity Tests', () =>
     // AC3 confirmed by successful match despite case difference
   });
 
+  // New Test Case: CPARSE-P-012A
+  it('[CPARSE-P-012A] should parse hyphenated command verb "get-close" correctly', () => {
+    const hyphenAction = {
+      id: 'core:get-close',
+      commandVerb: 'get-close',
+      name: 'Get Close',
+    };
+    mockGetAllActionDefinitions.mockReturnValueOnce([
+      ...MOCK_ACTIONS,
+      hyphenAction,
+    ]);
+
+    const input = 'get-close enemy';
+    /** @type {ParsedCommand} */
+    const expectedOutput = {
+      actionId: 'core:get-close',
+      directObjectPhrase: 'enemy',
+      preposition: null,
+      indirectObjectPhrase: null,
+      originalInput: input,
+      error: null,
+    };
+
+    const result = commandParser.parse(input);
+
+    expect(result).toEqual(expectedOutput);
+    expect(mockGetAllActionDefinitions).toHaveBeenCalledTimes(1);
+  });
+
+  // New Test Case: CPARSE-P-012B
+  it('[CPARSE-P-012B] should parse camelCase command verb "getClose" case-insensitively', () => {
+    const camelAction = {
+      id: 'core:getClose',
+      commandVerb: 'getClose',
+      name: 'GetClose',
+    };
+    mockGetAllActionDefinitions.mockReturnValueOnce([
+      ...MOCK_ACTIONS,
+      camelAction,
+    ]);
+
+    const input = 'GETCLOSE';
+    /** @type {ParsedCommand} */
+    const expectedOutput = {
+      actionId: 'core:getClose',
+      directObjectPhrase: null,
+      preposition: null,
+      indirectObjectPhrase: null,
+      originalInput: input,
+      error: null,
+    };
+
+    const result = commandParser.parse(input);
+
+    expect(result).toEqual(expectedOutput);
+    expect(mockGetAllActionDefinitions).toHaveBeenCalledTimes(1);
+  });
+
   // Test Case: CPARSE-P-013
   it('[CPARSE-P-013] should return null actionId and error for unknown verb "fly" (AC1, AC2, AC4)', () => {
     const input = 'fly';


### PR DESCRIPTION
## Summary
- relax pattern in action definition schema to permit hyphenated and camelCase verbs
- match command verbs case-insensitively in `CommandParser`
- test parsing of hyphenated and camelCase verbs

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2304 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e9125a2e883319ddeb401b73b55cf