### PR TITLE
[Agent] ensure macro loader registered

### DIFF
--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -22,6 +22,7 @@ import { ActionIndexingService } from '../../turns/services/actionIndexingServic
  * @typedef {import('../../loaders/ruleLoader.js').default} RuleLoader
  * @typedef {import('../../loaders/actionLoader.js').default} ActionLoader
  * @typedef {import('../../loaders/eventLoader.js').default} EventLoader
+ * @typedef {import('../../loaders/macroLoader.js').default} MacroLoader
  * @typedef {import('../../loaders/entityLoader.js').default} EntityLoader
  * @typedef {import('../../loaders/gameConfigLoader.js').default} GameConfigLoader
  * @typedef {import('../../modding/modManifestLoader.js').default} ModManifestLoader
@@ -75,6 +76,7 @@ export function registerInfrastructure(container) {
         logger: c.resolve(tokens.ILogger),
         schemaLoader: c.resolve(tokens.SchemaLoader),
         componentLoader: c.resolve(tokens.ComponentDefinitionLoader),
+        macroLoader: c.resolve(tokens.MacroLoader),
         ruleLoader: c.resolve(tokens.RuleLoader),
         actionLoader: c.resolve(tokens.ActionLoader),
         eventLoader: c.resolve(tokens.EventLoader),

--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -41,6 +41,7 @@ import GameConfigLoader from '../../loaders/gameConfigLoader.js';
 import ModManifestLoader from '../../modding/modManifestLoader.js';
 import ActionLoader from '../../loaders/actionLoader.js';
 import EventLoader from '../../loaders/eventLoader.js';
+import MacroLoader from '../../loaders/macroLoader.js';
 import EntityLoader from '../../loaders/entityLoader.js';
 
 // --- DI & Helper Imports ---
@@ -211,6 +212,20 @@ export function registerLoaders(container) {
   );
   logger.debug(`Loaders Registration: Registered ${tokens.EventLoader}.`);
   // === END LOADER-003 ===
+
+  registrar.singletonFactory(
+    tokens.MacroLoader,
+    (c) =>
+      new MacroLoader(
+        c.resolve(tokens.IConfiguration),
+        c.resolve(tokens.IPathResolver),
+        c.resolve(tokens.IDataFetcher),
+        c.resolve(tokens.ISchemaValidator),
+        c.resolve(tokens.IDataRegistry),
+        c.resolve(tokens.ILogger)
+      )
+  );
+  logger.debug(`Loaders Registration: Registered ${tokens.MacroLoader}.`);
 
   // === ADDED: LOADER-004-F ===
   registrar.singletonFactory(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -53,6 +53,7 @@ import { freeze } from '../utils/objectUtils';
  * @property {DiToken} ComponentDefinitionLoader - Token for loading component definitions.
  * @property {DiToken} ActionLoader - Token for the action loading service.
  * @property {DiToken} EventLoader - Token for the event loading service.
+ * @property {DiToken} MacroLoader - Token for the macro loading service.
  * @property {DiToken} EntityLoader - Token for loading entity definitions.
  * @property {DiToken} WorldLoader - Token for orchestrating world data loading.
  * @property {DiToken} GameConfigLoader - Token for loading the main game configuration file.
@@ -182,6 +183,7 @@ export const tokens = freeze({
   ComponentDefinitionLoader: 'ComponentDefinitionLoader',
   ActionLoader: 'ActionLoader',
   EventLoader: 'EventLoader',
+  MacroLoader: 'MacroLoader',
   EntityLoader: 'EntityLoader',
   WorldLoader: 'WorldLoader',
   GameConfigLoader: 'GameConfigLoader',

--- a/tests/config/registrations/infrastructureRegistrations.test.js
+++ b/tests/config/registrations/infrastructureRegistrations.test.js
@@ -89,6 +89,9 @@ describe('registerInfrastructure', () => {
     container.register(tokens.RuleLoader, () => mockRuleLoader);
     container.register(tokens.ActionLoader, () => mockActionLoader);
     container.register(tokens.EventLoader, () => mockEventLoader);
+    container.register(tokens.MacroLoader, () => ({
+      loadItemsForMod: jest.fn(),
+    }));
     container.register(tokens.EntityLoader, () => mockEntityLoader);
     container.register(tokens.IConfiguration, () => mockConfiguration);
     container.register(tokens.GameConfigLoader, () => mockGameConfigLoader);
@@ -122,6 +125,13 @@ describe('registerInfrastructure', () => {
     const worldLoader = container.resolve(tokens.WorldLoader);
     expect(worldLoader).toBeDefined();
     // expect(worldLoader).toBeInstanceOf(ActualWorldLoader); // If you import it
+  });
+
+  test('should register MacroLoader correctly', () => {
+    registerInfrastructure(container);
+    expect(() => container.resolve(tokens.MacroLoader)).not.toThrow();
+    const macroLoader = container.resolve(tokens.MacroLoader);
+    expect(macroLoader).toBeDefined();
   });
 
   test('should register GameDataRepository correctly (against IGameDataRepository)', () => {

--- a/tests/config/registrations/loadersRegistrations.test.js
+++ b/tests/config/registrations/loadersRegistrations.test.js
@@ -244,7 +244,7 @@ describe('registerLoaders (with Mock DI Container)', () => {
     // Keep register mock history
   });
 
-  it('should register all 14 services/loaders (+ ILogger) as singletons', () => {
+  it('should register all 15 services/loaders (+ ILogger) as singletons', () => {
     // Arrange: Logger is already registered in beforeEach
 
     // Act: Register the loaders
@@ -266,11 +266,12 @@ describe('registerLoaders (with Mock DI Container)', () => {
       tokens.ModManifestLoader,
       tokens.ActionLoader,
       tokens.EventLoader,
+      tokens.MacroLoader,
       tokens.EntityLoader,
     ];
-    const expectedRegistrationCount = expectedTokens.length; // 14
+    const expectedRegistrationCount = expectedTokens.length; // 15
 
-    // Expect 1 (ILogger from beforeEach) + 14 (from registerLoaders) = 15 calls
+    // Expect 1 (ILogger from beforeEach) + 15 (from registerLoaders) = 16 calls
     expect(mockContainer.register).toHaveBeenCalledTimes(
       expectedRegistrationCount + 1
     );
@@ -302,7 +303,7 @@ describe('registerLoaders (with Mock DI Container)', () => {
     // Verify logger calls within registerLoaders
     expect(mockLogger.debug).toHaveBeenCalledTimes(
       2 + expectedRegistrationCount
-    ); // 1 Starting + 14 Registered
+    ); // 1 Starting + 15 Registered
     expect(mockLogger.info).toHaveBeenCalledTimes(0);
     expect(mockLogger.debug).toHaveBeenCalledWith(
       'Loaders Registration: Completed.'

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -26,6 +26,7 @@ jest.mock('../../src/modding/modLoadOrderResolver.js', () => ({
 /** @typedef {import('../../src/interfaces/coreServices.js').IConfiguration} IConfiguration */
 /** @typedef {import('../../src/loaders/actionLoader.js').default} ActionLoader */
 /** @typedef {import('../../src/loaders/eventLoader.js').default} EventLoader */
+/** @typedef {import('../../src/loaders/macroLoader.js').default} MacroLoader */
 /** @typedef {import('../../src/loaders/componentLoader.js').default} ComponentLoader */
 /** @typedef {import('../../src/loaders/ruleLoader.js').default} RuleLoader */
 /** @typedef {import('../../src/loaders/schemaLoader.js').default} SchemaLoader */
@@ -54,6 +55,8 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
   let mockActionLoader;
   /** @type {jest.Mocked<EventLoader>} */
   let mockEventLoader;
+  /** @type {jest.Mocked<MacroLoader>} */
+  let mockMacroLoader;
   /** @type {jest.Mocked<EntityLoader>} */
   let mockEntityLoader;
   /** @type {jest.Mocked<ISchemaValidator>} */
@@ -146,6 +149,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     mockActionLoader = { loadItemsForMod: jest.fn() };
     mockComponentLoader = { loadItemsForMod: jest.fn() };
     mockEventLoader = { loadItemsForMod: jest.fn() };
+    mockMacroLoader = { loadItemsForMod: jest.fn() };
     mockRuleLoader = { loadItemsForMod: jest.fn() };
     mockEntityLoader = { loadItemsForMod: jest.fn() };
 
@@ -163,6 +167,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
         actions: ['core/action_move.json', 'core/action_look.json'],
         components: ['core/comp_position.json'],
         characters: ['core/entity_player_base.json'],
+        macros: ['core/logSuccess.macro.json'],
       },
     };
     mockManifestMap = new Map();
@@ -270,6 +275,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
 
     setupContentLoaderMock(mockActionLoader, 'actions', 2);
     setupContentLoaderMock(mockComponentLoader, 'components', 1);
+    setupContentLoaderMock(mockMacroLoader, 'macros', 2);
     setupContentLoaderMock(mockEntityLoader, 'characters', 1); // Use 'characters' as typeName
 
     // --- 4. Instantiate SUT ---
@@ -278,6 +284,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       logger: mockLogger,
       schemaLoader: mockSchemaLoader,
       componentLoader: mockComponentLoader,
+      macroLoader: mockMacroLoader,
       ruleLoader: mockRuleLoader,
       actionLoader: mockActionLoader,
       eventLoader: mockEventLoader,
@@ -390,6 +397,15 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       'components',
       'components',
       'components'
+    );
+
+    expect(mockMacroLoader.loadItemsForMod).toHaveBeenCalledTimes(1);
+    expect(mockMacroLoader.loadItemsForMod).toHaveBeenCalledWith(
+      CORE_MOD_ID,
+      mockCoreManifest,
+      'macros',
+      'macros',
+      'macros'
     );
 
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenCalledTimes(1);

--- a/tests/services/macroLoader.happyPath.core.test.js
+++ b/tests/services/macroLoader.happyPath.core.test.js
@@ -1,0 +1,112 @@
+import MacroLoader from '../../src/loaders/macroLoader.js';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { CORE_MOD_ID } from '../../src/constants/core';
+
+const createMockConfiguration = (overrides = {}) => ({
+  getModsBasePath: jest.fn(() => './data/mods'),
+  getContentTypeSchemaId: jest.fn((typeName) => {
+    if (typeName === 'macros') {
+      return 'http://example.com/schemas/macro.schema.json';
+    }
+    return undefined;
+  }),
+  ...overrides,
+});
+
+const createMockPathResolver = (overrides = {}) => ({
+  resolveModContentPath: jest.fn(
+    (modId, dir, filename) => `./data/mods/${modId}/${dir}/${filename}`
+  ),
+  ...overrides,
+});
+
+const createMockDataFetcher = (map) => ({
+  fetch: jest.fn(async (path) => {
+    if (path in map) return JSON.parse(JSON.stringify(map[path]));
+    throw new Error(`Unexpected fetch path: ${path}`);
+  }),
+});
+
+const createMockSchemaValidator = (overrides = {}) => ({
+  isSchemaLoaded: jest.fn(() => true),
+  getValidator: jest.fn(() => () => ({ isValid: true, errors: null })),
+  validate: jest.fn(() => ({ isValid: true, errors: null })),
+  addSchema: jest.fn(),
+  removeSchema: jest.fn(),
+  ...overrides,
+});
+
+const createMockDataRegistry = () => ({
+  store: jest.fn(),
+  get: jest.fn(),
+  clear: jest.fn(),
+});
+
+const createMockLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('MacroLoader (Happy Path - Core Mod)', () => {
+  let macroLoader;
+  let mockRegistry;
+  let mockLogger;
+
+  const manifest = {
+    id: CORE_MOD_ID,
+    content: {
+      macros: [
+        'logSuccessAndEndTurn.macro.json',
+        'logFailureAndEndTurn.macro.json',
+      ],
+    },
+  };
+
+  const logSuccess = require('../../data/mods/core/macros/logSuccessAndEndTurn.macro.json');
+  const logFailure = require('../../data/mods/core/macros/logFailureAndEndTurn.macro.json');
+
+  beforeEach(() => {
+    mockRegistry = createMockDataRegistry();
+    mockLogger = createMockLogger();
+    macroLoader = new MacroLoader(
+      createMockConfiguration(),
+      createMockPathResolver(),
+      createMockDataFetcher({
+        [`./data/mods/${CORE_MOD_ID}/macros/logSuccessAndEndTurn.macro.json`]:
+          logSuccess,
+        [`./data/mods/${CORE_MOD_ID}/macros/logFailureAndEndTurn.macro.json`]:
+          logFailure,
+      }),
+      createMockSchemaValidator(),
+      mockRegistry,
+      mockLogger
+    );
+  });
+
+  it('loads macros and stores them in the registry', async () => {
+    const result = await macroLoader.loadItemsForMod(
+      CORE_MOD_ID,
+      manifest,
+      'macros',
+      'macros',
+      'macros'
+    );
+
+    expect(result).toEqual({ count: 2, overrides: 0, errors: 0 });
+
+    expect(mockRegistry.store).toHaveBeenCalledWith(
+      'macros',
+      'core:logSuccessAndEndTurn',
+      expect.objectContaining({ id: 'core:logSuccessAndEndTurn' })
+    );
+    expect(mockRegistry.store).toHaveBeenCalledWith(
+      'macros',
+      'core:logFailureAndEndTurn',
+      expect.objectContaining({ id: 'core:logFailureAndEndTurn' })
+    );
+
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce MacroLoader token and DI registration
- wire MacroLoader into infrastructure so WorldLoader invokes it
- add integration test verifying MacroLoader loads macros

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors, 1811 warnings)*
- `npm test`
- `cd llm-proxy-server && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef8a8a4ac8331a80af3d9b29fce45