### PR TITLE
[Agent] update stop following rule failure handling

### DIFF
--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -116,23 +116,13 @@
         ],
         "else_actions": [
           {
-            "type": "DISPATCH_EVENT",
-            "comment": "Inform the UI that the action failed because the actor wasn't following anyone.",
+            "type": "SET_VARIABLE",
             "parameters": {
-              "eventType": "core:display_failed_action_result",
-              "payload": {
-                "message": "You are not following anyone."
-              }
+              "variable_name": "logMessage",
+              "value": "You are not following anyone."
             }
           },
-          {
-            "type": "END_TURN",
-            "comment": "End the turn unsuccessfully.",
-            "parameters": {
-              "entityId": "{event.payload.actorId}",
-              "success": false
-            }
-          }
+          { "macro": "core:logFailureAndEndTurn" }
         ]
       }
     }


### PR DESCRIPTION
Summary: Updated failure branch of stop_following.rule.json to log a message and invoke a macro instead of dispatching events directly.

Changes Made:
- Added SET_VARIABLE using `logMessage` and inserted macro `core:logFailureAndEndTurn`.
- Adjusted integration test to expand macros and validate updated rule schema.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684ee410e5c4833196b1bd980e96d816