### PR TITLE
[Agent] Factor save validation helpers

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -216,15 +216,14 @@ class SaveLoadService extends ISaveLoadService {
   }
 
   /**
-   * Validates that a loaded save object contains required sections and that the
-   * stored checksum matches the recalculated checksum.
+   * Verifies that the loaded save object contains all required sections.
    *
    * @param {SaveGameStructure} obj - The deserialized save object.
    * @param {string} identifier - Identifier used for logging.
-   * @returns {Promise<{success: boolean, error?: PersistenceError}>} Result.
+   * @returns {{success: boolean, error?: PersistenceError}} Result.
    * @private
    */
-  async #validateLoadedSaveObject(obj, identifier) {
+  #validateStructure(obj, identifier) {
     const requiredSections = [
       'metadata',
       'modManifest',
@@ -253,7 +252,18 @@ class SaveLoadService extends ISaveLoadService {
     this.#logger.debug(
       `Basic structure validation passed for ${identifier}. All required sections present.`
     );
+    return { success: true };
+  }
 
+  /**
+   * Recalculates and compares the checksum against the stored value.
+   *
+   * @param {SaveGameStructure} obj - The deserialized save object.
+   * @param {string} identifier - Identifier used for logging.
+   * @returns {Promise<{success: boolean, error?: PersistenceError}>} Result.
+   * @private
+   */
+  async #verifyChecksum(obj, identifier) {
     const storedChecksum = obj.integrityChecks.gameStateChecksum;
     if (!storedChecksum || typeof storedChecksum !== 'string') {
       const devMsg = `Save file ${identifier} is missing gameStateChecksum.`;
@@ -302,8 +312,25 @@ class SaveLoadService extends ISaveLoadService {
       };
     }
     this.#logger.debug(`Checksum VERIFIED for ${identifier}.`);
-
     return { success: true };
+  }
+
+  /**
+   * Validates that a loaded save object contains required sections and that the
+   * stored checksum matches the recalculated checksum.
+   *
+   * @param {SaveGameStructure} obj - The deserialized save object.
+   * @param {string} identifier - Identifier used for logging.
+   * @returns {Promise<{success: boolean, error?: PersistenceError}>} Result.
+   * @private
+   */
+  async #validateLoadedSaveObject(obj, identifier) {
+    const structureResult = this.#validateStructure(obj, identifier);
+    if (!structureResult.success) {
+      return structureResult;
+    }
+
+    return this.#verifyChecksum(obj, identifier);
   }
 
   /**


### PR DESCRIPTION
Summary:
- split validation logic into #validateStructure and #verifyChecksum helper methods
- orchestrate helpers in #validateLoadedSaveObject

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684efa4668788331b92ba63675a5d6ca