### PR TITLE
[Agent] extract jsonLogic condition helper

### DIFF
--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -136,3 +136,40 @@ class JsonLogicEvaluationService {
 }
 
 export default JsonLogicEvaluationService;
+
+/**
+ * Evaluate a JSON Logic condition using the provided service with additional
+ * logging and error handling.
+ *
+ * @param {JsonLogicEvaluationService} service - Service used to evaluate the condition.
+ * @param {object} condition - JSON Logic rule to evaluate.
+ * @param {JsonLogicEvaluationContext} ctx - Data context for evaluation.
+ * @param {ILogger} logger - Logger for debug/error messages.
+ * @param {string} label - Prefix for log statements.
+ * @returns {{result: boolean, errored: boolean, error: Error|undefined}} Outcome
+ *          of the evaluation.
+ */
+export function evaluateConditionWithLogging(
+  service,
+  condition,
+  ctx,
+  logger,
+  label
+) {
+  let rawResult;
+  let result = false;
+  try {
+    rawResult = service.evaluate(condition, ctx);
+    logger.debug(`${label} Condition evaluation raw result: ${rawResult}`);
+    result = !!rawResult;
+  } catch (error) {
+    logger.error(
+      `${label} Error during condition evaluation. Treating condition as FALSE.`,
+      error
+    );
+    return { result: false, errored: true, error };
+  }
+
+  logger.debug(`${label} Condition evaluation final boolean result: ${result}`);
+  return { result, errored: false, error: undefined };
+}


### PR DESCRIPTION
Summary: 
- add `evaluateConditionWithLogging` helper to `jsonLogicEvaluationService`
- refactor `_evaluateCondition` and `#handleIf` to use the helper

Testing Done:
- [x] `npm run format`
- [ ] `npm run lint` *(fails: many pre-existing lint errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format`
- [x] `cd llm-proxy-server && npm run lint`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684ee2d4754c833189509adc19738f29