### PR TITLE
[Agent] centralize default UI constants

### DIFF
--- a/src/domUI/currentTurnActorRenderer.js
+++ b/src/domUI/currentTurnActorRenderer.js
@@ -12,8 +12,7 @@ import { BoundDomRendererBase } from './boundDomRendererBase.js'; // Adjusted pa
 import { TURN_STARTED_ID } from '../constants/eventIds.js';
 // NAME_COMPONENT_ID and PORTRAIT_COMPONENT_ID are no longer directly used here
 // import {NAME_COMPONENT_ID, PORTRAIT_COMPONENT_ID} from "../constants/componentIds.js";
-
-const DEFAULT_ACTOR_NAME = 'N/A';
+import { DEFAULT_ACTOR_NAME } from './uiDefaults.js';
 
 export class CurrentTurnActorRenderer extends BoundDomRendererBase {
   /** @type {EntityDisplayDataProvider} */

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -43,8 +43,10 @@ import {
  * @property {Array<CharacterDisplayData>} characters - List of characters present in the location.
  */
 
-const DEFAULT_LOCATION_NAME = 'Unknown Location';
-const DEFAULT_LOCATION_DESCRIPTION = 'You see nothing remarkable.';
+import {
+  DEFAULT_LOCATION_NAME,
+  DEFAULT_LOCATION_DESCRIPTION,
+} from './uiDefaults.js';
 
 /**
  * Renders details of the current location, including its name, description, exits, and characters.
@@ -100,7 +102,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       !safeEventDispatcher ||
       typeof safeEventDispatcher.dispatch !== 'function'
     ) {
-      const errMsg = `${this._logPrefix} ISafeEventDispatcher dependency is required.`;
+      const errMsg = `[LocationRenderer] ISafeEventDispatcher dependency is required.`;
       throw new Error(errMsg);
     }
 

--- a/src/domUI/speechBubbleRenderer.js
+++ b/src/domUI/speechBubbleRenderer.js
@@ -7,6 +7,7 @@ import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DISPLAY_SPEECH_ID } from '../constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../constants/componentIds.js';
 import { buildSpeechMeta } from './helpers/buildSpeechMeta.js';
+import { DEFAULT_SPEAKER_NAME } from './uiDefaults.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -21,8 +22,6 @@ import { buildSpeechMeta } from './helpers/buildSpeechMeta.js';
 /**
  * @typedef {import('../constants/eventIds.js').DisplaySpeechPayload} DisplaySpeechPayload
  */
-
-const DEFAULT_SPEAKER_NAME = 'Unknown Speaker';
 
 export class SpeechBubbleRenderer extends BoundDomRendererBase {
   #entityManager;

--- a/src/domUI/uiDefaults.js
+++ b/src/domUI/uiDefaults.js
@@ -1,0 +1,36 @@
+// src/domUI/uiDefaults.js
+// --- FILE START ---
+
+/**
+ * @file Defines shared default values for various UI components.
+ */
+
+/**
+ * Default display name used when an actor's name cannot be resolved.
+ *
+ * @type {string}
+ */
+export const DEFAULT_ACTOR_NAME = 'N/A';
+
+/**
+ * Default location name used when a location's name is unavailable.
+ *
+ * @type {string}
+ */
+export const DEFAULT_LOCATION_NAME = 'Unknown Location';
+
+/**
+ * Default description used when a location lacks one.
+ *
+ * @type {string}
+ */
+export const DEFAULT_LOCATION_DESCRIPTION = 'You see nothing remarkable.';
+
+/**
+ * Default speaker name when a speaking entity's name is not found.
+ *
+ * @type {string}
+ */
+export const DEFAULT_SPEAKER_NAME = 'Unknown Speaker';
+
+// --- FILE END ---


### PR DESCRIPTION
## Summary
- add `uiDefaults.js` module to centralize UI default values
- use new defaults in current turn actor, location, and speech bubble renderers
- avoid referencing `this` before `super()` in LocationRenderer

## Testing
- `npm run format`
- `npm run lint` *(fails: 2351 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ee8a2041883319ff92c2328c6ab5b