### PR TITLE
[Agent] Inject crypto dependency into SaveLoadService

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -27,6 +27,7 @@ const MANUAL_SAVE_PATTERN = /^manual_save_.*\.sav$/; // Pattern to identify pote
 class SaveLoadService extends ISaveLoadService {
   #logger;
   #storageProvider;
+  #crypto;
 
   /**
    * Creates a new SaveLoadService instance.
@@ -34,8 +35,9 @@ class SaveLoadService extends ISaveLoadService {
    * @param {object} dependencies - The dependencies object.
    * @param {ILogger} dependencies.logger - The logging service.
    * @param {IStorageProvider} dependencies.storageProvider - The storage provider service.
+   * @param {Crypto} [dependencies.crypto] - Web Crypto implementation.
    */
-  constructor({ logger, storageProvider }) {
+  constructor({ logger, storageProvider, crypto = globalThis.crypto }) {
     // <<< MODIFIED SIGNATURE with destructuring
     super();
     if (!logger)
@@ -48,6 +50,7 @@ class SaveLoadService extends ISaveLoadService {
       );
     this.#logger = logger;
     this.#storageProvider = storageProvider;
+    this.#crypto = crypto;
     this.#logger.debug('SaveLoadService initialized.');
   }
 
@@ -86,7 +89,7 @@ class SaveLoadService extends ISaveLoadService {
     }
 
     try {
-      const hashBuffer = await window.crypto.subtle.digest(
+      const hashBuffer = await this.#crypto.subtle.digest(
         'SHA-256',
         dataToHash
       );

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -67,7 +67,11 @@ describe('Persistence round-trip', () => {
   beforeEach(() => {
     logger = makeLogger();
     storageProvider = createMemoryStorageProvider();
-    saveLoadService = new SaveLoadService({ logger, storageProvider });
+    saveLoadService = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
 
     entity = makeEntity('e1', receptionistDef);
 

--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -44,7 +44,11 @@ describe('SaveLoadService additional coverage', () => {
 
   beforeEach(() => {
     ({ logger, storageProvider } = makeDeps());
-    service = new SaveLoadService({ logger, storageProvider });
+    service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
   });
 
   it('returns empty list when directory missing', async () => {

--- a/tests/services/saveLoadService.constructor.test.js
+++ b/tests/services/saveLoadService.constructor.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
+import { webcrypto } from 'crypto';
 
 /**
  *
@@ -21,12 +22,18 @@ describe('SaveLoadService constructor validation', () => {
   test('throws if logger missing', () => {
     const deps = makeDeps();
     expect(
-      () => new SaveLoadService({ storageProvider: deps.storageProvider })
+      () =>
+        new SaveLoadService({
+          storageProvider: deps.storageProvider,
+          crypto: webcrypto,
+        })
     ).toThrow();
   });
 
   test('throws if storageProvider missing', () => {
     const deps = makeDeps();
-    expect(() => new SaveLoadService({ logger: deps.logger })).toThrow();
+    expect(
+      () => new SaveLoadService({ logger: deps.logger, crypto: webcrypto })
+    ).toThrow();
   });
 });

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -48,7 +48,11 @@ describe('SaveLoadService edge cases', () => {
 
   beforeEach(() => {
     ({ logger, storageProvider } = makeDeps());
-    service = new SaveLoadService({ logger, storageProvider });
+    service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
   });
 
   describe('private helper failures via saveManualGame', () => {

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -57,7 +57,11 @@ describe('SaveLoadService error paths', () => {
 
   beforeEach(() => {
     ({ logger, storageProvider } = makeDeps());
-    service = new SaveLoadService({ logger, storageProvider });
+    service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
     global.encodeMock = jest.fn();
     global.decodeMock = jest.fn();
   });

--- a/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -35,7 +35,11 @@ function makeDeps() {
 describe('SaveLoadService without ensureDirectoryExists', () => {
   it('saves successfully when directory helper is absent', async () => {
     const { logger, storageProvider } = makeDeps();
-    const service = new SaveLoadService({ logger, storageProvider });
+    const service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
 
     storageProvider.writeFileAtomically.mockResolvedValue({ success: true });
 

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, jest, beforeAll } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  jest,
+  beforeAll,
+} from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
@@ -42,7 +49,11 @@ describe('SaveLoadService private helper error propagation', () => {
 
   beforeEach(() => {
     ({ logger, storageProvider } = makeDeps());
-    service = new SaveLoadService({ logger, storageProvider });
+    service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
   });
 
   it('propagates readSaveFile errors', async () => {


### PR DESCRIPTION
Summary: Accept crypto as dependency for checksum generation

Changes Made:
- updated `SaveLoadService` constructor to accept a `crypto` parameter with default to `globalThis.crypto`
- stored crypto in private field and used it in checksum generation
- updated JSDoc for constructor
- updated instantiations and tests to pass `webcrypto`

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (skipped)


------
https://chatgpt.com/codex/tasks/task_e_684eb2e2f58c83318335da89588df6ef