### PR TITLE
[Feat] helper for selectable slot items

### DIFF
--- a/src/domUI/helpers/createSelectableItem.js
+++ b/src/domUI/helpers/createSelectableItem.js
@@ -1,0 +1,66 @@
+/**
+ * @file Helper function to build a selectable slot or list item element.
+ */
+
+/** @typedef {import('../domElementFactory.js').default} DomElementFactory */
+
+/**
+ * @description Creates an element representing a selectable slot or list item.
+ * The returned element has the standard classes and ARIA attributes used
+ * throughout the save/load and LLM selection modals.
+ * @param {DomElementFactory} domFactory - The DOM element factory.
+ * @param {string} tagName - Tag name for the element (e.g., 'div', 'li').
+ * @param {string} datasetKey - Name of the dataset property to set.
+ * @param {string|number} datasetValue - Value for the dataset property.
+ * @param {string} labelText - Text label for the item.
+ * @param {boolean} [isEmpty] - Whether the item represents an empty slot.
+ * @param {boolean} [isCorrupted] - Whether the item is marked as corrupted.
+ * @param {string|string[]} [extraClasses] - Additional CSS classes to apply.
+ * @param {(Event) => void} [onClick] - Optional click handler to attach.
+ * @returns {HTMLElement | null} The configured element or null if creation fails.
+ */
+export function createSelectableItem(
+  domFactory,
+  tagName,
+  datasetKey,
+  datasetValue,
+  labelText,
+  isEmpty = false,
+  isCorrupted = false,
+  extraClasses = undefined,
+  onClick
+) {
+  if (!domFactory) return null;
+
+  const classes = [];
+  if (extraClasses) {
+    if (Array.isArray(extraClasses)) {
+      classes.push(...extraClasses);
+    } else {
+      classes.push(extraClasses);
+    }
+  }
+  classes.push('save-slot');
+  if (isEmpty) classes.push('empty');
+  if (isCorrupted) classes.push('corrupted');
+
+  const element = domFactory.create(tagName, {
+    cls: classes.join(' '),
+    text: tagName === 'li' ? labelText : undefined,
+  });
+  if (!element) return null;
+
+  if (tagName !== 'li') {
+    element.textContent = labelText;
+  }
+
+  element.dataset[datasetKey] = String(datasetValue);
+  element.setAttribute('role', 'radio');
+  element.setAttribute('aria-checked', 'false');
+
+  if (typeof onClick === 'function') {
+    element.addEventListener('click', onClick);
+  }
+
+  return element;
+}

--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 
 import { SlotModalBase } from './slotModalBase.js';
+import { createSelectableItem } from './helpers/createSelectableItem.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -228,10 +229,16 @@ export class LlmSelectionModal extends SlotModalBase {
 
     const nameForDisplay = displayName || configId; // Fallback to configId if displayName is missing
 
-    const listItemElement = this.#domElementFactory.create('li', {
-      cls: 'llm-item save-slot',
-      text: nameForDisplay,
-    });
+    const listItemElement = createSelectableItem(
+      this.#domElementFactory,
+      'li',
+      'llmId',
+      configId,
+      nameForDisplay,
+      false,
+      false,
+      'llm-item'
+    );
 
     if (!listItemElement) {
       this.logger.error(
@@ -239,9 +246,6 @@ export class LlmSelectionModal extends SlotModalBase {
       );
       return null;
     }
-
-    listItemElement.dataset.llmId = configId;
-    listItemElement.setAttribute('role', 'radio');
     // Tabindex will be managed by _onListRendered
 
     const isActive = configId === currentActiveLlmId;

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -3,6 +3,7 @@
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import { formatPlaytime, formatTimestamp } from '../utils/textUtils.js';
+import { createSelectableItem } from './helpers/createSelectableItem.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -291,16 +292,17 @@ class LoadGameUI extends SlotModalBase {
       return null;
     }
 
