### PR TITLE
[Agent] replace log.error with error event dispatch

### DIFF
--- a/tests/utils/contextVariableUtils.test.js
+++ b/tests/utils/contextVariableUtils.test.js
@@ -30,8 +30,16 @@ describe('storeResult', () => {
     );
   });
 
-  test('logs error when dispatcher not provided', () => {
-    const ctx = {};
+  test('dispatches using context dispatcher when dispatcher not provided', async () => {
+    const validated = {
+      dispatch: jest.fn().mockResolvedValue(true),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    const ctx = {
+      evaluationContext: null,
+      validatedEventDispatcher: validated,
+    };
     const logger = {
       error: jest.fn(),
       warn: jest.fn(),
@@ -39,7 +47,13 @@ describe('storeResult', () => {
       debug: jest.fn(),
     };
     const success = storeResult('baz', 7, ctx, undefined, logger);
+    await Promise.resolve();
     expect(success).toBe(false);
-    expect(logger.error).toHaveBeenCalled();
+    expect(validated.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({ message: expect.any(String) }),
+      expect.any(Object)
+    );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher inside `storeResult`
- update storeResult unit tests

## Testing
- `npx eslint src/utils/contextVariableUtils.js tests/utils/contextVariableUtils.test.js --fix`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ebc0384188331a6aa7d7b9ececef8