### PR TITLE
[Agent] Add macros for successful and failed action logging

### DIFF
--- a/data/mods/core/macros/logFailureAndEndTurn.macro.json
+++ b/data/mods/core/macros/logFailureAndEndTurn.macro.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://example.com/schemas/macro.schema.json",
+  "macro_id": "core:logFailureAndEndTurn",
+  "actions": [
+    {
+      "type": "DISPATCH_EVENT",
+      "parameters": {
+        "eventType": "core:display_failed_action_result",
+        "payload": {
+          "message": "{context.logMessage}"
+        }
+      }
+    },
+    {
+      "type": "END_TURN",
+      "parameters": {
+        "entityId": "{event.payload.actorId}",
+        "success": false
+      }
+    }
+  ]
+}

--- a/data/mods/core/macros/logSuccessAndEndTurn.macro.json
+++ b/data/mods/core/macros/logSuccessAndEndTurn.macro.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://example.com/schemas/macro.schema.json",
+  "macro_id": "core:logSuccessAndEndTurn",
+  "actions": [
+    {
+      "type": "GET_TIMESTAMP",
+      "parameters": {
+        "result_variable": "nowIso"
+      }
+    },
+    {
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
+      "parameters": {
+        "location_id": "{context.locationId}",
+        "description_text": "{context.logMessage}",
+        "perception_type": "{context.perceptionType}",
+        "actor_id": "{event.payload.actorId}",
+        "target_id": "{context.targetId}"
+      }
+    },
+    {
+      "type": "DISPATCH_EVENT",
+      "parameters": {
+        "eventType": "core:display_successful_action_result",
+        "payload": {
+          "message": "{context.logMessage}"
+        }
+      }
+    },
+    {
+      "type": "END_TURN",
+      "parameters": {
+        "entityId": "{event.payload.actorId}",
+        "success": true
+      }
+    }
+  ]
+}

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -54,6 +54,10 @@
       "dismiss.rule.json",
       "follow_auto_move.rule.json"
     ],
+    "macros": [
+      "logSuccessAndEndTurn.macro.json",
+      "logFailureAndEndTurn.macro.json"
+    ],
     "events": [
       "action_decided.event.json",
       "ui_ready.event.json",


### PR DESCRIPTION
## Summary
- add macros folder for core and intimacy mods
- implement logSuccessAndEndTurn and logFailureAndEndTurn macros
- reference new macros in the core mod manifest

## Testing
- `npm run format`
- `npm run lint` *(fails: 533 errors, 1788 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684edbc28bd08331a1e749b51bf7253e