### PR TITLE
[Agent] Replace logger.error with safe event dispatch

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -123,6 +123,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -153,7 +153,11 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
+    QUERY_COMPONENT: new QueryComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: eventBus,
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -170,7 +170,11 @@ function init(entities) {
       jsonLogicEvaluationService: jsonLogic,
       safeEventDispatcher: eventBus,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
+    QUERY_COMPONENT: new QueryComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: eventBus,
+    }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     SYSTEM_MOVE_ENTITY: new SystemMoveEntityHandler({

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -110,7 +110,11 @@ describe('core_handle_follow rule integration', () => {
         logger,
         safeEventDispatcher: safeDispatcher,
       }),
-      QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
+      QUERY_COMPONENT: new QueryComponentHandler({
+        entityManager,
+        logger,
+        safeEventDispatcher: safeDispatcher,
+      }),
       ADD_COMPONENT: new AddComponentHandler({
         entityManager,
         logger,

--- a/tests/integration/rules/waitRule.integration.test.js
+++ b/tests/integration/rules/waitRule.integration.test.js
@@ -84,7 +84,11 @@ function init(entities) {
   entityManager = new SimpleEntityManager(entities);
 
   const handlers = {
-    QUERY_COMPONENT: new QueryComponentHandler({ entityManager, logger }),
+    QUERY_COMPONENT: new QueryComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: eventBus,
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
   };
 


### PR DESCRIPTION
## Summary
- dispatch `DISPLAY_ERROR_ID` in `QueryComponentHandler`
- inject `safeEventDispatcher` into `QueryComponentHandler`
- update interpreter registrations
- adjust tests for new dispatcher dependency
- pass dispatcher to handler in integration tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684eb28b8a908331a089e10789ee44e6