### PR TITLE
[Agent] dispatch display error from LLMResponseProcessor

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -348,6 +348,7 @@ export function registerAI(container) {
       new LLMResponseProcessor({
         schemaValidator: c.resolve(tokens.ISchemaValidator),
         logger: c.resolve(tokens.ILogger), // <-- INJECT LOGGER HERE
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
   r.singletonFactory(

--- a/tests/integration/EndToEndMemoryFlow.test.js
+++ b/tests/integration/EndToEndMemoryFlow.test.js
@@ -114,7 +114,12 @@ describe('End-to-End Short-Term Memory Flow', () => {
     });
 
     schemaValidator = new AjvSchemaValidator(logger);
-    responseProcessor = new LLMResponseProcessor({ schemaValidator, logger });
+    const safeEventDispatcher = { dispatch: jest.fn() };
+    responseProcessor = new LLMResponseProcessor({
+      schemaValidator,
+      logger,
+      safeEventDispatcher,
+    });
   });
 
   test('thought persists and appears in next prompt', async () => {

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -134,7 +134,12 @@ describe('End-to-End Notes Persistence Flow', () => {
     });
 
     schemaValidator = new AjvSchemaValidator(logger);
-    processor = new LLMResponseProcessor({ schemaValidator, logger });
+    const safeEventDispatcher = { dispatch: jest.fn() };
+    processor = new LLMResponseProcessor({
+      schemaValidator,
+      logger,
+      safeEventDispatcher,
+    });
   });
 
   test('notes persist and appear in subsequent prompt', async () => {

--- a/tests/turns/services/LLMResponseProcessor.test.js
+++ b/tests/turns/services/LLMResponseProcessor.test.js
@@ -26,15 +26,18 @@ describe('LLMResponseProcessor', () => {
   let processor;
   let logger;
   let schemaValidatorMock;
+  let safeEventDispatcher;
   const actorId = 'testActor123';
 
   beforeEach(() => {
     jest.clearAllMocks();
     logger = mockLogger();
     schemaValidatorMock = mockSchemaValidator();
+    safeEventDispatcher = { dispatch: jest.fn() };
     processor = new LLMResponseProcessor({
       schemaValidator: schemaValidatorMock,
       logger,
+      safeEventDispatcher,
     });
   });
 
@@ -47,10 +50,15 @@ describe('LLMResponseProcessor', () => {
 
     test('throws if invalid dependencies are provided', () => {
       const aLogger = mockLogger();
+      const dispatcher = { dispatch: jest.fn() };
       // Test with missing schemaValidator
-      expect(() => new LLMResponseProcessor({ logger: aLogger })).toThrow(
-        'LLMResponseProcessor needs a valid ISchemaValidator'
-      );
+      expect(
+        () =>
+          new LLMResponseProcessor({
+            logger: aLogger,
+            safeEventDispatcher: dispatcher,
+          })
+      ).toThrow('LLMResponseProcessor needs a valid ISchemaValidator');
 
       // Test with partially implemented schemaValidator (missing isSchemaLoaded)
       expect(
@@ -58,13 +66,27 @@ describe('LLMResponseProcessor', () => {
           new LLMResponseProcessor({
             schemaValidator: { validate: () => {} },
             logger: aLogger,
+            safeEventDispatcher: dispatcher,
           })
       ).toThrow('LLMResponseProcessor needs a valid ISchemaValidator');
 
       // Test with missing logger
       expect(
-        () => new LLMResponseProcessor({ schemaValidator: schemaValidatorMock })
+        () =>
+          new LLMResponseProcessor({
+            schemaValidator: schemaValidatorMock,
+            safeEventDispatcher: dispatcher,
+          })
       ).toThrow('LLMResponseProcessor needs a valid ILogger');
+
+      // Test with missing safeEventDispatcher
+      expect(
+        () =>
+          new LLMResponseProcessor({
+            schemaValidator: schemaValidatorMock,
+            logger: aLogger,
+          })
+      ).toThrow('LLMResponseProcessor requires a valid ISafeEventDispatcher');
     });
   });
 


### PR DESCRIPTION
## Summary
- emit DISPLAY_ERROR_ID event when LLMResponseProcessor hits errors
- inject SafeEventDispatcher in DI
- update tests for SafeEventDispatcher

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ec5cf33888331836adf3f4ee894be