### PR TITLE
[Agent] replace log errors with event dispatch

### DIFF
--- a/src/configuration/loggerConfigLoader.js
+++ b/src/configuration/loggerConfigLoader.js
@@ -61,6 +61,9 @@ export class LoggerConfigLoader {
    */
   #defaultMaxDelayMs = 1000;
 
+  /** @type {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} */
+  #safeEventDispatcher;
+
   /**
    * Creates an instance of LoggerConfigLoader.
    *
@@ -73,6 +76,16 @@ export class LoggerConfigLoader {
     // Use the provided logger, or fallback to the global console object.
     // This is crucial because this loader might run very early in the app lifecycle.
     this.#logger = dependencies.logger || console;
+
+    if (
+      !dependencies.safeEventDispatcher ||
+      typeof dependencies.safeEventDispatcher.dispatch !== 'function'
+    ) {
+      throw new Error(
+        'LoggerConfigLoader requires a valid ISafeEventDispatcher instance.'
+      );
+    }
+    this.#safeEventDispatcher = dependencies.safeEventDispatcher;
     if (
       dependencies.configPath &&
       typeof dependencies.configPath === 'string'
@@ -118,6 +131,7 @@ export class LoggerConfigLoader {
         this.#defaultMaxRetries,
         this.#defaultBaseDelayMs,
         this.#defaultMaxDelayMs,
+        this.#safeEventDispatcher,
         this.#logger
       );
 

--- a/src/dependencyInjection/containerConfig.js
+++ b/src/dependencyInjection/containerConfig.js
@@ -66,7 +66,10 @@ export function configureContainer(container, uiElements) {
   // --- Asynchronously load logger configuration and update level ---
   (async () => {
     try {
-      const loggerConfigLoader = new LoggerConfigLoader({ logger: logger });
+      const loggerConfigLoader = new LoggerConfigLoader({
+        logger: logger,
+        safeEventDispatcher: container.resolve(tokens.ISafeEventDispatcher),
+      });
       logger.debug(
         '[ContainerConfig] Starting asynchronous load of logger configuration...'
       );

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -148,6 +148,9 @@ class InitializationService extends IInitializationService {
             logger: this.#container.resolve(tokens.ILogger),
             schemaValidator: this.#container.resolve(tokens.ISchemaValidator),
             configuration: this.#container.resolve(tokens.IConfiguration),
+            safeEventDispatcher: this.#container.resolve(
+              tokens.ISafeEventDispatcher
+            ),
           });
           this.#logger.debug(
             'InitializationService: LlmConfigLoader instance created for adapter initialization.'

--- a/src/llms/services/llmConfigLoader.js
+++ b/src/llms/services/llmConfigLoader.js
@@ -115,6 +115,7 @@ export class LlmConfigLoader {
   #logger;
   #schemaValidator;
   #configuration;
+  #safeEventDispatcher;
   #defaultConfigPath = 'config/llm-configs.json';
   #defaultMaxRetries = 3;
   #defaultBaseDelayMs = 500;
@@ -137,6 +138,16 @@ export class LlmConfigLoader {
         'LlmConfigLoader: Constructor requires a valid IConfiguration instance.'
       );
     this.#configuration = dependencies.configuration;
+
+    if (
+      !dependencies.safeEventDispatcher ||
+      typeof dependencies.safeEventDispatcher.dispatch !== 'function'
+    ) {
+      throw new Error(
+        'LlmConfigLoader: Constructor requires a valid ISafeEventDispatcher instance.'
+      );
+    }
+    this.#safeEventDispatcher = dependencies.safeEventDispatcher;
 
     if (
       dependencies.defaultConfigPath &&
@@ -297,6 +308,7 @@ export class LlmConfigLoader {
         this.#defaultMaxRetries,
         this.#defaultBaseDelayMs,
         this.#defaultMaxDelayMs,
+        this.#safeEventDispatcher,
         this.#logger
       );
       this.#logger.debug(

--- a/tests/initializers/services/initializationService.runInitializationSequence.test.js
+++ b/tests/initializers/services/initializationService.runInitializationSequence.test.js
@@ -176,6 +176,7 @@ describe('InitializationService', () => {
         tokens.LLMAdapter,
         tokens.ISchemaValidator, // Resolved by LlmConfigLoader via container
         tokens.IConfiguration, // Resolved by LlmConfigLoader via container
+        tokens.ISafeEventDispatcher,
         tokens.SystemInitializer,
         tokens.WorldInitializer,
         tokens.ISafeEventDispatcher,
@@ -328,6 +329,8 @@ describe('InitializationService', () => {
           if (token === tokens.LLMAdapter) return mockLlmAdapter;
           if (token === tokens.ISchemaValidator) return mockSchemaValidator;
           if (token === tokens.IConfiguration) return mockConfiguration;
+          if (token === tokens.ISafeEventDispatcher)
+            return { dispatch: jest.fn(), subscribe: jest.fn(), unsubscribe: jest.fn() };
           if (token === tokens.SystemInitializer) throw error;
           return undefined;
         });
@@ -361,6 +364,8 @@ describe('InitializationService', () => {
           if (token === tokens.LLMAdapter) return mockLlmAdapter;
           if (token === tokens.ISchemaValidator) return mockSchemaValidator;
           if (token === tokens.IConfiguration) return mockConfiguration;
+          if (token === tokens.ISafeEventDispatcher)
+            return { dispatch: jest.fn(), subscribe: jest.fn(), unsubscribe: jest.fn() };
           if (token === tokens.SystemInitializer) return mockSystemInitializer;
           if (token === tokens.WorldInitializer) throw error;
           return undefined;

--- a/tests/llms/services/llmConfigLoader.initialization.test.js
+++ b/tests/llms/services/llmConfigLoader.initialization.test.js
@@ -75,12 +75,14 @@ describe('LlmConfigLoader - Initialization and Schema Handling', () => {
   let schemaValidatorMock;
   /** @type {ReturnType<typeof mockConfigurationInstance>} */
   let configurationMock;
+  let dispatcherMock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     loggerMock = mockLoggerInstance();
     schemaValidatorMock = mockSchemaValidatorInstance();
     configurationMock = mockConfigurationInstance();
+    dispatcherMock = { dispatch: jest.fn().mockResolvedValue(true) };
 
     // Default successful fetch for most tests
     Workspace_retry.mockResolvedValue(
@@ -94,6 +96,7 @@ describe('LlmConfigLoader - Initialization and Schema Handling', () => {
       logger: loggerMock,
       schemaValidator: schemaValidatorMock,
       configuration: configurationMock,
+      safeEventDispatcher: dispatcherMock,
     });
   });
 
