### PR TITLE
[Agent] add deepClone helper and refactor persistence

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -16,6 +16,7 @@ import { IGamePersistenceService } from '../interfaces/IGamePersistenceService.j
 
 // --- Import Tokens ---
 import { tokens } from '../dependencyInjection/tokens.js';
+import { deepClone } from '../utils/objectUtils.js';
 // --- MODIFICATION START: Import component IDs for cleaning logic ---
 import {
   CURRENT_ACTOR_COMPONENT_ID,
@@ -71,22 +72,6 @@ class GamePersistenceService extends IGamePersistenceService {
   }
 
   /**
-   * @param obj
-   * @private
-   */
-  #deepClone(obj) {
-    if (obj === null || typeof obj !== 'object') {
-      return obj;
-    }
-    try {
-      return JSON.parse(JSON.stringify(obj));
-    } catch (e) {
-      this.#logger.error('GamePersistenceService.#deepClone failed:', e, obj);
-      throw new Error('Failed to deep clone object data.');
-    }
-  }
-
-  /**
    * Captures the current game state.
    *
    * @param {string | null | undefined} activeWorldName - The name of the currently active world, passed from GameEngine.
@@ -118,7 +103,17 @@ class GamePersistenceService extends IGamePersistenceService {
         }
 
         // --- TKT-008 MODIFICATION START: Clean component data before saving ---
-        const dataToSave = this.#deepClone(componentData);
+        let dataToSave;
+        try {
+          dataToSave = deepClone(componentData);
+        } catch (e) {
+          this.#logger.error(
+            'GamePersistenceService.#deepClone failed:',
+            e,
+            componentData
+          );
+          throw new Error('Failed to deep clone object data.');
+        }
 
         // This switch handles cleaning for specific, known component structures.
         // This is more robust than checking for properties on every single component.

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -68,4 +68,25 @@ export function freeze(o) {
   return Object.freeze(o);
 }
 
+/**
+ * Creates a deep clone of a plain object or array using JSON
+ * serialization.
+ *
+ * @description
+ * Suitable for cloning simple data structures that do not contain
+ * functions or circular references. Non-serializable values will be
+ * dropped during cloning.
+ * @template T
+ * @param {T} value - The value to clone.
+ * @returns {T} The cloned value or the original primitive.
+ * @throws {Error} If the value cannot be stringified (e.g. circular structure).
+ */
+export function deepClone(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
 // Add other generic object utilities here in the future if needed.

--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -127,7 +127,7 @@ describe('SaveLoadService additional coverage', () => {
     expect(res.success).toBe(true);
   });
 
-  it('#deepClone returns primitive values unchanged', async () => {
+  it('deepClone returns primitive values unchanged', async () => {
     storageProvider.ensureDirectoryExists.mockResolvedValue();
     let written;
     storageProvider.writeFileAtomically.mockImplementation((path, data) => {

--- a/tests/utils/deepClone.test.js
+++ b/tests/utils/deepClone.test.js
@@ -1,0 +1,22 @@
+import { deepClone } from '../../src/utils/objectUtils.js';
+import { describe, it, expect } from '@jest/globals';
+
+describe('deepClone', () => {
+  it('creates an independent copy of nested objects', () => {
+    const obj = { a: { b: { c: 1 } } };
+    const clone = deepClone(obj);
+    expect(clone).toEqual(obj);
+    expect(clone).not.toBe(obj);
+    clone.a.b.c = 2;
+    expect(obj.a.b.c).toBe(1);
+  });
+
+  it('clones arrays within objects', () => {
+    const obj = { list: [1, { v: 2 }] };
+    const clone = deepClone(obj);
+    expect(clone).toEqual(obj);
+    expect(clone.list).not.toBe(obj.list);
+    clone.list[1].v = 99;
+    expect(obj.list[1].v).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `deepClone` utility
- update game persistence services to use the helper
- adjust tests and add unit tests for `deepClone`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2284 problems)*
- `npm test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e9a3683f0833194e6772a7ac6032f