### PR TITLE
[Agent] add dispatchWithLogging helper to ShutdownService

### DIFF
--- a/tests/shutdown/services/shutdownService.test.js
+++ b/tests/shutdown/services/shutdownService.test.js
@@ -1,4 +1,5 @@
 // src/tests/shutdown/services/shutdownService.test.js
+/* eslint-disable jest/no-conditional-expect */
 
 import ShutdownService from '../../../src/shutdown/services/shutdownService.js';
 import { SHUTDOWNABLE } from '../../../src/dependencyInjection/tags.js';
@@ -288,9 +289,7 @@ describe('ShutdownService', () => {
       expect(loggerDebugCalls).toContain(
         "Dispatched 'shutdown:shutdown_service:started' event."
       );
-      expect(loggerDebugCalls).toContain(
-        'ShutdownService: Dispatched ui:show_message event.'
-      );
+      expect(loggerDebugCalls).toContain("Dispatched 'ui:show_message' event.");
 
       // 2. Stop Turn Manager (Indices 4, 5) <<< UPDATED
       expect(loggerDebugCalls[4]).toBe(


### PR DESCRIPTION
Summary: add a helper for dispatching shutdown events with error logging and update tests.

Testing Done:
- [x] `npm run format`
- [ ] `npm run lint` *(fails: many existing errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format`
- [x] `npm run lint` *(proxy)*
- [x] `npm run test` *(proxy)*
- [x] `npm run start` (manual smoke)


------
https://chatgpt.com/codex/tasks/task_e_684eb94ea9d083319c049ee2af248338