### PR TITLE
[Agent] implement structured error objects

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -22,6 +22,10 @@ import SaveMetadataBuilder from './saveMetadataBuilder.js';
 // --- MODIFICATION START: Import component IDs for cleaning logic ---
 import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
 import { CORE_MOD_ID } from '../constants/core';
+import {
+  PersistenceError,
+  PersistenceErrorCodes,
+} from './persistenceErrors.js';
 // --- MODIFICATION END ---
 
 /**
@@ -292,7 +296,13 @@ class GamePersistenceService extends IGamePersistenceService {
     if (!this.#saveLoadService) {
       const errorMsg = 'SaveLoadService is not available. Cannot save game.';
       this.#logger.error(`GamePersistenceService.saveGame: ${errorMsg}`);
-      return { success: false, error: errorMsg };
+      return {
+        success: false,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          errorMsg
+        ),
+      };
     }
 
     if (!this.isSavingAllowed(isEngineInitialized)) {
@@ -300,7 +310,13 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.warn(
         `GamePersistenceService.saveGame: Saving is not currently allowed.`
       );
-      return { success: false, error: errorMsg };
+      return {
+        success: false,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          errorMsg
+        ),
+      };
     }
 
     try {
@@ -341,7 +357,13 @@ class GamePersistenceService extends IGamePersistenceService {
       );
       return {
         success: false,
-        error: `Unexpected error during save: ${errorMessage}`,
+        error:
+          error instanceof PersistenceError
+            ? error
+            : new PersistenceError(
+                PersistenceErrorCodes.UNEXPECTED_ERROR,
+                `Unexpected error during save: ${errorMessage}`
+              ),
       };
     }
   }
@@ -357,12 +379,30 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.error(
         `GamePersistenceService.restoreGameState: ${errorMsg}`
       );
-      return { success: false, error: errorMsg };
+      return {
+        success: false,
+        error: new PersistenceError(
+          PersistenceErrorCodes.INVALID_GAME_STATE,
+          errorMsg
+        ),
+      };
     }
     if (!this.#entityManager)
-      return { success: false, error: 'EntityManager not available.' };
+      return {
+        success: false,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          'EntityManager not available.'
+        ),
+      };
     if (!this.#playtimeTracker)
-      return { success: false, error: 'PlaytimeTracker not available.' };
+      return {
+        success: false,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          'PlaytimeTracker not available.'
+        ),
+      };
 
     try {
       this.#entityManager.clearAll();
@@ -377,7 +417,10 @@ class GamePersistenceService extends IGamePersistenceService {
       );
       return {
         success: false,
-        error: `Critical error during state clearing: ${errorMsg}`,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          `Critical error during state clearing: ${errorMsg}`
+        ),
       };
     }
 
@@ -451,7 +494,10 @@ class GamePersistenceService extends IGamePersistenceService {
     if (!this.#saveLoadService) {
       return {
         success: false,
-        error: 'SaveLoadService is not available.',
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          'SaveLoadService is not available.'
+        ),
         data: null,
       };
     }
@@ -467,7 +513,10 @@ class GamePersistenceService extends IGamePersistenceService {
       );
       return {
         success: false,
-        error: `Unexpected error during data loading: ${serviceError.message}`,
+        error: new PersistenceError(
+          PersistenceErrorCodes.UNEXPECTED_ERROR,
+          `Unexpected error during data loading: ${serviceError.message}`
+        ),
         data: null,
       };
     }
@@ -479,7 +528,13 @@ class GamePersistenceService extends IGamePersistenceService {
       );
       return {
         success: false,
-        error: loadResult?.error || 'Failed to load raw game data.',
+        error:
+          loadResult?.error instanceof PersistenceError
+            ? loadResult.error
+            : new PersistenceError(
+                PersistenceErrorCodes.UNEXPECTED_ERROR,
+                loadResult?.error || 'Failed to load raw game data.'
+              ),
         data: null,
       };
     }
@@ -503,7 +558,13 @@ class GamePersistenceService extends IGamePersistenceService {
       );
       return {
         success: false,
-        error: restoreResult.error || 'Failed to restore game state.',
+        error:
+          restoreResult.error instanceof PersistenceError
+            ? restoreResult.error
+            : new PersistenceError(
+                PersistenceErrorCodes.UNEXPECTED_ERROR,
+                restoreResult.error || 'Failed to restore game state.'
+              ),
         data: null,
       };
     }

--- a/src/persistence/persistenceErrors.js
+++ b/src/persistence/persistenceErrors.js
@@ -1,0 +1,37 @@
+export const PersistenceErrorCodes = {
+  INVALID_SAVE_NAME: 'INVALID_SAVE_NAME',
+  INVALID_SAVE_IDENTIFIER: 'INVALID_SAVE_IDENTIFIER',
+  FILE_READ_ERROR: 'FILE_READ_ERROR',
+  EMPTY_FILE: 'EMPTY_FILE',
+  DECOMPRESSION_ERROR: 'DECOMPRESSION_ERROR',
+  DESERIALIZATION_ERROR: 'DESERIALIZATION_ERROR',
+  INVALID_GAME_STATE: 'INVALID_GAME_STATE',
+  CHECKSUM_GENERATION_FAILED: 'CHECKSUM_GENERATION_FAILED',
+  CHECKSUM_MISMATCH: 'CHECKSUM_MISMATCH',
+  CHECKSUM_CALCULATION_ERROR: 'CHECKSUM_CALCULATION_ERROR',
+  DIRECTORY_CREATION_FAILED: 'DIRECTORY_CREATION_FAILED',
+  WRITE_ERROR: 'WRITE_ERROR',
+  DELETE_FILE_NOT_FOUND: 'DELETE_FILE_NOT_FOUND',
+  DELETE_FAILED: 'DELETE_FAILED',
+  DEEP_CLONE_FAILED: 'DEEP_CLONE_FAILED',
+  UNEXPECTED_ERROR: 'UNEXPECTED_ERROR',
+};
+
+/**
+ * Custom error class for persistence-related operations.
+ *
+ * @class PersistenceError
+ * @augments Error
+ * @param {string} code - Machine readable code from PersistenceErrorCodes.
+ * @param {string} message - Human readable message.
+ */
+export class PersistenceError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'PersistenceError';
+    this.code = code;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PersistenceError);
+    }
+  }
+}

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -166,7 +166,7 @@ describe('GamePersistenceService additional coverage', () => {
       });
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
-      expect(res.error).toBe('no');
+      expect(res.error.message).toBe('no');
     });
 
     it('loads and restores on success', async () => {

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -102,7 +102,7 @@ describe('GamePersistenceService edge cases', () => {
 
       const res = await service.saveGame('Save1', true, 'World');
       expect(res.success).toBe(false);
-      expect(res.error).toMatch('boom');
+      expect(res.error.message).toMatch('boom');
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -156,7 +156,7 @@ describe('GamePersistenceService edge cases', () => {
       });
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
-      expect(res.error).toBe('no');
+      expect(res.error.message).toBe('no');
     });
 
     it('returns failure when restoreGameState fails', async () => {
@@ -167,7 +167,7 @@ describe('GamePersistenceService edge cases', () => {
         .mockResolvedValue({ success: false, error: 'bad' });
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
-      expect(res.error).toBe('bad');
+      expect(res.error.message).toBe('bad');
     });
   });
 });

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -87,7 +87,7 @@ describe('GamePersistenceService error paths', () => {
         gameState: { entities: [] },
       });
       expect(result.success).toBe(false);
