### PR TITLE
[Agent] dispatch display_error in QueryComponentOptionalHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -133,6 +133,7 @@ export function registerInterpreters(container) {
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
           logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],
     [

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -73,6 +73,7 @@ function init(entities) {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
+      safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -154,6 +154,7 @@ function init(entities) {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
+      safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     SET_VARIABLE: new SetVariableHandler({ logger }),

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -141,6 +141,7 @@ function init(entities) {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
       logger,
+      safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),

--- a/tests/logic/operationHandlers/queryComponentOptionalHandler.test.js
+++ b/tests/logic/operationHandlers/queryComponentOptionalHandler.test.js
@@ -43,29 +43,40 @@ const ctx = (overrides = {}) => ({
 describe('QueryComponentOptionalHandler', () => {
   /** @type {QueryComponentOptionalHandler} */
   let handler;
+  let safeDispatcher;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    safeDispatcher = { dispatch: jest.fn() };
     handler = new QueryComponentOptionalHandler({
       entityManager: mockEntityManager,
       logger: mockLogger,
+      safeEventDispatcher: safeDispatcher,
     });
   });
 
   test('constructor throws with invalid deps', () => {
     expect(
-      () => new QueryComponentOptionalHandler({ logger: mockLogger })
+      () =>
+        new QueryComponentOptionalHandler({
+          logger: mockLogger,
+          safeEventDispatcher: { dispatch: jest.fn() },
+        })
     ).toThrow(/EntityManager/);
     expect(
       () =>
         new QueryComponentOptionalHandler({
           entityManager: {},
           logger: mockLogger,
+          safeEventDispatcher: { dispatch: jest.fn() },
         })
     ).toThrow(/getComponentData/);
     expect(
       () =>
-        new QueryComponentOptionalHandler({ entityManager: mockEntityManager })
+        new QueryComponentOptionalHandler({
+          entityManager: mockEntityManager,
+          safeEventDispatcher: { dispatch: jest.fn() },
+        })
     ).toThrow(/ILogger/);
   });
 
@@ -85,6 +96,7 @@ describe('QueryComponentOptionalHandler', () => {
     );
     expect(c.evaluationContext.context.data).toEqual(result);
     expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(safeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 
   test('stores null when component missing', () => {
@@ -100,6 +112,7 @@ describe('QueryComponentOptionalHandler', () => {
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining("Stored 'null'")
     );
+    expect(safeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 
   test('uses execution context logger if provided', () => {
@@ -119,5 +132,6 @@ describe('QueryComponentOptionalHandler', () => {
     handler.execute(params, c);
     expect(customLogger.debug).toHaveBeenCalled();
     expect(mockLogger.debug).not.toHaveBeenCalled();
+    expect(safeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `QueryComponentOptionalHandler`
- emit `DISPLAY_ERROR_ID` instead of `logger.error`
- update dependency injection registration
- adjust tests to provide SafeEventDispatcher

## Testing Done
- `npm run format`
- `npx eslint src/dependencyInjection/registrations/interpreterRegistrations.js src/logic/operationHandlers/queryComponentOptionalHandler.js tests/integration/rules/entitySpeechRule.integration.test.js tests/integration/rules/goRule.integration.test.js tests/integration/rules/stopFollowingRule.integration.test.js tests/logic/operationHandlers/queryComponentOptionalHandler.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684ec00f42308331b7f3cddb0fb4eca3