### PR TITLE
[Agent] Extract metadata builder

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -23,6 +23,7 @@ import { Registrar } from '../registrarHelpers.js';
 import PlaytimeTracker from '../../engine/playtimeTracker.js';
 import ComponentCleaningService from '../../persistence/componentCleaningService.js';
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
+import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
 import ReferenceResolver from '../../initializers/services/referenceResolver.js';
 import SaveLoadService from '../../persistence/saveLoadService.js';
 import { BrowserStorageProvider } from '../../storage/browserStorageProvider.js';
@@ -66,6 +67,11 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.ComponentCleaningService)}.`
   );
 
+  r.single(tokens.SaveMetadataBuilder, SaveMetadataBuilder, [tokens.ILogger]);
+  logger.debug(
+    `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
+  );
+
   r.singletonFactory(tokens.GamePersistenceService, (c) => {
     return new GamePersistenceService({
       logger: c.resolve(tokens.ILogger),
@@ -74,6 +80,7 @@ export function registerPersistence(container) {
       dataRegistry: c.resolve(tokens.IDataRegistry),
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
       componentCleaningService: c.resolve(tokens.ComponentCleaningService),
+      metadataBuilder: c.resolve(tokens.SaveMetadataBuilder),
     });
   });
   logger.debug(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -202,6 +202,7 @@ export const tokens = freeze({
   CommandOutcomeInterpreter: 'CommandOutcomeInterpreter',
   PlaytimeTracker: 'PlaytimeTracker',
   ComponentCleaningService: 'ComponentCleaningService',
+  SaveMetadataBuilder: 'SaveMetadataBuilder',
   GamePersistenceService: 'GamePersistenceService',
   EntityDisplayDataProvider: 'EntityDisplayDataProvider',
   AlertRouter: 'AlertRouter',

--- a/src/persistence/saveMetadataBuilder.js
+++ b/src/persistence/saveMetadataBuilder.js
@@ -1,0 +1,64 @@
+// src/persistence/saveMetadataBuilder.js
+
+import { ENGINE_VERSION } from '../engine/engineVersion.js';
+
+/**
+ * @typedef {object} SaveMetadataBuilderDeps
+ * @property {import('../interfaces/coreServices.js').ILogger} logger - Logger for warnings.
+ * @property {string} [engineVersion] - Default engine version to use if none provided.
+ * @property {string} [saveFormatVersion] - Version for the save format.
+ */
+
+/**
+ * @class SaveMetadataBuilder
+ * @description Constructs metadata blocks for save files.
+ */
+export default class SaveMetadataBuilder {
+  /** @type {import('../interfaces/coreServices.js').ILogger} */
+  #logger;
+  /** @type {string} */
+  #engineVersion;
+  /** @type {string} */
+  #saveFormatVersion;
+
+  /**
+   * @param {SaveMetadataBuilderDeps} deps
+   */
+  constructor({
+    logger,
+    engineVersion = ENGINE_VERSION,
+    saveFormatVersion = '1.0.0',
+  }) {
+    if (!logger) {
+      throw new Error('SaveMetadataBuilder requires a logger.');
+    }
+    this.#logger = logger;
+    this.#engineVersion = engineVersion;
+    this.#saveFormatVersion = saveFormatVersion;
+  }
+
+  /**
+   * Builds a metadata object for a save file.
+   *
+   * @param {string | null | undefined} worldName - Active world name.
+   * @param {number} playtimeSeconds - Accumulated playtime.
+   * @param {string} [engineVersion] - Override engine version.
+   * @returns {object} Metadata structure.
+   */
+  build(worldName, playtimeSeconds, engineVersion = this.#engineVersion) {
+    const title = worldName || 'Unknown Game';
+    if (!worldName) {
+      this.#logger.warn(
+        `${this.constructor.name}.build: No worldName provided. Defaulting to 'Unknown Game'.`
+      );
+    }
+    return {
+      saveFormatVersion: this.#saveFormatVersion,
+      engineVersion,
+      gameTitle: title,
+      timestamp: new Date().toISOString(),
+      playtimeSeconds,
+      saveName: '',
+    };
+  }
+}

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -23,6 +23,7 @@ import PlaytimeTracker from '../../../src/engine/playtimeTracker.js';
 import ComponentCleaningService from '../../../src/persistence/componentCleaningService.js';
 import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
 import ReferenceResolver from '../../../src/initializers/services/referenceResolver.js';
+import SaveMetadataBuilder from '../../../src/persistence/saveMetadataBuilder.js';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import { BrowserStorageProvider } from '../../../src/storage/browserStorageProvider.js';
 
@@ -75,6 +76,9 @@ describe('registerPersistence', () => {
       `Persistence Registration: Registered ${String(tokens.ComponentCleaningService)}.`
     );
     expect(logs).toContain(
+      `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
+    );
+    expect(logs).toContain(
       `Persistence Registration: Registered ${String(tokens.GamePersistenceService)}.`
     );
     expect(logs).toContain(
@@ -106,6 +110,12 @@ describe('registerPersistence', () => {
       {
         token: tokens.ComponentCleaningService,
         Class: ComponentCleaningService,
+        lifecycle: 'singleton',
+        deps: [tokens.ILogger],
+      },
+      {
+        token: tokens.SaveMetadataBuilder,
+        Class: SaveMetadataBuilder,
         lifecycle: 'singleton',
         deps: [tokens.ILogger],
       },

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -62,6 +62,7 @@ describe('Persistence round-trip', () => {
   let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
+  let metadataBuilder;
   let persistence;
   let entity;
   const saveName = 'RoundTripTest';
@@ -100,6 +101,7 @@ describe('Persistence round-trip', () => {
       setAccumulatedPlaytime: jest.fn(),
     };
     componentCleaningService = new ComponentCleaningService({ logger });
+    metadataBuilder = { build: jest.fn((n,p)=>({ saveFormatVersion:'1', engineVersion:'x', gameTitle:n||'Unknown Game', timestamp:'t', playtimeSeconds:p, saveName:'' })) };
 
     persistence = new GamePersistenceService({
       logger,
@@ -108,6 +110,7 @@ describe('Persistence round-trip', () => {
       dataRegistry,
       playtimeTracker,
       componentCleaningService,
+      metadataBuilder,
     });
   });
 

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -23,6 +23,7 @@ describe('GamePersistenceService additional coverage', () => {
   let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
+  let metadataBuilder;
   let service;
 
   beforeEach(() => {
@@ -39,6 +40,16 @@ describe('GamePersistenceService additional coverage', () => {
       setAccumulatedPlaytime: jest.fn(),
     };
     componentCleaningService = { clean: jest.fn((id, data) => data) };
+    metadataBuilder = {
+      build: jest.fn((n, p) => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: n || 'Unknown Game',
+        timestamp: 't',
+        playtimeSeconds: p,
+        saveName: '',
+      })),
+    };
     service = new GamePersistenceService({
       logger,
       saveLoadService,
@@ -46,6 +57,7 @@ describe('GamePersistenceService additional coverage', () => {
       dataRegistry,
       playtimeTracker,
       componentCleaningService,
+      metadataBuilder,
     });
   });
 

--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -12,6 +12,7 @@ function makeDeps() {
     dataRegistry: {},
     playtimeTracker: {},
     componentCleaningService: { clean: jest.fn() },
+    metadataBuilder: { build: jest.fn() },
   };
 }
 
@@ -23,6 +24,7 @@ describe('GamePersistenceService constructor validation', () => {
     'dataRegistry',
     'playtimeTracker',
     'componentCleaningService',
+    'metadataBuilder',
   ];
 
   test.each(required)('throws if %s is missing', (prop) => {

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -29,6 +29,7 @@ describe('GamePersistenceService edge cases', () => {
   let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
+  let metadataBuilder;
   let service;
 
   beforeEach(() => {
@@ -45,6 +46,16 @@ describe('GamePersistenceService edge cases', () => {
       setAccumulatedPlaytime: jest.fn(),
     };
     componentCleaningService = new ComponentCleaningService({ logger });
+    metadataBuilder = {
+      build: jest.fn((n, p) => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: n || 'Unknown Game',
+        timestamp: 't',
+        playtimeSeconds: p,
+        saveName: '',
+      })),
+    };
     service = new GamePersistenceService({
       logger,
       saveLoadService,
@@ -52,6 +63,7 @@ describe('GamePersistenceService edge cases', () => {
       dataRegistry,
       playtimeTracker,
       componentCleaningService,
+      metadataBuilder,
     });
   });
 

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -22,6 +22,7 @@ describe('GamePersistenceService error paths', () => {
   let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
+  let metadataBuilder;
   let service;
 
   beforeEach(() => {
@@ -38,6 +39,16 @@ describe('GamePersistenceService error paths', () => {
       setAccumulatedPlaytime: jest.fn(),
     };
     componentCleaningService = new ComponentCleaningService({ logger });
+    metadataBuilder = {
+      build: jest.fn((n, p) => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: n || 'Unknown Game',
+        timestamp: 't',
+        playtimeSeconds: p,
+        saveName: '',
+      })),
+    };
     service = new GamePersistenceService({
       logger,
       saveLoadService,
@@ -45,6 +56,7 @@ describe('GamePersistenceService error paths', () => {
       dataRegistry,
       playtimeTracker,
       componentCleaningService,
+      metadataBuilder,
     });
   });
 

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -33,6 +33,7 @@ const mockDataRegistry = {};
 /** @type {jest.Mocked<PlaytimeTracker>} */
 const mockPlaytimeTracker = {};
 const mockComponentCleaningService = { clean: jest.fn() };
+const mockMetadataBuilder = { build: jest.fn() };
 /** @type {jest.Mocked<AppContainer>} */
 const mockAppContainer = {
   resolve: jest.fn(), // Mock resolve as it might be used in the TODO part in the future
@@ -52,6 +53,7 @@ describe('GamePersistenceService', () => {
       dataRegistry: mockDataRegistry,
       playtimeTracker: mockPlaytimeTracker,
       componentCleaningService: mockComponentCleaningService,
+      metadataBuilder: mockMetadataBuilder,
     });
     // Clear the logger.info/debug calls made by the constructor, if any,
     // to not interfere with test-specific logger assertions.

--- a/tests/services/saveMetadataBuilder.test.js
+++ b/tests/services/saveMetadataBuilder.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import SaveMetadataBuilder from '../../src/persistence/saveMetadataBuilder.js';
+import { ENGINE_VERSION } from '../../src/engine/engineVersion.js';
+
+describe('SaveMetadataBuilder', () => {
+  let logger;
+  let builder;
+
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    builder = new SaveMetadataBuilder({ logger });
+  });
+
+  it('builds metadata with provided parameters', () => {
+    const meta = builder.build('World', 12);
+    expect(meta.gameTitle).toBe('World');
+    expect(meta.playtimeSeconds).toBe(12);
+    expect(meta.engineVersion).toBe(ENGINE_VERSION);
+    expect(meta.saveFormatVersion).toBe('1.0.0');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('defaults world name and logs warning when missing', () => {
+    const meta = builder.build(undefined, 5);
+    expect(meta.gameTitle).toBe('Unknown Game');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Added `SaveMetadataBuilder` to centralize save metadata creation and updated `GamePersistenceService` to use it. Updated DI registrations and tests to include the new builder.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684ebcd42da88331b1e44230bb9be580