-      expect(result.error).toMatch('Critical error');
+      expect(result.error.message).toMatch('Critical error');
       expect(logger.error).toHaveBeenCalled();
     });
   });
@@ -114,7 +114,7 @@ describe('GamePersistenceService error paths', () => {
       saveLoadService.loadGameData.mockRejectedValue(new Error('load fail'));
       const result = await service.loadAndRestoreGame('slot');
       expect(result.success).toBe(false);
-      expect(result.error).toMatch('Unexpected error');
+      expect(result.error.message).toMatch('Unexpected error');
       expect(logger.error).toHaveBeenCalled();
     });
   });

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -69,7 +69,7 @@ describe('SaveLoadService edge cases', () => {
       };
       const result = await service.saveManualGame('Slot', obj);
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Checksum generation failed/);
+      expect(result.error.message).toMatch(/Checksum generation failed/);
       expect(logger.error).toHaveBeenCalled();
       digestSpy.mockRestore();
     });
@@ -85,7 +85,7 @@ describe('SaveLoadService edge cases', () => {
       cyc.self = cyc;
       const result = await service.saveManualGame('Loop', cyc);
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/deep clone/);
+      expect(result.error.message).toMatch(/deep clone/);
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -94,7 +94,7 @@ describe('SaveLoadService edge cases', () => {
       const obj = { metadata: {}, modManifest: {}, integrityChecks: {} };
       const result = await service.saveManualGame('Bad', obj);
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Invalid gameState/);
+      expect(result.error.message).toMatch(/Invalid gameState/);
       expect(logger.error).toHaveBeenCalled();
     });
   });
