### PR TITLE
[Feat] Extract GameStateCaptureService

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -23,6 +23,7 @@ import { Registrar } from '../registrarHelpers.js';
 import PlaytimeTracker from '../../engine/playtimeTracker.js';
 import ComponentCleaningService from '../../persistence/componentCleaningService.js';
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
+import GameStateCaptureService from '../../persistence/gameStateCaptureService.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
 import ReferenceResolver from '../../initializers/services/referenceResolver.js';
 import SaveLoadService from '../../persistence/saveLoadService.js';
@@ -73,15 +74,27 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
   );
 
-  r.singletonFactory(tokens.GamePersistenceService, (c) => {
-    return new GamePersistenceService({
+  r.singletonFactory(tokens.GameStateCaptureService, (c) => {
+    return new GameStateCaptureService({
       logger: c.resolve(tokens.ILogger),
-      saveLoadService: c.resolve(tokens.ISaveLoadService),
       entityManager: c.resolve(tokens.IEntityManager),
       dataRegistry: c.resolve(tokens.IDataRegistry),
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
       componentCleaningService: c.resolve(tokens.ComponentCleaningService),
       metadataBuilder: c.resolve(tokens.SaveMetadataBuilder),
+    });
+  });
+  logger.debug(
+    `Persistence Registration: Registered ${String(tokens.GameStateCaptureService)}.`
+  );
+
+  r.singletonFactory(tokens.GamePersistenceService, (c) => {
+    return new GamePersistenceService({
+      logger: c.resolve(tokens.ILogger),
+      saveLoadService: c.resolve(tokens.ISaveLoadService),
+      entityManager: c.resolve(tokens.IEntityManager),
+      playtimeTracker: c.resolve(tokens.PlaytimeTracker),
+      gameStateCaptureService: c.resolve(tokens.GameStateCaptureService),
     });
   });
   logger.debug(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -77,6 +77,7 @@ import { freeze } from '../utils/objectUtils';
  * @property {DiToken} CommandOutcomeInterpreter - Token for the service interpreting command outcomes (implementation).
  * @property {DiToken} PlaytimeTracker - Token for the service managing player playtime.
  * @property {DiToken} ComponentCleaningService - Token for the service cleaning component data.
+ * @property {DiToken} GameStateCaptureService - Token for the service capturing game state.
  * @property {DiToken} GamePersistenceService - Token for the game state persistence service.
  * @property {DiToken} EntityDisplayDataProvider - Token for the service providing entity display data.
  * @property {DiToken} AlertRouter - Token for the service that routes alerts to the UI or console.
@@ -203,6 +204,7 @@ export const tokens = freeze({
   PlaytimeTracker: 'PlaytimeTracker',
   ComponentCleaningService: 'ComponentCleaningService',
   SaveMetadataBuilder: 'SaveMetadataBuilder',
+  GameStateCaptureService: 'GameStateCaptureService',
   GamePersistenceService: 'GamePersistenceService',
   EntityDisplayDataProvider: 'EntityDisplayDataProvider',
   AlertRouter: 'AlertRouter',

--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -1,5 +1,5 @@
 import { IGamePersistenceService } from '../interfaces/IGamePersistenceService.js';
-import SaveMetadataBuilder from './saveMetadataBuilder.js';
+import GameStateCaptureService from './gameStateCaptureService.js';
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -8,20 +8,15 @@ import SaveMetadataBuilder from './saveMetadataBuilder.js';
 /** @typedef {import('../interfaces/ISaveLoadService.js').LoadGameResult} LoadGameResult */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('../entities/entity.js').default} Entity */
-/** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 /** @typedef {import('../engine/playtimeTracker.js').default} PlaytimeTracker */
-/** @typedef {import('../interfaces/IComponentCleaningService.js').IComponentCleaningService} IComponentCleaningService */
 /** @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer */
 /** @typedef {import('../turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
 /** @typedef {import('../loaders/worldLoader.js').default} WorldLoader */
-/** @typedef {import('../../data/schemas/mod.manifest.schema.json').ModManifest} ModManifest */
 
 // --- Import Tokens ---
 // tokens import removed as not used after refactor
 
 // --- MODIFICATION START: Import component IDs for cleaning logic ---
-import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
-import { CORE_MOD_ID } from '../constants/core';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -37,10 +32,8 @@ class GamePersistenceService extends IGamePersistenceService {
   #logger;
   #saveLoadService;
   #entityManager;
-  #dataRegistry;
   #playtimeTracker;
-  #componentCleaningService;
-  #metadataBuilder;
+  #gameStateCaptureService;
 
   /**
    * Creates a new GamePersistenceService instance.
@@ -49,30 +42,24 @@ class GamePersistenceService extends IGamePersistenceService {
    * @param {ILogger} dependencies.logger - Logging service.
    * @param {ISaveLoadService} dependencies.saveLoadService - Save/load service.
    * @param {EntityManager} dependencies.entityManager - Entity manager.
-   * @param {IDataRegistry} dependencies.dataRegistry - Data registry.
    * @param {PlaytimeTracker} dependencies.playtimeTracker - Playtime tracker.
-   * @param {IComponentCleaningService} dependencies.componentCleaningService - Component cleaning service.
-   * @param {SaveMetadataBuilder} dependencies.metadataBuilder - Builder for save metadata.
+   * @param {GameStateCaptureService} dependencies.gameStateCaptureService - Service capturing current game state.
    */
   constructor({
     logger,
     saveLoadService,
     entityManager,
-    dataRegistry,
     playtimeTracker,
-    componentCleaningService,
-    metadataBuilder,
+    gameStateCaptureService,
   }) {
     super();
     const missingDependencies = [];
     if (!logger) missingDependencies.push('logger');
     if (!saveLoadService) missingDependencies.push('saveLoadService');
     if (!entityManager) missingDependencies.push('entityManager');
-    if (!dataRegistry) missingDependencies.push('dataRegistry');
     if (!playtimeTracker) missingDependencies.push('playtimeTracker');
-    if (!componentCleaningService)
-      missingDependencies.push('componentCleaningService');
-    if (!metadataBuilder) missingDependencies.push('metadataBuilder');
+    if (!gameStateCaptureService)
+      missingDependencies.push('gameStateCaptureService');
 
     if (missingDependencies.length > 0) {
       const errorMessage = `GamePersistenceService: Fatal - Missing required dependencies: ${missingDependencies.join(', ')}.`;
@@ -87,65 +74,9 @@ class GamePersistenceService extends IGamePersistenceService {
     this.#logger = logger;
     this.#saveLoadService = saveLoadService;
     this.#entityManager = entityManager;
-    this.#dataRegistry = dataRegistry;
     this.#playtimeTracker = playtimeTracker;
-    this.#componentCleaningService = componentCleaningService;
-    this.#metadataBuilder = metadataBuilder;
+    this.#gameStateCaptureService = gameStateCaptureService;
     this.#logger.debug('GamePersistenceService: Instance created.');
-  }
-
-  /**
-   * @description Serializes a single entity for saving.
-   * @param {Entity} entity - The entity instance to serialize.
-   * @returns {{instanceId: string, definitionId: string, components: Record<string, any>}}
-   *   Clean serialized representation of the entity.
-   * @private
-   */
-  #serializeEntity(entity) {
-    const components = this.#applyComponentCleaners(
-      entity.componentEntries,
-      entity.id
-    );
-    return {
-      instanceId: entity.id,
-      definitionId: entity.definitionId,
-      components,
-    };
-  }
-
-  /**
-   * @description Cleans and prepares component data for serialization.
-   * @param {Map<string, any>} componentEntries - Raw component map from the entity.
-   * @param {string} entityId - Identifier of the owning entity (for logging).
-   * @returns {Record<string, any>} Object containing cleaned components.
-   * @private
-   */
-  #applyComponentCleaners(componentEntries, entityId) {
-    const components = {};
-    for (const [componentTypeId, componentData] of componentEntries) {
-      if (componentTypeId === CURRENT_ACTOR_COMPONENT_ID) {
-        this.#logger.debug(
-          `GamePersistenceService.captureCurrentGameState: Skipping component '${CURRENT_ACTOR_COMPONENT_ID}' for entity '${entityId}' during save.`
-        );
-        continue;
-      }
-
-      const dataToSave = this.#componentCleaningService.clean(
-        componentTypeId,
-        componentData
-      );
-
-      if (dataToSave !== null && typeof dataToSave !== 'object') {
-        components[componentTypeId] = dataToSave;
-      } else if (Object.keys(dataToSave).length > 0) {
-        components[componentTypeId] = dataToSave;
-      } else {
-        this.#logger.debug(
-          `Skipping component '${componentTypeId}' for entity '${entityId}' as it is empty after cleaning.`
-        );
-      }
-    }
-    return components;
   }
 
   /**
@@ -302,40 +233,6 @@ class GamePersistenceService extends IGamePersistenceService {
    * @returns {{modId: string, version: string}[]} Array of active mod info.
    * @private
    */
-  #buildActiveModsManifest() {
-    /** @type {ModManifest[]} */
-    const loadedManifestObjects = this.#dataRegistry.getAll('mod_manifests');
-    let activeModsManifest = [];
-    if (loadedManifestObjects && loadedManifestObjects.length > 0) {
-      activeModsManifest = loadedManifestObjects.map((manifest) => ({
-        modId: manifest.id,
-        version: manifest.version,
-      }));
-      this.#logger.debug(
-        `GamePersistenceService: Captured ${activeModsManifest.length} active mods from 'mod_manifests' type in registry.`
-      );
-    } else {
-      this.#logger.warn(
-        'GamePersistenceService: No mod manifests found in registry under "mod_manifests" type. Mod manifest may be incomplete. Using fallback.'
-      );
-      const coreModManifest = loadedManifestObjects?.find(
-        (m) => m.id === CORE_MOD_ID
-      );
-      if (coreModManifest) {
-        activeModsManifest = [
-          { modId: CORE_MOD_ID, version: coreModManifest.version },
-        ];
-      } else {
-        activeModsManifest = [
-          { modId: CORE_MOD_ID, version: 'unknown_fallback' },
-        ];
-      }
-      this.#logger.debug(
-        'GamePersistenceService: Used fallback for mod manifest.'
-      );
-    }
-    return activeModsManifest;
-  }
 
   /**
    * Captures the current game state.
@@ -343,61 +240,6 @@ class GamePersistenceService extends IGamePersistenceService {
    * @param {string | null | undefined} activeWorldName - The name of the currently active world, passed from GameEngine.
    * @returns {SaveGameStructure} The captured game state object.
    */
