### PR TITLE
[Agent] add follow relation operations

### DIFF
--- a/data/mods/core/rules/follow.rule.json
+++ b/data/mods/core/rules/follow.rule.json
@@ -61,100 +61,10 @@
         },
         "then_actions": [
           {
-            "type": "HAS_COMPONENT",
-            "comment": "Check if the actor was previously following someone.",
+            "type": "ESTABLISH_FOLLOW_RELATION",
             "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:following",
-              "result_variable": "wasFollowing"
-            }
-          },
-          {
-            "type": "IF",
-            "comment": "IF an old leader existed, remove actor from their list.",
-            "parameters": {
-              "condition": {
-                "var": "context.wasFollowing"
-              },
-              "then_actions": [
-                {
-                  "type": "QUERY_COMPONENT",
-                  "comment": "Now that we know the component exists, get its data.",
-                  "parameters": {
-                    "entity_ref": "actor",
-                    "component_type": "core:following",
-                    "result_variable": "oldFollowComp"
-                  }
-                },
-                {
-                  "type": "MODIFY_ARRAY_FIELD",
-                  "comment": "Remove this actor from the old leader's 'core:leading' component.",
-                  "parameters": {
-                    "entity_ref": {
-                      "entityId": "{context.oldFollowComp.leaderId}"
-                    },
-                    "component_type": "core:leading",
-                    "field": "followers",
-                    "mode": "remove_by_value",
-                    "value": "{event.payload.actorId}"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "type": "ADD_COMPONENT",
-            "comment": "Authoritative mutation – the follower now points at the new leader.",
-            "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:following",
-              "value": {
-                "leaderId": "{event.payload.targetId}"
-              }
-            }
-          },
-          {
-            "type": "HAS_COMPONENT",
-            "comment": "Check if the new leader already has a 'leading' component.",
-            "parameters": {
-              "entity_ref": "target",
-              "component_type": "core:leading",
-              "result_variable": "leaderHasLeadingComponent"
-            }
-          },
-          {
-            "type": "IF",
-            "comment": "Conditionally add or modify the leader's component.",
-            "parameters": {
-              "condition": {
-                "var": "context.leaderHasLeadingComponent"
-              },
-              "then_actions": [
-                {
-                  "type": "MODIFY_ARRAY_FIELD",
-                  "comment": "This now only runs if the component already exists.",
-                  "parameters": {
-                    "entity_ref": "target",
-                    "component_type": "core:leading",
-                    "field": "followers",
-                    "mode": "push",
-                    "value": "{event.payload.actorId}"
-                  }
-                }
-              ],
-              "else_actions": [
-                {
-                  "type": "ADD_COMPONENT",
-                  "comment": "If component doesn't exist, create it with the first follower.",
-                  "parameters": {
-                    "entity_ref": "target",
-                    "component_type": "core:leading",
-                    "value": {
-                      "followers": ["{event.payload.actorId}"]
-                    }
-                  }
-                }
-              ]
+              "follower_id": "{event.payload.actorId}",
+              "leader_id": "{event.payload.targetId}"
             }
           },
           {

--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -30,24 +30,9 @@
         },
         "then_actions": [
           {
-            "type": "REMOVE_COMPONENT",
-            "comment": "Authoritatively remove the following relationship from the actor.",
+            "type": "BREAK_FOLLOW_RELATION",
             "parameters": {
-              "entity_ref": "actor",
-              "component_type": "core:following"
-            }
-          },
-          {
-            "type": "MODIFY_ARRAY_FIELD",
-            "comment": "Remove the actor from the old leader's 'core:leading' component followers list.",
-            "parameters": {
-              "entity_ref": {
-                "entityId": "{context.oldFollowingData.leaderId}"
-              },
-              "component_type": "core:leading",
-              "field": "followers",
-              "mode": "remove_by_value",
-              "value": "{event.payload.actorId}"
+              "follower_id": "{event.payload.actorId}"
             }
           },
           {

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -32,6 +32,8 @@
             "SYSTEM_MOVE_ENTITY",
             "REBUILD_LEADER_LIST_CACHE",
             "CHECK_FOLLOW_CYCLE",
+            "ESTABLISH_FOLLOW_RELATION",
+            "BREAK_FOLLOW_RELATION",
             "ADD_PERCEPTION_LOG_ENTRY",
             "HAS_COMPONENT",
             "QUERY_ENTITIES",
@@ -373,6 +375,32 @@
               "parameters": {
                 "$ref": "#/$defs/CheckFollowCycleParameters"
               }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "ESTABLISH_FOLLOW_RELATION" } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "$ref": "#/$defs/EstablishFollowRelationParameters"
+              }
+            },
+            "required": ["parameters"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "BREAK_FOLLOW_RELATION" } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "parameters": { "$ref": "#/$defs/BreakFollowRelationParameters" }
             },
             "required": ["parameters"]
           }
