### PR TITLE
[Agent] Add IF handler and delegate through registry

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -38,6 +38,7 @@ import HasComponentHandler from '../../logic/operationHandlers/hasComponentHandl
 import ModifyArrayFieldHandler from '../../logic/operationHandlers/modifyArrayFieldHandler';
 import MathHandler from '../../logic/operationHandlers/mathHandler.js';
 import IfCoLocatedHandler from '../../logic/operationHandlers/ifCoLocatedHandler.js';
+import IfHandler from '../../logic/operationHandlers/ifHandler.js';
 
 /**
  * Registers all interpreter-layer services in the DI container.
@@ -249,6 +250,18 @@ export function registerInterpreters(container) {
         }),
     ],
     [
+      tokens.IfHandler,
+      IfHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          jsonLogicEvaluationService: c.resolve(
+            tokens.JsonLogicEvaluationService
+          ),
+          operationInterpreter: c.resolve(tokens.OperationInterpreter),
+        }),
+    ],
+    [
       tokens.IfCoLocatedHandler,
       IfCoLocatedHandler,
       (c, Handler) =>
@@ -330,6 +343,7 @@ export function registerInterpreters(container) {
       'MODIFY_ARRAY_FIELD',
       bind(tokens.ModifyArrayFieldHandler)
     );
+    registry.register('IF', bind(tokens.IfHandler));
     registry.register('IF_CO_LOCATED', bind(tokens.IfCoLocatedHandler));
     registry.register('MATH', bind(tokens.MathHandler));
 

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -265,6 +265,7 @@ export const tokens = freeze({
   HasComponentHandler: 'HasComponentHandler',
   ModifyArrayFieldHandler: 'ModifyArrayFieldHandler',
   IfCoLocatedHandler: 'IfCoLocatedHandler',
+  IfHandler: 'IfHandler',
   MathHandler: 'MathHandler',
 
   // --- Actions ---

--- a/src/logic/operationHandlers/ifHandler.js
+++ b/src/logic/operationHandlers/ifHandler.js
@@ -1,0 +1,83 @@
+// src/logic/operationHandlers/ifHandler.js
+
+/**
+ * @file Executes conditional actions using JsonLogic.
+ * @see src/logic/operationHandlers/ifHandler.js
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../jsonLogicEvaluationService.js').default} JsonLogicEvaluationService */
+/** @typedef {import('../operationInterpreter.js').default} OperationInterpreter */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../defs.js').OperationParams} OperationParams */
+
+class IfHandler {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {JsonLogicEvaluationService} */
+  #jsonLogic;
+  /** @type {OperationInterpreter} */
+  #opInterpreter;
+
+  /**
+   * @param {object} deps
+   * @param {ILogger} deps.logger
+   * @param {JsonLogicEvaluationService} deps.jsonLogicEvaluationService
+   * @param {OperationInterpreter} deps.operationInterpreter
+   */
+  constructor({ logger, jsonLogicEvaluationService, operationInterpreter }) {
+    if (!logger?.debug) throw new Error('IfHandler requires ILogger');
+    if (!jsonLogicEvaluationService?.evaluate)
+      throw new Error('IfHandler requires JsonLogicEvaluationService');
+    if (!operationInterpreter?.execute)
+      throw new Error('IfHandler requires OperationInterpreter');
+    this.#logger = logger;
+    this.#jsonLogic = jsonLogicEvaluationService;
+    this.#opInterpreter = operationInterpreter;
+  }
+
+  /**
+   * Parameters for the IF operation.
+   *
+   * @typedef {object} IfOperationParams
+   * @property {object} condition
+   * @property {import('../../data/schemas/operation.schema.json').Operation[]} [then_actions]
+   * @property {import('../../data/schemas/operation.schema.json').Operation[]} [else_actions]
+   */
+
+  /**
+   * Execute the IF operation.
+   *
+   * @param {IfOperationParams|OperationParams|null|undefined} params
+   * @param {ExecutionContext} execCtx
+   */
+  execute(params, execCtx) {
+    const log = execCtx?.logger ?? this.#logger;
+    if (!params || typeof params !== 'object') {
+      log.warn('IF: parameters missing or invalid');
+      return;
+    }
+    const {
+      condition,
+      then_actions: thenActs = [],
+      else_actions: elseActs = [],
+    } = params;
+    let result = false;
+    try {
+      result = this.#jsonLogic.evaluate(condition, execCtx.evaluationContext);
+    } catch (e) {
+      log.error('IF: condition error', e);
+      return;
+    }
+
+    const actions = Array.isArray(result ? thenActs : elseActs)
+      ? result
+        ? thenActs
+        : elseActs
+      : [];
+
+    return actions;
+  }
+}
+
+export default IfHandler;

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -108,7 +108,7 @@ class OperationInterpreter {
     // -----------------------------------------------------------------------
     try {
       this.#logger.debug(`Executing handler for operation type "${opType}"…`);
-      handler(paramsForHandler, executionContext);
+      return handler(paramsForHandler, executionContext);
     } catch (handlerErr) {
       // Bubble up – SystemLogicInterpreter will handle halting the sequence
       this.#logger.debug(

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -389,14 +389,21 @@ class SystemLogicInterpreter {
 
       // delegate -----------------------------------------------------------
       try {
-        if (opType === 'IF') {
-          this.#handleIf(op, nestedCtx, `${scopeLabel} IF#${opIndex}`);
-        } else if (opType === 'FOR_EACH') {
+        if (opType === 'FOR_EACH') {
           this.#handleForEach(
             op,
             nestedCtx,
             `${scopeLabel} FOR_EACH#${opIndex}`
           );
+        } else if (opType === 'IF') {
+          const actionsToRun =
+            this.#operationInterpreter.execute(op, nestedCtx) || [];
+          if (Array.isArray(actionsToRun) && actionsToRun.length)
+            this._executeActions(
+              actionsToRun,
+              nestedCtx,
+              `${scopeLabel} IF#${opIndex}`
+            );
         } else {
           this.#operationInterpreter.execute(op, nestedCtx);
         }
@@ -417,24 +424,6 @@ class SystemLogicInterpreter {
   /* --------------------------------------------------------------------- */
 
   /* Built-in flow-control helpers                                         */
-
-  #handleIf(node, nestedCtx, label) {
-    const {
-      condition,
-      then_actions: thenActs = [],
-      else_actions: elseActs = [],
-    } = node.parameters || {};
-
-    let result = false;
-    try {
-      result = this.#jsonLogic.evaluate(condition, nestedCtx.evaluationContext);
-    } catch (e) {
-      this.#logger.error(`${label}: condition error`, e);
-      return;
-    }
-
-    this._executeActions(result ? thenActs : elseActs, nestedCtx, label);
-  }
 
   #handleForEach(node, nestedCtx, label) {
     const {

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -17,6 +17,7 @@ import QueryComponentOptionalHandler from '../../../src/logic/operationHandlers/
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
+import IfHandler from '../../../src/logic/operationHandlers/ifHandler.js';
 import {
   NAME_COMPONENT_ID,
   POSITION_COMPONENT_ID,
@@ -67,7 +68,14 @@ function init(entities) {
   operationRegistry = new OperationRegistry({ logger });
   entityManager = new SimpleEntityManager(entities);
 
+  jsonLogic = new JsonLogicEvaluationService({ logger });
+
   const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+
+  operationInterpreter = new OperationInterpreter({
+    logger,
+    operationRegistry,
+  });
 
   const handlers = {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
@@ -80,18 +88,16 @@ function init(entities) {
       dispatcher: eventBus,
       logger,
     }),
+    IF: new IfHandler({
+      logger,
+      jsonLogicEvaluationService: jsonLogic,
+      operationInterpreter,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
-
-  operationInterpreter = new OperationInterpreter({
-    logger,
-    operationRegistry,
-  });
-
-  jsonLogic = new JsonLogicEvaluationService({ logger });
 
   interpreter = new SystemLogicInterpreter({
     logger,

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -19,6 +19,7 @@ import QueryComponentHandler from '../../../src/logic/operationHandlers/queryCom
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import SystemMoveEntityHandler from '../../../src/logic/operationHandlers/systemMoveEntityHandler.js';
+import IfHandler from '../../../src/logic/operationHandlers/ifHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -158,6 +159,11 @@ function init(entities) {
   operationRegistry = new OperationRegistry({ logger });
   entityManager = new SimpleEntityManager(entities);
 
+  operationInterpreter = new OperationInterpreter({
+    logger,
+    operationRegistry,
+  });
+
   const handlers = {
     REBUILD_LEADER_LIST_CACHE: new RebuildLeaderListCacheHandler({
       logger,
@@ -178,16 +184,16 @@ function init(entities) {
       safeEventDispatcher: eventBus,
       logger,
     }),
+    IF: new IfHandler({
+      logger,
+      jsonLogicEvaluationService: jsonLogic,
+      operationInterpreter,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
-
-  operationInterpreter = new OperationInterpreter({
-    logger,
-    operationRegistry,
-  });
 
   interpreter = new SystemLogicInterpreter({
     logger,

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -22,6 +22,7 @@ import ModifyArrayFieldHandler from '../../../src/logic/operationHandlers/modify
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
+import IfHandler from '../../../src/logic/operationHandlers/ifHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -99,6 +100,13 @@ describe('core_handle_follow rule integration', () => {
       }),
     };
 
+    jsonLogic = new JsonLogicEvaluationService({ logger });
+
+    operationInterpreter = new OperationInterpreter({
+      logger,
+      operationRegistry,
+    });
+
     const handlers = {
       CHECK_FOLLOW_CYCLE: new CheckFollowCycleHandler({
         logger,
@@ -127,18 +135,16 @@ describe('core_handle_follow rule integration', () => {
       }),
       END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
       GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+      IF: new IfHandler({
+        logger,
+        jsonLogicEvaluationService: jsonLogic,
+        operationInterpreter,
+      }),
     };
 
     for (const [type, handler] of Object.entries(handlers)) {
       operationRegistry.register(type, handler.execute.bind(handler));
     }
-
-    operationInterpreter = new OperationInterpreter({
-      logger,
-      operationRegistry,
-    });
-
-    jsonLogic = new JsonLogicEvaluationService({ logger });
 
     interpreter = new SystemLogicInterpreter({
       logger,

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -20,6 +20,7 @@ import ResolveDirectionHandler from '../../../src/logic/operationHandlers/resolv
 import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
+import IfHandler from '../../../src/logic/operationHandlers/ifHandler.js';
 import {
   NAME_COMPONENT_ID,
   POSITION_COMPONENT_ID,
@@ -150,6 +151,13 @@ function init(entities) {
 
   const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
+  jsonLogic = new JsonLogicEvaluationService({ logger });
+
+  operationInterpreter = new OperationInterpreter({
+    logger,
+    operationRegistry,
+  });
+
   const handlers = {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
       entityManager,
@@ -168,18 +176,16 @@ function init(entities) {
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    IF: new IfHandler({
+      logger,
+      jsonLogicEvaluationService: jsonLogic,
+      operationInterpreter,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
-
-  operationInterpreter = new OperationInterpreter({
-    logger,
-    operationRegistry,
-  });
-
-  jsonLogic = new JsonLogicEvaluationService({ logger });
 
   interpreter = new SystemLogicInterpreter({
     logger,

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -20,6 +20,7 @@ import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimesta
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import IfCoLocatedHandler from '../../../src/logic/operationHandlers/ifCoLocatedHandler.js';
+import IfHandler from '../../../src/logic/operationHandlers/ifHandler.js';
 import {
   FOLLOWING_COMPONENT_ID,
   LEADING_COMPONENT_ID,
@@ -127,6 +128,8 @@ function init(entities) {
     operationRegistry,
   });
 
+  jsonLogic = new JsonLogicEvaluationService({ logger });
+
   const handlers = {
     REMOVE_COMPONENT: new RemoveComponentHandler({
       entityManager,
@@ -151,13 +154,16 @@ function init(entities) {
       operationInterpreter,
       safeEventDispatcher: safeDispatcher,
     }),
+    IF: new IfHandler({
+      logger,
+      jsonLogicEvaluationService: jsonLogic,
+      operationInterpreter,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
-
-  jsonLogic = new JsonLogicEvaluationService({ logger });
 
   interpreter = new SystemLogicInterpreter({
     logger,

--- a/tests/logic/operationInterpreter.test.js
+++ b/tests/logic/operationInterpreter.test.js
@@ -280,12 +280,19 @@ describe('OperationInterpreter', () => {
      IF behaves like any other op (no special logic in interpreter)
      ─────────────────────────────────────────────────────────────────────── */
   test('execute should treat IF like any other type (lookup in registry)', () => {
-    mockRegistry.getHandler.mockReturnValue(undefined);
+    const mockIfHandler = jest.fn();
+    mockRegistry.getHandler.mockReturnValue(mockIfHandler);
     interpreter.execute(ifOperation, mockExecutionContext);
     expect(mockRegistry.getHandler).toHaveBeenCalledWith('IF');
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      'OperationInterpreter: ---> HANDLER NOT FOUND for operation type: "IF".'
+    expect(mockIfHandler).toHaveBeenCalledTimes(1);
+    expect(mockIfHandler).toHaveBeenCalledWith(
+      {
+        condition: { '==': [1, 1] },
+        then_actions: [{ type: 'LOG', parameters: { message: 'IF was true' } }],
+      },
+      mockExecutionContext
     );
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   /* ────────────────────────────────────────────────────────────────────────

--- a/tests/logic/systemLogicInterpreter.operationExecution.integration.test.js
+++ b/tests/logic/systemLogicInterpreter.operationExecution.integration.test.js
@@ -48,6 +48,21 @@ const testRule_ActionOrder = {
   ],
 };
 
+/** @type {SystemRule} */
+const testRule_IfDelegation = {
+  rule_id: 'TestRule_IF',
+  event_type: 'test:event_if',
+  actions: [
+    {
+      type: 'IF',
+      parameters: {
+        condition: { '==': [1, 1] },
+        then_actions: [{ type: 'LOG', parameters: { message: 'inside IF' } }],
+      },
+    },
+  ],
+};
+
 // --- Test Suite ---
 describe('SystemLogicInterpreter - Operation Execution Integration Test', () => {
   /** @type {jest.Mocked<ILogger>} */
@@ -204,6 +219,23 @@ describe('SystemLogicInterpreter - Operation Execution Integration Test', () => 
         parameters: { message: 'Second Action - Event: {event.type}' },
       }),
       expectedContextForOperationInterpreter // Context should be the same for subsequent actions of the same rule
+    );
+  });
+
+  it('delegates IF operations to OperationInterpreter.execute', async () => {
+    mockDataRegistry.getAllSystemRules.mockReturnValue([testRule_IfDelegation]);
+
+    systemLogicInterpreter.initialize();
+
+    const eventPayload = { actorId: 'testActor001' };
+    const eventType = 'test:event_if';
+    await eventBusInstance.dispatch(eventType, eventPayload);
+
+    // Only the IF operation itself should trigger execute since no handler is registered
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'IF' }),
+      expect.any(Object)
     );
   });
 });


### PR DESCRIPTION
Summary:
- implement `IfHandler` to evaluate JsonLogic conditions
- register IF handler in interpreter DI setup
- delegate IF actions via `OperationInterpreter` in `SystemLogicInterpreter`
- return handler results from `OperationInterpreter`
- update integration tests for new handler design

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 534 errors)*
- [x] `npm test`
- [x] `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea8925f8c833193135203c6dabaa2