### PR TITLE
[Agent] replace logger.error with event dispatch

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -62,6 +62,7 @@ export function registerPersistence(container) {
 
   r.single(tokens.ComponentCleaningService, ComponentCleaningService, [
     tokens.ILogger,
+    tokens.ISafeEventDispatcher,
   ]);
   logger.debug(
     `Persistence Registration: Registered ${String(tokens.ComponentCleaningService)}.`

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -111,7 +111,7 @@ describe('registerPersistence', () => {
         token: tokens.ComponentCleaningService,
         Class: ComponentCleaningService,
         lifecycle: 'singleton',
-        deps: [tokens.ILogger],
+        deps: [tokens.ILogger, tokens.ISafeEventDispatcher],
       },
       {
         token: tokens.SaveMetadataBuilder,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -63,6 +63,7 @@ describe('Persistence round-trip', () => {
   let playtimeTracker;
   let componentCleaningService;
   let metadataBuilder;
+  let safeEventDispatcher;
   let persistence;
   let entity;
   const saveName = 'RoundTripTest';
@@ -100,7 +101,11 @@ describe('Persistence round-trip', () => {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
     };
-    componentCleaningService = new ComponentCleaningService({ logger });
+    safeEventDispatcher = { dispatch: jest.fn() };
+    componentCleaningService = new ComponentCleaningService({
+      logger,
+      safeEventDispatcher,
+    });
     metadataBuilder = {
       build: jest.fn((n, p) => ({
         saveFormatVersion: '1',

--- a/tests/services/componentCleaningService.test.js
+++ b/tests/services/componentCleaningService.test.js
@@ -11,13 +11,22 @@ const makeLogger = () => ({
   error: jest.fn(),
 });
 
+const makeDispatcher = () => ({
+  dispatch: jest.fn(),
+});
+
 describe('ComponentCleaningService', () => {
   let logger;
+  let dispatcher;
   let service;
 
   beforeEach(() => {
     logger = makeLogger();
-    service = new ComponentCleaningService({ logger });
+    dispatcher = makeDispatcher();
+    service = new ComponentCleaningService({
+      logger,
+      safeEventDispatcher: dispatcher,
+    });
   });
 
   it('allows registering and executing custom cleaners', () => {
@@ -45,10 +54,12 @@ describe('ComponentCleaningService', () => {
     expect(() => service.clean('loop', cyc)).toThrow(
       'Failed to deep clone object data.'
     );
-    expect(logger.error).toHaveBeenCalledWith(
-      'ComponentCleaningService.clean deepClone failed:',
-      expect.any(Error),
-      cyc
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      'core:display_error',
+      expect.objectContaining({
+        message: 'ComponentCleaningService.clean deepClone failed',
+        details: expect.objectContaining({ componentId: 'loop' }),
+      })
     );
   });
 });

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -30,6 +30,7 @@ describe('GamePersistenceService edge cases', () => {
   let playtimeTracker;
   let componentCleaningService;
   let metadataBuilder;
+  let safeEventDispatcher;
   let service;
 
   beforeEach(() => {
@@ -45,7 +46,11 @@ describe('GamePersistenceService edge cases', () => {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
     };
-    componentCleaningService = new ComponentCleaningService({ logger });
+    safeEventDispatcher = { dispatch: jest.fn() };
+    componentCleaningService = new ComponentCleaningService({
+      logger,
+      safeEventDispatcher,
+    });
     metadataBuilder = {
       build: jest.fn((n, p) => ({
         saveFormatVersion: '1',


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in `ComponentCleaningService`
- update persistence registrations to provide SafeEventDispatcher
- update tests for new constructor dependencies and behaviour

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ec2951d0883319d16f0559d54a53d