### PR TITLE
[Agent] add parseAndValidateId helper

### DIFF
--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -17,7 +17,7 @@
 
 // --- Base Class Import ---
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js'; // Correct path assumed based on sibling loaders
-import { extractBaseId } from '../utils/idUtils.js';
+import { parseAndValidateId } from '../utils/idUtils.js';
 
 /**
  * Loads action definitions from mods.
@@ -92,34 +92,8 @@ class ActionLoader extends BaseManifestItemLoader {
     // No need to call this._validatePrimarySchema(data, filename, modId, resolvedPath); here
 
     // --- Step 2: ID Extraction & Validation ---
-    const idFromFile = data.id;
-
-    if (typeof idFromFile !== 'string' || idFromFile.trim() === '') {
-      this._logger.error(
-        `ActionLoader [${modId}]: Invalid or missing 'id' in action definition file '${filename}'. ID must be a non-empty string.`,
-        { modId, filename, resolvedPath, receivedId: idFromFile }
-      );
-      throw new Error(
-        `Invalid or missing 'id' in action definition file '${filename}' for mod '${modId}'.`
-      );
-    }
-
-    const trimmedIdFromFile = idFromFile.trim();
-
-    // --- CORRECTED: Refined Base ID Extraction Logic ---
-    const baseActionId = extractBaseId(trimmedIdFromFile);
-
-    // Check if baseActionId was successfully extracted (is not null)
-    if (!baseActionId) {
-      this._logger.error(
-        `ActionLoader [${modId}]: Could not extract valid base ID from ID '${trimmedIdFromFile}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
-      );
-      // Throw a more specific error message matching the test expectation update
-      throw new Error(
-        `Could not extract base Action ID from '${trimmedIdFromFile}' in ${filename}. Invalid format.`
-      );
-    }
-    // --- END CORRECTION ---
+    const { fullId: trimmedIdFromFile, baseId: baseActionId } =
+      parseAndValidateId(data, 'id', modId, filename, this._logger);
 
     const finalRegistryKey = `${modId}:${baseActionId}`; // This IS the key used in the registry by the helper
 

--- a/src/loaders/componentLoader.js
+++ b/src/loaders/componentLoader.js
@@ -1,7 +1,7 @@
 // src/loaders/componentLoader.js
 
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
-import { extractBaseId } from '../utils/idUtils.js';
+import { parseAndValidateId } from '../utils/idUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
@@ -79,32 +79,10 @@ class ComponentLoader extends BaseManifestItemLoader {
       `ComponentLoader [${modId}]: Processing fetched item: ${filename} (Type: ${typeName})`
     );
 
-    // --- 1. Property Extraction ---
-    const componentIdFromFile = data.id;
+    // --- 1. Property Extraction & Validation ---
+    const { fullId: trimmedComponentIdFromFile, baseId: baseComponentId } =
+      parseAndValidateId(data, 'id', modId, filename, this._logger);
     const dataSchema = data.dataSchema;
-
-    // --- 2. Property Validation ---
-    const trimmedComponentIdFromFile = componentIdFromFile?.toString().trim();
-    if (!trimmedComponentIdFromFile) {
-      const errorMsg = `ComponentLoader [${modId}]: Missing or invalid 'id' field in component definition file '${filename}'. Found: ${JSON.stringify(componentIdFromFile)}`;
-      this._logger.error(errorMsg, {
-        modId,
-        filename,
-        resolvedPath,
-        componentIdValue: componentIdFromFile,
-      });
-      throw new Error(`Invalid Component ID in ${filename}`);
-    }
-
-    const baseComponentId = extractBaseId(trimmedComponentIdFromFile);
-    if (!baseComponentId) {
-      this._logger.error(
-        `ComponentLoader [${modId}]: Could not extract valid base ID from component ID '${trimmedComponentIdFromFile}' in file '${filename}'.`
-      );
-      throw new Error(
-        `Could not extract base Component ID from '${trimmedComponentIdFromFile}' in ${filename}`
-      );
-    }
 
     if (typeof dataSchema !== 'object' || dataSchema === null) {
       const dataType = dataSchema === null ? 'null' : typeof dataSchema;

--- a/src/loaders/entityLoader.js
+++ b/src/loaders/entityLoader.js
@@ -7,7 +7,7 @@
 
 // --- Base Class Import ---
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
-import { extractBaseId } from '../utils/idUtils.js';
+import { parseAndValidateId } from '../utils/idUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -187,38 +187,14 @@ class EntityLoader extends BaseManifestItemLoader {
     // Primary validation happens in BaseManifestItemLoader._processFileWrapper
 
     // --- Step 1: ID Extraction & Validation ---
-    const idFromFile = data?.id;
-    if (typeof idFromFile !== 'string' || idFromFile.trim() === '') {
-      this._logger.error(
-        `EntityLoader [${modId}]: Invalid or missing 'id' in ${typeName} file '${filename}'.`,
-        { modId, filename, resolvedPath, receivedId: idFromFile }
-      );
-      throw new Error(
-        `Invalid or missing 'id' in ${typeName} file '${filename}' for mod '${modId}'.`
-      );
-    }
-    const trimmedId = idFromFile.trim();
-    const extracted = extractBaseId(trimmedId);
-    let baseEntityId;
-    if (extracted) {
-      baseEntityId = extracted;
-    } else {
-      baseEntityId = trimmedId;
-      if (trimmedId.includes(':')) {
-        this._logger.warn(
-          `EntityLoader [${modId}]: ID '${trimmedId}' in ${filename} has an unusual format. Using full ID as base ID.`
-        );
-      }
-    }
-
-    if (!baseEntityId) {
-      this._logger.error(
-        `EntityLoader [${modId}]: Could not derive a non-empty base ID from '${trimmedId}' in file '${filename}'.`
-      );
-      throw new Error(
-        `Could not derive a valid base ID from '${trimmedId}' in ${filename}`
-      );
-    }
+    const { fullId: trimmedId, baseId: baseEntityId } = parseAndValidateId(
+      data,
+      'id',
+      modId,
+      filename,
+      this._logger,
+      { allowFallback: true }
+    );
     this._logger.debug(
       `EntityLoader [${modId}]: Extracted full ID '${trimmedId}' and derived base ID '${baseEntityId}' from ${filename}.`
     );

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -8,7 +8,7 @@
 // --- Base Class Import ---
 // Adjust path relative to this file's location if needed
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js'; // Assuming it's in loaders sibling dir
-import { extractBaseId } from '../utils/idUtils.js';
+import { parseAndValidateId } from '../utils/idUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -93,37 +93,8 @@ class EventLoader extends BaseManifestItemLoader {
     // Primary validation happens in BaseManifestItemLoader._processFileWrapper
 
     // --- Event ID Extraction & Validation ---
-    const fullEventIdFromFile = data.id;
-    if (
-      typeof fullEventIdFromFile !== 'string' ||
-      fullEventIdFromFile.trim() === ''
-    ) {
-      const errorMsg = `EventLoader [${modId}]: Invalid or missing 'id' in event definition file '${filename}'.`;
-      this._logger.error(errorMsg, {
-        modId,
-        filename,
-        resolvedPath,
-        receivedId: fullEventIdFromFile,
-      });
-      throw new Error(
-        `Invalid or missing 'id' in event definition file '${filename}' for mod '${modId}'.`
-      );
-    }
-
-    const trimmedFullEventId = fullEventIdFromFile.trim();
-    const baseEventId = extractBaseId(trimmedFullEventId);
-
-    if (!baseEventId) {
-      const errorMsg = `EventLoader [${modId}]: Could not extract valid base event ID from full ID '${trimmedFullEventId}' in file '${filename}'.`;
-      this._logger.error(errorMsg, {
-        modId,
-        filename,
-        fullEventIdFromFile: trimmedFullEventId,
-      });
-      throw new Error(
-        `Could not extract valid base event ID from '${trimmedFullEventId}' in ${filename}`
-      );
-    }
+    const { fullId: trimmedFullEventId, baseId: baseEventId } =
+      parseAndValidateId(data, 'id', modId, filename, this._logger);
     this._logger.debug(
       `EventLoader [${modId}]: Extracted full event ID '${trimmedFullEventId}' and base event ID '${baseEventId}' from ${filename}.`
     );

--- a/src/utils/idUtils.js
+++ b/src/utils/idUtils.js
@@ -30,3 +30,64 @@ export function extractBaseId(fullId) {
   }
   return null;
 }
+
+/**
+ * Parses and validates an ID property from a data object.
+ * Ensures the ID exists and is a non-empty string, then attempts to
+ * derive the base ID using {@link extractBaseId}.
+ *
+ * If `allowFallback` is `true` and base extraction fails, the trimmed full ID
+ * will be used as the base ID with a warning.
+ *
+ * @param {object} data - The object containing the ID property.
+ * @param {string} idProp - The property name of the ID within the object.
+ * @param {string} modId - ID of the mod that owns the data.
+ * @param {string} filename - Filename for logging context.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger used for messages.
+ * @param {{ allowFallback?: boolean }} options - Options object.
+ * @returns {{ fullId: string, baseId: string }} Parsed IDs.
+ * @throws {Error} If the ID is missing/invalid or base extraction fails without fallback.
+ */
+export function parseAndValidateId(
+  data,
+  idProp,
+  modId,
+  filename,
+  logger,
+  { allowFallback = false } = {}
+) {
+  const rawId = data?.[idProp];
+
+  if (typeof rawId !== 'string' || rawId.trim() === '') {
+    logger.error(`Invalid or missing '${idProp}' in file '${filename}'.`, {
+      modId,
+      filename,
+      receivedId: rawId,
+    });
+    throw new Error(
+      `Invalid or missing '${idProp}' in ${filename} for mod '${modId}'.`
+    );
+  }
+
+  const trimmedId = rawId.trim();
+  const baseId = extractBaseId(trimmedId);
+
+  if (!baseId) {
+    if (allowFallback) {
+      logger.warn(
+        `Could not extract base ID from '${trimmedId}' in file '${filename}'. Falling back to full ID.`,
+        { modId, filename, receivedId: trimmedId }
+      );
+      return { fullId: trimmedId, baseId: trimmedId };
+    }
+    logger.error(
+      `Could not extract base ID from '${trimmedId}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`,
+      { modId, filename, receivedId: trimmedId }
+    );
+    throw new Error(
+      `Could not extract base ID from '${trimmedId}' in ${filename}. Invalid format.`
+    );
+  }
+
+  return { fullId: trimmedId, baseId };
+}

