### PR TITLE
[Agent] implement dispatch perceptible event operation

### DIFF
--- a/data/mods/core/rules/dismiss.rule.json
+++ b/data/mods/core/rules/dismiss.rule.json
@@ -69,20 +69,15 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "DISPATCH_PERCEPTIBLE_EVENT",
             "comment": "This event is for other characters to observe.",
             "parameters": {
-              "eventType": "core:perceptible_event",
-              "payload": {
-                "eventName": "core:perceptible_event",
-                "locationId": "{context.actorPosition.locationId}",
-                "descriptionText": "{context.actorName} has dismissed {context.targetName} from their service.",
-                "timestamp": "{context.nowIso}",
-                "perceptionType": "state_change_observable",
-                "actorId": "{event.payload.actorId}",
-                "targetId": "{event.payload.targetId}",
-                "involvedEntities": []
-              }
+              "location_id": "{context.actorPosition.locationId}",
+              "description_text": "{context.actorName} has dismissed {context.targetName} from their service.",
+              "perception_type": "state_change_observable",
+              "actor_id": "{event.payload.actorId}",
+              "target_id": "{event.payload.targetId}",
+              "involved_entities": []
             }
           }
         ]

--- a/data/mods/core/rules/entity_speech.rule.json
+++ b/data/mods/core/rules/entity_speech.rule.json
@@ -41,22 +41,17 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "DISPATCH_PERCEPTIBLE_EVENT",
             "comment": "Dispatch a perceptible event for the speech act, to be logged.",
             "parameters": {
-              "eventType": "core:perceptible_event",
-              "payload": {
-                "eventName": "core:perceptible_event",
-                "locationId": "{context.speakerPositionComponent.locationId}",
-                "descriptionText": "{context.speakerNameComponent.text} says: \"{event.payload.speechContent}\"",
-                "timestamp": "{context.currentTimestamp}",
-                "perceptionType": "speech_local",
-                "actorId": "{event.payload.entityId}",
-                "targetId": null,
-                "involvedEntities": [],
-                "contextualData": {
-                  "speechContent": "{event.payload.speechContent}"
-                }
+              "location_id": "{context.speakerPositionComponent.locationId}",
+              "description_text": "{context.speakerNameComponent.text} says: \"{event.payload.speechContent}\"",
+              "perception_type": "speech_local",
+              "actor_id": "{event.payload.entityId}",
+              "target_id": null,
+              "involved_entities": [],
+              "contextual_data": {
+                "speechContent": "{event.payload.speechContent}"
               }
             }
           },

--- a/data/mods/core/rules/follow.rule.json
+++ b/data/mods/core/rules/follow.rule.json
@@ -190,20 +190,15 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "DISPATCH_PERCEPTIBLE_EVENT",
             "comment": "Human-visible log: “<Follower> has decided to follow <Leader>”.",
             "parameters": {
-              "eventType": "core:perceptible_event",
-              "payload": {
-                "eventName": "core:perceptible_event",
-                "locationId": "{context.actorPos.locationId}",
-                "descriptionText": "{context.followerName} has decided to follow {context.leaderName}.",
-                "timestamp": "{context.nowIso}",
-                "perceptionType": "action_target_general",
-                "actorId": "{event.payload.actorId}",
-                "targetId": "{event.payload.targetId}",
-                "involvedEntities": []
-              }
+              "location_id": "{context.actorPos.locationId}",
+              "description_text": "{context.followerName} has decided to follow {context.leaderName}.",
+              "perception_type": "action_target_general",
+              "actor_id": "{event.payload.actorId}",
+              "target_id": "{event.payload.targetId}",
+              "involved_entities": []
             }
           },
           {

--- a/data/mods/core/rules/follow_auto_move.rule.json
+++ b/data/mods/core/rules/follow_auto_move.rule.json
@@ -99,23 +99,18 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "DISPATCH_PERCEPTIBLE_EVENT",
                   "comment": "Send a perceptible event to the new location.",
                   "parameters": {
-                    "eventType": "core:perceptible_event",
-                    "payload": {
-                      "eventName": "core:perceptible_event",
-                      "locationId": "{event.payload.currentLocationId}",
-                      "descriptionText": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}.",
-                      "timestamp": "{context.nowIso}",
-                      "perceptionType": "character_enter",
-                      "actorId": "{context.followerId}",
-                      "targetId": "{event.payload.entityId}",
-                      "involvedEntities": [],
-                      "contextualData": {
-                        "leaderId": "{event.payload.entityId}",
-                        "originLocationId": "{event.payload.previousLocationId}"
-                      }
+                    "location_id": "{event.payload.currentLocationId}",
+                    "description_text": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}.",
+                    "perception_type": "character_enter",
+                    "actor_id": "{context.followerId}",
+                    "target_id": "{event.payload.entityId}",
+                    "involved_entities": [],
+                    "contextual_data": {
+                      "leaderId": "{event.payload.entityId}",
+                      "originLocationId": "{event.payload.previousLocationId}"
                     }
                   }
                 },

