### PR TITLE
[Agent] return info from loader storage helper

### DIFF
--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -499,7 +499,7 @@ export class BaseManifestItemLoader {
    * @param {string} baseItemId - The item's **un-prefixed** base ID (extracted from the item data or filename).
    * @param {object} dataToStore - The original data object fetched and validated for the item.
    * @param {string} sourceFilename - The original filename from which the data was loaded (for logging).
-   * @returns {boolean} Returns `true` if an existing item was overwritten, `false` otherwise.
+   * @returns {{qualifiedId: string, didOverride: boolean}} Object containing the fully qualified ID and override flag.
    * @throws {Error} Re-throws any error encountered during interaction with the data registry (`get` or `store`).
    */
   _storeItemInRegistry(
@@ -509,9 +509,8 @@ export class BaseManifestItemLoader {
     dataToStore,
     sourceFilename
   ) {
-    // <<< MODIFIED RETURN TYPE
     const finalRegistryKey = `${modId}:${baseItemId}`;
-    let didOverwrite = false; // <<< ADDED flag
+    let didOverwrite = false;
     try {
       const existingDefinition = this._dataRegistry.get(
         category,
@@ -534,7 +533,7 @@ export class BaseManifestItemLoader {
       this._logger.debug(
         `${this.constructor.name} [${modId}]: Successfully stored ${category} item '${finalRegistryKey}' from file '${sourceFilename}'.`
       );
-      return didOverwrite; // <<< RETURN the flag
+      return { qualifiedId: finalRegistryKey, didOverride: didOverwrite };
     } catch (error) {
       this._logger.error(
         `${this.constructor.name} [${modId}]: Failed to store ${category} item with key '${finalRegistryKey}' from file '${sourceFilename}' in data registry.`,
@@ -574,14 +573,14 @@ export class BaseManifestItemLoader {
       this._logger,
       options
     );
-    const didOverride = this._storeItemInRegistry(
+    const { qualifiedId, didOverride } = this._storeItemInRegistry(
       category,
       modId,
       baseId,
       data,
       filename
     );
-    return { qualifiedId: `${modId}:${baseId}`, didOverride };
+    return { qualifiedId, didOverride };
   }
 
   /**

--- a/src/loaders/ruleLoader.js
+++ b/src/loaders/ruleLoader.js
@@ -152,16 +152,18 @@ class RuleLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `RuleLoader [${modId}]: Delegating storage for rule (base ID: '${baseRuleId}') from ${filename} to base helper.`
     );
-    let didOverride = false; // <<< Initialize override flag
+    let qualifiedId;
+    let didOverride = false;
     try {
-      // Capture the boolean return value from the helper
-      didOverride = this._storeItemInRegistry(
+      const result = this._storeItemInRegistry(
         'rules',
         modId,
         baseRuleId,
         data,
         filename
-      ); // <<< CAPTURE result
+      );
+      qualifiedId = result.qualifiedId;
+      didOverride = result.didOverride;
     } catch (storageError) {
       // Error logging happens in helper, re-throw
       throw storageError;
@@ -169,12 +171,11 @@ class RuleLoader extends BaseManifestItemLoader {
     // --- End Storage ---
 
     // --- Return Value ---
-    const finalRegistryKey = `${modId}:${baseRuleId}`; // Construct the prefixed ID used for storage
+    const finalRegistryKey = qualifiedId ?? `${modId}:${baseRuleId}`;
     this._logger.debug(
       `RuleLoader [${modId}]: Successfully processed rule from ${filename}. Returning final registry key: ${finalRegistryKey}, Overwrite: ${didOverride}`
     );
-    // Return the object as required by the base class contract
-    return { qualifiedId: finalRegistryKey, didOverride: didOverride }; // <<< MODIFIED Return Value
+    return { qualifiedId: finalRegistryKey, didOverride };
   }
 
   /**

--- a/tests/loaders/entityLoader.test.js
+++ b/tests/loaders/entityLoader.test.js
@@ -245,9 +245,11 @@ beforeEach(() => {
   //     entityLoader['_validateEntityComponents'] = EntityLoader.prototype['_validateEntityComponents'].bind(entityLoader);
   // }
 
-  // --- TEST CORRECTION: Ensure the spy on _storeItemInRegistry returns the expected boolean ---
-  // The base class method `_storeItemInRegistry` now returns a boolean. Mock it to return `false` by default.
-  entityLoader._storeItemInRegistry.mockReturnValue(false);
+  // Ensure calls to _storeItemInRegistry invoke the real implementation so the
+  // returned object includes the calculated qualifiedId.
+  entityLoader._storeItemInRegistry.mockImplementation((...args) =>
+    EntityLoader.prototype._storeItemInRegistry.apply(entityLoader, args)
+  );
 });
 
 // --- Test Suite ---
@@ -466,8 +468,9 @@ describe('EntityLoader', () => {
 
       // --- [LOADER-REFACTOR-04 Test Change]: Mock base class methods called within/around _processFetchedItem ---
       entityLoader._storeItemInRegistry.mockClear(); // Clear spy calls from beforeEach
-      // --- TEST CORRECTION: Ensure the spy on _storeItemInRegistry returns the expected boolean ---
-      entityLoader._storeItemInRegistry.mockReturnValue(false); // Default to no overwrite
+      entityLoader._storeItemInRegistry.mockImplementation((...args) =>
+        EntityLoader.prototype._storeItemInRegistry.apply(entityLoader, args)
+      );
     });
 
     // --- Adjusted success paths ---

--- a/tests/loaders/eventLoader.test.js
+++ b/tests/loaders/eventLoader.test.js
@@ -152,6 +152,7 @@ let eventLoader;
 // --- Spies ---
 let validatePrimarySchemaSpy;
 let storeItemInRegistrySpy;
+const realStoreItemInRegistry = BaseManifestItemLoader.prototype._storeItemInRegistry;
 let loadItemsInternalSpy;
 
 // --- Test Constants ---
@@ -218,7 +219,9 @@ beforeEach(() => {
   // --- Mock Base Class Internal Methods' Behavior ---
   loadItemsInternalSpy.mockResolvedValue({ count: 0, overrides: 0, errors: 0 });
   validatePrimarySchemaSpy.mockReturnValue({ isValid: true, errors: null });
-  storeItemInRegistrySpy.mockReturnValue(false); // Default: no override
+  storeItemInRegistrySpy.mockImplementation((...args) =>
+    realStoreItemInRegistry.apply(eventLoader, args)
+  );
 
   // Bind the actual _processFetchedItem method for testing
   if (EventLoader.prototype._processFetchedItem) {
@@ -466,7 +469,9 @@ describe('EventLoader', () => {
       mockValidator.isSchemaLoaded.mockReturnValue(false);
       mockValidator.addSchema.mockResolvedValue(undefined);
       mockRegistry.get.mockReturnValue(undefined);
-      storeItemInRegistrySpy.mockReturnValue(false); // Default: no override
+      storeItemInRegistrySpy.mockImplementation((...args) =>
+        realStoreItemInRegistry.apply(eventLoader, args)
+      );
       validatePrimarySchemaSpy.mockClear();
       storeItemInRegistrySpy.mockClear();
     });
@@ -724,7 +729,9 @@ describe('EventLoader', () => {
 
     it('Warning: Payload schema already loaded', async () => {
       mockValidator.isSchemaLoaded.mockReturnValueOnce(true);
-      storeItemInRegistrySpy.mockReturnValue(false);
+      storeItemInRegistrySpy.mockImplementation((...args) =>
+        realStoreItemInRegistry.apply(eventLoader, args)
+      );
       const fetchedData = JSON.parse(JSON.stringify(baseEventData));
       const result = await eventLoader._processFetchedItem(
         TEST_MOD_ID,

--- a/tests/services/actionLoader.test.js
+++ b/tests/services/actionLoader.test.js
@@ -435,7 +435,9 @@ describe('ActionLoader', () => {
       // It's usually better to spy on the *dependency* (registry.store)
       // but since the logic for overwriting check and return value is *in* the helper,
       // let's mock the helper itself for these specific unit tests.
-      jest.spyOn(actionLoader, '_storeItemInRegistry').mockReturnValue(false); // Default: no override
+      jest
+        .spyOn(actionLoader, '_storeItemInRegistry')
+        .mockReturnValue({ qualifiedId: finalRegistryKey, didOverride: false });
     });
 
     it('Success Path: should check registry, store, log, and return ID with override=false', async () => {
@@ -446,7 +448,7 @@ describe('ActionLoader', () => {
       // Mock the helper to return false (no override)
       const storeItemSpy = jest
         .spyOn(actionLoader, '_storeItemInRegistry')
-        .mockReturnValue(false);
+        .mockReturnValue({ qualifiedId: finalRegistryKey, didOverride: false });
 
       const result = await actionLoader._processFetchedItem(
         TEST_MOD_ID,
@@ -506,7 +508,7 @@ describe('ActionLoader', () => {
       // Mock the helper to return true (override occurred)
       const storeItemSpy = jest
         .spyOn(actionLoader, '_storeItemInRegistry')
-        .mockReturnValue(true);
+        .mockReturnValue({ qualifiedId: finalRegistryKey, didOverride: true });
 
       const result = await actionLoader._processFetchedItem(
         TEST_MOD_ID,
@@ -560,7 +562,7 @@ describe('ActionLoader', () => {
       // Spy on the helper, ensure it's NOT called if _processFetchedItem throws early (which it shouldn't now)
       const storeItemSpy = jest
         .spyOn(actionLoader, '_storeItemInRegistry')
-        .mockReturnValue(false);
+        .mockReturnValue({ qualifiedId: finalRegistryKey, didOverride: false });
 
       // --- REMOVED: Mocking the spy to throw ---
       // validatePrimarySchemaSpy.mockImplementation(() => { throw validationError; });

--- a/tests/services/componentDefinitionLoader.happyPath.core.test.js
+++ b/tests/services/componentDefinitionLoader.happyPath.core.test.js
@@ -367,8 +367,8 @@ describe('ComponentLoader (Happy Path - Core Mod)', () => {
           modId: modId,
           _sourceFile: filename,
         };
-        mockRegistry.store(category, finalId, storedData); // Use the actual mock registry's store
-        // console.log(`Mock _storeItemInRegistry called with: ${finalId}`) // Optional debug log
+        mockRegistry.store(category, finalId, storedData);
+        return { qualifiedId: finalId, didOverride: false };
       });
 
     // Spy on the base validation method. We *expect* this to be called by the base wrapper.


### PR DESCRIPTION
## Summary
- adjust BaseManifestItemLoader._storeItemInRegistry to return `{qualifiedId, didOverride}`
- propagate new return to _parseIdAndStoreItem and RuleLoader
- update unit tests to handle updated structure

## Testing Done
- [x] `npm run format` (root)
- [x] `npm run lint` (root, expected failures)
- [x] `npm run test` (root)
- [x] `cd llm-proxy-server && npm run format`
- [x] `npm run lint` (proxy)
- [x] `npm run test` (proxy)


------
https://chatgpt.com/codex/tasks/task_e_684ea9986fc0833183d8abf1de061967