### PR TITLE
[Agent] add ruleId filename helper

### DIFF
--- a/src/loaders/ruleLoader.js
+++ b/src/loaders/ruleLoader.js
@@ -3,6 +3,7 @@
 // Import BaseManifestItemLoader
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
 import { expandMacros } from '../utils/macroUtils.js';
+import { deriveBaseRuleIdFromFilename } from '../utils/ruleIdUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
@@ -25,12 +26,6 @@ import { expandMacros } from '../utils/macroUtils.js';
  */
 class RuleLoader extends BaseManifestItemLoader {
   /**
-   * @private
-   * @type {object | null | undefined} - Cached 'path' module. undefined means not yet attempted, null means failed to load.
-   */
-  #pathModule = undefined;
-
-  /**
    * Constructs a RuleLoader instance.
    * Calls the parent constructor, specifying the content type 'rules' and passing dependencies.
    *
@@ -48,31 +43,6 @@ class RuleLoader extends BaseManifestItemLoader {
     // Log initialization (Base class constructor handles logging)
     // this._logger.debug(`RuleLoader: Initialized.`); // Optional: Add specific RuleLoader init log if needed after super()
     // Don't import 'path' here yet.
-  }
-
-  /**
-   * @private
-   * Attempts to dynamically load the 'path' module and caches it.
-   * @returns {Promise<object | null>} The loaded path module or null if unavailable/failed.
-   */
-  async #getPathModule() {
-    if (this.#pathModule === undefined) {
-      // Only attempt loading once
-      try {
-        // Dynamically import the 'path' module
-        // Note: Ensure the environment supports dynamic import()
-        this.#pathModule = await import('path');
-        this._logger.debug(
-          "RuleLoader: Successfully loaded Node.js 'path' module dynamically."
-        );
-      } catch (e) {
-        this.#pathModule = null; // Mark as failed
-        this._logger.warn(
-          "RuleLoader: Node.js 'path' module is not available in this environment. Filename parsing fallback will be used."
-        );
-      }
-    }
-    return this.#pathModule;
   }
 
   /**
@@ -117,28 +87,8 @@ class RuleLoader extends BaseManifestItemLoader {
         baseRuleId = baseRuleId.substring(modId.length + 1);
       }
     } else {
-      // Fallback to filename
-      const pathModule = await this.#getPathModule();
-      let namePart;
-      if (pathModule) {
-        namePart = pathModule.parse(filename).name;
-      } else {
-        const baseFilename = filename.includes('/')
-          ? filename.substring(filename.lastIndexOf('/') + 1)
-          : filename;
-        namePart = baseFilename.includes('.')
-          ? baseFilename.substring(0, baseFilename.lastIndexOf('.'))
-          : baseFilename;
-      }
-      // Remove common suffixes
-      const ruleSuffixes = ['.rule', '.rule.json', '.rule.yml', '.rule.yaml'];
-      for (const suffix of ruleSuffixes) {
-        if (namePart.endsWith(suffix)) {
-          namePart = namePart.substring(0, namePart.length - suffix.length);
-          break;
-        }
-      }
-      baseRuleId = namePart;
+      // Fallback to filename using utility helper
+      baseRuleId = deriveBaseRuleIdFromFilename(filename);
       this._logger.debug(
         `RuleLoader [${modId}]: No valid 'rule_id' found. Derived baseRuleId '${baseRuleId}' from filename.`
       );
@@ -179,7 +129,7 @@ class RuleLoader extends BaseManifestItemLoader {
       // Error logging happens in helper, re-throw
       throw storageError;
     }
-    
+
     // --- End Storage ---
 
     // --- Return Value ---

--- a/src/utils/ruleIdUtils.js
+++ b/src/utils/ruleIdUtils.js
@@ -1,0 +1,44 @@
+/**
+ * @file Utility functions for deriving rule IDs from filenames.
+ */
+
+/**
+ * Derives the base rule ID from a filename by stripping directory segments,
+ * extensions, and common rule-specific suffixes.
+ *
+ * @param {string} filename - The filename to parse.
+ * @returns {string} The derived base ID, or an empty string if it cannot be determined.
+ */
+export function deriveBaseRuleIdFromFilename(filename) {
+  if (typeof filename !== 'string') {
+    return '';
+  }
+  let name = filename.trim();
+  if (name === '') {
+    return '';
+  }
+
+  // Normalize path separators and remove directories
+  name = name.replace(/\\/g, '/');
+  if (name.includes('/')) {
+    name = name.substring(name.lastIndexOf('/') + 1);
+  }
+
+  // Remove the final extension
+  if (name.includes('.')) {
+    name = name.substring(0, name.lastIndexOf('.'));
+  }
+
+  // Remove common rule suffixes
+  const suffixes = ['.rule', '.rule.json', '.rule.yml', '.rule.yaml'];
+  for (const suffix of suffixes) {
+    if (name.toLowerCase().endsWith(suffix)) {
+      name = name.substring(0, name.length - suffix.length);
+      break;
+    }
+  }
+
+  return name;
+}
+
+export default deriveBaseRuleIdFromFilename;

--- a/tests/utils/ruleIdUtils.test.js
+++ b/tests/utils/ruleIdUtils.test.js
@@ -1,0 +1,32 @@
+// tests/utils/ruleIdUtils.test.js
+
+import { describe, it, expect } from '@jest/globals';
+import { deriveBaseRuleIdFromFilename } from '../../src/utils/ruleIdUtils.js';
+
+describe('deriveBaseRuleIdFromFilename', () => {
+  it('removes rule suffixes and extensions', () => {
+    expect(deriveBaseRuleIdFromFilename('test.rule.json')).toBe('test');
+    expect(deriveBaseRuleIdFromFilename('example.rule.yml')).toBe('example');
+    expect(deriveBaseRuleIdFromFilename('demo.rule.yaml')).toBe('demo');
+    expect(deriveBaseRuleIdFromFilename('sample.rule')).toBe('sample');
+  });
+
+  it('handles nested paths and different separators', () => {
+    expect(deriveBaseRuleIdFromFilename('dir/sub/test.rule.json')).toBe('test');
+    expect(deriveBaseRuleIdFromFilename('dir\\sub\\other.rule.yaml')).toBe(
+      'other'
+    );
+  });
+
+  it('returns filename without suffix when none present', () => {
+    expect(deriveBaseRuleIdFromFilename('basic.json')).toBe('basic');
+    expect(deriveBaseRuleIdFromFilename('sub/inner/simple')).toBe('simple');
+  });
+
+  it('gracefully handles empty or invalid input', () => {
+    expect(deriveBaseRuleIdFromFilename('')).toBe('');
+    expect(deriveBaseRuleIdFromFilename('   ')).toBe('');
+    // @ts-ignore Testing invalid input type
+    expect(deriveBaseRuleIdFromFilename(null)).toBe('');
+  });
+});


### PR DESCRIPTION
Summary: add shared utility for deriving rule IDs from filenames. RuleLoader now relies on this helper. New tests cover various suffixes and path separators.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684ed692aa348331bc4ccff3037102a9