### PR TITLE
[Agent] use setupService for persistence services

### DIFF
--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -1,6 +1,7 @@
 // src/persistence/componentCleaningService.js
 
 import { deepClone } from '../utils/objectUtils.js';
+import { setupService } from '../utils/serviceInitializer.js';
 import {
   NOTES_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
@@ -30,20 +31,12 @@ class ComponentCleaningService {
    * @param dependencies.safeEventDispatcher
    */
   constructor({ logger, safeEventDispatcher }) {
-    if (!logger) {
-      console.error('ComponentCleaningService: logger dependency missing.');
-      throw new Error('ComponentCleaningService requires a logger.');
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      const errMsg =
-        'ComponentCleaningService: Missing or invalid safeEventDispatcher.';
-      console.error(errMsg);
-      throw new Error(errMsg);
-    }
-    this.#logger = logger;
+    this.#logger = setupService('ComponentCleaningService', logger, {
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#safeEventDispatcher = safeEventDispatcher;
     this.#cleaners = new Map();
 

--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -1,5 +1,6 @@
 import { IGamePersistenceService } from '../interfaces/IGamePersistenceService.js';
 import GameStateCaptureService from './gameStateCaptureService.js';
+import { setupService } from '../utils/serviceInitializer.js';
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -53,25 +54,24 @@ class GamePersistenceService extends IGamePersistenceService {
     gameStateCaptureService,
   }) {
     super();
-    const missingDependencies = [];
-    if (!logger) missingDependencies.push('logger');
-    if (!saveLoadService) missingDependencies.push('saveLoadService');
-    if (!entityManager) missingDependencies.push('entityManager');
-    if (!playtimeTracker) missingDependencies.push('playtimeTracker');
-    if (!gameStateCaptureService)
-      missingDependencies.push('gameStateCaptureService');
-
-    if (missingDependencies.length > 0) {
-      const errorMessage = `GamePersistenceService: Fatal - Missing required dependencies: ${missingDependencies.join(', ')}.`;
-      if (logger && typeof logger.error === 'function') {
-        logger.error(errorMessage);
-      } else {
-        console.error(errorMessage);
-      }
-      throw new Error(errorMessage);
-    }
-
-    this.#logger = logger;
+    this.#logger = setupService('GamePersistenceService', logger, {
+      saveLoadService: {
+        value: saveLoadService,
+        requiredMethods: ['saveManualGame', 'loadGameData'],
+      },
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['clearAll', 'reconstructEntity'],
+      },
+      playtimeTracker: {
+        value: playtimeTracker,
+        requiredMethods: ['getTotalPlaytime', 'setAccumulatedPlaytime'],
+      },
+      gameStateCaptureService: {
+        value: gameStateCaptureService,
+        requiredMethods: ['captureCurrentGameState'],
+      },
+    });
     this.#saveLoadService = saveLoadService;
     this.#entityManager = entityManager;
     this.#playtimeTracker = playtimeTracker;

--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -2,6 +2,7 @@
 
 import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
 import { CORE_MOD_ID } from '../constants/core.js';
+import { setupService } from '../utils/serviceInitializer.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -50,25 +51,19 @@ class GameStateCaptureService {
     componentCleaningService,
     metadataBuilder,
   }) {
-    const missing = [];
-    if (!logger) missing.push('logger');
-    if (!entityManager) missing.push('entityManager');
-    if (!dataRegistry) missing.push('dataRegistry');
-    if (!playtimeTracker) missing.push('playtimeTracker');
-    if (!componentCleaningService) missing.push('componentCleaningService');
-    if (!metadataBuilder) missing.push('metadataBuilder');
-
-    if (missing.length > 0) {
-      const msg = `GameStateCaptureService: Missing required dependencies: ${missing.join(', ')}`;
-      if (logger && typeof logger.error === 'function') {
-        logger.error(msg);
-      } else {
-        console.error(msg);
-      }
-      throw new Error(msg);
-    }
-
-    this.#logger = logger;
+    this.#logger = setupService('GameStateCaptureService', logger, {
+      entityManager: { value: entityManager },
+      dataRegistry: { value: dataRegistry, requiredMethods: ['getAll'] },
+      playtimeTracker: {
+        value: playtimeTracker,
+        requiredMethods: ['getTotalPlaytime'],
+      },
+      componentCleaningService: {
+        value: componentCleaningService,
+        requiredMethods: ['clean'],
+      },
+      metadataBuilder: { value: metadataBuilder, requiredMethods: ['build'] },
+    });
     this.#entityManager = entityManager;
     this.#dataRegistry = dataRegistry;
     this.#playtimeTracker = playtimeTracker;

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -4,6 +4,7 @@ import { ISaveLoadService } from '../interfaces/ISaveLoadService.js';
 import { encode } from '@msgpack/msgpack';
 import { deepClone } from '../utils/objectUtils.js';
 import GameStateSerializer from './gameStateSerializer.js';
