### PR TITLE
[Agent] Introduce AbstractLoader for shared validation

### DIFF
--- a/src/loaders/abstractLoader.js
+++ b/src/loaders/abstractLoader.js
@@ -1,0 +1,28 @@
+// src/loaders/abstractLoader.js
+
+/**
+ * Provides shared constructor logic for loader classes.
+ * Validates dependencies and initializes a logger.
+ *
+ * @class AbstractLoader
+ */
+
+import { ensureValidLogger } from '../utils/loggerUtils.js';
+import { validateLoaderDeps } from '../utils/validationUtils.js';
+
+export class AbstractLoader {
+  /** @protected */
+  _logger;
+
+  /**
+   * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger instance.
+   * @param {Array<{dependency: *, name: string, methods: string[]}>} checks - Dependencies to validate.
+   */
+  constructor(logger, checks = []) {
+    validateLoaderDeps(logger, checks);
+    this._logger = ensureValidLogger(logger, this.constructor.name);
+    this._logger.debug(`${this.constructor.name}: Base loader initialized.`);
+  }
+}
+
+export default AbstractLoader;

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -11,7 +11,7 @@
  * @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult
  */
 
-import { validateLoaderDeps } from '../utils/validationUtils.js';
+import AbstractLoader from './abstractLoader.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 import { validateAgainstSchema } from '../utils/schemaValidation.js';
 
@@ -32,7 +32,7 @@ import { validateAgainstSchema } from '../utils/schemaValidation.js';
  * @abstract
  * @class BaseManifestItemLoader
  */
