### PR TITLE
[Agent] expose scrollToBottom utility

### DIFF
--- a/src/domUI/actionResultRenderer.js
+++ b/src/domUI/actionResultRenderer.js
@@ -207,6 +207,6 @@ export class ActionResultRenderer extends BoundDomRendererBase {
    * @private
    */
   #scrollToBottom() {
-    this._scrollToPanelBottom('scrollContainer', 'listContainerElement');
+    this.scrollToBottom('scrollContainer', 'listContainerElement');
   }
 }

--- a/src/domUI/boundDomRendererBase.js
+++ b/src/domUI/boundDomRendererBase.js
@@ -201,6 +201,17 @@ export class BoundDomRendererBase extends RendererBase {
   }
 
   /**
+   * Convenience wrapper that delegates to `_scrollToPanelBottom`.
+   *
+   * @protected
+   * @param {string} scrollKey - Key for the scroll container in `this.elements`.
+   * @param {string} contentKey - Key for the content container for fallback scrolling.
+   */
+  scrollToBottom(scrollKey, contentKey) {
+    this._scrollToPanelBottom(scrollKey, contentKey);
+  }
+
+  /**
    * Dispose method. Calls super.dispose() for base class cleanup.
    * Derived classes can override this to add their own specific disposal logic,
    * ensuring they also call super.dispose().

--- a/src/domUI/chatAlertRenderer.js
+++ b/src/domUI/chatAlertRenderer.js
@@ -143,7 +143,7 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
    * @private
    */
   #scrollToBottom() {
-    this._scrollToPanelBottom('scrollContainer', 'chatPanel');
+    this.scrollToBottom('scrollContainer', 'chatPanel');
   }
 
   /**

--- a/src/domUI/speechBubbleRenderer.js
+++ b/src/domUI/speechBubbleRenderer.js
@@ -330,7 +330,7 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
    * @private
    */
   #scrollToBottom() {
-    this._scrollToPanelBottom('outputDivElement', 'speechContainer');
+    this.scrollToBottom('outputDivElement', 'speechContainer');
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a `scrollToBottom()` wrapper in `BoundDomRendererBase`
- use the new wrapper in `ChatAlertRenderer`, `SpeechBubbleRenderer`, and `ActionResultRenderer`

## Testing
- `npm run format`
- `npm run lint` *(fails: 535 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ee3f056808331b01aa6681650e23b