-  captureCurrentGameState(activeWorldName) {
-    this.#logger.debug(
-      'GamePersistenceService: Capturing current game state...'
-    );
-
-    if (!this.#entityManager)
-      throw new Error('EntityManager not available for capturing game state.');
-    if (!this.#dataRegistry)
-      throw new Error('DataRegistry not available for capturing mod manifest.');
-    if (!this.#playtimeTracker)
-      throw new Error(
-        'PlaytimeTracker not available for capturing game state.'
-      );
-
-    const entitiesData = [];
-    for (const entity of this.#entityManager.activeEntities.values()) {
-      entitiesData.push(this.#serializeEntity(entity));
-    }
-    this.#logger.debug(
-      `GamePersistenceService: Captured ${entitiesData.length} entities.`
-    );
-
-    const activeModsManifest = this.#buildActiveModsManifest();
-
-    const currentTotalPlaytime = this.#playtimeTracker.getTotalPlaytime();
-    this.#logger.debug(
-      `GamePersistenceService: Fetched total playtime: ${currentTotalPlaytime}s.`
-    );
-
-    const metadata = this.#metadataBuilder.build(
-      activeWorldName,
-      currentTotalPlaytime
-    );
-
-    const gameStateObject = {
-      metadata,
-      modManifest: {
-        activeMods: activeModsManifest,
-      },
-      gameState: {
-        entities: entitiesData,
-        playerState: {},
-        worldState: {},
-        engineInternals: {},
-      },
-      integrityChecks: {
-        gameStateChecksum: 'PENDING_CALCULATION',
-      },
-    };
-
-    this.#logger.debug(
-      `GamePersistenceService: Game state capture complete. Game Title: ${metadata.gameTitle}, ${entitiesData.length} entities captured. Playtime: ${currentTotalPlaytime}s.`
-    );
-    return gameStateObject;
-  }
 
   isSavingAllowed(isEngineInitialized) {
     if (!isEngineInitialized) {
@@ -447,7 +289,8 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.debug(
         `GamePersistenceService.saveGame: Capturing current game state for save "${saveName}".`
       );
-      const gameStateObject = this.captureCurrentGameState(activeWorldName);
+      const gameStateObject =
+        this.#gameStateCaptureService.captureCurrentGameState(activeWorldName);
       if (!gameStateObject.metadata) gameStateObject.metadata = {};
       gameStateObject.metadata.saveName = saveName;
       this.#logger.debug(

--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -1,0 +1,240 @@
+// src/persistence/gameStateCaptureService.js
+
+import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
+import { CORE_MOD_ID } from '../constants/core.js';
+
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../entities/entityManager.js').default} EntityManager
+ * @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry
+ * @typedef {import('../engine/playtimeTracker.js').default} PlaytimeTracker
+ * @typedef {import('./componentCleaningService.js').default} ComponentCleaningService
+ * @typedef {import('./saveMetadataBuilder.js').default} SaveMetadataBuilder
+ * @typedef {import('../entities/entity.js').default} Entity
+ */
+
+/**
+ * @class GameStateCaptureService
+ * @description Captures the current game state for saving.
+ */
+class GameStateCaptureService {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {EntityManager} */
+  #entityManager;
+  /** @type {IDataRegistry} */
+  #dataRegistry;
+  /** @type {PlaytimeTracker} */
+  #playtimeTracker;
+  /** @type {ComponentCleaningService} */
+  #componentCleaningService;
+  /** @type {SaveMetadataBuilder} */
+  #metadataBuilder;
+
+  /**
+   * Creates a new GameStateCaptureService instance.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logging service.
+   * @param {EntityManager} deps.entityManager - Entity manager.
+   * @param {IDataRegistry} deps.dataRegistry - Data registry.
+   * @param {PlaytimeTracker} deps.playtimeTracker - Playtime tracker.
+   * @param {ComponentCleaningService} deps.componentCleaningService - Component cleaning service.
+   * @param {SaveMetadataBuilder} deps.metadataBuilder - Builder for save metadata.
+   */
+  constructor({
+    logger,
+    entityManager,
+    dataRegistry,
+    playtimeTracker,
+    componentCleaningService,
+    metadataBuilder,
+  }) {
+    const missing = [];
+    if (!logger) missing.push('logger');
+    if (!entityManager) missing.push('entityManager');
+    if (!dataRegistry) missing.push('dataRegistry');
+    if (!playtimeTracker) missing.push('playtimeTracker');
+    if (!componentCleaningService) missing.push('componentCleaningService');
+    if (!metadataBuilder) missing.push('metadataBuilder');
+
+    if (missing.length > 0) {
+      const msg = `GameStateCaptureService: Missing required dependencies: ${missing.join(', ')}`;
+      if (logger && typeof logger.error === 'function') {
+        logger.error(msg);
+      } else {
+        console.error(msg);
+      }
+      throw new Error(msg);
+    }
+
+    this.#logger = logger;
+    this.#entityManager = entityManager;
+    this.#dataRegistry = dataRegistry;
+    this.#playtimeTracker = playtimeTracker;
+    this.#componentCleaningService = componentCleaningService;
+    this.#metadataBuilder = metadataBuilder;
+    this.#logger.debug('GameStateCaptureService: Instance created.');
+  }
+
+  /**
+   * Cleans and prepares component data for serialization.
+   *
+   * @param {Map<string, any>} componentEntries - Raw component map from the entity.
+   * @param {string} entityId - Identifier of the owning entity.
+   * @returns {Record<string, any>} Object containing cleaned components.
+   * @private
+   */
+  #applyComponentCleaners(componentEntries, entityId) {
+    const components = {};
+    for (const [componentTypeId, componentData] of componentEntries) {
+      if (componentTypeId === CURRENT_ACTOR_COMPONENT_ID) {
+        this.#logger.debug(
+          `GameStateCaptureService.captureCurrentGameState: Skipping component '${CURRENT_ACTOR_COMPONENT_ID}' for entity '${entityId}' during save.`
+        );
+        continue;
+      }
+
+      const dataToSave = this.#componentCleaningService.clean(
+        componentTypeId,
+        componentData
+      );
+
+      if (dataToSave !== null && typeof dataToSave !== 'object') {
+        components[componentTypeId] = dataToSave;
+      } else if (Object.keys(dataToSave).length > 0) {
+        components[componentTypeId] = dataToSave;
+      } else {
+        this.#logger.debug(
+          `Skipping component '${componentTypeId}' for entity '${entityId}' as it is empty after cleaning.`
+        );
+      }
+    }
+    return components;
+  }
+
+  /**
+   * Serializes a single entity for saving.
+   *
+   * @param {Entity} entity - The entity instance to serialize.
+   * @returns {{instanceId: string, definitionId: string, components: Record<string, any>}}
+   *   Clean serialized representation of the entity.
+   * @private
+   */
+  #serializeEntity(entity) {
+    const components = this.#applyComponentCleaners(
+      entity.componentEntries,
+      entity.id
+    );
+    return {
+      instanceId: entity.id,
+      definitionId: entity.definitionId,
+      components,
+    };
+  }
+
+  /**
+   * Builds the active mods manifest section for the save data.
+   *
+   * @returns {{modId: string, version: string}[]} Array of active mod info.
+   * @private
+   */
+  #buildActiveModsManifest() {
+    /** @type {import('../../data/schemas/mod.manifest.schema.json').ModManifest[]} */
+    const loadedManifestObjects = this.#dataRegistry.getAll('mod_manifests');
+    let activeModsManifest = [];
+    if (loadedManifestObjects && loadedManifestObjects.length > 0) {
+      activeModsManifest = loadedManifestObjects.map((manifest) => ({
+        modId: manifest.id,
+        version: manifest.version,
+      }));
+      this.#logger.debug(
+        `GameStateCaptureService: Captured ${activeModsManifest.length} active mods from 'mod_manifests' type in registry.`
+      );
+    } else {
+      this.#logger.warn(
+        'GameStateCaptureService: No mod manifests found in registry under "mod_manifests" type. Mod manifest may be incomplete. Using fallback.'
+      );
+      const coreModManifest = loadedManifestObjects?.find(
+        (m) => m.id === CORE_MOD_ID
+      );
+      if (coreModManifest) {
+        activeModsManifest = [
+          { modId: CORE_MOD_ID, version: coreModManifest.version },
+        ];
+      } else {
+        activeModsManifest = [
+          { modId: CORE_MOD_ID, version: 'unknown_fallback' },
+        ];
+      }
+      this.#logger.debug(
+        'GameStateCaptureService: Used fallback for mod manifest.'
+      );
+    }
+    return activeModsManifest;
+  }
+
+  /**
+   * Captures the current game state.
+   *
+   * @param {string | null | undefined} activeWorldName - The name of the currently active world.
+   * @returns {import('../interfaces/ISaveLoadService.js').SaveGameStructure} The captured game state object.
+   */
+  captureCurrentGameState(activeWorldName) {
+    this.#logger.debug(
+      'GameStateCaptureService: Capturing current game state...'
+    );
+
+    if (!this.#entityManager)
+      throw new Error('EntityManager not available for capturing game state.');
+    if (!this.#dataRegistry)
+      throw new Error('DataRegistry not available for capturing mod manifest.');
+    if (!this.#playtimeTracker)
+      throw new Error(
+        'PlaytimeTracker not available for capturing game state.'
+      );
+
+    const entitiesData = [];
+    for (const entity of this.#entityManager.activeEntities.values()) {
+      entitiesData.push(this.#serializeEntity(entity));
+    }
+    this.#logger.debug(
+      `GameStateCaptureService: Captured ${entitiesData.length} entities.`
+    );
+
+    const activeModsManifest = this.#buildActiveModsManifest();
+
+    const currentTotalPlaytime = this.#playtimeTracker.getTotalPlaytime();
+    this.#logger.debug(
+      `GameStateCaptureService: Fetched total playtime: ${currentTotalPlaytime}s.`
+    );
+
+    const metadata = this.#metadataBuilder.build(
+      activeWorldName,
+      currentTotalPlaytime
+    );
+
+    const gameStateObject = {
+      metadata,
+      modManifest: {
+        activeMods: activeModsManifest,
+      },
+      gameState: {
+        entities: entitiesData,
+        playerState: {},
+        worldState: {},
+        engineInternals: {},
+      },
+      integrityChecks: {
+        gameStateChecksum: 'PENDING_CALCULATION',
+      },
+    };
+
+    this.#logger.debug(
+      `GameStateCaptureService: Game state capture complete. Game Title: ${metadata.gameTitle}, ${entitiesData.length} entities captured. Playtime: ${currentTotalPlaytime}s.`
+    );
+    return gameStateObject;
+  }
+}
+
+export default GameStateCaptureService;

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -22,6 +22,7 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import PlaytimeTracker from '../../../src/engine/playtimeTracker.js';
 import ComponentCleaningService from '../../../src/persistence/componentCleaningService.js';
 import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
