### PR TITLE
[Agent] refactor schema registration

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -9,6 +9,7 @@
 // Adjust path relative to this file's location if needed
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js'; // Assuming it's in loaders sibling dir
 import { extractBaseId } from '../utils/idUtils.js';
+import { registerSchema } from '../utils/schemaUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -143,29 +144,26 @@ class EventLoader extends BaseManifestItemLoader {
         `EventLoader [${modId}]: Generated payload schema ID: ${payloadSchemaId}`
       );
 
-      if (!this._schemaValidator.isSchemaLoaded(payloadSchemaId)) {
-        this._logger.debug(
-          `EventLoader [${modId}]: Payload schema '${payloadSchemaId}' not loaded. Attempting registration...`
-        );
-        try {
-          await this._schemaValidator.addSchema(payloadSchema, payloadSchemaId);
-          this._logger.debug(
-            `EventLoader [${modId}]: Successfully registered payload schema '${payloadSchemaId}'.`
-          );
-        } catch (addSchemaError) {
-          const errorMsg = `EventLoader [${modId}]: CRITICAL - Failed to register payload schema '${payloadSchemaId}' for event '${trimmedFullEventId}'.`;
-          this._logger.error(
-            errorMsg,
-            { error: addSchemaError?.message || addSchemaError },
-            addSchemaError
-          );
-          throw new Error(
-            `CRITICAL: Failed to register payload schema '${payloadSchemaId}'.`
-          );
-        }
-      } else {
-        this._logger.warn(
+      try {
+        await registerSchema(
+          this._schemaValidator,
+          payloadSchema,
+          payloadSchemaId,
+          this._logger,
           `EventLoader [${modId}]: Payload schema ID '${payloadSchemaId}' for event '${trimmedFullEventId}' was already loaded. Overwriting/duplicate.`
+        );
+        this._logger.debug(
+          `EventLoader [${modId}]: Successfully registered payload schema '${payloadSchemaId}'.`
+        );
+      } catch (addSchemaError) {
+        const errorMsg = `EventLoader [${modId}]: CRITICAL - Failed to register payload schema '${payloadSchemaId}' for event '${trimmedFullEventId}'.`;
+        this._logger.error(
+          errorMsg,
+          { error: addSchemaError?.message || addSchemaError },
+          addSchemaError
+        );
+        throw new Error(
+          `CRITICAL: Failed to register payload schema '${payloadSchemaId}'.`
         );
       }
     } else {

--- a/tests/loaders/eventLoader.test.js
+++ b/tests/loaders/eventLoader.test.js
@@ -744,7 +744,11 @@ describe('EventLoader', () => {
           `Payload schema ID '${payloadSchemaId}' for event '${fullEventIdFromFile}' was already loaded.`
         )
       );
-      expect(mockValidator.addSchema).not.toHaveBeenCalled();
+      expect(mockValidator.removeSchema).toHaveBeenCalledWith(payloadSchemaId);
+      expect(mockValidator.addSchema).toHaveBeenCalledWith(
+        fetchedData.payloadSchema,
+        payloadSchemaId
+      );
       expect(storeItemInRegistrySpy).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).not.toHaveBeenCalled();
     });

--- a/tests/services/componentDefinitionLoader.schemaRegistrationFailure.test.js
+++ b/tests/services/componentDefinitionLoader.schemaRegistrationFailure.test.js
@@ -331,7 +331,7 @@ describe('ComponentLoader (Sub-Ticket 6.8: Data Schema Registration Failure)', (
     // --- Verify: Error Logs ---
     expect(mockLogger.error).toHaveBeenCalledTimes(2); // Specific + Wrapper
     // 1. Inner Log (_processFetchedItem addSchema catch block)
-    const expectedInnerLogMessageAdd = `ComponentLoader [${modId}]: Error during addSchema for component '${componentIdFromFile}' from file '${filename}'.`;
+    const expectedInnerLogMessageAdd = `ComponentLoader [${modId}]: Error registering data schema for component '${componentIdFromFile}' from file '${filename}'.`;
     expect(mockLogger.error).toHaveBeenNthCalledWith(
       1,
       expectedInnerLogMessageAdd,
@@ -443,7 +443,7 @@ describe('ComponentLoader (Sub-Ticket 6.8: Data Schema Registration Failure)', (
     // --- Verify: Error Logs ---
     expect(mockLogger.error).toHaveBeenCalledTimes(2); // Specific + Wrapper
     // 1. Inner Log (_processFetchedItem removeSchema catch block - NOW re-throws)
-    const expectedInnerLogMessageRemove = `ComponentLoader [${modId}]: Error during removeSchema for component '${componentIdFromFile}' from file '${filename}'.`;
+    const expectedInnerLogMessageRemove = `ComponentLoader [${modId}]: Error registering data schema for component '${componentIdFromFile}' from file '${filename}'.`;
     expect(mockLogger.error).toHaveBeenNthCalledWith(
       1,
       expectedInnerLogMessageRemove,


### PR DESCRIPTION
Summary: replace manual schema management in component and event loaders with registerSchema utility. Updated warning logs, wrapped in try/catch, and revised tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on modified files `npx eslint src/loaders/componentLoader.js src/loaders/eventLoader.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684e954af60c833185ffc29ea9d2f93f