### PR TITLE
[Agent] centralize EntityManager method list

### DIFF
--- a/src/constants/entityManager.js
+++ b/src/constants/entityManager.js
@@ -1,0 +1,15 @@
+// src/constants/entityManager.js
+// -------------------------------------------------
+// Constants related to the IEntityManager interface
+
+/**
+ * List of EntityManager methods required by various
+ * game logic components.
+ *
+ * @type {string[]}
+ */
+export const REQUIRED_ENTITY_MANAGER_METHODS = [
+  'getEntityInstance',
+  'getComponentData',
+  'hasComponent',
+];

--- a/src/logic/contextAssembler.js
+++ b/src/logic/contextAssembler.js
@@ -14,6 +14,7 @@ import {
   initLogger,
   validateServiceDeps,
 } from '../utils/serviceInitializer.js';
+import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 
 /** @typedef {string | number | null | undefined} EntityId */
 
@@ -222,11 +223,7 @@ export function createJsonLogicContext(
   validateServiceDeps('createJsonLogicContext', effectiveLogger, {
     entityManager: {
       value: entityManager,
-      requiredMethods: [
-        'getComponentData',
-        'getEntityInstance',
-        'hasComponent',
-      ],
+      requiredMethods: REQUIRED_ENTITY_MANAGER_METHODS,
     },
   });
 

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -7,6 +7,7 @@
 import { createJsonLogicContext } from './contextAssembler.js';
 import { resolvePath } from '../utils/objectUtils.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
+import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import {
   initLogger,
   validateServiceDeps,
@@ -64,11 +65,7 @@ class SystemLogicInterpreter {
       },
       entityManager: {
         value: entityManager,
-        requiredMethods: [
-          'getEntityInstance',
-          'getComponentData',
-          'hasComponent',
-        ],
+        requiredMethods: REQUIRED_ENTITY_MANAGER_METHODS,
       },
       operationInterpreter: {
         value: operationInterpreter,


### PR DESCRIPTION
Summary: Consolidated the list of required EntityManager methods into a shared constant and updated context usage.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684eab9767c48331a65b33adb3180dbb