### PR TITLE
[Agent] add helper for loader dependency validation

### DIFF
--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -10,6 +10,7 @@
  * @typedef {import('../interfaces/manifestItems.js').ModManifest} ModManifest
  * @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult
  */
+import { validateLoaderDeps } from '../utils/validationUtils.js';
 // --- Add LoadItemsResult typedef here for clarity ---
 /**
  * @typedef {object} LoadItemsResult
@@ -111,132 +112,34 @@ export class BaseManifestItemLoader {
       throw new TypeError(errorMsg);
     }
     const trimmedContentType = contentType.trim();
-    if (!logger || typeof logger !== 'object') {
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid ILogger instance.'
-      );
-    }
-    const requiredLoggerMethods = ['info', 'warn', 'error', 'debug'];
-    for (const method of requiredLoggerMethods) {
-      if (typeof logger[method] !== 'function') {
-        throw new TypeError(
-          `BaseManifestItemLoader: ILogger instance must have a '${method}' method.`
-        );
-      }
-    }
+    validateLoaderDeps(logger, [
+      {
+        dependency: config,
+        name: 'IConfiguration',
+        methods: ['getModsBasePath', 'getContentTypeSchemaId'],
+      },
+      {
+        dependency: pathResolver,
+        name: 'IPathResolver',
+        methods: ['resolveModContentPath'],
+      },
+      {
+        dependency: dataFetcher,
+        name: 'IDataFetcher',
+        methods: ['fetch'],
+      },
+      {
+        dependency: schemaValidator,
+        name: 'ISchemaValidator',
+        methods: ['validate', 'getValidator', 'isSchemaLoaded'],
+      },
+      {
+        dependency: dataRegistry,
+        name: 'IDataRegistry',
+        methods: ['store', 'get'],
+      },
+    ]);
     this._logger = logger;
-    if (!config || typeof config !== 'object') {
-      this._logger.error(
-        'BaseManifestItemLoader: Invalid IConfiguration dependency provided.'
-      );
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid IConfiguration instance.'
-      );
-    }
-    if (typeof config.getModsBasePath !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IConfiguration missing 'getModsBasePath' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IConfiguration instance must have a 'getModsBasePath' method."
-      );
-    }
-    if (typeof config.getContentTypeSchemaId !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IConfiguration missing 'getContentTypeSchemaId' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IConfiguration instance must have a 'getContentTypeSchemaId' method."
-      );
-    }
-    if (!pathResolver || typeof pathResolver !== 'object') {
-      this._logger.error(
-        'BaseManifestItemLoader: Invalid IPathResolver dependency provided.'
-      );
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid IPathResolver instance.'
-      );
-    }
-    if (typeof pathResolver.resolveModContentPath !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IPathResolver missing 'resolveModContentPath' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IPathResolver instance must have a 'resolveModContentPath' method."
-      );
-    }
-    if (!dataFetcher || typeof dataFetcher !== 'object') {
-      this._logger.error(
-        'BaseManifestItemLoader: Invalid IDataFetcher dependency provided.'
-      );
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid IDataFetcher instance.'
-      );
-    }
-    if (typeof dataFetcher.fetch !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IDataFetcher missing 'fetch' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IDataFetcher instance must have a 'fetch' method."
-      );
-    }
-    if (!schemaValidator || typeof schemaValidator !== 'object') {
-      this._logger.error(
-        'BaseManifestItemLoader: Invalid ISchemaValidator dependency provided.'
-      );
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid ISchemaValidator instance.'
-      );
-    }
-    if (typeof schemaValidator.validate !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: ISchemaValidator missing 'validate' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: ISchemaValidator instance must have a 'validate' method."
-      );
-    }
-    if (typeof schemaValidator.getValidator !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: ISchemaValidator missing 'getValidator' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: ISchemaValidator instance must have a 'getValidator' method."
-      );
-    }
-    if (typeof schemaValidator.isSchemaLoaded !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: ISchemaValidator missing 'isSchemaLoaded' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: ISchemaValidator instance must have a 'isSchemaLoaded' method."
-      );
-    }
-    if (!dataRegistry || typeof dataRegistry !== 'object') {
-      this._logger.error(
-        'BaseManifestItemLoader: Invalid IDataRegistry dependency provided.'
-      );
-      throw new TypeError(
-        'BaseManifestItemLoader requires a valid IDataRegistry instance.'
-      );
-    }
-    if (typeof dataRegistry.store !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IDataRegistry missing 'store' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IDataRegistry instance must have a 'store' method."
-      );
-    }
-    if (typeof dataRegistry.get !== 'function') {
-      this._logger.error(
-        "BaseManifestItemLoader: IDataRegistry missing 'get' method."
-      );
-      throw new TypeError(
-        "BaseManifestItemLoader: IDataRegistry instance must have a 'get' method."
-      );
-    }
 
     // --- Store Dependencies ---
     this._config = config;

--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -12,7 +12,7 @@
 /** @typedef {import('../../data/schemas/game.schema.json')} GameConfig */ // Assuming this type exists
 
 import { CORE_MOD_ID } from '../constants/core';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateLoaderDeps } from '../utils/validationUtils.js';
 import { ensureValidLogger } from '../utils/loggerUtils.js';
 import { formatAjvErrors } from '../utils/ajvUtils.js';
 
