### PR TITLE
[Agent] centralize ID parsing and storage

### DIFF
--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -91,34 +91,20 @@ class ActionLoader extends BaseManifestItemLoader {
     // Primary validation happens in BaseManifestItemLoader._processFileWrapper now
     // No need to call this._validatePrimarySchema(data, filename, modId, resolvedPath); here
 
-    // --- Step 2: ID Extraction & Validation ---
-    const { fullId: trimmedIdFromFile, baseId: baseActionId } =
-      parseAndValidateId(data, 'id', modId, filename, this._logger);
-
-    const finalRegistryKey = `${modId}:${baseActionId}`; // This IS the key used in the registry by the helper
-
-    this._logger.debug(
-      `ActionLoader [${modId}]: Extracted full ID '${trimmedIdFromFile}' and base ID '${baseActionId}' from ${filename}. Final registry key will be '${finalRegistryKey}'.`
-    );
-
-    // --- Step 3: Data Storage (Using Base Helper) ---
-    this._logger.debug(
-      `ActionLoader [${modId}]: Delegating storage for action (base ID: '${baseActionId}') from ${filename} to base helper.`
-    );
-    const didOverride = this._storeItemInRegistry(
+    // --- Step 2 & 3: ID Handling and Storage via Helper ---
+    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+      data,
+      'id',
       'actions',
       modId,
-      baseActionId,
-      data,
       filename
     );
 
     // --- Step 4: Return Value ---
     this._logger.debug(
-      `ActionLoader [${modId}]: Successfully processed action from ${filename}. Returning final registry key: ${finalRegistryKey}, Overwrite: ${didOverride}`
+      `ActionLoader [${modId}]: Successfully processed action from ${filename}. Returning final registry key: ${qualifiedId}, Overwrite: ${didOverride}`
     );
-    // Return the object as required by the base class contract
-    return { qualifiedId: finalRegistryKey, didOverride: didOverride }; // <<< MODIFIED Return Value
+    return { qualifiedId, didOverride };
   }
 }
 

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -10,6 +10,7 @@
  * @typedef {import('../interfaces/manifestItems.js').ModManifest} ModManifest
  * @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult
  */
