### PR TITLE
[Agent] centralize save validation

### DIFF
--- a/src/persistence/saveInputValidators.js
+++ b/src/persistence/saveInputValidators.js
@@ -1,0 +1,25 @@
+// src/persistence/saveInputValidators.js
+
+/**
+ * @file Provides validation helpers for save operations.
+ */
+
+/**
+ * Validates a manual save name.
+ *
+ * @param {*} saveName - The candidate save name.
+ * @returns {boolean} `true` if the save name is a non-empty string.
+ */
+export function validateSaveName(saveName) {
+  return typeof saveName === 'string' && saveName.trim() !== '';
+}
+
+/**
+ * Validates a save identifier.
+ *
+ * @param {*} saveIdentifier - The identifier to validate.
+ * @returns {boolean} `true` if the identifier is a non-empty string.
+ */
+export function validateSaveIdentifier(saveIdentifier) {
+  return typeof saveIdentifier === 'string' && saveIdentifier.trim() !== '';
+}

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -4,6 +4,10 @@ import { ISaveLoadService } from '../interfaces/ISaveLoadService.js';
 import { encode } from '@msgpack/msgpack';
 import { deepClone } from '../utils/objectUtils.js';
 import GameStateSerializer from './gameStateSerializer.js';
+import {
+  validateSaveName,
+  validateSaveIdentifier,
+} from './saveInputValidators.js';
 // REMOVED: import {createHash} from 'crypto';
 
 // --- Type Imports ---
@@ -266,11 +270,7 @@ class SaveLoadService extends ISaveLoadService {
       `Attempting to load game data from: "${saveIdentifier}"`
     );
 
-    if (
-      !saveIdentifier ||
-      typeof saveIdentifier !== 'string' ||
-      saveIdentifier.trim() === ''
-    ) {
+    if (!validateSaveIdentifier(saveIdentifier)) {
       const errorMsg = 'Invalid saveIdentifier provided for loading.';
       const userMsg = 'Cannot load game: No save file was specified.';
       this.#logger.error(errorMsg);
@@ -364,7 +364,7 @@ class SaveLoadService extends ISaveLoadService {
   async saveManualGame(saveName, gameStateObject) {
     this.#logger.debug(`Attempting to save manual game: "${saveName}"`);
 
-    if (!saveName || typeof saveName !== 'string' || saveName.trim() === '') {
+    if (!validateSaveName(saveName)) {
       const userMsg = 'Invalid save name provided. Please enter a valid name.';
       this.#logger.error('Invalid saveName provided for manual save.');
       return { success: false, error: userMsg };
@@ -463,11 +463,7 @@ class SaveLoadService extends ISaveLoadService {
    */
   async deleteManualSave(saveIdentifier) {
     this.#logger.debug(`Attempting to delete manual save: "${saveIdentifier}"`);
-    if (
-      !saveIdentifier ||
-      typeof saveIdentifier !== 'string' ||
-      saveIdentifier.trim() === ''
-    ) {
+    if (!validateSaveIdentifier(saveIdentifier)) {
       const msg = 'Invalid saveIdentifier provided for deletion.';
       const userMsg = 'Cannot delete: No save file specified.';
       this.#logger.error(msg);

--- a/tests/utils/saveInputValidators.test.js
+++ b/tests/utils/saveInputValidators.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  validateSaveName,
+  validateSaveIdentifier,
+} from '../../src/persistence/saveInputValidators.js';
+
+describe('save input validators', () => {
+  describe('validateSaveName', () => {
+    it('returns true for non-empty strings', () => {
+      expect(validateSaveName('slot1')).toBe(true);
+    });
+
+    it('returns false for empty or non-string values', () => {
+      expect(validateSaveName('')).toBe(false);
+      expect(validateSaveName('   ')).toBe(false);
+      expect(validateSaveName(null)).toBe(false);
+      expect(validateSaveName(undefined)).toBe(false);
+    });
+  });
+
+  describe('validateSaveIdentifier', () => {
+    it('returns true for non-empty strings', () => {
+      expect(validateSaveIdentifier('path/file.sav')).toBe(true);
+    });
+
+    it('returns false for empty or non-string values', () => {
+      expect(validateSaveIdentifier('')).toBe(false);
+      expect(validateSaveIdentifier('   ')).toBe(false);
+      expect(validateSaveIdentifier(0)).toBe(false);
+      expect(validateSaveIdentifier(null)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `saveInputValidators` helper with reusable validators
- use helpers inside `SaveLoadService`
- unit test new validators

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors, 1772 warnings)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ebfdc3ce88331852c275c81128561