@@ -47,18 +47,28 @@ class GameConfigLoader {
   }) {
     this.#logger = ensureValidLogger(logger, 'GameConfigLoader');
 
-    validateDependency(configuration, 'IConfiguration', this.#logger, {
-      requiredMethods: ['getGameConfigFilename', 'getContentTypeSchemaId'],
-    });
-    validateDependency(pathResolver, 'IPathResolver', this.#logger, {
-      requiredMethods: ['resolveGameConfigPath'],
-    });
-    validateDependency(dataFetcher, 'IDataFetcher', this.#logger, {
-      requiredMethods: ['fetch'],
-    });
-    validateDependency(schemaValidator, 'ISchemaValidator', this.#logger, {
-      requiredMethods: ['isSchemaLoaded', 'getValidator'],
-    });
+    validateLoaderDeps(this.#logger, [
+      {
+        dependency: configuration,
+        name: 'IConfiguration',
+        methods: ['getGameConfigFilename', 'getContentTypeSchemaId'],
+      },
+      {
+        dependency: pathResolver,
+        name: 'IPathResolver',
+        methods: ['resolveGameConfigPath'],
+      },
+      {
+        dependency: dataFetcher,
+        name: 'IDataFetcher',
+        methods: ['fetch'],
+      },
+      {
+        dependency: schemaValidator,
+        name: 'ISchemaValidator',
+        methods: ['isSchemaLoaded', 'getValidator'],
+      },
+    ]);
 
     this.#configuration = configuration;
     this.#pathResolver = pathResolver;

--- a/src/loaders/schemaLoader.js
+++ b/src/loaders/schemaLoader.js
@@ -19,6 +19,8 @@
  * and compilation of JSON schemas specified in the application's configuration.
  * It focuses solely on processing the schemas listed in the configuration's `schemaFiles`.
  */
