### PR TITLE
[Agent] Introduce setupService helper

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -14,10 +14,7 @@
 import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
 import { getAvailableExits } from '../utils/locationUtils.js';
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../utils/serviceInitializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchError.js';
@@ -52,8 +49,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     safeEventDispatcher,
   }) {
     super();
-    this.#logger = initLogger('ActionDiscoveryService', logger);
-    validateServiceDeps('ActionDiscoveryService', this.#logger, {
+    this.#logger = setupService('ActionDiscoveryService', logger, {
       gameDataRepository: {
         value: gameDataRepository,
         requiredMethods: ['getAllActionDefinitions'],

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -1,9 +1,6 @@
 // src/actions/validation/prerequisiteEvaluationService.js
 
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../../utils/serviceInitializer.js';
+import { setupService } from '../../utils/serviceInitializer.js';
 
 /* type-only imports */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -47,32 +44,16 @@ export class PrerequisiteEvaluationService {
     jsonLogicEvaluationService,
     actionValidationContextBuilder,
   }) {
-    try {
-      this.#logger = initLogger('PrerequisiteEvaluationService', logger);
-    } catch (e) {
-      const errorMsg = `PrerequisiteEvaluationService Constructor: CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
-      // eslint-disable-next-line no-console
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-
-    try {
-      validateServiceDeps('PrerequisiteEvaluationService', this.#logger, {
-        jsonLogicEvaluationService: {
-          value: jsonLogicEvaluationService,
-          requiredMethods: ['evaluate'],
-        },
-        actionValidationContextBuilder: {
-          value: actionValidationContextBuilder,
-          requiredMethods: ['buildContext'],
-        },
-      });
-    } catch (e) {
-      this.#logger.error(
-        `PrerequisiteEvaluationService Constructor: Dependency validation failed. Error: ${e.message}`
-      );
-      throw e;
-    }
+    this.#logger = setupService('PrerequisiteEvaluationService', logger, {
+      jsonLogicEvaluationService: {
+        value: jsonLogicEvaluationService,
+        requiredMethods: ['evaluate'],
+      },
+      actionValidationContextBuilder: {
+        value: actionValidationContextBuilder,
+        requiredMethods: ['buildContext'],
+      },
+    });
 
     this.#jsonLogicEvaluationService = jsonLogicEvaluationService;
     this.#actionValidationContextBuilder = actionValidationContextBuilder;

--- a/src/logic/contextAssembler.js
+++ b/src/logic/contextAssembler.js
@@ -10,10 +10,7 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../utils/serviceInitializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { createComponentAccessor } from './componentAccessor.js';
 
@@ -99,8 +96,7 @@ export function createJsonLogicContext(
       "createJsonLogicContext: Missing or invalid 'event' object."
     );
   }
-  const effectiveLogger = initLogger('createJsonLogicContext', logger);
-  validateServiceDeps('createJsonLogicContext', effectiveLogger, {
+  const effectiveLogger = setupService('createJsonLogicContext', logger, {
     entityManager: {
       value: entityManager,
       requiredMethods: REQUIRED_ENTITY_MANAGER_METHODS,

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -1,9 +1,6 @@
 // src/logic/jsonLogicEvaluationService.js
 import jsonLogic from 'json-logic-js';
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../utils/serviceInitializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 
 // -----------------------------------------------------------------------------
 // Ensure the alias "not" behaves the same as the built‑in "!" operator.
@@ -50,8 +47,7 @@ class JsonLogicEvaluationService {
    * @throws {Error} If required dependencies are missing or invalid.
    */
   constructor({ logger }) {
-    this.#logger = initLogger('JsonLogicEvaluationService', logger);
-    validateServiceDeps('JsonLogicEvaluationService', this.#logger);
+    this.#logger = setupService('JsonLogicEvaluationService', logger);
     this.#logger.debug('JsonLogicEvaluationService initialized.');
   }
 

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -4,10 +4,7 @@
 // -----------------------------------------------------------------------------
 
 import { resolvePlaceholders } from './contextUtils.js';
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../utils/serviceInitializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */
 /** @typedef {import('./defs.js').ExecutionContext}                               ExecutionContext */
@@ -21,8 +18,7 @@ class OperationInterpreter {
   /** @type {OperationRegistry} */ #registry;
 
   constructor({ logger, operationRegistry }) {
-    this.#logger = initLogger('OperationInterpreter', logger);
-    validateServiceDeps('OperationInterpreter', this.#logger, {
+    this.#logger = setupService('OperationInterpreter', logger, {
       operationRegistry: {
         value: operationRegistry,
         requiredMethods: ['getHandler'],

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -8,10 +8,7 @@ import { createJsonLogicContext } from './contextAssembler.js';
 import { resolvePath } from '../utils/objectUtils.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
-import {
-  initLogger,
-  validateServiceDeps,
-} from '../utils/serviceInitializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 
 /* ---------------------------------------------------------------------------
  * Internal types (JSDoc only)
@@ -49,8 +46,7 @@ class SystemLogicInterpreter {
     entityManager,
     operationInterpreter,
   }) {
-    this.#logger = initLogger('SystemLogicInterpreter', logger);
-    validateServiceDeps('SystemLogicInterpreter', this.#logger, {
+    this.#logger = setupService('SystemLogicInterpreter', logger, {
       eventBus: {
         value: eventBus,
         requiredMethods: ['subscribe', 'unsubscribe'],

--- a/src/utils/serviceInitializer.js
+++ b/src/utils/serviceInitializer.js
@@ -44,4 +44,22 @@ export function validateServiceDeps(serviceName, logger, deps) {
   }
 }
 
+/**
+ * @description Convenience helper that initializes a service logger and
+ * validates its dependencies in one step.
+ * @param {string} serviceName - The service name used for logger prefixing and
+ *   validation messages.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to
+ *   validate and wrap.
+ * @param {Record<string, DependencySpec>} [deps] - Optional dependency map for
+ *   validation via {@link validateServiceDeps}.
+ * @returns {import('../interfaces/coreServices.js').ILogger} The initialized and
+ *   prefixed logger instance.
+ */
+export function setupService(serviceName, logger, deps) {
+  const prefixedLogger = initLogger(serviceName, logger);
+  validateServiceDeps(serviceName, prefixedLogger, deps);
+  return prefixedLogger;
+}
+
 // --- FILE END ---

--- a/tests/utils/loggerInitUsage.test.js
+++ b/tests/utils/loggerInitUsage.test.js
@@ -14,13 +14,19 @@ const mockLogger = {
  * @param expectedName
  * @param expectOptional
  */
-function setup(modulePath, ctorArgs, expectedName, expectOptional = false) {
+function setup(
+  modulePath,
+  ctorArgs,
+  expectedName,
+  expectOptional = false,
+  useHelper = true
+) {
   jest.resetModules();
-  const initLogger = jest.fn(() => mockLogger);
+  const setupService = jest.fn(() => mockLogger);
   const baseInitLogger = jest.fn(() => mockLogger);
   jest.doMock('../../src/utils/serviceInitializer.js', () => {
     const actual = jest.requireActual('../../src/utils/serviceInitializer.js');
-    return { ...actual, initLogger };
+    return { ...actual, setupService };
   });
   jest.doMock('../../src/utils/loggerUtils.js', () => {
     const actual = jest.requireActual('../../src/utils/loggerUtils.js');
@@ -29,12 +35,18 @@ function setup(modulePath, ctorArgs, expectedName, expectOptional = false) {
 
   const Mod = require(modulePath).default || require(modulePath);
   new Mod(ctorArgs);
-  if (expectOptional) {
-    expect(baseInitLogger).toHaveBeenCalledWith(expectedName, mockLogger, {
-      optional: true,
-    });
+  if (useHelper) {
+    expect(setupService).toHaveBeenCalled();
+    const call = setupService.mock.calls[0];
+    expect(call[0]).toBe(expectedName);
+    expect(call[1]).toBe(mockLogger);
+  } else {
+    expect(baseInitLogger).toHaveBeenCalledWith(
+      expectedName,
+      mockLogger,
+      expect.objectContaining({ optional: expectOptional || false })
+    );
   }
-  expect(initLogger).toHaveBeenCalledWith(expectedName, mockLogger);
   jest.dontMock('../../src/utils/loggerUtils.js');
   jest.dontMock('../../src/utils/serviceInitializer.js');
 }
@@ -53,7 +65,8 @@ describe('initLogger usage in constructors', () => {
       '../../src/logic/operationRegistry.js',
       { logger: mockLogger },
       'OperationRegistry',
-      true
+      true,
+      false
     );
   });
 
@@ -67,12 +80,12 @@ describe('initLogger usage in constructors', () => {
 
   it('createJsonLogicContext uses initLogger', () => {
     jest.resetModules();
-    const initLogger = jest.fn(() => mockLogger);
+    const setupService = jest.fn(() => mockLogger);
     jest.doMock('../../src/utils/serviceInitializer.js', () => {
       const actual = jest.requireActual(
         '../../src/utils/serviceInitializer.js'
       );
-      return { ...actual, initLogger };
+      return { ...actual, setupService };
     });
     jest.doMock('../../src/utils/loggerUtils.js', () => {
       const actual = jest.requireActual('../../src/utils/loggerUtils.js');
@@ -92,10 +105,10 @@ describe('initLogger usage in constructors', () => {
       },
       mockLogger
     );
-    expect(initLogger).toHaveBeenCalledWith(
-      'createJsonLogicContext',
-      mockLogger
-    );
+    expect(setupService).toHaveBeenCalled();
+    const call = setupService.mock.calls[0];
+    expect(call[0]).toBe('createJsonLogicContext');
+    expect(call[1]).toBe(mockLogger);
     jest.dontMock('../../src/utils/loggerUtils.js');
     jest.dontMock('../../src/utils/serviceInitializer.js');
   });

--- a/tests/utils/serviceInitializer.test.js
+++ b/tests/utils/serviceInitializer.test.js
@@ -10,6 +10,7 @@ import {
 import {
   initLogger,
   validateServiceDeps,
+  setupService,
 } from '../../src/utils/serviceInitializer.js';
 import {
   createPrefixedLogger,
@@ -91,6 +92,23 @@ describe('serviceInitializer utilities', () => {
         baseLogger,
         { requiredMethods: ['x'], isFunction: undefined }
       );
+    });
+  });
+
+  describe('setupService', () => {
+    it('initializes logger then validates deps', () => {
+      const deps = {
+        depA: { value: {}, requiredMethods: ['a'] },
+      };
+      const logger = setupService('Svc', baseLogger, deps);
+      expect(baseInitLogger).toHaveBeenCalledWith('Svc', baseLogger);
+      expect(validateDependency).toHaveBeenCalledWith(
+        deps.depA.value,
+        'Svc: depA',
+        expect.any(Object),
+        { requiredMethods: ['a'], isFunction: undefined }
+      );
+      expect(logger).toEqual({ prefix: 'Svc: ', logger: baseLogger });
     });
   });
 });


### PR DESCRIPTION
Summary: Adds a setupService helper to streamline service initialization and dependency validation. Refactored major services and context utilities to use it. Updated related tests for the new helper.

Changes Made:
- Added setupService in serviceInitializer.js
- Updated constructors in logic and action services to use setupService
- Adjusted contextAssembler to use the helper
- Modified unit tests to cover setupService usage

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint <paths>`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684eb73c41988331b09f650392b1ba47