### PR TITLE
[Agent] add timestamp formatting helper

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -2,7 +2,7 @@
 
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
-import { formatPlaytime } from '../utils/textUtils.js';
+import { formatPlaytime, formatTimestamp } from '../utils/textUtils.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -315,14 +315,13 @@ class LoadGameUI extends SlotModalBase {
       slotData.timestamp &&
       slotData.timestamp !== 'N/A'
     ) {
-      try {
-        timestampText = `Saved: ${new Date(slotData.timestamp).toLocaleString()}`;
-      } catch {
+      const formatted = formatTimestamp(slotData.timestamp);
+      if (formatted === 'Invalid Date') {
         this.logger.warn(
           `${this._logPrefix} Invalid timestamp for slot ${slotData.identifier}: ${slotData.timestamp}`
         );
-        timestampText = 'Saved: Invalid Date';
       }
+      timestampText = `Saved: ${formatted}`;
     }
     const slotTimestampEl = this.domElementFactory.span(
       'slot-timestamp',

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -2,7 +2,7 @@
 
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
-import { formatPlaytime } from '../utils/textUtils.js';
+import { formatPlaytime, formatTimestamp } from '../utils/textUtils.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -332,14 +332,13 @@ export class SaveGameUI extends SlotModalBase {
       slotData.timestamp &&
       slotData.timestamp !== 'N/A'
     ) {
-      try {
-        timestampText = `Saved: ${new Date(slotData.timestamp).toLocaleString()}`;
-      } catch (e) {
+      const formatted = formatTimestamp(slotData.timestamp);
+      if (formatted === 'Invalid Date') {
         this.logger.warn(
           `${this._logPrefix} Invalid timestamp for slot ${slotData.slotId}: ${slotData.timestamp}`
         );
-        timestampText = 'Saved: Invalid Date';
       }
+      timestampText = `Saved: ${formatted}`;
     } else if (slotData.isCorrupted) {
       timestampText = 'Timestamp: N/A';
     }

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -90,4 +90,23 @@ export function formatPlaytime(totalSeconds) {
   );
 }
 
+/**
+ * Formats an ISO timestamp string to a locale-specific string.
+ *
+ * @param {string} timestamp - ISO timestamp to format.
+ * @param {string} [fallback] - Text to return on parse failure.
+ * @returns {string} Formatted timestamp or fallback on error.
+ */
+export function formatTimestamp(timestamp, fallback = 'Invalid Date') {
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      return fallback;
+    }
+    return date.toLocaleString();
+  } catch {
+    return fallback;
+  }
+}
+
 // --- FILE END ---

--- a/tests/domUI/loadGameUI.test.js
+++ b/tests/domUI/loadGameUI.test.js
@@ -127,6 +127,9 @@ describe('LoadGameUI basic behaviors', () => {
     expect(el.querySelector('.slot-playtime')?.textContent).toContain(
       '00:01:00'
     );
+    expect(el.querySelector('.slot-timestamp')?.textContent).toBe(
+      `Saved: ${new Date(slotData.timestamp).toLocaleString()}`
+    );
   });
 
   it('should populate the load slots list using the shared method', async () => {

--- a/tests/domUI/saveGameUI.test.js
+++ b/tests/domUI/saveGameUI.test.js
@@ -195,6 +195,10 @@ describe('SaveGameUI', () => {
       const slots = listContainerElement.querySelectorAll('.save-slot');
       expect(slots.length).toBe(10);
       expect(slots[0].textContent).toContain('Slot One');
+      const tsText = slots[0].querySelector('.slot-timestamp')?.textContent;
+      expect(tsText).toBe(
+        `Saved: ${new Date('2023-01-01T00:00:00Z').toLocaleString()}`
+      );
       expect(slots[1].dataset.slotId).toBe('1');
     });
   });

--- a/tests/utils/textUtils.formatTimestamp.test.js
+++ b/tests/utils/textUtils.formatTimestamp.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatTimestamp } from '../../src/utils/textUtils.js';
+
+describe('formatTimestamp', () => {
+  it('returns locale string for valid ISO input', () => {
+    const ts = '2023-01-01T00:00:00Z';
+    const expected = new Date(ts).toLocaleString();
+    expect(formatTimestamp(ts)).toBe(expected);
+  });
+
+  it('returns fallback for invalid date', () => {
+    expect(formatTimestamp('not-a-date')).toBe('Invalid Date');
+  });
+
+  it('uses provided fallback on error', () => {
+    const fallback = 'N/A';
+    expect(formatTimestamp('???', fallback)).toBe(fallback);
+  });
+});


### PR DESCRIPTION
Summary: implement `formatTimestamp` utility and refactor slot UIs to use it.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_684ebbd773588331bb2157e81f1f0ef9