### PR TITLE
[Agent] dispatch error event for mod version incompatibility

### DIFF
--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -350,7 +350,11 @@ class WorldLoader {
       // Run validations - these may throw ModDependencyError
       ModDependencyValidator.validate(manifestsForValidation, this.#logger);
       try {
-        validateModEngineVersions(manifestsForValidation, this.#logger);
+        validateModEngineVersions(
+          manifestsForValidation,
+          this.#logger,
+          this.#validatedEventDispatcher
+        );
       } catch (e) {
         // Capture engine version specific errors for summary, but re-throw
         if (e instanceof ModDependencyError) {

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -351,7 +351,8 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     expect(mockedValidateModEngineVersions).toHaveBeenCalledTimes(1);
     expect(mockedValidateModEngineVersions).toHaveBeenCalledWith(
       expectedValidationMap,
-      mockLogger
+      mockLogger,
+      mockValidatedEventDispatcher
     );
 
     // 9. Verify resolveOrder was called.


### PR DESCRIPTION
## Summary
- add SafeEventDispatcher parameter to mod version validator
- dispatch `core:display_error` instead of logging
- pass dispatcher from world loader and validation script
- update affected tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 533 errors)*
- `npx eslint src/modding/modVersionValidator.js src/loaders/worldLoader.js scripts/validateMods.mjs tests/services/modVersionValidator.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ec07592ec8331ae1181a264ed9517