### PR TITLE
[Agent] Centralize loader init logging

### DIFF
--- a/src/loaders/abstractLoader.js
+++ b/src/loaders/abstractLoader.js
@@ -21,7 +21,7 @@ export class AbstractLoader {
   constructor(logger, checks = []) {
     validateLoaderDeps(logger, checks);
     this._logger = ensureValidLogger(logger, this.constructor.name);
-    this._logger.debug(`${this.constructor.name}: Base loader initialized.`);
+    this._logger.debug(`${this.constructor.name}: Initialized.`);
   }
 }
 

--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -59,7 +59,6 @@ class ActionLoader extends BaseManifestItemLoader {
       dataRegistry,
       logger
     );
-    this._logger.debug(`ActionLoader: Initialized.`);
   }
 
   /**

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -155,9 +155,6 @@ export class BaseManifestItemLoader extends AbstractLoader {
       );
       this._primarySchemaId = null;
     }
-    this._logger.debug(
-      `${this.constructor.name}: Initialized successfully for content type '${trimmedContentType}'.`
-    );
   }
 
   /**

--- a/src/loaders/componentLoader.js
+++ b/src/loaders/componentLoader.js
@@ -54,7 +54,6 @@ class ComponentLoader extends BaseInlineSchemaLoader {
       dataRegistry,
       logger
     );
-    this._logger.debug(`ComponentLoader: Initialized.`);
   }
 
   /**

--- a/src/loaders/entityLoader.js
+++ b/src/loaders/entityLoader.js
@@ -76,8 +76,6 @@ class EntityLoader extends BaseManifestItemLoader {
     //     this._logger.warn(`EntityLoader: Schema ID for 'entities' is missing. Entity validation will be skipped or may fail.`);
     // }
     // --- [LOADER-REFACTOR-04 Change END] ---
-
-    this._logger.debug(`EntityLoader: Initialized.`);
   }
 
   /**

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -64,9 +64,6 @@ class EventLoader extends BaseInlineSchemaLoader {
       dataRegistry,
       logger
     );
-
-    // AC: Log initialization message.
-    this._logger.debug(`EventLoader: Initialized.`);
   }
 
   /**

--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -73,8 +73,6 @@ class GameConfigLoader extends AbstractLoader {
     this.#dataFetcher = dataFetcher;
     this.#schemaValidator = schemaValidator;
     this.#logger = this._logger;
-
-    this.#logger.debug('GameConfigLoader: Instance created.');
   }
 
   /**

--- a/src/loaders/macroLoader.js
+++ b/src/loaders/macroLoader.js
@@ -46,7 +46,6 @@ class MacroLoader extends BaseManifestItemLoader {
       dataRegistry,
       logger
     );
-    this._logger.debug('MacroLoader: Initialized.');
   }
 
   /**

--- a/src/loaders/schemaLoader.js
+++ b/src/loaders/schemaLoader.js
@@ -68,8 +68,7 @@ class SchemaLoader extends AbstractLoader {
     this.#validator = validator;
     this.#logger = this._logger;
 
-    // --- Changed log level from info to debug for instance creation ---
-    this.#logger.debug('SchemaLoader: Instance created and services injected.');
+    // --- Dependencies stored; initialization complete ---
   }
 
   /**

--- a/tests/loaders/baseManifestItemLoader.constructor.test.js
+++ b/tests/loaders/baseManifestItemLoader.constructor.test.js
@@ -189,7 +189,7 @@ describe('BaseManifestItemLoader Constructor', () => {
       `BaseManifestItemLoader: Primary schema ID for content type '${mockContentType}' found: '${schemaId}'`
     ); // <<< ADDED: Check schema ID log
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `BaseManifestItemLoader: Initialized successfully for content type '${mockContentType}'.` // <<< MODIFIED: Updated init log message
+      `BaseManifestItemLoader: Initialized.`
     );
     expect(mockLogger.warn).not.toHaveBeenCalled(); // No warnings expected
   });
@@ -218,7 +218,7 @@ describe('BaseManifestItemLoader Constructor', () => {
       `BaseManifestItemLoader: Primary schema ID for content type '${mockContentType}' not found in configuration. Primary validation might be skipped.`
     ); // <<< ADDED: Check warning log
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `BaseManifestItemLoader: Initialized successfully for content type '${mockContentType}'.`
+      `BaseManifestItemLoader: Initialized.`
     );
   });
 
@@ -246,7 +246,7 @@ describe('BaseManifestItemLoader Constructor', () => {
       `BaseManifestItemLoader: Primary schema ID for content type '${mockContentType}' not found in configuration. Primary validation might be skipped.`
     ); // <<< ADDED: Check warning log
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `BaseManifestItemLoader: Initialized successfully for content type '${mockContentType}'.`
+      `BaseManifestItemLoader: Initialized.`
     );
   });
 

--- a/tests/loaders/entityLoader.test.js
+++ b/tests/loaders/entityLoader.test.js
@@ -326,12 +326,11 @@ describe('EntityLoader', () => {
       );
       // --- [LOADER-REFACTOR-04 Test Change END] ---
 
-      // Debug logs should still happen (base class init + entityloader init)
-      // EntityLoader init log:
+      // Debug log from AbstractLoader should still happen
       expect(warnLogger.debug).toHaveBeenCalledWith(
         'EntityLoader: Initialized.'
       );
-      expect(warnLogger.debug).toHaveBeenCalledTimes(3); // Base loader init + base init + entity loader init
+      expect(warnLogger.debug).toHaveBeenCalledTimes(1); // Only AbstractLoader logs initialization now
     });
   });
 


### PR DESCRIPTION
## Summary
- centralize constructor logging to `AbstractLoader`
- drop redundant initialization logs from all loader subclasses
- adjust tests for new base log message

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684edd0817a48331aefe1529913fada0