@@ -835,6 +863,25 @@
         }
       },
       "required": ["follower_id", "leader_id", "result_variable"],
+      "additionalProperties": false
+    },
+    "EstablishFollowRelationParameters": {
+      "type": "object",
+      "description": "Parameters for the ESTABLISH_FOLLOW_RELATION operation.",
+      "properties": {
+        "follower_id": { "type": "string", "minLength": 1 },
+        "leader_id": { "type": "string", "minLength": 1 }
+      },
+      "required": ["follower_id", "leader_id"],
+      "additionalProperties": false
+    },
+    "BreakFollowRelationParameters": {
+      "type": "object",
+      "description": "Parameters for the BREAK_FOLLOW_RELATION operation.",
+      "properties": {
+        "follower_id": { "type": "string", "minLength": 1 }
+      },
+      "required": ["follower_id"],
       "additionalProperties": false
     },
     "AddPerceptionLogEntryParameters": {

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -32,6 +32,8 @@ import GetNameHandler from '../../logic/operationHandlers/getNameHandler.js';
 import ResolveDirectionHandler from '../../logic/operationHandlers/resolveDirectionHandler.js';
 import RebuildLeaderListCacheHandler from '../../logic/operationHandlers/rebuildLeaderListCacheHandler';
 import CheckFollowCycleHandler from '../../logic/operationHandlers/checkFollowCycleHandler';
+import EstablishFollowRelationHandler from '../../logic/operationHandlers/establishFollowRelationHandler.js';
+import BreakFollowRelationHandler from '../../logic/operationHandlers/breakFollowRelationHandler.js';
 import AddPerceptionLogEntryHandler from '../../logic/operationHandlers/addPerceptionLogEntryHandler';
 import QueryEntitiesHandler from '../../logic/operationHandlers/queryEntitiesHandler.js';
 import HasComponentHandler from '../../logic/operationHandlers/hasComponentHandler';
@@ -205,6 +207,32 @@ export function registerInterpreters(container) {
         }),
     ],
     [
+      tokens.EstablishFollowRelationHandler,
+      EstablishFollowRelationHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          entityManager: c.resolve(tokens.IEntityManager),
+          rebuildLeaderListCacheHandler: c.resolve(
+            tokens.RebuildLeaderListCacheHandler
+          ),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        }),
+    ],
+    [
+      tokens.BreakFollowRelationHandler,
+      BreakFollowRelationHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          entityManager: c.resolve(tokens.IEntityManager),
+          rebuildLeaderListCacheHandler: c.resolve(
+            tokens.RebuildLeaderListCacheHandler
+          ),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        }),
+    ],
+    [
       tokens.AddPerceptionLogEntryHandler,
       AddPerceptionLogEntryHandler,
       (c, H) =>
@@ -322,6 +350,14 @@ export function registerInterpreters(container) {
     registry.register(
       'CHECK_FOLLOW_CYCLE',
       bind(tokens.CheckFollowCycleHandler)
+    );
+    registry.register(
+      'ESTABLISH_FOLLOW_RELATION',
+      bind(tokens.EstablishFollowRelationHandler)
+    );
+    registry.register(
+      'BREAK_FOLLOW_RELATION',
+      bind(tokens.BreakFollowRelationHandler)
     );
     registry.register(
       'ADD_PERCEPTION_LOG_ENTRY',

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -263,6 +263,8 @@ export const tokens = freeze({
   ResolveDirectionHandler: 'ResolveDirectionHandler',
   RebuildLeaderListCacheHandler: 'RebuildLeaderListCacheHandler',
   CheckFollowCycleHandler: 'CheckFollowCycleHandler',
+  EstablishFollowRelationHandler: 'EstablishFollowRelationHandler',
+  BreakFollowRelationHandler: 'BreakFollowRelationHandler',
   AddPerceptionLogEntryHandler: 'AddPerceptionLogEntryHandler',
   QueryEntitiesHandler: 'QueryEntitiesHandler',
   HasComponentHandler: 'HasComponentHandler',

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -1,0 +1,112 @@
+/**
+ * @file Handler for BREAK_FOLLOW_RELATION.
+ * Removes a follower's `core:following` component and rebuilds the former
+ * leader's follower cache.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
+
+import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
+
+class BreakFollowRelationHandler {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {EntityManager} */
+  #entityManager;
+  /** @type {RebuildLeaderListCacheHandler} */
+  #rebuildHandler;
+  /** @type {ISafeEventDispatcher} */
+  #dispatcher;
+
+  /**
+   * @param {object} deps
+   * @param {ILogger} deps.logger
+   * @param {EntityManager} deps.entityManager
+   * @param {RebuildLeaderListCacheHandler} deps.rebuildLeaderListCacheHandler
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
+   */
+  constructor({
+    logger,
+    entityManager,
+    rebuildLeaderListCacheHandler,
+    safeEventDispatcher,
+  }) {
+    if (!logger || typeof logger.debug !== 'function') {
+      throw new Error('BreakFollowRelationHandler requires a valid ILogger');
+    }
+    if (!entityManager || typeof entityManager.removeComponent !== 'function') {
+      throw new Error(
+        'BreakFollowRelationHandler requires a valid EntityManager'
+      );
+    }
+    if (
+      !rebuildLeaderListCacheHandler ||
+      typeof rebuildLeaderListCacheHandler.execute !== 'function'
+    ) {
+      throw new Error(
+        'BreakFollowRelationHandler requires a valid RebuildLeaderListCacheHandler'
+      );
+    }
+    if (
+      !safeEventDispatcher ||
+      typeof safeEventDispatcher.dispatch !== 'function'
+    ) {
+      throw new Error(
+        'BreakFollowRelationHandler requires a valid ISafeEventDispatcher'
+      );
+    }
+    this.#logger = logger;
+    this.#entityManager = entityManager;
+    this.#rebuildHandler = rebuildLeaderListCacheHandler;
+    this.#dispatcher = safeEventDispatcher;
+    this.#logger.debug('[BreakFollowRelationHandler] Initialized');
+  }
+
+  /**
+   * @param {{ follower_id: string }} params
+   * @param {ExecutionContext} execCtx
+   */
+  execute(params, execCtx) {
+    const { follower_id } = params || {};
+    if (typeof follower_id !== 'string' || !follower_id.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'BREAK_FOLLOW_RELATION: Invalid "follower_id" parameter',
+        details: { params },
+      });
+      return;
+    }
+    const fid = follower_id.trim();
+    const currentData = this.#entityManager.getComponentData(
+      fid,
+      FOLLOWING_COMPONENT_ID
+    );
+    if (!currentData) {
+      this.#logger.debug(
+        `[BreakFollowRelationHandler] ${fid} is not following anyone.`
+      );
+      return;
+    }
+    try {
+      this.#entityManager.removeComponent(fid, FOLLOWING_COMPONENT_ID);
+    } catch (err) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'BREAK_FOLLOW_RELATION: Failed removing following component',
+        details: { error: err.message, stack: err.stack, follower_id: fid },
+      });
+      return;
+    }
+    if (currentData.leaderId) {
+      this.#rebuildHandler.execute(
+        { leaderIds: [currentData.leaderId] },
+        execCtx
+      );
+    }
+  }
+}
+
+export default BreakFollowRelationHandler;

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -1,0 +1,137 @@
+/**
+ * @file Handler for ESTABLISH_FOLLOW_RELATION.
+ * Validates against follow cycles, updates the follower's `core:following`
+ * component, and rebuilds the affected leaders' `core:leading` caches.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
+
+import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
+import { wouldCreateCycle } from '../../utils/followUtils.js';
+
+class EstablishFollowRelationHandler {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {EntityManager} */
+  #entityManager;
+  /** @type {RebuildLeaderListCacheHandler} */
+  #rebuildHandler;
+  /** @type {ISafeEventDispatcher} */
+  #dispatcher;
+
+  /**
+   * @param {object} deps
+   * @param {ILogger} deps.logger
+   * @param {EntityManager} deps.entityManager
+   * @param {RebuildLeaderListCacheHandler} deps.rebuildLeaderListCacheHandler
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
+   */
+  constructor({
+    logger,
+    entityManager,
+    rebuildLeaderListCacheHandler,
+    safeEventDispatcher,
+  }) {
+    if (!logger || typeof logger.debug !== 'function') {
+      throw new Error(
+        'EstablishFollowRelationHandler requires a valid ILogger'
+      );
+    }
+    if (!entityManager || typeof entityManager.addComponent !== 'function') {
+      throw new Error(
+        'EstablishFollowRelationHandler requires a valid EntityManager'
+      );
+    }
+    if (
+      !rebuildLeaderListCacheHandler ||
+      typeof rebuildLeaderListCacheHandler.execute !== 'function'
+    ) {
+      throw new Error(
+        'EstablishFollowRelationHandler requires a valid RebuildLeaderListCacheHandler'
+      );
+    }
+    if (
+      !safeEventDispatcher ||
+      typeof safeEventDispatcher.dispatch !== 'function'
+    ) {
+      throw new Error(
+        'EstablishFollowRelationHandler requires a valid ISafeEventDispatcher'
+      );
+    }
+    this.#logger = logger;
+    this.#entityManager = entityManager;
+    this.#rebuildHandler = rebuildLeaderListCacheHandler;
+    this.#dispatcher = safeEventDispatcher;
+    this.#logger.debug('[EstablishFollowRelationHandler] Initialized');
+  }
+
+  /**
+   * @param {{ follower_id: string, leader_id: string }} params
+   * @param {ExecutionContext} execCtx
+   */
+  execute(params, execCtx) {
+    const { follower_id, leader_id } = params || {};
+    if (typeof follower_id !== 'string' || !follower_id.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'ESTABLISH_FOLLOW_RELATION: Invalid "follower_id" parameter',
+        details: { params },
+      });
+      return;
+    }
+    if (typeof leader_id !== 'string' || !leader_id.trim()) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'ESTABLISH_FOLLOW_RELATION: Invalid "leader_id" parameter',
+        details: { params },
+      });
+      return;
+    }
+
+    const fid = follower_id.trim();
+    const lid = leader_id.trim();
+    this.#logger.debug(
+      `[EstablishFollowRelationHandler] establishing follow: follower=${fid}, leader=${lid}`
+    );
+
+    if (wouldCreateCycle(fid, lid, this.#entityManager)) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message: 'ESTABLISH_FOLLOW_RELATION: Following would create a cycle',
+        details: { follower_id: fid, leader_id: lid },
+      });
+      return;
+    }
+
+    const oldData = this.#entityManager.getComponentData(
+      fid,
+      FOLLOWING_COMPONENT_ID
+    );
+    try {
+      this.#entityManager.addComponent(fid, FOLLOWING_COMPONENT_ID, {
+        leaderId: lid,
+      });
+    } catch (err) {
+      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        message:
+          'ESTABLISH_FOLLOW_RELATION: Failed updating follower component',
+        details: {
+          error: err.message,
+          stack: err.stack,
+          follower_id: fid,
+          leader_id: lid,
+        },
+      });
+      return;
+    }
+
+    const leaderIds = [lid];
+    if (oldData?.leaderId && oldData.leaderId !== lid)
+      leaderIds.push(oldData.leaderId);
+    this.#rebuildHandler.execute({ leaderIds }, execCtx);
+  }
+}
+
+export default EstablishFollowRelationHandler;

