### PR TITLE
[Agent] factor SaveLoadService helpers

### DIFF
--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, jest, beforeAll } from '@jest/globals';
+import SaveLoadService from '../../src/persistence/saveLoadService.js';
+import pako from 'pako';
+import { webcrypto } from 'crypto';
+
+beforeAll(() => {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+  Object.defineProperty(global, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+});
+
+/**
+ * Creates mocked dependencies for SaveLoadService.
+ *
+ * @returns {object} Mocked dependencies
+ */
+function makeDeps() {
+  return {
+    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    storageProvider: {
+      listFiles: jest.fn(),
+      readFile: jest.fn(),
+      writeFileAtomically: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      ensureDirectoryExists: jest.fn(),
+    },
+  };
+}
+
+describe('SaveLoadService private helper error propagation', () => {
+  let logger;
+  let storageProvider;
+  let service;
+
+  beforeEach(() => {
+    ({ logger, storageProvider } = makeDeps());
+    service = new SaveLoadService({ logger, storageProvider });
+  });
+
+  it('propagates readSaveFile errors', async () => {
+    storageProvider.readFile.mockRejectedValue(new Error('read fail'));
+    const res = await service.loadGameData('saves/manual_saves/test.sav');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Could not access/);
+  });
+
+  it('propagates empty file error', async () => {
+    storageProvider.readFile.mockResolvedValue(new Uint8Array());
+    const res = await service.loadGameData('saves/manual_saves/test.sav');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/empty or cannot be read/);
+  });
+
+  it('propagates decompression errors', async () => {
+    storageProvider.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const res = await service.loadGameData('saves/manual_saves/test.sav');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/could not decompress/);
+  });
+
+  it('propagates deserialization errors', async () => {
+    const badGzip = pako.gzip(new Uint8Array([1, 2, 3]));
+    storageProvider.readFile.mockResolvedValue(badGzip);
+    const res = await service.loadGameData('saves/manual_saves/test.sav');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/could not understand/);
+  });
+});


### PR DESCRIPTION
Summary: Introduced private helper methods in `SaveLoadService` for reading files, decompressing data, and deserializing MessagePack. Updated `#deserializeAndDecompress` to use these helpers. Added tests covering error propagation from the helpers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint (targeted files) `npx eslint src/persistence/saveLoadService.js tests/services/saveLoadService.privateHelpers.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ea9823a248331a40600f9ed0378a4