### PR TITLE
[Agent] share slot list population

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -376,8 +376,7 @@ class LoadGameUI extends SlotModalBase {
    */
   async _populateLoadSlotsList() {
     this.logger.debug(`${this._logPrefix} Populating load slots list...`);
-    const listContainer = this.elements.listContainerElement;
-    if (!listContainer) {
+    if (!this.elements.listContainerElement) {
       this.logger.error(
         `${this._logPrefix} List container element not found in this.elements.`
       );
@@ -388,34 +387,12 @@ class LoadGameUI extends SlotModalBase {
       return;
     }
 
-    this._setOperationInProgress(true); // Disables interactions, shows "Loading..."
-    this._displayStatusMessage('Loading saved games...', 'info');
-
-    DomUtils.clearElement(listContainer);
-    this.currentSlotsDisplayData = [];
-
-    const slotsData = await this._getLoadSlotsData();
-
-    if (slotsData.length === 0) {
-      const emptyMessageElement = this._getEmptyLoadSlotsMessage();
-      listContainer.appendChild(
-        emptyMessageElement instanceof HTMLElement
-          ? emptyMessageElement
-          : this.documentContext.document.createTextNode(
-              String(emptyMessageElement)
-            )
-      );
-    } else {
-      slotsData.forEach((slotData, index) => {
-        const listItemElement = this._renderLoadSlotItem(slotData, index);
-        if (listItemElement) {
-          listContainer.appendChild(listItemElement);
-        }
-      });
-    }
-
-    this._clearStatusMessage(); // Clear "Loading saved games..."
-    this._setOperationInProgress(false); // Re-enable interactions
+    await this.populateSlotsList(
+      () => this._getLoadSlotsData(),
+      (slotData, index) => this._renderLoadSlotItem(slotData, index),
+      () => this._getEmptyLoadSlotsMessage(),
+      'Loading saved games...'
+    );
 
     this._handleSlotSelection(null, null); // Update button states
     this.logger.debug(`${this._logPrefix} Load slots list populated.`);

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -394,8 +394,7 @@ export class SaveGameUI extends SlotModalBase {
    */
   async _populateSaveSlotsList() {
     this.logger.debug(`${this._logPrefix} Populating save slots list...`);
-    const listContainer = this.elements.listContainerElement;
-    if (!listContainer) {
+    if (!this.elements.listContainerElement) {
       this.logger.error(`${this._logPrefix} List container element not found.`);
       this._displayStatusMessage(
         'Error: UI component for slots missing.',
@@ -404,38 +403,12 @@ export class SaveGameUI extends SlotModalBase {
       return;
     }
 
-    this._setOperationInProgress(true); // Disable interactions while loading list
-    this._displayStatusMessage('Loading save slots...', 'info');
-
-    DomUtils.clearElement(listContainer); // Clear previous items
-
-    const slotsData = await this._getSaveSlotsData();
-
-    if (slotsData.length === 0) {
-      const emptyMessage = this._getEmptySaveSlotsMessage();
-      if (typeof emptyMessage === 'string') {
-        if (this.domElementFactory) {
-          listContainer.appendChild(
-            this.domElementFactory.p(undefined, emptyMessage) ||
-              this.documentContext.document.createTextNode(emptyMessage)
-          );
-        } else {
-          listContainer.textContent = emptyMessage;
-        }
-      } else {
-        listContainer.appendChild(emptyMessage);
-      }
-    } else {
-      slotsData.forEach((slotData, index) => {
-        const listItemElement = this._renderSaveSlotItem(slotData, index);
-        if (listItemElement) {
-          listContainer.appendChild(listItemElement);
-        }
-      });
-    }
-
-    this._clearStatusMessage(); // Clear "Loading save slots..."
-    this._setOperationInProgress(false); // Re-enable interactions
+    await this.populateSlotsList(
+      () => this._getSaveSlotsData(),
+      (slotData, index) => this._renderSaveSlotItem(slotData, index),
+      () => this._getEmptySaveSlotsMessage(),
+      'Loading save slots...'
+    );
 
     // Ensure buttons are correctly disabled if no selection or no valid input
     this._handleSaveNameInput();

--- a/tests/domUI/loadGameUI.test.js
+++ b/tests/domUI/loadGameUI.test.js
@@ -129,6 +129,26 @@ describe('LoadGameUI basic behaviors', () => {
     );
   });
 
+  it('should populate the load slots list using the shared method', async () => {
+    mockSaveLoadService.listManualSaveSlots.mockResolvedValueOnce([
+      {
+        identifier: 'slotA',
+        saveName: 'Save A',
+        timestamp: '2023-09-01T00:00:00Z',
+        playtimeSeconds: 3,
+        isCorrupted: false,
+      },
+    ]);
+
+    await loadGameUI._populateLoadSlotsList();
+
+    const slots = document
+      .getElementById('load-slots-container')
+      .querySelectorAll('.save-slot');
+    expect(slots.length).toBe(1);
+    expect(slots[0].dataset.slotIdentifier).toBe('slotA');
+  });
+
   it('should update selection and button states', () => {
     const container = document.getElementById('load-slots-container');
     const slotData1 = {

--- a/tests/domUI/saveGameUI.test.js
+++ b/tests/domUI/saveGameUI.test.js
@@ -168,6 +168,37 @@ describe('SaveGameUI', () => {
     await awaitTick();
   }
 
+  describe('populateSlotsList integration', () => {
+    it('should populate the save slots container with slot items', async () => {
+      mockSaveLoadService.listManualSaveSlots.mockResolvedValueOnce([
+        {
+          identifier: 'id1',
+          saveName: 'Slot One',
+          timestamp: '2023-01-01T00:00:00Z',
+          playtimeSeconds: 5,
+          isEmpty: false,
+          isCorrupted: false,
+        },
+        {
+          identifier: 'id2',
+          saveName: 'Slot Two',
+          timestamp: '2023-01-02T00:00:00Z',
+          playtimeSeconds: 10,
+          isEmpty: false,
+          isCorrupted: false,
+        },
+      ]);
+
+      await saveGameUI._populateSaveSlotsList();
+      await awaitMockCall(mockSaveLoadService.listManualSaveSlots, 0);
+
+      const slots = listContainerElement.querySelectorAll('.save-slot');
+      expect(slots.length).toBe(10);
+      expect(slots[0].textContent).toContain('Slot One');
+      expect(slots[1].dataset.slotId).toBe('1');
+    });
+  });
+
   describe('Save Operation and Slot Re-selection', () => {
     it('should correctly re-select the slot after a successful save to an empty slot', async () => {
       const saveName = 'My Awesome Game';


### PR DESCRIPTION
Summary: Added new protected `populateSlotsList` helper to `SlotModalBase` for shared slot list rendering. Updated `SaveGameUI` and `LoadGameUI` to delegate list building to this method. Extended unit tests to ensure slot lists populate correctly using the shared method.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint` *(fails: 534 errors)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_684eb228e6888331b12f8ca055858613