### PR TITLE
[Test] Add integration tests for step_back rule

### DIFF
--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -1,0 +1,353 @@
+/**
+ * @file Integration tests for the intimacy step_back rule.
+ */
+
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import Ajv from 'ajv';
+import ruleSchema from '../../../data/schemas/rule.schema.json';
+import commonSchema from '../../../data/schemas/common.schema.json';
+import operationSchema from '../../../data/schemas/operation.schema.json';
+import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import stepBackRule from '../../../data/mods/intimacy/rules/step_back.rule.json';
+import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
+import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
+import OperationRegistry from '../../../src/logic/operationRegistry.js';
+import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
+import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
+import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modifyArrayFieldHandler.js';
+import RemoveComponentHandler from '../../../src/logic/operationHandlers/removeComponentHandler.js';
+import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
+import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
+import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
+import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
+import {
+  NAME_COMPONENT_ID,
+  POSITION_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
+
+/**
+ * Minimal in-memory entity manager used for integration tests.
+ * Provides just enough of IEntityManager for the tested handlers.
+ */
+class SimpleEntityManager {
+  /**
+   * Create the manager with the provided entities.
+   *
+   * @param {Array<{id:string,components:object}>} entities - seed entities
+   */
+  constructor(entities) {
+    this.entities = new Map();
+    for (const e of entities) {
+      this.entities.set(e.id, {
+        id: e.id,
+        components: { ...e.components },
+      });
+    }
+  }
+
+  /**
+   * Return an entity instance.
+   *
+   * @param {string} id - entity id
+   * @returns {object|undefined} entity object
+   */
+  getEntityInstance(id) {
+    return this.entities.get(id);
+  }
+
+  /**
+   * Retrieve component data.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   * @returns {any} component data or null
+   */
+  getComponentData(id, type) {
+    return this.entities.get(id)?.components[type] ?? null;
+  }
+
+  /**
+   * Determine if an entity has a component.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   * @returns {boolean} true if present
+   */
+  hasComponent(id, type) {
+    return Object.prototype.hasOwnProperty.call(
+      this.entities.get(id)?.components || {},
+      type
+    );
+  }
+
+  /**
+   * Add or replace a component on an entity.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   * @param {object} data - component data
+   */
+  addComponent(id, type, data) {
+    const ent = this.entities.get(id);
+    if (ent) {
+      ent.components[type] = JSON.parse(JSON.stringify(data));
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Remove a component from an entity.
+   *
+   * @param {string} id - entity id
+   * @param {string} type - component type
+   */
+  removeComponent(id, type) {
+    const ent = this.entities.get(id);
+    if (ent) {
+      delete ent.components[type];
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Helper to (re)initialize the interpreter with the provided entities.
+ *
+ * @param {Array<{id:string,components:object}>} entities - initial entities
+ */
+function init(entities) {
+  operationRegistry = new OperationRegistry({ logger });
+  entityManager = new SimpleEntityManager(entities);
+
+  const handlers = {
+    QUERY_COMPONENT: new QueryComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
+    MODIFY_ARRAY_FIELD: new ModifyArrayFieldHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
+    REMOVE_COMPONENT: new RemoveComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
+    MODIFY_COMPONENT: new ModifyComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
+    GET_NAME: new GetNameHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
+    GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+  };
+
+  for (const [type, handler] of Object.entries(handlers)) {
+    operationRegistry.register(type, handler.execute.bind(handler));
+  }
+
+  operationInterpreter = new OperationInterpreter({
+    logger,
+    operationRegistry,
+  });
+
+  jsonLogic = new JsonLogicEvaluationService({ logger });
+
+  interpreter = new SystemLogicInterpreter({
+    logger,
+    eventBus,
+    dataRegistry,
+    jsonLogicEvaluationService: jsonLogic,
+    entityManager,
+    operationInterpreter,
+  });
+
+  listener = null;
+  interpreter.initialize();
+}
+
+let logger;
+let eventBus;
+let dataRegistry;
+let entityManager;
+let operationRegistry;
+let operationInterpreter;
+let jsonLogic;
+let interpreter;
+let events;
+let listener;
+let safeDispatcher;
+
+describe('intimacy_handle_step_back rule integration', () => {
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    events = [];
+    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    eventBus = {
+      subscribe: jest.fn((ev, l) => {
+        if (ev === '*') listener = l;
+      }),
+      unsubscribe: jest.fn(),
+      dispatch: jest.fn((eventType, payload) => {
+        events.push({ eventType, payload });
+        return Promise.resolve();
+      }),
+      listenerCount: jest.fn().mockReturnValue(1),
+    };
+
+    dataRegistry = {
+      getAllSystemRules: jest.fn().mockReturnValue([stepBackRule]),
+    };
+
+    init([]);
+  });
+
+  it('validates step_back.rule.json against schema', () => {
+    const ajv = new Ajv({ allErrors: true });
+    ajv.addSchema(
+      commonSchema,
+      'http://example.com/schemas/common.schema.json'
+    );
+    ajv.addSchema(
+      operationSchema,
+      'http://example.com/schemas/operation.schema.json'
+    );
+    ajv.addSchema(
+      jsonLogicSchema,
+      'http://example.com/schemas/json-logic.schema.json'
+    );
+    const valid = ajv.validate(ruleSchema, stepBackRule);
+    if (!valid) console.error(ajv.errors);
+    expect(valid).toBe(true);
+  });
+
+  it('actor leaves a triad leaving remaining pair intact', () => {
+    interpreter.shutdown();
+    init([
+      {
+        id: 'a1',
+        components: {
+          [NAME_COMPONENT_ID]: { text: 'A' },
+          [POSITION_COMPONENT_ID]: { locationId: 'room1' },
+          'intimacy:closeness': { partners: ['b1', 'c1'] },
+          'core:movement': { locked: true },
+        },
+      },
+      {
+        id: 'b1',
+        components: {
+          [NAME_COMPONENT_ID]: { text: 'B' },
+          'intimacy:closeness': { partners: ['a1', 'c1'] },
+          'core:movement': { locked: true },
+        },
+      },
+      {
+        id: 'c1',
+        components: {
+          [NAME_COMPONENT_ID]: { text: 'C' },
+          'intimacy:closeness': { partners: ['a1', 'b1'] },
+          'core:movement': { locked: true },
+        },
+      },
+    ]);
+
+    listener({
+      type: ATTEMPT_ACTION_ID,
+      payload: { actorId: 'a1', actionId: 'intimacy:step_back' },
+    });
+
+    expect(
+      entityManager.getComponentData('a1', 'intimacy:closeness')
+    ).toBeNull();
+    expect(entityManager.getComponentData('a1', 'core:movement')).toEqual({
+      locked: false,
+    });
+    expect(entityManager.getComponentData('b1', 'intimacy:closeness')).toEqual({
+      partners: ['c1'],
+    });
+    expect(entityManager.getComponentData('b1', 'core:movement')).toEqual({
+      locked: true,
+    });
+    expect(entityManager.getComponentData('c1', 'intimacy:closeness')).toEqual({
+      partners: ['b1'],
+    });
+    expect(entityManager.getComponentData('c1', 'core:movement')).toEqual({
+      locked: true,
+    });
+    const types = events.map((e) => e.eventType);
+    expect(types).toEqual(
+      expect.arrayContaining([
+        'core:perceptible_event',
+        'core:display_successful_action_result',
+        'core:turn_ended',
+      ])
+    );
+  });
+
+  it('actor stepping back from a pair frees the partner', () => {
+    interpreter.shutdown();
+    init([
+      {
+        id: 'a1',
+        components: {
+          [NAME_COMPONENT_ID]: { text: 'A' },
+          [POSITION_COMPONENT_ID]: { locationId: 'room1' },
+          'intimacy:closeness': { partners: ['b1'] },
+          'core:movement': { locked: true },
+        },
+      },
+      {
+        id: 'b1',
+        components: {
+          [NAME_COMPONENT_ID]: { text: 'B' },
+          'intimacy:closeness': { partners: ['a1'] },
+          'core:movement': { locked: true },
+        },
+      },
+    ]);
+
+    listener({
+      type: ATTEMPT_ACTION_ID,
+      payload: { actorId: 'a1', actionId: 'intimacy:step_back' },
+    });
+
+    expect(
+      entityManager.getComponentData('a1', 'intimacy:closeness')
+    ).toBeNull();
+    expect(entityManager.getComponentData('a1', 'core:movement')).toEqual({
+      locked: false,
+    });
+    expect(
+      entityManager.getComponentData('b1', 'intimacy:closeness')
+    ).toBeNull();
+    expect(entityManager.getComponentData('b1', 'core:movement')).toEqual({
+      locked: false,
+    });
+    const types = events.map((e) => e.eventType);
+    expect(types).toEqual(
+      expect.arrayContaining([
+        'core:perceptible_event',
+        'core:display_successful_action_result',
+        'core:turn_ended',
+      ])
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added a new integration test suite covering the intimacy `step_back` rule with scenarios for leaving a triad and for leaving a pair. The suite validates the rule schema and checks component updates, movement unlocking, and event dispatching.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` and proxy lint)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test


------
https://chatgpt.com/codex/tasks/task_e_684ebee1c90c8331b7d14b0c1550b4df