### PR TITLE
[Agent] refactor restore helpers

### DIFF
--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -131,6 +131,8 @@ describe('GamePersistenceService edge cases', () => {
       const res = await service.restoreGameState({});
       expect(res.success).toBe(false);
       expect(logger.error).toHaveBeenCalled();
+      expect(entityManager.clearAll).not.toHaveBeenCalled();
+      expect(playtimeTracker.setAccumulatedPlaytime).not.toHaveBeenCalled();
     });
 
     it('handles reconstructEntity throwing and null return', async () => {

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -114,6 +114,16 @@ describe('GamePersistenceService error paths', () => {
       expect(logger.error).toHaveBeenCalled();
       expect(playtimeTracker.setAccumulatedPlaytime).toHaveBeenCalledWith(0);
     });
+
+    it('resets playtime when metadata is missing', async () => {
+      const data = {
+        gameState: { entities: [] },
+        metadata: {},
+      };
+      await service.restoreGameState(data);
+      expect(playtimeTracker.setAccumulatedPlaytime).toHaveBeenCalledWith(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
   });
 
   describe('loadAndRestoreGame failures', () => {


### PR DESCRIPTION
Summary: 
- add helper methods to GamePersistenceService for validating restore data, clearing entities, restoring entities, and playtime
- refactor restoreGameState to use new helpers
- extend service tests for early-return and playtime edge cases

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [x] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684ed02c82bc8331816d2f07f0d3dfec