### PR TITLE
[Agent] dispatch error via safe dispatcher

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -162,7 +162,7 @@ export function registerInterpreters(container) {
       EndTurnHandler,
       (c, Handler) =>
         new Handler({
-          dispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
           logger: c.resolve(tokens.ILogger),
         }),
     ],

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -165,7 +165,10 @@ function init(entities) {
       safeEventDispatcher: eventBus,
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({
+      safeEventDispatcher: safeDispatcher,
+      logger,
+    }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     GET_NAME: new GetNameHandler({
       entityManager,
@@ -233,7 +236,12 @@ describe('core_handle_dismiss rule integration', () => {
       listenerCount: jest.fn().mockReturnValue(1),
     };
 
-    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    safeDispatcher = {
+      dispatch: jest.fn((eventType, payload) => {
+        events.push({ eventType, payload });
+        return Promise.resolve(true);
+      }),
+    };
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([dismissRule]),

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -70,6 +70,10 @@ class SimpleEntityManager {
   }
 }
 
+/**
+ *
+ * @param em
+ */
 function makeStubRebuild(em) {
   return {
     execute({ leaderIds }) {
@@ -143,7 +147,10 @@ describe('core_handle_follow rule integration', () => {
         dispatcher: eventBus,
         logger,
       }),
-      END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+      END_TURN: new EndTurnHandler({
+        safeEventDispatcher: safeDispatcher,
+        logger,
+      }),
       GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     };
 

--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -87,7 +87,12 @@ function init(entities) {
   operationRegistry = new OperationRegistry({ logger });
   entityManager = new SimpleEntityManager(entities);
 
-  const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+  const safeDispatcher = {
+    dispatch: jest.fn((eventType, payload) => {
+      events.push({ eventType, payload });
+      return Promise.resolve(true);
+    }),
+  };
 
   // Register all necessary handlers for the rule to run
   const handlers = {
@@ -129,7 +134,10 @@ function init(entities) {
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({
+      safeEventDispatcher: safeDispatcher,
+      logger,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -151,7 +151,12 @@ function init(entities) {
   entityManager = new SimpleEntityManager(entities);
   worldContext = new SimpleWorldContext(entityManager, logger);
 
-  const safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+  const safeDispatcher = {
+    dispatch: jest.fn((eventType, payload) => {
+      events.push({ eventType, payload });
+      return Promise.resolve(true);
+    }),
+  };
 
   const handlers = {
     QUERY_COMPONENT_OPTIONAL: new QueryComponentOptionalHandler({
@@ -176,7 +181,10 @@ function init(entities) {
       addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({
+      safeEventDispatcher: safeDispatcher,
+      logger,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -158,7 +158,10 @@ function init(entities) {
       addPerceptionLogEntryHandler: { execute: jest.fn() },
     }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({
+      safeEventDispatcher: safeDispatcher,
+      logger,
+    }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {
@@ -207,7 +210,12 @@ describe('intimacy_handle_step_back rule integration', () => {
     };
 
     events = [];
-    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    safeDispatcher = {
+      dispatch: jest.fn((eventType, payload) => {
+        events.push({ eventType, payload });
+        return Promise.resolve(true);
+      }),
+    };
     eventBus = {
       subscribe: jest.fn((ev, l) => {
         if (ev === '*') listener = l;

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -116,6 +116,10 @@ class SimpleEntityManager {
   }
 }
 
+/**
+ *
+ * @param em
+ */
 function makeStubRebuild(em) {
   return {
     execute({ leaderIds }) {
@@ -172,7 +176,10 @@ function init(entities) {
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    END_TURN: new EndTurnHandler({ dispatcher: eventBus, logger }),
+    END_TURN: new EndTurnHandler({
+      safeEventDispatcher: safeDispatcher,
+      logger,
+    }),
     IF_CO_LOCATED: new IfCoLocatedHandler({
       entityManager,
       logger,
@@ -234,7 +241,12 @@ describe('core_handle_stop_following rule integration', () => {
       listenerCount: jest.fn().mockReturnValue(1),
     };
 
-    safeDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    safeDispatcher = {
+      dispatch: jest.fn((eventType, payload) => {
+        events.push({ eventType, payload });
+        return Promise.resolve(true);
+      }),
+    };
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([stopFollowingRule]),


### PR DESCRIPTION
## Summary
- update EndTurnHandler to use SafeEventDispatcher
- route EndTurnHandler errors to DISPLAY_ERROR_ID event
- register EndTurnHandler with ISafeEventDispatcher
- adjust unit test for EndTurnHandler
- update integration tests to reflect safe dispatch

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' imported from eslint.config.mjs)*
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ee812a9dc8331988883a9bbc7da2b