--- a/data/mods/core/rules/go.rule.json
+++ b/data/mods/core/rules/go.rule.json
@@ -117,20 +117,15 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "DISPATCH_PERCEPTIBLE_EVENT",
                   "comment": "Dispatch perceptible event for actor leaving current location.",
                   "parameters": {
-                    "eventType": "core:perceptible_event",
-                    "payload": {
-                      "eventName": "core:perceptible_event",
-                      "locationId": "{context.actorPositionComponentPreMove.locationId}",
-                      "descriptionText": "{context.actorNameComponent.text} leaves to go to {context.targetLocationNameComponent.text}.",
-                      "timestamp": "{context.currentTimestamp}",
-                      "perceptionType": "character_exit",
-                      "actorId": "{event.payload.actorId}",
-                      "targetId": null,
-                      "involvedEntities": []
-                    }
+                    "location_id": "{context.actorPositionComponentPreMove.locationId}",
+                    "description_text": "{context.actorNameComponent.text} leaves to go to {context.targetLocationNameComponent.text}.",
+                    "perception_type": "character_exit",
+                    "actor_id": "{event.payload.actorId}",
+                    "target_id": null,
+                    "involved_entities": []
                   }
                 },
                 {
@@ -160,20 +155,15 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "DISPATCH_PERCEPTIBLE_EVENT",
                   "comment": "Dispatch perceptible event for actor entering new location.",
                   "parameters": {
-                    "eventType": "core:perceptible_event",
-                    "payload": {
-                      "eventName": "core:perceptible_event",
-                      "locationId": "{context.resolvedTargetLocationId}",
-                      "descriptionText": "{context.actorNameComponent.text} arrives from {context.currentLocationNameComponentPreMove.text}.",
-                      "timestamp": "{context.currentTimestamp}",
-                      "perceptionType": "character_enter",
-                      "actorId": "{event.payload.actorId}",
-                      "targetId": null,
-                      "involvedEntities": []
-                    }
+                    "location_id": "{context.resolvedTargetLocationId}",
+                    "description_text": "{context.actorNameComponent.text} arrives from {context.currentLocationNameComponentPreMove.text}.",
+                    "perception_type": "character_enter",
+                    "actor_id": "{event.payload.actorId}",
+                    "target_id": null,
+                    "involved_entities": []
                   }
                 },
                 {

--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -96,20 +96,15 @@
               },
               "then_actions": [
                 {
-                  "type": "DISPATCH_EVENT",
+                  "type": "DISPATCH_PERCEPTIBLE_EVENT",
                   "comment": "This event is for other characters to observe.",
                   "parameters": {
-                    "eventType": "core:perceptible_event",
-                    "payload": {
-                      "eventName": "core:perceptible_event",
-                      "timestamp": "{context.currentTimestamp}",
-                      "locationId": "{context.actorPosition.locationId}",
-                      "descriptionText": "{context.actorName.text} is no longer following {context.oldLeaderName.text}.",
-                      "perceptionType": "state_change_observable",
-                      "actorId": "{event.payload.actorId}",
-                      "targetId": "{context.oldFollowingData.leaderId}",
-                      "involvedEntities": []
-                    }
+                    "location_id": "{context.actorPosition.locationId}",
+                    "description_text": "{context.actorName.text} is no longer following {context.oldLeaderName.text}.",
+                    "perception_type": "state_change_observable",
+                    "actor_id": "{event.payload.actorId}",
+                    "target_id": "{context.oldFollowingData.leaderId}",
+                    "involved_entities": []
                   }
                 }
               ]