+import { setupService } from '../utils/serviceInitializer.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -55,15 +56,18 @@ class SaveLoadService extends ISaveLoadService {
   }) {
     // <<< MODIFIED SIGNATURE with destructuring
     super();
-    if (!logger)
-      throw new Error(
-        'SaveLoadService requires a valid ILogger instance (after destructuring).'
-      );
-    if (!storageProvider)
-      throw new Error(
-        'SaveLoadService requires a valid IStorageProvider instance (after destructuring).'
-      );
-    this.#logger = logger;
+    this.#logger = setupService('SaveLoadService', logger, {
+      storageProvider: {
+        value: storageProvider,
+        requiredMethods: [
+          'writeFileAtomically',
+          'listFiles',
+          'readFile',
+          'deleteFile',
+          'fileExists',
+        ],
+      },
+    });
     this.#storageProvider = storageProvider;
     this.#serializer =
       gameStateSerializer || new GameStateSerializer({ logger, crypto });

--- a/tests/services/componentCleaningService.test.js
+++ b/tests/services/componentCleaningService.test.js
@@ -7,6 +7,8 @@ import {
 } from '../../src/constants/componentIds.js';
 
 const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
   debug: jest.fn(),
   error: jest.fn(),
 });

--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -6,7 +6,12 @@ import GamePersistenceService from '../../src/persistence/gamePersistenceService
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    },
     saveLoadService: {},
     entityManager: {},
     playtimeTracker: {},

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -25,11 +25,20 @@ const mockLogger = {
 // Mock other constructor dependencies. They don't need specific method implementations
 // for these tests unless the constructor or isSavingAllowed calls them.
 /** @type {jest.Mocked<ISaveLoadService>} */
-const mockSaveLoadService = {};
+const mockSaveLoadService = {
+  saveManualGame: jest.fn(),
+  loadGameData: jest.fn(),
+};
 /** @type {jest.Mocked<EntityManager>} */
-const mockEntityManager = {};
+const mockEntityManager = {
+  clearAll: jest.fn(),
+  reconstructEntity: jest.fn(),
+};
 /** @type {jest.Mocked<PlaytimeTracker>} */
-const mockPlaytimeTracker = {};
+const mockPlaytimeTracker = {
+  getTotalPlaytime: jest.fn(),
+  setAccumulatedPlaytime: jest.fn(),
+};
 /** @type {jest.Mocked<AppContainer>} */
 const mockAppContainer = {
   resolve: jest.fn(), // Mock resolve as it might be used in the TODO part in the future
@@ -65,7 +74,9 @@ describe('GamePersistenceService', () => {
       expect(result).toBe(false);
       expect(mockLogger.warn).toHaveBeenCalledTimes(1);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'GamePersistenceService.isSavingAllowed: Save attempt while engine not initialized.'
+        expect.stringContaining(
+          'GamePersistenceService.isSavingAllowed: Save attempt while engine not initialized.'
+        )
       );
       expect(mockLogger.debug).not.toHaveBeenCalled(); // Ensure debug log isn't called
       expect(mockLogger.error).not.toHaveBeenCalled(); // Ensure no errors logged
@@ -77,7 +88,9 @@ describe('GamePersistenceService', () => {
       expect(result).toBe(true);
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'GamePersistenceService.isSavingAllowed: Check returned true (currently a basic stub).'
+        expect.stringContaining(
+          'GamePersistenceService.isSavingAllowed: Check returned true (currently a basic stub).'
+        )
       );
       expect(mockLogger.warn).not.toHaveBeenCalled(); // Ensure warning log isn't called
       expect(mockLogger.error).not.toHaveBeenCalled(); // Ensure no errors logged

--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -25,7 +25,12 @@ beforeAll(() => {
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       listFiles: jest.fn(),
       readFile: jest.fn(),

--- a/tests/services/saveLoadService.constructor.test.js
+++ b/tests/services/saveLoadService.constructor.test.js
@@ -7,7 +7,12 @@ import { webcrypto } from 'crypto';
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       writeFileAtomically: jest.fn(),
       listFiles: jest.fn(),

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -29,7 +29,12 @@ beforeAll(() => {
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       listFiles: jest.fn(),
       readFile: jest.fn(),

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -38,7 +38,12 @@ beforeAll(() => {
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       listFiles: jest.fn(),
       readFile: jest.fn(),

--- a/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -20,7 +20,12 @@ beforeAll(() => {
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       listFiles: jest.fn(),
       readFile: jest.fn(),

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -30,7 +30,12 @@ beforeAll(() => {
  */
 function makeDeps() {
   return {
-    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logger: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
     storageProvider: {
       listFiles: jest.fn(),
       readFile: jest.fn(),


### PR DESCRIPTION
Summary: Added setupService integration for persistence-layer services. Constructors now validate dependencies via serviceInitializer and store prefixed loggers. Updated all relevant unit tests with complete ILogger mocks and adjusted expectations to match new log prefixes.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: ESLint reported 534 errors)*
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test` *(skipped: no proxy server in repo)*
- [ ] Manual smoke run `npm run start` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684efa34ed7c8331b931b0e205e97ae5