### PR TITLE
[Agent] Update JSDoc types for persistence errors

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -150,7 +150,7 @@ class GameStateSerializer {
    * Decompresses Gzip-compressed data.
    *
    * @param {Uint8Array} data - Compressed data.
-   * @returns {{success: boolean, data?: Uint8Array, error?: string, userFriendlyError?: string}} Outcome of decompression.
+   * @returns {{success: boolean, data?: Uint8Array, error?: PersistenceError, userFriendlyError?: string}} Outcome of decompression.
    */
   decompress(data) {
     try {
@@ -178,7 +178,7 @@ class GameStateSerializer {
    * Deserializes MessagePack data.
    *
    * @param {Uint8Array} buffer - Data to deserialize.
-   * @returns {{success: boolean, data?: object, error?: string, userFriendlyError?: string}} Outcome of deserialization.
+   * @returns {{success: boolean, data?: object, error?: PersistenceError, userFriendlyError?: string}} Outcome of deserialization.
    */
   deserialize(buffer) {
     try {

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -74,7 +74,7 @@ class SaveLoadService extends ISaveLoadService {
    * Reads the save file from storage provider.
    *
    * @param {string} filePath - Path to the save file.
-   * @returns {Promise<{success: boolean, data?: Uint8Array, error?: string, userFriendlyError?: string}>} Outcome of the read.
+   * @returns {Promise<{success: boolean, data?: Uint8Array, error?: PersistenceError, userFriendlyError?: string}>} Outcome of the read.
    * @private
    */
   async #readSaveFile(filePath) {
@@ -116,7 +116,7 @@ class SaveLoadService extends ISaveLoadService {
    * Implements basic failure handling as per SL-T2.4.
    *
    * @param {string} filePath - The path to the save file.
-   * @returns {Promise<{success: boolean, data?: object, error?: string, userFriendlyError?: string}>} Resulting object or error info.
+   * @returns {Promise<{success: boolean, data?: object, error?: PersistenceError, userFriendlyError?: string}>} Resulting object or error info.
    * @private
    */
   async #deserializeAndDecompress(filePath) {


### PR DESCRIPTION
Summary: Updated JSDoc return types in `saveLoadService.js` and `gameStateSerializer.js` to specify that the `error` property returns a `PersistenceError` instance. This ensures clearer typing around persistence failures.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes for changed files `npx eslint src/persistence/saveLoadService.js src/persistence/gameStateSerializer.js`
- [x] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684ecbbafa5c8331a7cfaefeb6c58eda