+import GameStateCaptureService from '../../../src/persistence/gameStateCaptureService.js';
 import ReferenceResolver from '../../../src/initializers/services/referenceResolver.js';
 import SaveMetadataBuilder from '../../../src/persistence/saveMetadataBuilder.js';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
@@ -79,6 +80,9 @@ describe('registerPersistence', () => {
       `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
     );
     expect(logs).toContain(
+      `Persistence Registration: Registered ${String(tokens.GameStateCaptureService)}.`
+    );
+    expect(logs).toContain(
       `Persistence Registration: Registered ${String(tokens.GamePersistenceService)}.`
     );
     expect(logs).toContain(
@@ -118,6 +122,11 @@ describe('registerPersistence', () => {
         Class: SaveMetadataBuilder,
         lifecycle: 'singleton',
         deps: [tokens.ILogger],
+      },
+      {
+        token: tokens.GameStateCaptureService,
+        Class: GameStateCaptureService,
+        lifecycle: 'singletonFactory',
       },
       {
         token: tokens.GamePersistenceService,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -1,6 +1,7 @@
 import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
+import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import ComponentCleaningService from '../../src/persistence/componentCleaningService.js';
 import receptionistDef from '../../data/mods/isekai/characters/receptionist.character.json';
 import { webcrypto } from 'crypto';
@@ -117,14 +118,20 @@ describe('Persistence round-trip', () => {
       })),
     };
 
-    persistence = new GamePersistenceService({
+    const captureService = new GameStateCaptureService({
       logger,
-      saveLoadService,
       entityManager,
       dataRegistry,
       playtimeTracker,
       componentCleaningService,
       metadataBuilder,
+    });
+    persistence = new GamePersistenceService({
+      logger,
+      saveLoadService,
+      entityManager,
+      playtimeTracker,
+      gameStateCaptureService: captureService,
     });
   });
 

--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -9,10 +9,8 @@ function makeDeps() {
     logger: { debug: jest.fn(), error: jest.fn() },
     saveLoadService: {},
     entityManager: {},
-    dataRegistry: {},
     playtimeTracker: {},
-    componentCleaningService: { clean: jest.fn() },
-    metadataBuilder: { build: jest.fn() },
+    gameStateCaptureService: {},
   };
 }
 
@@ -21,10 +19,8 @@ describe('GamePersistenceService constructor validation', () => {
     'logger',
     'saveLoadService',
     'entityManager',
-    'dataRegistry',
     'playtimeTracker',
-    'componentCleaningService',
-    'metadataBuilder',
+    'gameStateCaptureService',
   ];
 
   test.each(required)('throws if %s is missing', (prop) => {

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -3,12 +3,12 @@
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
+import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../core/interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
-/** @typedef {import('../core/interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 /** @typedef {import('./playtimeTracker.js').default} PlaytimeTracker */
 /** @typedef {import('../config/appContainer.js').default} AppContainer */
 
@@ -28,12 +28,8 @@ const mockLogger = {
 const mockSaveLoadService = {};
 /** @type {jest.Mocked<EntityManager>} */
 const mockEntityManager = {};
-/** @type {jest.Mocked<IDataRegistry>} */
-const mockDataRegistry = {};
 /** @type {jest.Mocked<PlaytimeTracker>} */
 const mockPlaytimeTracker = {};
-const mockComponentCleaningService = { clean: jest.fn() };
-const mockMetadataBuilder = { build: jest.fn() };
 /** @type {jest.Mocked<AppContainer>} */
 const mockAppContainer = {
   resolve: jest.fn(), // Mock resolve as it might be used in the TODO part in the future
@@ -46,14 +42,15 @@ describe('GamePersistenceService', () => {
   beforeEach(() => {
     jest.clearAllMocks(); // Clear mocks before each test
 
+    const captureService = {
+      captureCurrentGameState: jest.fn(),
+    };
     service = new GamePersistenceService({
       logger: mockLogger,
       saveLoadService: mockSaveLoadService,
       entityManager: mockEntityManager,
-      dataRegistry: mockDataRegistry,
       playtimeTracker: mockPlaytimeTracker,
-      componentCleaningService: mockComponentCleaningService,
-      metadataBuilder: mockMetadataBuilder,
+      gameStateCaptureService: captureService,
     });
     // Clear the logger.info/debug calls made by the constructor, if any,
     // to not interfere with test-specific logger assertions.


### PR DESCRIPTION
Summary: Introduced `GameStateCaptureService` to handle game state capture logic previously inside `GamePersistenceService`. Updated persistence registration, DI tokens, and tests to use the new service.

Changes Made:
- Added new module for capturing and serializing game state.
- Refactored `GamePersistenceService` to depend on `GameStateCaptureService` and delegate capture logic.
- Adjusted DI registration and tokens to register the new service.
- Updated unit and integration tests to instantiate and mock the new service.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint executed (`npm run lint`) – known repository warnings remain
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684ee11e8c2c833198b39a8c4c7cae86