### PR TITLE
[Agent] Emit UI error event from ActionResultRenderer

### DIFF
--- a/src/domUI/actionResultRenderer.js
+++ b/src/domUI/actionResultRenderer.js
@@ -26,6 +26,7 @@ import DomElementFactory from './domElementFactory.js';
 // Runtime imports
 // ────────────────────────────────────────────────────────────────────────────────
 import { BoundDomRendererBase } from './boundDomRendererBase.js';
+import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {object} ActionResultPayload
@@ -179,17 +180,19 @@ export class ActionResultRenderer extends BoundDomRendererBase {
     const listEl = this.elements.listContainerElement;
 
     if (!listEl) {
-      this.logger.error(
-        `${this._logPrefix} listContainerElement not found – cannot render bubble.`
-      );
+      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: `${this._logPrefix} listContainerElement not found – cannot render bubble.`,
+        details: { message, cssClass },
+      });
       return;
     }
 
     const li = this.#domElementFactory.li(cssClass);
     if (!li) {
-      this.logger.error(
-        `${this._logPrefix} DomElementFactory.li() returned null – cannot render bubble.`
-      );
+      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: `${this._logPrefix} DomElementFactory.li() returned null – cannot render bubble.`,
+        details: { message, cssClass },
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- dispatch `core:display_error` when ActionResultRenderer can't render a bubble
- cover missing DOM cases in ActionResultRenderer tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea6677e008331be9fb78144200943