--- a/tests/logic/operationHandlers/breakFollowRelationHandler.test.js
+++ b/tests/logic/operationHandlers/breakFollowRelationHandler.test.js
@@ -1,0 +1,74 @@
+/**
+ * @file Tests for BreakFollowRelationHandler.
+ */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import BreakFollowRelationHandler from '../../../src/logic/operationHandlers/breakFollowRelationHandler.js';
+import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { FOLLOWING_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+
+const makeMockLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+const makeMockEntityManager = () => ({
+  removeComponent: jest.fn(),
+  getComponentData: jest.fn(),
+});
+const makeMockDispatcher = () => ({ dispatch: jest.fn() });
+const makeMockRebuild = () => ({ execute: jest.fn() });
+
+describe('BreakFollowRelationHandler', () => {
+  let logger;
+  let em;
+  let dispatcher;
+  let rebuild;
+  let handler;
+  let execCtx;
+
+  beforeEach(() => {
+    logger = makeMockLogger();
+    em = makeMockEntityManager();
+    dispatcher = makeMockDispatcher();
+    rebuild = makeMockRebuild();
+    handler = new BreakFollowRelationHandler({
+      logger,
+      entityManager: em,
+      rebuildLeaderListCacheHandler: rebuild,
+      safeEventDispatcher: dispatcher,
+    });
+    execCtx = { logger };
+    jest.clearAllMocks();
+  });
+
+  test('removes following component and rebuilds old leader', () => {
+    em.getComponentData.mockReturnValue({ leaderId: 'L1' });
+    handler.execute({ follower_id: 'A' }, execCtx);
+    expect(em.removeComponent).toHaveBeenCalledWith(
+      'A',
+      FOLLOWING_COMPONENT_ID
+    );
+    expect(rebuild.execute).toHaveBeenCalledWith(
+      { leaderIds: ['L1'] },
+      execCtx
+    );
+  });
+
+  test('skips when not following', () => {
+    em.getComponentData.mockReturnValue(null);
+    handler.execute({ follower_id: 'A' }, execCtx);
+    expect(em.removeComponent).not.toHaveBeenCalled();
+    expect(rebuild.execute).not.toHaveBeenCalled();
+  });
+
+  test('validates parameters', () => {
+    handler.execute({}, execCtx);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('follower_id'),
+      })
+    );
+  });
+});