-export class BaseManifestItemLoader {
+export class BaseManifestItemLoader extends AbstractLoader {
   /**
    * Protected reference to the configuration service.
    *
@@ -68,13 +68,6 @@ export class BaseManifestItemLoader {
    * @type {IDataRegistry}
    */
   _dataRegistry;
-  /**
-   * Protected reference to the logger service.
-   *
-   * @protected
-   * @type {ILogger}
-   */
-  _logger;
 
   /**
    * The primary schema ID used for validation by this loader instance.
@@ -107,16 +100,7 @@ export class BaseManifestItemLoader {
     dataRegistry,
     logger
   ) {
-    // --- Dependency Validation ---
-    if (typeof contentType !== 'string' || contentType.trim() === '') {
-      const errorMsg = `BaseManifestItemLoader requires a non-empty string for 'contentType'. Received: ${contentType}`;
-      if (logger && typeof logger.error === 'function') {
-        logger.error(errorMsg);
-      }
-      throw new TypeError(errorMsg);
-    }
-    const trimmedContentType = contentType.trim();
-    validateLoaderDeps(logger, [
+    super(logger, [
       {
         dependency: config,
         name: 'IConfiguration',
@@ -143,7 +127,13 @@ export class BaseManifestItemLoader {
         methods: ['store', 'get'],
       },
     ]);
-    this._logger = logger;
+
+    if (typeof contentType !== 'string' || contentType.trim() === '') {
+      const errorMsg = `BaseManifestItemLoader requires a non-empty string for 'contentType'. Received: ${contentType}`;
+      this._logger.error(errorMsg);
+      throw new TypeError(errorMsg);
+    }
+    const trimmedContentType = contentType.trim();
 
     // --- Store Dependencies ---
     this._config = config;

--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -12,8 +12,7 @@
 /** @typedef {import('../../data/schemas/game.schema.json')} GameConfig */ // Assuming this type exists
 
 import { CORE_MOD_ID } from '../constants/core';
-import { validateLoaderDeps } from '../utils/validationUtils.js';
-import { ensureValidLogger } from '../utils/loggerUtils.js';
+import AbstractLoader from './abstractLoader.js';
 import { formatAjvErrors } from '../utils/ajvUtils.js';
 import { validateAgainstSchema } from '../utils/schemaValidation.js';
 
@@ -21,7 +20,7 @@ import { validateAgainstSchema } from '../utils/schemaValidation.js';
  * Service responsible for locating, fetching, validating, and parsing the game configuration file (e.g., game.json).
  * After validation, it ensures CORE_MOD_ID is the first mod and returns the list of mod IDs.
  */
-class GameConfigLoader {
+class GameConfigLoader extends AbstractLoader {
   #configuration;
   #pathResolver;
   #dataFetcher;
@@ -46,9 +45,7 @@ class GameConfigLoader {
     schemaValidator,
     logger,
   }) {
-    this.#logger = ensureValidLogger(logger, 'GameConfigLoader');
-
-    validateLoaderDeps(this.#logger, [
+    super(logger, [
       {
         dependency: configuration,
         name: 'IConfiguration',
@@ -75,6 +72,7 @@ class GameConfigLoader {
     this.#pathResolver = pathResolver;
     this.#dataFetcher = dataFetcher;
     this.#schemaValidator = schemaValidator;
+    this.#logger = this._logger;
 
     this.#logger.debug('GameConfigLoader: Instance created.');
   }

--- a/src/loaders/schemaLoader.js
+++ b/src/loaders/schemaLoader.js
@@ -19,9 +19,9 @@
  * and compilation of JSON schemas specified in the application's configuration.
  * It focuses solely on processing the schemas listed in the configuration's `schemaFiles`.
  */
-import { validateLoaderDeps } from '../utils/validationUtils.js';
+import AbstractLoader from './abstractLoader.js';
 
-class SchemaLoader {
+class SchemaLoader extends AbstractLoader {
   #config;
   #resolver;
   #fetcher;
@@ -39,7 +39,7 @@ class SchemaLoader {
    * @throws {Error} If any required dependency is not provided or invalid.
    */
   constructor(configuration, pathResolver, fetcher, validator, logger) {
-    validateLoaderDeps(logger, [
+    super(logger, [
       {
         dependency: configuration,
         name: 'IConfiguration',
@@ -66,7 +66,7 @@ class SchemaLoader {
     this.#resolver = pathResolver;
     this.#fetcher = fetcher;
     this.#validator = validator;
-    this.#logger = logger;
+    this.#logger = this._logger;
 
     // --- Changed log level from info to debug for instance creation ---
     this.#logger.debug('SchemaLoader: Instance created and services injected.');

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -24,8 +24,7 @@ import ModDependencyError from '../errors/modDependencyError.js';
 import WorldLoaderError from '../errors/worldLoaderError.js';
 // import {ENGINE_VERSION} from '../engineVersion.js'; // Not directly used in this logic, commented out
 import { resolveOrder } from '../modding/modLoadOrderResolver.js';
-import { validateLoaderDeps } from '../utils/validationUtils.js';
-import { ensureValidLogger } from '../utils/loggerUtils.js';
+import AbstractLoader from './abstractLoader.js';
 
 // --- Type Definitions for Loader Results ---
 /**
@@ -62,7 +61,7 @@ import { ensureValidLogger } from '../utils/loggerUtils.js';
  */
 
 // ── Class ────────────────────────────────────────────────────────────────────
-class WorldLoader {
+class WorldLoader extends AbstractLoader {
   // Private fields
   /** @type {IDataRegistry}  */ #registry;
   /** @type {ILogger}        */ #logger;
@@ -122,9 +121,7 @@ class WorldLoader {
     modManifestLoader,
     validatedEventDispatcher,
   }) {
-    this.#logger = ensureValidLogger(logger, 'WorldLoader');
-
-    validateLoaderDeps(this.#logger, [
+    super(logger, [
       {
         dependency: registry,
         name: 'IDataRegistry',
@@ -186,6 +183,8 @@ class WorldLoader {
         methods: ['dispatch'],
       },
     ]);
+
+    this.#logger = this._logger;
 
     // --- Store dependencies ---
     this.#registry = registry;

--- a/tests/loaders/entityLoader.test.js
+++ b/tests/loaders/entityLoader.test.js
@@ -331,7 +331,7 @@ describe('EntityLoader', () => {
       expect(warnLogger.debug).toHaveBeenCalledWith(
         'EntityLoader: Initialized.'
       );
-      expect(warnLogger.debug).toHaveBeenCalledTimes(2); // Only 2 debug logs when schema isn't found
+      expect(warnLogger.debug).toHaveBeenCalledTimes(3); // Base loader init + base init + entity loader init
     });
   });
 


### PR DESCRIPTION
## Summary
- add `AbstractLoader` base class with logger/dep validation
- refactor loaders to extend `AbstractLoader`
- adjust tests for new debug log

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 'module' is not defined)*
- [x] `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ec9c1b82883318266e7bc9d40f991