@@ -266,7 +266,7 @@ describe('SaveLoadService edge cases', () => {
       };
       const res = await service.saveManualGame('Dir', obj);
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/Failed to create save directory/);
+      expect(res.error.message).toMatch(/Failed to create save directory/);
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -284,7 +284,7 @@ describe('SaveLoadService edge cases', () => {
       };
       const res = await service.saveManualGame('Disk', obj);
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/Not enough disk space/);
+      expect(res.error.message).toMatch(/Not enough disk space/);
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -301,7 +301,7 @@ describe('SaveLoadService edge cases', () => {
       };
       const res = await service.saveManualGame('Reject', obj);
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/unexpected error/i);
+      expect(res.error.message).toMatch(/unexpected error/i);
       expect(logger.error).toHaveBeenCalled();
     });
   });

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -78,7 +78,7 @@ describe('SaveLoadService error paths', () => {
     storageProvider.deleteFile.mockRejectedValue(new Error('fs failure'));
     const res = await service.deleteManualSave('saves/manual_saves/bad.sav');
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/unexpected error/i);
+    expect(res.error.message).toMatch(/unexpected error/i);
     expect(logger.error).toHaveBeenCalled();
   });
 
@@ -132,7 +132,7 @@ describe('SaveLoadService error paths', () => {
     cyc.self = cyc;
     const res = await service.saveManualGame('Loop', cyc);
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/deep clone/i);
+    expect(res.error.message).toMatch(/deep clone/i);
     expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -60,21 +60,21 @@ describe('SaveLoadService private helper error propagation', () => {
     storageProvider.readFile.mockRejectedValue(new Error('read fail'));
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/Could not access/);
+    expect(res.error.message).toMatch(/Could not access/);
   });
 
   it('propagates empty file error', async () => {
     storageProvider.readFile.mockResolvedValue(new Uint8Array());
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/empty or cannot be read/);
+    expect(res.error.message).toMatch(/empty or cannot be read/);
   });
 
   it('propagates decompression errors', async () => {
     storageProvider.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/could not decompress/);
+    expect(res.error.message).toMatch(/could not decompress/);
   });
 
   it('propagates deserialization errors', async () => {
@@ -82,6 +82,6 @@ describe('SaveLoadService private helper error propagation', () => {
     storageProvider.readFile.mockResolvedValue(badGzip);
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/could not understand/);
+    expect(res.error.message).toMatch(/could not understand/);
   });
 });


### PR DESCRIPTION
## Summary
- introduce `PersistenceError` and codes for persistence
- use structured errors in save/load helpers
- update serializer to provide friendly messages
- adapt game persistence service to return error objects
- revise tests for new error structures

## Testing
- `npm run format`
- `npm run lint` *(fails: 532 errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ec5c49f9483318d9cba33ddbe6bba