--- a/tests/loaders/entityLoader.test.js
+++ b/tests/loaders/entityLoader.test.js
@@ -656,10 +656,10 @@ describe('EntityLoader', () => {
           entityType
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in ${entityType} file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
-        `EntityLoader [${TEST_MOD_ID}]: Invalid or missing 'id' in ${entityType} file '${filename}'.`,
+        `Invalid or missing 'id' in file '${filename}'.`,
         expect.objectContaining({ receivedId: undefined })
       );
       expect(entityLoader._storeItemInRegistry).not.toHaveBeenCalled();
@@ -680,11 +680,11 @@ describe('EntityLoader', () => {
           entityType
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in ${entityType} file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in ${entityType} file '${filename}'.`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({ receivedId: 123 })
       );
@@ -702,11 +702,11 @@ describe('EntityLoader', () => {
           entityType
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in ${entityType} file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in ${entityType} file '${filename}'.`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({ receivedId: '   ' })
       );
@@ -733,8 +733,9 @@ describe('EntityLoader', () => {
       // Check logs and storage call
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining(
-          `ID 'core:' in ${filename} has an unusual format. Using full ID as base ID.`
-        )
+          `Could not extract base ID from 'core:' in file '${filename}'. Falling back to full ID.`
+        ),
+        expect.objectContaining({ modId: TEST_MOD_ID })
       );
       expect(mockLogger.error).not.toHaveBeenCalledWith(
         expect.stringContaining('Could not derive base ID')
@@ -890,7 +891,7 @@ describe('EntityLoader', () => {
 
       // Check logs and storage
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining(`unusual format`)
+        expect.stringContaining('Falling back to full ID')
       ); // No warning for this case
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -927,7 +928,7 @@ describe('EntityLoader', () => {
 
       // Check logs and storage
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining(`unusual format`)
+        expect.stringContaining('Falling back to full ID')
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(

--- a/tests/loaders/eventLoader.test.js
+++ b/tests/loaders/eventLoader.test.js
@@ -583,16 +583,15 @@ describe('EventLoader', () => {
           EVENT_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in event definition file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in event definition file '${filename}'.`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({
           modId: TEST_MOD_ID,
           filename,
-          resolvedPath,
           receivedId: undefined,
         })
       );
@@ -611,16 +610,15 @@ describe('EventLoader', () => {
           EVENT_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in event definition file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in event definition file '${filename}'`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({
           modId: TEST_MOD_ID,
           filename,
-          resolvedPath,
           receivedId: undefined,
         })
       );
@@ -639,11 +637,11 @@ describe('EventLoader', () => {
           EVENT_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in event definition file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in event definition file '${filename}'`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({ receivedId: 123 })
       );
@@ -662,16 +660,16 @@ describe('EventLoader', () => {
           EVENT_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Could not extract valid base event ID from ':' in ${filename}`
+        `Could not extract base ID from ':' in ${filename}. Invalid format.`
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Could not extract valid base event ID from full ID ':' in file '${filename}'`
+          `Could not extract base ID from ':' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
         ),
         expect.objectContaining({
           modId: TEST_MOD_ID,
           filename,
-          fullEventIdFromFile: ':',
+          receivedId: ':',
         })
       );
       expect(mockValidator.addSchema).not.toHaveBeenCalled();

--- a/tests/services/actionLoader.test.js
+++ b/tests/services/actionLoader.test.js
@@ -631,7 +631,7 @@ describe('ActionLoader', () => {
           ACTION_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Invalid or missing 'id' in action definition file '${filename}' for mod '${TEST_MOD_ID}'.`
+        `Invalid or missing 'id' in ${filename} for mod '${TEST_MOD_ID}'.`
       );
 
       // --- REMOVED: Asserting the schema spy was called ---
@@ -642,7 +642,7 @@ describe('ActionLoader', () => {
       expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Invalid or missing 'id' in action definition file '${filename}'`
+          `Invalid or missing 'id' in file '${filename}'`
         ),
         expect.objectContaining({ receivedId: undefined })
       );
@@ -711,7 +711,7 @@ describe('ActionLoader', () => {
           ACTION_TYPE_NAME
         )
       ).rejects.toThrow(
-        `Could not extract base Action ID from '${invalidId}' in ${filename}. Invalid format.`
+        `Could not extract base ID from '${invalidId}' in ${filename}. Invalid format.`
       );
 
       // --- REMOVED: Asserting the schema spy was called ---
@@ -721,8 +721,14 @@ describe('ActionLoader', () => {
       expect(mockLogger.error).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Could not extract valid base ID from ID '${invalidId}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
+          `Could not extract base ID from '${invalidId}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
         )
+        ,
+        expect.objectContaining({
+          filename,
+          modId: TEST_MOD_ID,
+          receivedId: invalidId,
+        })
       );
 
       // Assert not stored

--- a/tests/services/componentDefinitionLoader.internalError.test.js
+++ b/tests/services/componentDefinitionLoader.internalError.test.js
@@ -382,12 +382,11 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
 
     // --- File 1: invalid_null_id.component.json ---
     // 1a. Specific internal error log (_processFetchedItem check for ID)
-    const expectedSpecificErrorMsg1 = `ComponentLoader [${modId}]: Missing or invalid 'id' field in component definition file '${filenameNullId}'. Found: ${JSON.stringify(invalidDataNullId.id)}`;
+    const expectedSpecificErrorMsg1 = `Invalid or missing 'id' in file '${filenameNullId}'.`;
     const expectedSpecificErrorDetails1 = expect.objectContaining({
-      resolvedPath: filePathNullId,
-      componentIdValue: invalidDataNullId.id,
       modId: modId,
       filename: filenameNullId,
+      receivedId: invalidDataNullId.id,
     });
     expect(mockLogger.error).toHaveBeenCalledWith(
       expectedSpecificErrorMsg1,
@@ -397,14 +396,14 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
     // 1b. Wrapper error log (_processFileWrapper catch)
     const expectedWrapperMsgBase = `Error processing file:`; // Base class logs this prefix
     const idError1 = expect.objectContaining({
-      message: `Invalid Component ID in ${filenameNullId}`,
+      message: `Invalid or missing 'id' in ${filenameNullId} for mod '${modId}'.`,
     });
     const expectedWrapperDetails1 = expect.objectContaining({
       filename: filenameNullId,
       path: filePathNullId,
       modId: modId,
       typeName: 'components', // Check typeName is included
-      error: `Invalid Component ID in ${filenameNullId}`, // The specific error thrown
+      error: `Invalid or missing 'id' in ${filenameNullId} for mod '${modId}'.`, // The specific error thrown
     });
     // Check if either base or specific loader logs the wrapper error
     expect(mockLogger.error).toHaveBeenCalledWith(
@@ -415,12 +414,11 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
 
     // --- File 2: invalid_empty_id.component.json ---
     // 2a. Specific internal error log (_processFetchedItem check for ID)
-    const expectedSpecificErrorMsg2 = `ComponentLoader [${modId}]: Missing or invalid 'id' field in component definition file '${filenameEmptyId}'. Found: ${JSON.stringify(invalidDataEmptyId.id)}`;
+    const expectedSpecificErrorMsg2 = `Invalid or missing 'id' in file '${filenameEmptyId}'.`;
     const expectedSpecificErrorDetails2 = expect.objectContaining({
-      resolvedPath: filePathEmptyId,
-      componentIdValue: invalidDataEmptyId.id,
       modId: modId,
       filename: filenameEmptyId,
+      receivedId: invalidDataEmptyId.id,
     });
     expect(mockLogger.error).toHaveBeenCalledWith(
       expectedSpecificErrorMsg2,
@@ -429,14 +427,14 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
 
     // 2b. Wrapper error log (_processFileWrapper catch)
     const idError2 = expect.objectContaining({
-      message: `Invalid Component ID in ${filenameEmptyId}`,
+      message: `Invalid or missing 'id' in ${filenameEmptyId} for mod '${modId}'.`,
     });
     const expectedWrapperDetails2 = expect.objectContaining({
       filename: filenameEmptyId,
       path: filePathEmptyId,
       modId: modId,
       typeName: 'components', // Check typeName is included
-      error: `Invalid Component ID in ${filenameEmptyId}`, // Specific error
+      error: `Invalid or missing 'id' in ${filenameEmptyId} for mod '${modId}'.`, // Specific error
     });
     expect(mockLogger.error).toHaveBeenCalledWith(
       expectedWrapperMsgBase, // Check for the base prefix


### PR DESCRIPTION
## Summary
- introduce `parseAndValidateId` to centralize ID validation
- use new helper in ActionLoader, ComponentLoader, EntityLoader, EventLoader
- update related tests to check new log messages

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 544 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e954bf33883319840fcca6ccac34e