### PR TITLE
[Agent] Dispatch display_error in ClientApiKeyProvider

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -136,7 +136,10 @@ export function registerAI(container) {
       projectRootPath: null,
       proxyServerUrl: globalThis.process?.env?.PROXY_URL || undefined,
     });
-    const apiKeyProvider = new ClientApiKeyProvider({ logger });
+    const apiKeyProvider = new ClientApiKeyProvider({
+      logger,
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+    });
     const httpClient = c.resolve(tokens.IHttpClient);
     const llmStrategyFactory = new LLMStrategyFactory({ httpClient, logger });
 


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into ClientApiKeyProvider
- dispatch DISPLAY_ERROR_ID instead of logging errors
- wire dispatcher when registering AI services
- update corresponding tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm install globals`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ebab170dc8331889ed52a6f7e1ab9