### PR TITLE
[Agent] add save helpers and tests

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -135,6 +135,29 @@ class SaveLoadService extends ISaveLoadService {
   }
 
   /**
+   * Builds a sanitized manual save filename.
+   *
+   * @param {string} saveName - Raw save name input.
+   * @returns {string} Sanitized filename including prefix and extension.
+   * @private
+   */
+  #buildManualFileName(saveName) {
+    const sanitized = saveName.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return `manual_save_${sanitized}.sav`;
+  }
+
+  /**
+   * Removes manual save prefix and suffix from a filename.
+   *
+   * @param {string} fileName - File name to clean.
+   * @returns {string} Extracted save name.
+   * @private
+   */
+  #extractSaveName(fileName) {
+    return fileName.replace(/^manual_save_/, '').replace(/\.sav$/, '');
+  }
+
+  /**
    * Builds the full path for a manual save file.
    *
    * @param {string} fileName - File name inside the manual saves directory.
@@ -168,9 +191,7 @@ class SaveLoadService extends ISaveLoadService {
         success: false,
         metadata: {
           identifier: filePath,
-          saveName:
-            fileName.replace(/\.sav$/, '').replace(/^manual_save_/, '') +
-            ' (Corrupted)',
+          saveName: this.#extractSaveName(fileName) + ' (Corrupted)',
           timestamp: 'N/A',
           playtimeSeconds: 0,
           isCorrupted: true,
@@ -194,9 +215,7 @@ class SaveLoadService extends ISaveLoadService {
         success: false,
         metadata: {
           identifier: filePath,
-          saveName:
-            fileName.replace(/\.sav$/, '').replace(/^manual_save_/, '') +
-            ' (No Metadata)',
+          saveName: this.#extractSaveName(fileName) + ' (No Metadata)',
           timestamp: 'N/A',
           playtimeSeconds: 0,
           isCorrupted: true,
@@ -482,7 +501,7 @@ class SaveLoadService extends ISaveLoadService {
       };
     }
 
-    const fileName = `manual_save_${saveName.replace(/[^a-zA-Z0-9_-]/g, '_')}.sav`;
+    const fileName = this.#buildManualFileName(saveName);
     // Ensure the directory structure exists before writing.
     // Some IStorageProvider implementations might handle this in writeFileAtomically,
     // others might need an explicit ensureDirectoryExists call.

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -85,3 +85,35 @@ describe('SaveLoadService private helper error propagation', () => {
     expect(res.error.message).toMatch(/could not understand/);
   });
 });
+
+describe('SaveLoadService helper functions', () => {
+  let logger;
+  let storageProvider;
+  let service;
+
+  beforeEach(() => {
+    ({ logger, storageProvider } = makeDeps());
+    service = new SaveLoadService({
+      logger,
+      storageProvider,
+      crypto: webcrypto,
+    });
+  });
+
+  it('sanitizes manual save file names', async () => {
+    storageProvider.ensureDirectoryExists.mockResolvedValue();
+    storageProvider.writeFileAtomically.mockResolvedValue({ success: true });
+    await service.saveManualGame('Bad Name*?', { gameState: {} });
+    expect(storageProvider.writeFileAtomically).toHaveBeenCalledWith(
+      'saves/manual_saves/manual_save_Bad_Name__.sav',
+      expect.anything()
+    );
+  });
+
+  it('extracts save name for corrupted files', async () => {
+    storageProvider.listFiles.mockResolvedValue(['manual_save_TestFile.sav']);
+    storageProvider.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const slots = await service.listManualSaveSlots();
+    expect(slots[0].saveName).toBe('TestFile (Corrupted)');
+  });
+});


### PR DESCRIPTION
Summary: Added helper methods to construct and extract manual save filenames in `saveLoadService`. Updated save creation and parsing logic to use these helpers. Extended unit tests to verify new functionality.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 534 errors across repo)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684efa3bb3648331ba0324148d77e8e5