+import { validateLoaderDeps } from '../utils/validationUtils.js';
+
 class SchemaLoader {
   #config;
   #resolver;
@@ -37,43 +39,28 @@ class SchemaLoader {
    * @throws {Error} If any required dependency is not provided or invalid.
    */
   constructor(configuration, pathResolver, fetcher, validator, logger) {
-    // Basic validation
-    // --- MODIFIED LINE: Updated error message ---
-    if (!configuration || typeof configuration.getSchemaFiles !== 'function') {
-      throw new Error(
-        "SchemaLoader: Missing or invalid 'configuration' dependency (IConfiguration - requires getSchemaFiles)."
-      );
-    }
-    // --- NOTE: pathResolver needs resolveSchemaPath, fetcher needs fetch, validator needs addSchema/isSchemaLoaded ---
-    // These checks correctly reflect the methods used within this class.
-    if (!pathResolver || typeof pathResolver.resolveSchemaPath !== 'function') {
-      throw new Error(
-        "SchemaLoader: Missing or invalid 'pathResolver' dependency (IPathResolver - requires resolveSchemaPath)."
-      );
-    }
-    if (!fetcher || typeof fetcher.fetch !== 'function') {
-      throw new Error(
-        "SchemaLoader: Missing or invalid 'fetcher' dependency (IDataFetcher - requires fetch)."
-      );
-    }
-    if (
-      !validator ||
-      typeof validator.addSchema !== 'function' ||
-      typeof validator.isSchemaLoaded !== 'function'
-    ) {
-      throw new Error(
-        "SchemaLoader: Missing or invalid 'validator' dependency (ISchemaValidator - requires addSchema, isSchemaLoaded)."
-      );
-    }
-    if (
-      !logger ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      throw new Error(
-        "SchemaLoader: Missing or invalid 'logger' dependency (ILogger - requires info, error, debug)."
-      );
-    }
+    validateLoaderDeps(logger, [
+      {
+        dependency: configuration,
+        name: 'IConfiguration',
+        methods: ['getSchemaFiles'],
+      },
+      {
+        dependency: pathResolver,
+        name: 'IPathResolver',
+        methods: ['resolveSchemaPath'],
+      },
+      {
+        dependency: fetcher,
+        name: 'IDataFetcher',
+        methods: ['fetch'],
+      },
+      {
+        dependency: validator,
+        name: 'ISchemaValidator',
+        methods: ['addSchema', 'isSchemaLoaded'],
+      },
+    ]);
 
     this.#config = configuration;
     this.#resolver = pathResolver;

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -58,6 +58,24 @@ export function validateDependency(
 }
 
 /**
+ * @description Validates a set of loader dependencies using {@link validateDependency}.
+ * The provided logger is validated first and then used for all subsequent checks.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to record validation errors.
+ * @param {Array<{dependency: *, name: string, methods: string[]}>} checks - Dependencies to validate.
+ * @returns {void}
+ * @throws {Error} If any dependency fails validation.
+ */
+export function validateLoaderDeps(logger, checks) {
+  validateDependency(logger, 'ILogger', console, {
+    requiredMethods: ['info', 'warn', 'error', 'debug'],
+  });
+
+  for (const { dependency, name, methods = [] } of checks) {
+    validateDependency(dependency, name, logger, { requiredMethods: methods });
+  }
+}
+
+/**
  * Validates that a chosen action index is an integer within the
  * bounds of the available actions.
  *

--- a/tests/loaders/baseManifestItemLoader.constructor.test.js
+++ b/tests/loaders/baseManifestItemLoader.constructor.test.js
@@ -363,13 +363,9 @@ describe('BaseManifestItemLoader Constructor', () => {
             mockRegistry,
             validLogger
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid IConfiguration instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: IConfiguration.'));
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid IConfiguration dependency provided.'
+        'Missing required dependency: IConfiguration.'
       );
     });
 
@@ -388,11 +384,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          'BaseManifestItemLoader requires a valid IConfiguration instance.'
+          "Invalid or missing method 'getModsBasePath' on dependency 'IConfiguration'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid IConfiguration dependency provided.'
+        "Invalid or missing method 'getModsBasePath' on dependency 'IConfiguration'."
       );
     });
 
@@ -415,11 +411,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IConfiguration instance must have a 'getModsBasePath' method."
+          "Invalid or missing method 'getModsBasePath' on dependency 'IConfiguration'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IConfiguration missing 'getModsBasePath' method."
+        "Invalid or missing method 'getModsBasePath' on dependency 'IConfiguration'."
       );
     });
 
@@ -442,11 +438,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IConfiguration instance must have a 'getContentTypeSchemaId' method."
+          "Invalid or missing method 'getContentTypeSchemaId' on dependency 'IConfiguration'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IConfiguration missing 'getContentTypeSchemaId' method."
+        "Invalid or missing method 'getContentTypeSchemaId' on dependency 'IConfiguration'."
       );
     });
   });
@@ -465,13 +461,9 @@ describe('BaseManifestItemLoader Constructor', () => {
             mockRegistry,
             validLogger
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid IPathResolver instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: IPathResolver.'));
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid IPathResolver dependency provided.'
+        'Missing required dependency: IPathResolver.'
       );
     });
 
@@ -494,11 +486,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IPathResolver instance must have a 'resolveModContentPath' method."
+          "Invalid or missing method 'resolveModContentPath' on dependency 'IPathResolver'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IPathResolver missing 'resolveModContentPath' method."
+        "Invalid or missing method 'resolveModContentPath' on dependency 'IPathResolver'."
       );
     });
   });
@@ -517,13 +509,9 @@ describe('BaseManifestItemLoader Constructor', () => {
             mockRegistry,
             validLogger
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid IDataFetcher instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: IDataFetcher.'));
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid IDataFetcher dependency provided.'
+        'Missing required dependency: IDataFetcher.'
       );
     });
 
@@ -546,11 +534,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IDataFetcher instance must have a 'fetch' method."
+          "Invalid or missing method 'fetch' on dependency 'IDataFetcher'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IDataFetcher missing 'fetch' method."
+        "Invalid or missing method 'fetch' on dependency 'IDataFetcher'."
       );
     });
   });
@@ -570,12 +558,10 @@ describe('BaseManifestItemLoader Constructor', () => {
             validLogger
           )
       ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid ISchemaValidator instance.'
-        )
+        new TypeError('Missing required dependency: ISchemaValidator.')
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid ISchemaValidator dependency provided.'
+        'Missing required dependency: ISchemaValidator.'
       );
     });
 
@@ -598,11 +584,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ISchemaValidator instance must have a 'validate' method."
+          "Invalid or missing method 'validate' on dependency 'ISchemaValidator'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: ISchemaValidator missing 'validate' method."
+        "Invalid or missing method 'validate' on dependency 'ISchemaValidator'."
       );
     });
 
@@ -625,11 +611,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ISchemaValidator instance must have a 'getValidator' method."
+          "Invalid or missing method 'getValidator' on dependency 'ISchemaValidator'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: ISchemaValidator missing 'getValidator' method."
+        "Invalid or missing method 'getValidator' on dependency 'ISchemaValidator'."
       );
     });
 
@@ -653,11 +639,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ISchemaValidator instance must have a 'isSchemaLoaded' method."
+          "Invalid or missing method 'isSchemaLoaded' on dependency 'ISchemaValidator'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: ISchemaValidator missing 'isSchemaLoaded' method."
+        "Invalid or missing method 'isSchemaLoaded' on dependency 'ISchemaValidator'."
       );
     });
   });
@@ -676,13 +662,9 @@ describe('BaseManifestItemLoader Constructor', () => {
             null,
             validLogger
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid IDataRegistry instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: IDataRegistry.'));
       expect(validLogger.error).toHaveBeenCalledWith(
-        'BaseManifestItemLoader: Invalid IDataRegistry dependency provided.'
+        'Missing required dependency: IDataRegistry.'
       );
     });
 
@@ -705,11 +687,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IDataRegistry instance must have a 'store' method."
+          "Invalid or missing method 'store' on dependency 'IDataRegistry'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IDataRegistry missing 'store' method."
+        "Invalid or missing method 'store' on dependency 'IDataRegistry'."
       );
     });
 
@@ -732,11 +714,11 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: IDataRegistry instance must have a 'get' method."
+          "Invalid or missing method 'get' on dependency 'IDataRegistry'."
         )
       );
       expect(validLogger.error).toHaveBeenCalledWith(
-        "BaseManifestItemLoader: IDataRegistry missing 'get' method."
+        "Invalid or missing method 'get' on dependency 'IDataRegistry'."
       );
     });
   });
@@ -755,11 +737,7 @@ describe('BaseManifestItemLoader Constructor', () => {
             mockRegistry,
             null
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid ILogger instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: ILogger.'));
     });
     it('should throw TypeError if logger is undefined', () => {
       expect(
@@ -773,11 +751,7 @@ describe('BaseManifestItemLoader Constructor', () => {
             mockRegistry,
             undefined
           )
-      ).toThrow(
-        new TypeError(
-          'BaseManifestItemLoader requires a valid ILogger instance.'
-        )
-      );
+      ).toThrow(new TypeError('Missing required dependency: ILogger.'));
     });
 
     it('should throw TypeError if logger is not an object', () => {
@@ -794,7 +768,7 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          'BaseManifestItemLoader requires a valid ILogger instance.'
+          "Invalid or missing method 'info' on dependency 'ILogger'."
         )
       );
     });
@@ -814,7 +788,7 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ILogger instance must have a 'info' method."
+          "Invalid or missing method 'info' on dependency 'ILogger'."
         )
       );
     });
@@ -833,7 +807,7 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ILogger instance must have a 'warn' method."
+          "Invalid or missing method 'warn' on dependency 'ILogger'."
         )
       );
     });
@@ -852,7 +826,7 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ILogger instance must have a 'error' method."
+          "Invalid or missing method 'error' on dependency 'ILogger'."
         )
       );
     });
@@ -871,7 +845,7 @@ describe('BaseManifestItemLoader Constructor', () => {
           )
       ).toThrow(
         new TypeError(
-          "BaseManifestItemLoader: ILogger instance must have a 'debug' method."
+          "Invalid or missing method 'debug' on dependency 'ILogger'."
         )
       );
     });

--- a/tests/services/schemaLoader.test.js
+++ b/tests/services/schemaLoader.test.js
@@ -270,7 +270,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/configuration/);
+      ).toThrow(/configuration/i);
       expect(
         () =>
           new SchemaLoader(
@@ -280,7 +280,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/configuration/);
+      ).toThrow(/configuration/i);
       // Check specific function existence based on constructor checks
       const invalidConfig = { ...mockConfiguration, getSchemaFiles: undefined };
       expect(
@@ -292,7 +292,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/configuration/);
+      ).toThrow(/configuration/i);
     });
     it('should throw error if pathResolver is missing or invalid', () => {
       expect(
@@ -304,7 +304,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/pathResolver/);
+      ).toThrow(/pathResolver/i);
       expect(
         () =>
           new SchemaLoader(
@@ -314,7 +314,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/pathResolver/);
+      ).toThrow(/pathResolver/i);
     });
     it('should throw error if fetcher is missing or invalid', () => {
       expect(
@@ -326,7 +326,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/fetcher/);
+      ).toThrow(/fetcher/i);
       expect(
         () =>
           new SchemaLoader(
@@ -336,7 +336,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             mockLogger
           )
-      ).toThrow(/fetcher/);
+      ).toThrow(/fetcher/i);
     });
     it('should throw error if validator is missing or invalid', () => {
       expect(
@@ -348,7 +348,7 @@ describe('SchemaLoader', () => {
             null,
             mockLogger
           )
-      ).toThrow(/validator/);
+      ).toThrow(/validator/i);
       expect(
         () =>
           new SchemaLoader(
@@ -358,7 +358,7 @@ describe('SchemaLoader', () => {
             {},
             mockLogger
           )
-      ).toThrow(/validator/);
+      ).toThrow(/validator/i);
       expect(
         () =>
           new SchemaLoader(
@@ -368,7 +368,7 @@ describe('SchemaLoader', () => {
             { addSchema: jest.fn() },
             mockLogger
           )
-      ).toThrow(/validator/); // Missing isSchemaLoaded
+      ).toThrow(/validator/i); // Missing isSchemaLoaded
       expect(
         () =>
           new SchemaLoader(
@@ -378,7 +378,7 @@ describe('SchemaLoader', () => {
             { isSchemaLoaded: jest.fn() },
             mockLogger
           )
-      ).toThrow(/validator/); // Missing addSchema
+      ).toThrow(/validator/i); // Missing addSchema
     });
     it('should throw error if logger is missing or invalid', () => {
       expect(
@@ -390,7 +390,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             null
           )
-      ).toThrow(/logger/);
+      ).toThrow(/logger/i);
       expect(
         () =>
           new SchemaLoader(
@@ -400,7 +400,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             {}
           )
-      ).toThrow(/logger/);
+      ).toThrow(/logger/i);
       expect(
         () =>
           new SchemaLoader(
@@ -410,7 +410,7 @@ describe('SchemaLoader', () => {
             mockSchemaValidator,
             { info: jest.fn() }
           )
-      ).toThrow(/logger/); // Missing error
+      ).toThrow(/logger/i); // Missing error
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `validateLoaderDeps` helper in `validationUtils`
- refactor loader constructors to use `validateLoaderDeps`
- adjust tests for new error messages

## Testing Done
- `npm run lint` *(fails: 533 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e99ca1c888331a1780fc1484796a0