-    const slotClasses = ['save-slot'];
-    if (slotData.isCorrupted) slotClasses.push('corrupted');
-
-    const slotDiv = this.domElementFactory.div(slotClasses);
+    const slotDiv = createSelectableItem(
+      this.domElementFactory,
+      'div',
+      'slotIdentifier',
+      slotData.identifier,
+      '',
+      false,
+      slotData.isCorrupted
+    );
     if (!slotDiv) return null;
-
-    slotDiv.setAttribute('role', 'radio');
-    slotDiv.setAttribute('aria-checked', 'false');
     slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1');
-    slotDiv.dataset.slotIdentifier = slotData.identifier;
 
     const slotInfoDiv = this.domElementFactory.div('slot-info');
     if (!slotInfoDiv) return slotDiv;

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -3,6 +3,7 @@
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import { formatPlaytime, formatTimestamp } from '../utils/textUtils.js';
+import { createSelectableItem } from './helpers/createSelectableItem.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -300,17 +301,17 @@ export class SaveGameUI extends SlotModalBase {
   _renderSaveSlotItem(slotData, itemIndex) {
     if (!this.domElementFactory) return null;
 
-    const slotClasses = ['save-slot'];
-    if (slotData.isEmpty) slotClasses.push('empty');
-    if (slotData.isCorrupted) slotClasses.push('corrupted');
-
-    const slotDiv = this.domElementFactory.div(slotClasses);
+    const slotDiv = createSelectableItem(
+      this.domElementFactory,
+      'div',
+      'slotId',
+      slotData.slotId,
+      '',
+      slotData.isEmpty,
+      slotData.isCorrupted
+    );
     if (!slotDiv) return null;
-
-    slotDiv.setAttribute('role', 'radio');
-    slotDiv.setAttribute('aria-checked', 'false');
-    slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1'); // First item focusable by default
-    slotDiv.dataset.slotId = String(slotData.slotId);
+    slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1');
 
     const slotInfoDiv = this.domElementFactory.div('slot-info');
     if (!slotInfoDiv) return slotDiv; // Return partially constructed div

--- a/tests/domUI/helpers/createSelectableItem.test.js
+++ b/tests/domUI/helpers/createSelectableItem.test.js
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import DocumentContext from '../../../src/domUI/documentContext.js';
+import DomElementFactory from '../../../src/domUI/domElementFactory.js';
+import { createSelectableItem } from '../../../src/domUI/helpers/createSelectableItem.js';
+
+describe('createSelectableItem', () => {
+  let factory;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const ctx = new DocumentContext(document);
+    factory = new DomElementFactory(ctx);
+  });
+
+  it('creates a div with expected attributes', () => {
+    const el = createSelectableItem(factory, 'div', 'slotId', 1, 'Label');
+    expect(el).toBeInstanceOf(HTMLElement);
+    expect(el.classList.contains('save-slot')).toBe(true);
+    expect(el.getAttribute('role')).toBe('radio');
+    expect(el.dataset.slotId).toBe('1');
+  });
+
+  it('applies empty and corrupted classes and attaches handler', () => {
+    const handler = jest.fn();
+    const el = createSelectableItem(
+      factory,
+      'div',
+      'slotId',
+      '2',
+      'Label',
+      true,
+      true,
+      undefined,
+      handler
+    );
+    expect(el.classList.contains('empty')).toBe(true);
+    expect(el.classList.contains('corrupted')).toBe(true);
+    el.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates li with text and extra classes', () => {
+    const el = createSelectableItem(
+      factory,
+      'li',
+      'llmId',
+      'abc',
+      'My LLM',
+      false,
+      false,
+      'llm-item'
+    );
+    expect(el.tagName).toBe('LI');
+    expect(el.textContent).toBe('My LLM');
+    expect(el.classList.contains('llm-item')).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary: Added a reusable helper for creating selectable slot/list elements and refactored save/load UI modules and LLM selection modal to use it.

Changes Made:
- New `createSelectableItem` helper under `domUI/helpers`.
- Refactored `SaveGameUI`, `LoadGameUI`, and `LlmSelectionModal` to use the helper.
- Added unit tests for the helper.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint executed (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684efb0ac05083319977412719ec3b74