--- a/tests/logic/operationHandlers/establishFollowRelationHandler.test.js
+++ b/tests/logic/operationHandlers/establishFollowRelationHandler.test.js
@@ -1,0 +1,87 @@
+/**
+ * @file Tests for EstablishFollowRelationHandler.
+ */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import EstablishFollowRelationHandler from '../../../src/logic/operationHandlers/establishFollowRelationHandler.js';
+import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { FOLLOWING_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+
+const makeMockLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+const makeMockEntityManager = () => ({
+  addComponent: jest.fn(),
+  getComponentData: jest.fn(),
+});
+const makeMockDispatcher = () => ({ dispatch: jest.fn() });
+const makeMockRebuild = () => ({ execute: jest.fn() });
+
+jest.mock('../../../src/utils/followUtils.js', () => ({
+  wouldCreateCycle: jest.fn(() => false),
+}));
+import { wouldCreateCycle } from '../../../src/utils/followUtils.js';
+
+describe('EstablishFollowRelationHandler', () => {
+  let logger;
+  let em;
+  let dispatcher;
+  let rebuild;
+  let handler;
+  let execCtx;
+
+  beforeEach(() => {
+    logger = makeMockLogger();
+    em = makeMockEntityManager();
+    dispatcher = makeMockDispatcher();
+    rebuild = makeMockRebuild();
+    handler = new EstablishFollowRelationHandler({
+      logger,
+      entityManager: em,
+      rebuildLeaderListCacheHandler: rebuild,
+      safeEventDispatcher: dispatcher,
+    });
+    execCtx = { logger };
+    jest.clearAllMocks();
+  });
+
+  test('adds following component and rebuilds cache', () => {
+    em.getComponentData.mockReturnValue(null);
+    handler.execute({ follower_id: 'A', leader_id: 'B' }, execCtx);
+    expect(em.addComponent).toHaveBeenCalledWith('A', FOLLOWING_COMPONENT_ID, {
+      leaderId: 'B',
+    });
+    expect(rebuild.execute).toHaveBeenCalledWith({ leaderIds: ['B'] }, execCtx);
+  });
+
+  test('rebuilds old and new leaders when switching', () => {
+    em.getComponentData.mockReturnValue({ leaderId: 'old' });
+    handler.execute({ follower_id: 'A', leader_id: 'new' }, execCtx);
+    expect(rebuild.execute).toHaveBeenCalledWith(
+      { leaderIds: ['new', 'old'] },
+      execCtx
+    );
+  });
+
+  test('dispatches error on cycle', () => {
+    wouldCreateCycle.mockReturnValueOnce(true);
+    handler.execute({ follower_id: 'A', leader_id: 'B' }, execCtx);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({ message: expect.stringContaining('cycle') })
+    );
+    expect(em.addComponent).not.toHaveBeenCalled();
+  });
+
+  test('validates parameters', () => {
+    handler.execute({}, execCtx);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('follower_id'),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Establish/Break follow relation handlers
- register new operation handlers and schema types
- simplify follow and stop_following rules
- test follow relation operations and update integration suites

## Testing
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ed0ffc9ac8331a7879cb383d37b16