--- a/data/mods/intimacy/rules/get_close.rule.json
+++ b/data/mods/intimacy/rules/get_close.rule.json
@@ -216,18 +216,14 @@
       }
     },
     {
-      "type": "DISPATCH_EVENT",
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
       "comment": "Step 8: Dispatch events for perception and UI.",
       "parameters": {
-        "eventType": "core:perceptible_event",
-        "payload": {
-          "locationId": "{context.actorPos.locationId}",
-          "descriptionText": "{context.actorName} and {context.targetName} draw close.",
-          "timestamp": "{context.now}",
-          "perceptionType": "state_change_observable",
-          "actorId": "{event.payload.actorId}",
-          "targetId": "{event.payload.targetId}"
-        }
+        "location_id": "{context.actorPos.locationId}",
+        "description_text": "{context.actorName} and {context.targetName} draw close.",
+        "perception_type": "state_change_observable",
+        "actor_id": "{event.payload.actorId}",
+        "target_id": "{event.payload.targetId}"
       }
     },
     {

--- a/data/mods/intimacy/rules/intimacy_show_onlookers.rule.json
+++ b/data/mods/intimacy/rules/intimacy_show_onlookers.rule.json
@@ -81,21 +81,17 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
+            "type": "DISPATCH_PERCEPTIBLE_EVENT",
             "comment": "Step 4: Dispatch the condensed perceptible event to the onlooker's log.",
             "parameters": {
-              "eventType": "core:perceptible_event",
-              "payload": {
-                "locationId": "{event.payload.currentLocationId}",
-                "descriptionText": "{context.onlookerName} walks in on {context.kisserAName} and {context.kisserBName} kissing.",
-                "timestamp": "{context.now}",
-                "perceptionType": "character_enter",
-                "actorId": "{event.payload.entityId}",
-                "involvedEntities": [
-                  "{context.kissingEntities[0]}",
-                  "{context.kissingEntities[1]}"
-                ]
-              }
+              "location_id": "{event.payload.currentLocationId}",
+              "description_text": "{context.onlookerName} walks in on {context.kisserAName} and {context.kisserBName} kissing.",
+              "perception_type": "character_enter",
+              "actor_id": "{event.payload.entityId}",
+              "involved_entities": [
+                "{context.kissingEntities[0]}",
+                "{context.kissingEntities[1]}"
+              ]
             }
           }
         ]

--- a/data/mods/intimacy/rules/step_back.rule.json
+++ b/data/mods/intimacy/rules/step_back.rule.json
@@ -136,17 +136,13 @@
       }
     },
     {
-      "type": "DISPATCH_EVENT",
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
       "comment": "Step 6: Dispatch UI and perception events.",
       "parameters": {
-        "eventType": "core:perceptible_event",
-        "payload": {
-          "locationId": "{context.actorPos.locationId}",
-          "descriptionText": "{context.actorName} steps back.",
-          "timestamp": "{context.now}",
-          "perceptionType": "state_change_observable",
-          "actorId": "{event.payload.actorId}"
-        }
+        "location_id": "{context.actorPos.locationId}",
+        "description_text": "{context.actorName} steps back.",
+        "perception_type": "state_change_observable",
+        "actor_id": "{event.payload.actorId}"
       }
     },
     {

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -20,6 +20,7 @@
             "ADD_COMPONENT",
             "REMOVE_COMPONENT",
             "DISPATCH_EVENT",
+            "DISPATCH_PERCEPTIBLE_EVENT",
             "DISPATCH_SPEECH",
             "END_TURN",
             "IF",
@@ -159,6 +160,24 @@
             "properties": {
               "parameters": {
                 "$ref": "#/$defs/DispatchEventParameters"
+              }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "DISPATCH_PERCEPTIBLE_EVENT"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "$ref": "#/$defs/DispatchPerceptibleEventParameters"
               }
             },
             "required": ["parameters"]