@@ -121,6 +124,7 @@ describe('LlmConfigLoader - Initialization and Schema Handling', () => {
       expect.any(Number),
       expect.any(Number),
       expect.any(Number),
+      dispatcherMock,
       loggerMock
     );
     expect(configurationMock.getContentTypeSchemaId).toHaveBeenCalledWith(

--- a/tests/services/LlmConfigLoader.test.js
+++ b/tests/services/LlmConfigLoader.test.js
@@ -152,17 +152,20 @@ describe('LlmConfigLoader', () => {
   let schemaValidatorMock;
   /** @type {ReturnType<typeof mockConfigurationInstance>} */
   let configurationMock;
+  let dispatcherMock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     loggerMock = mockLoggerInstance();
     schemaValidatorMock = mockSchemaValidatorInstance();
     configurationMock = mockConfigurationInstance();
+    dispatcherMock = { dispatch: jest.fn().mockResolvedValue(true) };
 
     loader = new LlmConfigLoader({
       logger: loggerMock,
       schemaValidator: schemaValidatorMock,
       configuration: configurationMock,
+      safeEventDispatcher: dispatcherMock,
     });
     Workspace_retry.mockReset();
   });
@@ -177,6 +180,7 @@ describe('LlmConfigLoader', () => {
         logger: specificLogger,
         schemaValidator: schemaValidatorMock,
         configuration: configurationMock,
+        safeEventDispatcher: dispatcherMock,
       });
       specificLoader.loadConfigs(); // Call loadConfigs to trigger logger usage
       expect(specificLogger.debug).toHaveBeenCalledWith(
@@ -207,6 +211,7 @@ describe('LlmConfigLoader', () => {
         logger: console, // Using actual console
         schemaValidator: schemaValidatorMock,
         configuration: configurationMock,
+        safeEventDispatcher: dispatcherMock,
       });
       Workspace_retry.mockResolvedValueOnce(
         JSON.parse(JSON.stringify(minimalValidRootConfigForPathTests))
@@ -225,6 +230,7 @@ describe('LlmConfigLoader', () => {
         expect.any(Number),
         expect.any(Number),
         expect.any(Number),
+        dispatcherMock,
         loggerMock
       );
     });
@@ -236,6 +242,7 @@ describe('LlmConfigLoader', () => {
         schemaValidator: schemaValidatorMock,
         configuration: configurationMock,
         defaultConfigPath: customPath,
+        safeEventDispatcher: dispatcherMock,
       });
       Workspace_retry.mockResolvedValueOnce(
         JSON.parse(JSON.stringify(minimalValidRootConfigForPathTests))
@@ -247,6 +254,7 @@ describe('LlmConfigLoader', () => {
         expect.any(Number),
         expect.any(Number),
         expect.any(Number),
+        dispatcherMock,
         loggerMock
       );
     });
@@ -298,6 +306,7 @@ describe('LlmConfigLoader', () => {
         3,
         500,
         5000,
+        dispatcherMock,
         loggerMock
       );
       expect(configurationMock.getContentTypeSchemaId).toHaveBeenCalledWith(
@@ -504,6 +513,7 @@ describe('LlmConfigLoader', () => {
         expect.any(Number),
         expect.any(Number),
         expect.any(Number),
+        dispatcherMock,
         loggerMock
       );
     });
@@ -519,6 +529,7 @@ describe('LlmConfigLoader', () => {
         expect.any(Number),
         expect.any(Number),
         expect.any(Number),
+        dispatcherMock,
         loggerMock
       );
     });

--- a/tests/services/actionLoader.test.js
+++ b/tests/services/actionLoader.test.js
@@ -722,8 +722,7 @@ describe('ActionLoader', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Could not extract base ID from '${invalidId}' in file '${filename}'. Format requires 'name' or 'namespace:name' with non-empty parts.`
-        )
-        ,
+        ),
         expect.objectContaining({
           filename,
           modId: TEST_MOD_ID,

--- a/tests/services/llmConfigLoader.extended.test.js
+++ b/tests/services/llmConfigLoader.extended.test.js
@@ -109,17 +109,20 @@ describe('LlmConfigLoader - Extended Prompt Config Tests', () => {
   let schemaValidatorMock;
   /** @type {ReturnType<typeof mockConfigurationInstance>} */
   let configurationMock;
+  let dispatcherMock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     loggerMock = mockLoggerInstance();
     schemaValidatorMock = mockSchemaValidatorInstance();
     configurationMock = mockConfigurationInstance();
+    dispatcherMock = { dispatch: jest.fn().mockResolvedValue(true) };
 
     loader = new LlmConfigLoader({
       logger: loggerMock,
       schemaValidator: schemaValidatorMock,
       configuration: configurationMock,
+      safeEventDispatcher: dispatcherMock,
     });
     Workspace_retry.mockReset();
   });
@@ -144,6 +147,7 @@ describe('LlmConfigLoader - Extended Prompt Config Tests', () => {
         expect.any(Number),
         expect.any(Number),
         expect.any(Number),
+        dispatcherMock,
         loggerMock
       );
       expect(schemaValidatorMock.validate).toHaveBeenCalledWith(

--- a/tests/services/loggerConfigLoader.test.js
+++ b/tests/services/loggerConfigLoader.test.js
@@ -17,11 +17,16 @@ describe('LoggerConfigLoader', () => {
   let loader;
   /** @type {ReturnType<typeof mockLogger>} */
   let logger;
+  let dispatcherMock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     logger = mockLogger();
-    loader = new LoggerConfigLoader({ logger });
+    dispatcherMock = { dispatch: jest.fn().mockResolvedValue(true) };
+    loader = new LoggerConfigLoader({
+      logger,
+      safeEventDispatcher: dispatcherMock,
+    });
   });
 
   it('loads configuration using default path', async () => {
@@ -36,6 +41,7 @@ describe('LoggerConfigLoader', () => {
       expect.any(Number),
       expect.any(Number),
       expect.any(Number),
+      dispatcherMock,
       logger
     );
   });

--- a/tests/utils/apiUtils.retry.network.test.js
+++ b/tests/utils/apiUtils.retry.network.test.js
@@ -3,6 +3,8 @@ import { Workspace_retry } from '../../src/utils/apiUtils.js';
 
 jest.useFakeTimers();
 
+let dispatcher;
+
 const mockResponse = (status, body, ok = true) => ({
   ok,
   status,
@@ -15,6 +17,7 @@ const mockResponse = (status, body, ok = true) => ({
 beforeEach(() => {
   global.fetch = jest.fn();
   jest.clearAllMocks();
+  dispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 });
 
 describe('Workspace_retry network errors', () => {
@@ -30,7 +33,7 @@ describe('Workspace_retry network errors', () => {
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
 
-    const promise = Workspace_retry(url, opts, 2, 100, 1000);
+    const promise = Workspace_retry(url, opts, 2, 100, 1000, dispatcher);
     await jest.runOnlyPendingTimersAsync();
     const result = await promise;
 
@@ -46,7 +49,9 @@ describe('Workspace_retry network errors', () => {
     fetch.mockRejectedValue(new TypeError('network request failed'));
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
 
-    const promise = Workspace_retry(url, opts, 2, 100, 1000).catch((e) => e);
+    const promise = Workspace_retry(url, opts, 2, 100, 1000, dispatcher).catch(
+      (e) => e
+    );
     await jest.runOnlyPendingTimersAsync();
     await jest.runOnlyPendingTimersAsync();
     const err = await promise;

--- a/tests/utils/apiUtils.retry.test.js
+++ b/tests/utils/apiUtils.retry.test.js
@@ -3,6 +3,8 @@ import { Workspace_retry } from '../../src/utils/apiUtils.js';
 
 jest.useFakeTimers();
 
+let dispatcher;
+
 const mockResponse = (
   status,
   body,
@@ -31,6 +33,7 @@ const mockResponse = (
 beforeEach(() => {
   global.fetch = jest.fn();
   jest.clearAllMocks();
+  dispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 });
 
 describe('Workspace_retry', () => {
@@ -45,7 +48,7 @@ describe('Workspace_retry', () => {
 
     let caught;
     try {
-      await Workspace_retry(url, opts, 1, 1, 1);
+      await Workspace_retry(url, opts, 1, 1, 1, dispatcher);
     } catch (e) {
       caught = e;
     }
@@ -60,7 +63,9 @@ describe('Workspace_retry', () => {
     resp.text.mockResolvedValue('bad text');
     fetch.mockResolvedValueOnce(resp);
 
-    const err = await Workspace_retry(url, opts, 1, 1, 1).catch((e) => e);
+    const err = await Workspace_retry(url, opts, 1, 1, 1, dispatcher).catch(
+      (e) => e
+    );
     expect(err.body).toBe('bad text');
   });
 
@@ -78,7 +83,7 @@ describe('Workspace_retry', () => {
     fetch.mockResolvedValueOnce(first).mockResolvedValueOnce(okResp);
 
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
-    const promise = Workspace_retry(url, opts, 2, 100, 1000);
+    const promise = Workspace_retry(url, opts, 2, 100, 1000, dispatcher);
     await jest.runOnlyPendingTimersAsync();
     await promise;
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
@@ -98,7 +103,9 @@ describe('Workspace_retry', () => {
     };
     fetch.mockResolvedValueOnce(resp);
 
-    const err = await Workspace_retry(url, opts, 1, 1, 1).catch((e) => e);
+    const err = await Workspace_retry(url, opts, 1, 1, 1, dispatcher).catch(
+      (e) => e
+    );
 
     expect(resp.clone).toHaveBeenCalled();
     expect(cloneText).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in api utils
- propagate dispatcher to config loaders
- pass dispatcher through initialization
- adjust tests for new Workspace_retry signature

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684e989a185c8331803655d391005ccd