### PR TITLE
[Agent] add BaseInlineSchemaLoader

### DIFF
--- a/src/loaders/baseInlineSchemaLoader.js
+++ b/src/loaders/baseInlineSchemaLoader.js
@@ -1,0 +1,42 @@
+// src/loaders/baseInlineSchemaLoader.js
+
+/**
+ * @file Provides BaseInlineSchemaLoader, extending BaseManifestItemLoader
+ * with helper for registering inline schemas defined within item data.
+ */
+
+import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { registerInlineSchema } from '../utils/schemaUtils.js';
+
+/**
+ * Extends {@link BaseManifestItemLoader} adding a convenience method for
+ * registering inline schemas found on loaded items.
+ *
+ * @class BaseInlineSchemaLoader
+ * @augments BaseManifestItemLoader
+ */
+export class BaseInlineSchemaLoader extends BaseManifestItemLoader {
+  /**
+   * Registers an inline schema extracted from `data[propName]` using
+   * {@link registerInlineSchema}.
+   *
+   * @protected
+   * @param {object} data - The item data containing the schema.
+   * @param {string} propName - Property name on `data` holding the schema object.
+   * @param {string} schemaId - ID to associate with the schema in the validator.
+   * @param {object} [messages] - Optional logging message overrides.
+   * @returns {Promise<void>} Resolves when registration completes.
+   */
+  async _registerItemSchema(data, propName, schemaId, messages = {}) {
+    const schema = data?.[propName];
+    await registerInlineSchema(
+      this._schemaValidator,
+      schema,
+      schemaId,
+      this._logger,
+      messages
+    );
+  }
+}
+
+export default BaseInlineSchemaLoader;

--- a/src/loaders/componentLoader.js
+++ b/src/loaders/componentLoader.js
@@ -1,10 +1,8 @@
 // src/loaders/componentLoader.js
 
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { BaseInlineSchemaLoader } from './baseInlineSchemaLoader.js';
 
 import { parseAndValidateId } from '../utils/idUtils.js';
-import { extractBaseId } from '../utils/idUtils.js';
-import { registerInlineSchema } from '../utils/schemaUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
@@ -25,9 +23,9 @@ import { registerInlineSchema } from '../utils/schemaUtils.js';
  * and implements the component-definition-specific processing logic in `_processFetchedItem`.
  *
  * @class ComponentLoader
- * @augments BaseManifestItemLoader
+ * @augments BaseInlineSchemaLoader
  */
-class ComponentLoader extends BaseManifestItemLoader {
+class ComponentLoader extends BaseInlineSchemaLoader {
   /**
    * Initializes the ComponentLoader by calling the parent constructor with the specific type name 'components'.
    *
@@ -114,11 +112,10 @@ class ComponentLoader extends BaseManifestItemLoader {
     this._logger.debug(
       `ComponentLoader [${modId}]: Attempting to register/manage data schema using FULL ID '${trimmedComponentIdFromFile}'.`
     );
-    await registerInlineSchema(
-      this._schemaValidator,
-      dataSchema,
+    await this._registerItemSchema(
+      data,
+      'dataSchema',
       trimmedComponentIdFromFile,
-      this._logger,
       {
         warnMessage: `Component Definition '${filename}' in mod '${modId}' is overwriting an existing data schema for component ID '${trimmedComponentIdFromFile}'.`,
         successDebugMessage: `ComponentLoader [${modId}]: Registered dataSchema for component ID '${trimmedComponentIdFromFile}' from file '${filename}'.`,

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -7,11 +7,9 @@
 
 // --- Base Class Import ---
 // Adjust path relative to this file's location if needed
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js'; // Assuming it's in loaders sibling dir
+import { BaseInlineSchemaLoader } from './baseInlineSchemaLoader.js';
 
 import { parseAndValidateId } from '../utils/idUtils.js';
-import { extractBaseId } from '../utils/idUtils.js';
-import { registerInlineSchema } from '../utils/schemaUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -30,9 +28,9 @@ import { registerInlineSchema } from '../utils/schemaUtils.js';
  * particularly payload schema registration, is implemented in this class.
  *
  * @class EventLoader
- * @augments BaseManifestItemLoader
+ * @augments BaseInlineSchemaLoader
  */
-class EventLoader extends BaseManifestItemLoader {
+class EventLoader extends BaseInlineSchemaLoader {
   /**
    * Creates an instance of EventLoader.
    * Passes dependencies and the specific content type 'events' to the base class constructor.
@@ -117,23 +115,17 @@ class EventLoader extends BaseManifestItemLoader {
         `EventLoader [${modId}]: Generated payload schema ID: ${payloadSchemaId}`
       );
 
-      await registerInlineSchema(
-        this._schemaValidator,
-        payloadSchema,
-        payloadSchemaId,
-        this._logger,
-        {
-          warnMessage: `EventLoader [${modId}]: Payload schema ID '${payloadSchemaId}' for event '${trimmedFullEventId}' was already loaded. Overwriting/duplicate.`,
-          successDebugMessage: `EventLoader [${modId}]: Successfully registered payload schema '${payloadSchemaId}'.`,
-          errorLogMessage: `EventLoader [${modId}]: CRITICAL - Failed to register payload schema '${payloadSchemaId}' for event '${trimmedFullEventId}'.`,
-          throwErrorMessage: `CRITICAL: Failed to register payload schema '${payloadSchemaId}'.`,
-          errorContext: () => ({
-            modId,
-            filename,
-            eventId: trimmedFullEventId,
-          }),
-        }
-      );
+      await this._registerItemSchema(data, 'payloadSchema', payloadSchemaId, {
+        warnMessage: `EventLoader [${modId}]: Payload schema ID '${payloadSchemaId}' for event '${trimmedFullEventId}' was already loaded. Overwriting/duplicate.`,
+        successDebugMessage: `EventLoader [${modId}]: Successfully registered payload schema '${payloadSchemaId}'.`,
+        errorLogMessage: `EventLoader [${modId}]: CRITICAL - Failed to register payload schema '${payloadSchemaId}' for event '${trimmedFullEventId}'.`,
+        throwErrorMessage: `CRITICAL: Failed to register payload schema '${payloadSchemaId}'.`,
+        errorContext: () => ({
+          modId,
+          filename,
+          eventId: trimmedFullEventId,
+        }),
+      });
     } else {
       this._logger.debug(
         `EventLoader [${modId}]: No valid payloadSchema found for event '${trimmedFullEventId}'. Skipping registration.`


### PR DESCRIPTION
Summary: Added a new BaseInlineSchemaLoader extending BaseManifestItemLoader to centralize inline schema registration. ComponentLoader and EventLoader now extend this new base and use its _registerItemSchema helper.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: many existing errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ec5fde2bc83319ae6b7baf42c15bd