### PR TITLE
[Agent] replace log.error with safe event dispatch

### DIFF
--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -68,6 +68,11 @@ function init(entities) {
   entityManager = new SimpleEntityManager(entities);
 
   const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+  const safeSpeechDispatcher = {
+    dispatch: jest.fn((eventType, payload) =>
+      eventBus.dispatch(eventType, payload)
+    ),
+  };
 
   const handlers = {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
@@ -78,7 +83,7 @@ function init(entities) {
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     DISPATCH_SPEECH: new DispatchSpeechHandler({
-      dispatcher: eventBus,
+      dispatcher: safeSpeechDispatcher,
       logger,
     }),
   };


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in `DispatchSpeechHandler`
- emit `core:display_error` when invalid params or dispatch errors occur
- update tests for new error event behaviour

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ec70a79cc8331a1a4b51eae709d37