@@ -853,6 +872,63 @@
         }
       },
       "required": ["location_id", "entry"],
+      "additionalProperties": false
+    },
+    "DispatchPerceptibleEventParameters": {
+      "type": "object",
+      "description": "Parameters for the DISPATCH_PERCEPTIBLE_EVENT operation. Builds and dispatches core:perceptible_event.",
+      "properties": {
+        "location_id": {
+          "type": "string"
+        },
+        "description_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "perception_type": {
+          "type": "string",
+          "enum": [
+            "character_enter",
+            "character_exit",
+            "item_pickup",
+            "item_drop",
+            "item_use",
+            "speech_local",
+            "action_self_general",
+            "action_target_general",
+            "combat_attack",
+            "combat_effect",
+            "state_change_observable"
+          ]
+        },
+        "actor_id": {
+          "type": "string"
+        },
+        "target_id": {
+          "type": ["string", "null"]
+        },
+        "involved_entities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "contextual_data": {
+          "type": "object",
+          "default": {}
+        },
+        "log_entry": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "location_id",
+        "description_text",
+        "perception_type",
+        "actor_id"
+      ],
       "additionalProperties": false
     },
     "QueryEntitiesParameters": {

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -17,6 +17,7 @@ import CommandOutcomeInterpreter from '../../commands/interpreters/commandOutcom
 
 // operation handlers
 import DispatchEventHandler from '../../logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import DispatchSpeechHandler from '../../logic/operationHandlers/dispatchSpeechHandler.js';
 import LogHandler from '../../logic/operationHandlers/logHandler.js';
 import ModifyComponentHandler from '../../logic/operationHandlers/modifyComponentHandler.js';
@@ -70,6 +71,18 @@ export function registerInterpreters(container) {
         new Handler({
           logger: c.resolve(tokens.ILogger),
           dispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        }),
+    ],
+    [
+      tokens.DispatchPerceptibleEventHandler,
+      DispatchPerceptibleEventHandler,
+      (c, Handler) =>
+        new Handler({
+          dispatcher: c.resolve(tokens.ISafeEventDispatcher),
+          logger: c.resolve(tokens.ILogger),
+          addPerceptionLogEntryHandler: c.resolve(
+            tokens.AddPerceptionLogEntryHandler
+          ),
         }),
     ],
     [
@@ -292,6 +305,10 @@ export function registerInterpreters(container) {
         c.resolve(tkn).execute(...args);
 
     registry.register('DISPATCH_EVENT', bind(tokens.DispatchEventHandler));
+    registry.register(
+      'DISPATCH_PERCEPTIBLE_EVENT',
+      bind(tokens.DispatchPerceptibleEventHandler)
+    );
     registry.register('DISPATCH_SPEECH', bind(tokens.DispatchSpeechHandler));
     registry.register('LOG', bind(tokens.LogHandler));
     registry.register('MODIFY_COMPONENT', bind(tokens.ModifyComponentHandler));

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -248,6 +248,7 @@ export const tokens = freeze({
 
   // Operation Handlers (Registered within Interpreter bundle)
   DispatchEventHandler: 'DispatchEventHandler',
+  DispatchPerceptibleEventHandler: 'DispatchPerceptibleEventHandler',
   DispatchSpeechHandler: 'DispatchSpeechHandler',
   LogHandler: 'LogHandler',
   ModifyComponentHandler: 'ModifyComponentHandler',

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -1,0 +1,161 @@
+/**
+ * @file Handler that emits a core:perceptible_event with standardized payload
+ * structure. Optionally logs the event via AddPerceptionLogEntryHandler.
+ */
+
+// --- Type Imports -----------------------------------------------------------
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('./addPerceptionLogEntryHandler.js').default} AddPerceptionLogEntryHandler */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
+import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+
+const EVENT_ID = 'core:perceptible_event';
+
+/**
+ * Parameters accepted by {@link DispatchPerceptibleEventHandler#execute}.
+ *
+ * @typedef {object} DispatchPerceptibleEventParams
+ * @property {string} location_id           - ID of the location where the event occurs.
+ * @property {string} description_text      - Human readable summary text.
+ * @property {string} perception_type       - Category of perceptible event.
+ * @property {string} actor_id              - Entity primarily responsible.
+ * @property {string=} target_id            - Optional target entity.
+ * @property {string[]=} involved_entities  - Optional array of other entity IDs.
+ * @property {object=} contextual_data      - Optional contextual data object.
+ * @property {boolean=} log_entry           - If true, also log via AddPerceptionLogEntryHandler.
+ */
+
+class DispatchPerceptibleEventHandler {
+  /** @type {ISafeEventDispatcher} */
+  #dispatcher;
+  /** @type {ILogger} */
+  #logger;
+  /** @type {AddPerceptionLogEntryHandler} */
+  #logHandler;
+
+  /**
+   * @param {object} deps
+   * @param {ISafeEventDispatcher} deps.dispatcher - Dispatcher used to emit events.
+   * @param {ILogger} deps.logger - Logger instance.
+   * @param {AddPerceptionLogEntryHandler} deps.addPerceptionLogEntryHandler - Handler used for optional logging.
+   */
+  constructor({ dispatcher, logger, addPerceptionLogEntryHandler }) {
+    if (!dispatcher?.dispatch) {
+      throw new Error(
+        'DispatchPerceptibleEventHandler requires ISafeEventDispatcher'
+      );
+    }
+    if (!logger?.debug) {
+      throw new Error('DispatchPerceptibleEventHandler requires ILogger');
+    }
+    if (!addPerceptionLogEntryHandler?.execute) {
+      throw new Error(
+        'DispatchPerceptibleEventHandler requires AddPerceptionLogEntryHandler'
+      );
+    }
+
+    this.#dispatcher = dispatcher;
+    this.#logger = logger;
+    this.#logHandler = addPerceptionLogEntryHandler;
+  }
+
+  /**
+   * Build the event payload and dispatch. If `log_entry` is true, also invoke
+   * {@link AddPerceptionLogEntryHandler} to store the log entry for observers.
+   *
+   * @param {DispatchPerceptibleEventParams} params - Resolved parameters.
+   * @param {ExecutionContext} _ctx - Execution context (unused).
+   */
+  execute(params, _ctx) {
+    if (!params || typeof params !== 'object') {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'DISPATCH_PERCEPTIBLE_EVENT: params missing or invalid',
+        details: { params },
+      });
+      return;
+    }
+
+    const {
+      location_id,
+      description_text,
+      perception_type,
+      actor_id,
+      target_id = null,
+      involved_entities = [],
+      contextual_data = {},
+      log_entry = false,
+    } = params;
+
+    if (typeof location_id !== 'string' || !location_id.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'DISPATCH_PERCEPTIBLE_EVENT: location_id required',
+        details: { location_id },
+      });
+      return;
+    }
+    if (typeof description_text !== 'string' || !description_text.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'DISPATCH_PERCEPTIBLE_EVENT: description_text required',
+        details: { description_text },
+      });
+      return;
+    }
+    if (typeof perception_type !== 'string' || !perception_type.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'DISPATCH_PERCEPTIBLE_EVENT: perception_type required',
+        details: { perception_type },
+      });
+      return;
+    }
+    if (typeof actor_id !== 'string' || !actor_id.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'DISPATCH_PERCEPTIBLE_EVENT: actor_id required',
+        details: { actor_id },
+      });
+      return;
+    }
+
+    const payload = {
+      eventName: EVENT_ID,
+      locationId: location_id,
+      descriptionText: description_text,
+      timestamp: new Date().toISOString(),
+      perceptionType: perception_type,
+      actorId: actor_id,
+      targetId: target_id ?? null,
+      involvedEntities: Array.isArray(involved_entities)
+        ? involved_entities
+        : [],
+      contextualData:
+        typeof contextual_data === 'object' && contextual_data !== null
+          ? contextual_data
+          : {},
+    };
+
+    this.#logger.debug('DISPATCH_PERCEPTIBLE_EVENT: dispatching event', {
+      payload,
+    });
+    this.#dispatcher.dispatch(EVENT_ID, payload);
+
+    if (log_entry) {
+      this.#logHandler.execute({
+        location_id,
+        entry: {
+          descriptionText: description_text,
+          timestamp: payload.timestamp,
+          perceptionType: perception_type,
+          actorId: actor_id,
+          targetId: target_id ?? null,
+          involvedEntities: Array.isArray(involved_entities)
+            ? involved_entities
+            : [],
+        },
+        originating_actor_id: actor_id,
+      });
+    }
+  }
+}
+
+export default DispatchPerceptibleEventHandler;

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -19,6 +19,7 @@ import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modify
 import HasComponentHandler from '../../../src/logic/operationHandlers/hasComponentHandler.js';
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
@@ -147,6 +148,11 @@ function init(entities) {
       entityManager,
       logger,
       safeEventDispatcher: safeDispatcher,
+    }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     HAS_COMPONENT: new HasComponentHandler({
       entityManager,

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -16,6 +16,7 @@ import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationSe
 import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
 import {
   NAME_COMPONENT_ID,
@@ -81,6 +82,11 @@ function init(entities) {
       safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     DISPATCH_SPEECH: new DispatchSpeechHandler({
       dispatcher: safeSpeechDispatcher,

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -18,6 +18,7 @@ import QueryEntitiesHandler from '../../../src/logic/operationHandlers/queryEnti
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import SystemMoveEntityHandler from '../../../src/logic/operationHandlers/systemMoveEntityHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
@@ -176,6 +177,11 @@ function init(entities) {
       safeEventDispatcher: eventBus,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     SYSTEM_MOVE_ENTITY: new SystemMoveEntityHandler({
       entityManager,

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -20,6 +20,7 @@ import QueryComponentHandler from '../../../src/logic/operationHandlers/queryCom
 import AddComponentHandler from '../../../src/logic/operationHandlers/addComponentHandler.js';
 import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modifyArrayFieldHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
@@ -124,6 +125,11 @@ describe('core_handle_follow rule integration', () => {
         entityManager,
         logger,
         safeEventDispatcher: safeDispatcher,
+      }),
+      DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+        dispatcher: eventBus,
+        logger,
+        addPerceptionLogEntryHandler: { execute: jest.fn() },
       }),
       DISPATCH_EVENT: new DispatchEventHandler({
         dispatcher: eventBus,

--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -23,6 +23,7 @@ import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   NAME_COMPONENT_ID,
@@ -134,6 +135,11 @@ function init(entities) {
       entityManager,
       logger,
       safeEventDispatcher: safeDispatcher,
+    }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     GET_NAME: new GetNameHandler({
       entityManager,

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -19,6 +19,7 @@ import SetVariableHandler from '../../../src/logic/operationHandlers/setVariable
 import ResolveDirectionHandler from '../../../src/logic/operationHandlers/resolveDirectionHandler.js';
 import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   NAME_COMPONENT_ID,
@@ -168,6 +169,11 @@ function init(entities) {
       entityManager,
       logger,
       safeEventDispatcher: { dispatch: jest.fn().mockResolvedValue(true) },
+    }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),

--- a/tests/integration/rules/intimacyShowOnlookersRule.integration.test.js
+++ b/tests/integration/rules/intimacyShowOnlookersRule.integration.test.js
@@ -17,6 +17,7 @@ import QueryEntitiesHandler from '../../../src/logic/operationHandlers/queryEnti
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import { POSITION_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { buildABCDWorld } from '../fixtures/intimacyFixtures.js';
 
@@ -85,6 +86,11 @@ function init(entities) {
       safeEventDispatcher: eventBus,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
   };
 

--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -20,6 +20,7 @@ import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyC
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   NAME_COMPONENT_ID,
@@ -151,6 +152,11 @@ function init(entities) {
       safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
+    }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
   };

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -20,6 +20,7 @@ import QueryComponentHandler from '../../../src/logic/operationHandlers/queryCom
 import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/queryComponentOptionalHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import IfCoLocatedHandler from '../../../src/logic/operationHandlers/ifCoLocatedHandler.js';
 import {
@@ -139,6 +140,11 @@ function init(entities) {
       entityManager,
       logger,
       safeEventDispatcher: safeDispatcher,
+    }),
+    DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
+      dispatcher: eventBus,
+      logger,
+      addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     QUERY_COMPONENT: new QueryComponentHandler({
       entityManager,

--- a/tests/logic/operationHandlers/dispatchPerceptibleEventHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchPerceptibleEventHandler.test.js
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
+import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+const makeDispatcher = () => ({ dispatch: jest.fn() });
+
+describe('DispatchPerceptibleEventHandler', () => {
+  let logger;
+  let dispatcher;
+  let logHandler;
+  let handler;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    dispatcher = makeDispatcher();
+    logHandler = { execute: jest.fn() };
+    handler = new DispatchPerceptibleEventHandler({
+      dispatcher,
+      logger,
+      addPerceptionLogEntryHandler: logHandler,
+    });
+    jest.clearAllMocks();
+  });
+
+  test('dispatches event with auto timestamp and logs when requested', () => {
+    const params = {
+      location_id: 'loc:1',
+      description_text: 'A arrives.',
+      perception_type: 'character_enter',
+      actor_id: 'npc:a',
+      log_entry: true,
+    };
+
+    const before = Date.now();
+    handler.execute(params, {});
+    const after = Date.now();
+
+    expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
+    const [eventType, payload] = dispatcher.dispatch.mock.calls[0];
+    expect(eventType).toBe('core:perceptible_event');
+    expect(payload.locationId).toBe(params.location_id);
+    expect(payload.descriptionText).toBe(params.description_text);
+    expect(payload.perceptionType).toBe(params.perception_type);
+    expect(payload.actorId).toBe(params.actor_id);
+    expect(new Date(payload.timestamp).getTime()).toBeGreaterThanOrEqual(
+      before
+    );
+    expect(new Date(payload.timestamp).getTime()).toBeLessThanOrEqual(after);
+
+    expect(logHandler.execute).toHaveBeenCalledTimes(1);
+    expect(logHandler.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location_id: params.location_id,
+        entry: expect.objectContaining({
+          descriptionText: params.description_text,
+          perceptionType: params.perception_type,
+          actorId: params.actor_id,
+        }),
+        originating_actor_id: params.actor_id,
+      })
+    );
+  });
+
+  test('dispatches error when params missing', () => {
+    handler.execute(null, {});
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('params missing'),
+      })
+    );
+  });
+});

--- a/tests/utils/loggerInitUsage.test.js
+++ b/tests/utils/loggerInitUsage.test.js
@@ -13,6 +13,7 @@ const mockLogger = {
  * @param ctorArgs
  * @param expectedName
  * @param expectOptional
+ * @param useHelper
  */
 function setup(
   modulePath,


### PR DESCRIPTION
## Summary
- add DISPATCH_PERCEPTIBLE_EVENT type and schema
- implement dispatchPerceptibleEventHandler
- register handler with DI system
- use new operation in core and intimacy rules
- add unit tests and update integration tests

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format && npm run lint && npm run test`
- [x] `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684ecbd91fd883319a4c4e6e370b4c1b