### PR TITLE
[Agent] refactor game state capture service

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -65,7 +65,6 @@ export function registerPersistence(container) {
       entityManager: c.resolve(tokens.IEntityManager),
       dataRegistry: c.resolve(tokens.IDataRegistry),
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
-      container: c,
     });
   });
   logger.debug(

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -100,7 +100,6 @@ describe('Persistence round-trip', () => {
       entityManager,
       dataRegistry,
       playtimeTracker,
-      container: {},
     });
   });
 
@@ -134,5 +133,11 @@ describe('Persistence round-trip', () => {
     );
     const restoredComponents = Object.fromEntries(restored.componentEntries);
     expect(restoredComponents).toEqual(expectedComponents);
+
+    expect(loadResult.data.metadata.gameTitle).toBe('TestWorld');
+    expect(loadResult.data.metadata.playtimeSeconds).toBe(0);
+    expect(loadResult.data.modManifest.activeMods).toEqual([
+      { modId: 'core', version: '1.0.0' },
+    ]);
   });
 });

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -22,7 +22,6 @@ describe('GamePersistenceService additional coverage', () => {
   let entityManager;
   let dataRegistry;
   let playtimeTracker;
-  let container;
   let service;
 
   beforeEach(() => {
@@ -38,14 +37,12 @@ describe('GamePersistenceService additional coverage', () => {
       getTotalPlaytime: jest.fn().mockReturnValue(42),
       setAccumulatedPlaytime: jest.fn(),
     };
-    container = {};
     service = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       dataRegistry,
       playtimeTracker,
-      container,
     });
   });
 

--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -11,7 +11,6 @@ function makeDeps() {
     entityManager: {},
     dataRegistry: {},
     playtimeTracker: {},
-    container: {},
   };
 }
 
@@ -22,7 +21,6 @@ describe('GamePersistenceService constructor validation', () => {
     'entityManager',
     'dataRegistry',
     'playtimeTracker',
-    'container',
   ];
 
   test.each(required)('throws if %s is missing', (prop) => {

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -27,7 +27,6 @@ describe('GamePersistenceService edge cases', () => {
   let entityManager;
   let dataRegistry;
   let playtimeTracker;
-  let container;
   let service;
 
   beforeEach(() => {
@@ -43,14 +42,12 @@ describe('GamePersistenceService edge cases', () => {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
     };
-    container = {};
     service = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       dataRegistry,
       playtimeTracker,
-      container,
     });
   });
 

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -20,7 +20,6 @@ describe('GamePersistenceService error paths', () => {
   let entityManager;
   let dataRegistry;
   let playtimeTracker;
-  let container;
   let service;
 
   beforeEach(() => {
@@ -36,14 +35,12 @@ describe('GamePersistenceService error paths', () => {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
     };
-    container = {};
     service = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       dataRegistry,
       playtimeTracker,
-      container,
     });
   });
 
@@ -58,7 +55,7 @@ describe('GamePersistenceService error paths', () => {
         'Failed to deep clone object data.'
       );
       expect(logger.error).toHaveBeenCalledWith(
-        'GamePersistenceService.#deepClone failed:',
+        'GamePersistenceService.#cleanComponentData deepClone failed:',
         expect.any(Error),
         cyc
       );

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -50,7 +50,6 @@ describe('GamePersistenceService', () => {
       entityManager: mockEntityManager,
       dataRegistry: mockDataRegistry,
       playtimeTracker: mockPlaytimeTracker,
-      container: mockAppContainer,
     });
     // Clear the logger.info/debug calls made by the constructor, if any,
     // to not interfere with test-specific logger assertions.


### PR DESCRIPTION
Summary: Refactored `GamePersistenceService` to modularize component cleaning and metadata assembly while updating tests.

Changes Made:
- Added private helper methods for component cleaning and manifest/metadata creation.
- Used a component cleaning map for extensibility.
- Simplified `captureCurrentGameState` to orchestrate helper calls.
- Removed unused DI container parameter and updated registration and tests.
- Extended round-trip integration test to verify metadata preservation.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` – warnings remain)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (skipped)


------
https://chatgpt.com/codex/tasks/task_e_684ea2ab09bc8331ae7b4bf31920ff57