### PR TITLE
[Agent] use textUtils validator

### DIFF
--- a/src/persistence/saveInputValidators.js
+++ b/src/persistence/saveInputValidators.js
@@ -4,6 +4,8 @@
  * @file Provides validation helpers for save operations.
  */
 
+import { isNonBlankString } from '../utils/textUtils.js';
+
 /**
  * Validates a manual save name.
  *
@@ -11,7 +13,7 @@
  * @returns {boolean} `true` if the save name is a non-empty string.
  */
 export function validateSaveName(saveName) {
-  return typeof saveName === 'string' && saveName.trim() !== '';
+  return isNonBlankString(saveName);
 }
 
 /**
@@ -21,5 +23,5 @@ export function validateSaveName(saveName) {
  * @returns {boolean} `true` if the identifier is a non-empty string.
  */
 export function validateSaveIdentifier(saveIdentifier) {
-  return typeof saveIdentifier === 'string' && saveIdentifier.trim() !== '';
+  return isNonBlankString(saveIdentifier);
 }


### PR DESCRIPTION
Summary: 
- import `isNonBlankString` in save input validators
- wrap save validator helpers with `isNonBlankString`

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 2311 problems)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684ecbcb15248331bf00db2ae8b160ad