### PR TITLE
[Fix] dispatch error event in ActionDiscoveryService

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -230,14 +230,10 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
           }
         }
       } catch (err) {
-        this.#logger.error(
-          `Error processing action ${actionDef.id} for actor ${actorEntity.id}:`,
-          err
-        );
         safeDispatchError(
           this.#safeEventDispatcher,
           `ActionDiscoveryService: Error processing action ${actionDef.id} for actor ${actorEntity.id}.`,
-          { error: err.message }
+          { error: err.message, stack: err.stack }
         );
       }
     }


### PR DESCRIPTION
Summary: replace a logger.error call with dispatching the DISPLAY_ERROR_ID event in ActionDiscoveryService.

Changes Made:
- removed log.error usage during action processing failures
- dispatched `core:display_error` via SafeEventDispatcher with error details

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_684ed75575a083319e4296b49caa2fdc