+import { parseAndValidateId } from '../utils/idUtils.js';
 // --- Add LoadItemsResult typedef here for clarity ---
 /**
  * @typedef {object} LoadItemsResult
@@ -644,6 +645,38 @@ export class BaseManifestItemLoader {
       );
       throw error;
     }
+  }
+
+  /**
+   * Parses an item's ID using {@link parseAndValidateId} and stores the item in
+   * the data registry.
+   *
+   * @protected
+   * @param {object} data - The raw item data containing the ID property.
+   * @param {string} idProp - The property name of the ID within `data`.
+   * @param {string} category - Registry category for storage.
+   * @param {string} modId - ID of the mod providing the item.
+   * @param {string} filename - Original filename for context in logs.
+   * @param {{ allowFallback?: boolean }} [options] - Optional parse options.
+   * @returns {{qualifiedId: string, didOverride: boolean}} Result info.
+   */
+  _parseIdAndStoreItem(data, idProp, category, modId, filename, options = {}) {
+    const { baseId } = parseAndValidateId(
+      data,
+      idProp,
+      modId,
+      filename,
+      this._logger,
+      options
+    );
+    const didOverride = this._storeItemInRegistry(
+      category,
+      modId,
+      baseId,
+      data,
+      filename
+    );
+    return { qualifiedId: `${modId}:${baseId}`, didOverride };
   }
 
   /**

--- a/src/loaders/componentLoader.js
+++ b/src/loaders/componentLoader.js
@@ -150,11 +150,11 @@ class ComponentLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `ComponentLoader [${modId}]: Delegating storage of component definition metadata using BASE ID '${baseComponentId}' to base class helper.`
     );
-    const didOverride = this._storeItemInRegistry(
+    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+      data,
+      'id',
       'components',
       modId,
-      baseComponentId,
-      data,
       filename
     );
 
@@ -162,7 +162,7 @@ class ComponentLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `ComponentLoader [${modId}]: Successfully processed component definition from ${filename}. Returning final registry key: ${finalRegistryKey}, Overwrite: ${didOverride}`
     );
-    return { qualifiedId: finalRegistryKey, didOverride: didOverride };
+    return { qualifiedId, didOverride };
   }
 }
 

--- a/src/loaders/entityLoader.js
+++ b/src/loaders/entityLoader.js
@@ -217,23 +217,23 @@ class EntityLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `EntityLoader [${modId}]: Delegating storage for original type '${typeName}' with base ID '${baseEntityId}' to base helper for file ${filename}. Storing under 'entities' category.`
     );
-    const didOverride = this._storeItemInRegistry(
+    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+      data,
+      'id',
       'entities',
       modId,
-      baseEntityId,
-      data,
-      filename
+      filename,
+      { allowFallback: true }
     );
 
-    // Construct the final fully qualified ID that was used as the registry key.
-    const finalRegistryKey = `${modId}:${baseEntityId}`;
+    const finalRegistryKey = qualifiedId;
 
     // --- Step 4: Return Result Object ---
     this._logger.debug(
       `EntityLoader [${modId}]: Successfully processed ${typeName} file '${filename}'. Returning final registry key: ${finalRegistryKey}, Overwrite: ${didOverride}`
     );
     // Return the object as required by the base class contract
-    return { qualifiedId: finalRegistryKey, didOverride: didOverride }; // <<< MODIFIED Return Value
+    return { qualifiedId, didOverride }; // <<< MODIFIED Return Value
   }
 }
 

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -149,20 +149,18 @@ class EventLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `EventLoader [${modId}]: Delegating storage for event (base ID: '${baseEventId}') from ${filename} to base helper.`
     );
-    const didOverride = this._storeItemInRegistry(
+    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+      data,
+      'id',
       typeName,
       modId,
-      baseEventId,
-      data,
       filename
     );
 
-    const finalRegistryKey = `${modId}:${baseEventId}`;
     this._logger.debug(
-      `EventLoader [${modId}]: Successfully processed event definition from ${filename}. Returning final registry key: ${finalRegistryKey}, Overwrite: ${didOverride}`
+      `EventLoader [${modId}]: Successfully processed event definition from ${filename}. Returning final registry key: ${qualifiedId}, Overwrite: ${didOverride}`
     );
-    // Return the object as required by the base class contract
-    return { qualifiedId: finalRegistryKey, didOverride: didOverride }; // <<< MODIFIED Return Value
+    return { qualifiedId, didOverride };
   }
 }
 

--- a/tests/loaders/baseManifestItemLoader.parseIdAndStoreItem.test.js
+++ b/tests/loaders/baseManifestItemLoader.parseIdAndStoreItem.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { BaseManifestItemLoader } from '../../src/loaders/baseManifestItemLoader.js';
+import { parseAndValidateId } from '../../src/utils/idUtils.js';
+
+jest.mock('../../src/utils/idUtils.js', () => {
+  const actual = jest.requireActual('../../src/utils/idUtils.js');
+  return { ...actual, parseAndValidateId: jest.fn() };
+});
+
+const createMockConfiguration = (overrides = {}) => ({
+  getModsBasePath: jest.fn().mockReturnValue('./data/mods'),
+  getContentTypeSchemaId: jest.fn().mockReturnValue('schema'),
+  getSchemaBasePath: jest.fn().mockReturnValue('schemas'),
+  getSchemaFiles: jest.fn().mockReturnValue([]),
+  getWorldBasePath: jest.fn().mockReturnValue('worlds'),
+  getBaseDataPath: jest.fn().mockReturnValue('./data'),
+  getGameConfigFilename: jest.fn().mockReturnValue('game.json'),
+  getModManifestFilename: jest.fn().mockReturnValue('mod.manifest.json'),
+  getContentBasePath: jest.fn((t) => `./data/${t}`),
+  ...overrides,
+});
+const createMockPathResolver = (overrides = {}) => ({
+  resolveModContentPath: jest.fn(),
+  resolveContentPath: jest.fn(),
+  resolveSchemaPath: jest.fn(),
+  resolveModManifestPath: jest.fn(),
+  resolveGameConfigPath: jest.fn(),
+  resolveRulePath: jest.fn(),
+  resolveManifestPath: jest.fn(),
+  ...overrides,
+});
+const createMockDataFetcher = () => ({ fetch: jest.fn() });
+const createMockSchemaValidator = () => ({
+  validate: jest.fn(),
+  getValidator: jest.fn(),
+  addSchema: jest.fn(),
+  removeSchema: jest.fn(),
+  isSchemaLoaded: jest.fn(),
+});
+const createMockDataRegistry = (overrides = {}) => ({
+  store: jest.fn(),
+  get: jest.fn(),
+  getAll: jest.fn(),
+  clear: jest.fn(),
+  ...overrides,
+});
+const createMockLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+class TestableLoader extends BaseManifestItemLoader {
+  publicParseAndStore(data, idProp, category, modId, filename, options) {
+    return this._parseIdAndStoreItem(
+      data,
+      idProp,
+      category,
+      modId,
+      filename,
+      options
+    );
+  }
+  async _processFetchedItem() {
+    return { qualifiedId: '', didOverride: false };
+  }
+}
+
+describe('BaseManifestItemLoader._parseIdAndStoreItem', () => {
+  const modId = 'testMod';
+  const filename = 'item.json';
+  const category = 'actions';
+  let loader;
+  let mockRegistry;
+  beforeEach(() => {
+    const config = createMockConfiguration();
+    const resolver = createMockPathResolver();
+    const fetcher = createMockDataFetcher();
+    const validator = createMockSchemaValidator();
+    mockRegistry = createMockDataRegistry();
+    const logger = createMockLogger();
+    loader = new TestableLoader(
+      'test',
+      config,
+      resolver,
+      fetcher,
+      validator,
+      mockRegistry,
+      logger
+    );
+    jest.clearAllMocks();
+  });
+
+  it('parses ID and stores item, returning result', () => {
+    const data = { id: 'core:test' };
+    parseAndValidateId.mockReturnValue({ fullId: 'core:test', baseId: 'test' });
+    mockRegistry.get.mockReturnValue(undefined);
+    mockRegistry.store.mockReturnValue(undefined);
+
+    const result = loader.publicParseAndStore(
+      data,
+      'id',
+      category,
+      modId,
+      filename
+    );
+
+    expect(parseAndValidateId).toHaveBeenCalledWith(
+      data,
+      'id',
+      modId,
+      filename,
+      loader._logger,
+      {}
+    );
+    expect(mockRegistry.store).toHaveBeenCalledWith(
+      category,
+      `${modId}:test`,
+      expect.any(Object)
+    );
+    expect(result).toEqual({
+      qualifiedId: `${modId}:test`,
+      didOverride: false,
+    });
+  });
+
+  it('throws when parse fails and does not store', () => {
+    const data = { id: 'bad' };
+    const err = new Error('bad');
+    parseAndValidateId.mockImplementation(() => {
+      throw err;
+    });
+    expect(() =>
+      loader.publicParseAndStore(data, 'id', category, modId, filename)
+    ).toThrow(err);
+    expect(mockRegistry.store).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/actionLoader.test.js
+++ b/tests/services/actionLoader.test.js
@@ -464,16 +464,6 @@ describe('ActionLoader', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(`Processing fetched item: ${filename}`)
       );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Extracted full ID '${namespacedActionIdFromFile}' and base ID '${baseActionIdExtracted}'`
-        )
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Delegating storage for action (base ID: '${baseActionIdExtracted}')`
-        )
-      );
       // Assert the helper was called correctly
       expect(storeItemSpy).toHaveBeenCalledTimes(1);
       expect(storeItemSpy).toHaveBeenCalledWith(
@@ -542,16 +532,6 @@ describe('ActionLoader', () => {
       // Assert logging (final success log comes from _processFetchedItem)
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(`Processing fetched item: ${filename}`)
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Extracted full ID '${namespacedActionIdFromFile}' and base ID '${baseActionIdExtracted}'`
-        )
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Delegating storage for action (base ID: '${baseActionIdExtracted}')`
-        )
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -722,8 +702,7 @@ describe('ActionLoader', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Could not extract base ID from '${invalidId}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
-        )
-        ,
+        ),
         expect.objectContaining({
           filename,
           modId: TEST_MOD_ID,


### PR DESCRIPTION
Summary:
- add `_parseIdAndStoreItem` helper to `BaseManifestItemLoader`
- refactor Action, Component, Event, and Entity loaders to use helper
- update ActionLoader tests for new log behaviour
- add new unit test for `_parseIdAndStoreItem`

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e99dfd1788331bfd03da8dc69ab73