### PR TITLE
[Agent] add $schema urls to mods

### DIFF
--- a/data/mods/core/actions/go.action.json
+++ b/data/mods/core/actions/go.action.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/action-definition.schema.json",
   "id": "core:go",
   "commandVerb": "go",
   "name": "Go",

--- a/data/mods/core/components/actor.component.json
+++ b/data/mods/core/components/actor.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:actor",
   "description": "Marker component identifying entities that can participate in the turn-based cycle and perform actions.",
   "dataSchema": {

--- a/data/mods/core/components/current_actor.component.json
+++ b/data/mods/core/components/current_actor.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:current_actor",
   "description": "Marker component identifying the entity whose turn it currently is in a turn-based system. Only one entity should have this component at any given time.",
   "dataSchema": {

--- a/data/mods/core/components/description.component.json
+++ b/data/mods/core/components/description.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:description",
   "description": "A textual description for an entity, which can be used for display or informational purposes.",
   "dataSchema": {

--- a/data/mods/core/components/exits.component.json
+++ b/data/mods/core/components/exits.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:exits",
   "description": "Signifies the possible exits from a location entity. Each exit defines a direction, a target location, and an optional entity that might block the path. Target and blocker IDs will be resolved to instance IDs during world initialization.",
   "dataSchema": {

--- a/data/mods/core/components/name.component.json
+++ b/data/mods/core/components/name.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:name",
   "description": "The primary display name or title of the entity (e.g., 'Player', 'Goblin Sentry', 'Iron Key').",
   "dataSchema": {

--- a/data/mods/core/components/player.component.json
+++ b/data/mods/core/components/player.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:player",
   "description": "A tag component indicating that the entity represents a player. Used by systems and conditions to identify player-controlled entities.",
   "dataSchema": {

--- a/data/mods/core/components/position.component.json
+++ b/data/mods/core/components/position.component.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/component-definition.schema.json",
   "id": "core:position",
   "description": "Represents the entity's location within the game world.",
   "dataSchema": {

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/mod.manifest.schema.json",
   "id": "core",
   "version": "1.0.0",
   "name": "core",

--- a/data/mods/isekai/characters/hero.character.json
+++ b/data/mods/isekai/characters/hero.character.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:hero",
   "components": {
     "core:actor": {},

--- a/data/mods/isekai/characters/ninja.character.json
+++ b/data/mods/isekai/characters/ninja.character.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:ninja",
   "components": {
     "core:actor": {},

--- a/data/mods/isekai/characters/receptionist.character.json
+++ b/data/mods/isekai/characters/receptionist.character.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:receptionist",
   "components": {
     "core:actor": {},

--- a/data/mods/isekai/characters/sidekick.character.json
+++ b/data/mods/isekai/characters/sidekick.character.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:sidekick",
   "components": {
     "core:actor": {},

--- a/data/mods/isekai/locations/adventurers_guild.location.json
+++ b/data/mods/isekai/locations/adventurers_guild.location.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:adventurers_guild",
   "components": {
     "core:name": {

--- a/data/mods/isekai/locations/town.location.json
+++ b/data/mods/isekai/locations/town.location.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/entity.schema.json",
   "id": "isekai:town",
   "components": {
     "core:name": {

--- a/data/mods/isekai/mod.manifest.json
+++ b/data/mods/isekai/mod.manifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://example.com/schemas/mod.manifest.schema.json",
   "id": "isekai",
   "version": "1.0.0",
   "name": "isekai",


### PR DESCRIPTION
Summary: Inserted missing `$schema` URLs in all mod JSON files under `data/mods/`.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ea59e3af083319703d332f2b70d9a