### PR TITLE
[Agent] add default scroll support in BoundDomRenderer

### DIFF
--- a/src/domUI/actionResultRenderer.js
+++ b/src/domUI/actionResultRenderer.js
@@ -88,6 +88,8 @@ export class ActionResultRenderer extends BoundDomRendererBase {
       documentContext,
       validatedEventDispatcher: safeEventDispatcher,
       elementsConfig,
+      scrollContainerKey: 'scrollContainer',
+      contentContainerKey: 'listContainerElement',
     });
 
     /** @private */ this.#domElementFactory = domElementFactory;
@@ -198,15 +200,6 @@ export class ActionResultRenderer extends BoundDomRendererBase {
 
     li.textContent = message;
     listEl.appendChild(li);
-    this.#scrollToBottom();
-  }
-
-  /**
-   * Scrolls the message list so the newest bubble is visible.
-   *
-   * @private
-   */
-  #scrollToBottom() {
-    this.scrollToBottom('scrollContainer', 'listContainerElement');
+    this.scrollToBottom();
   }
 }

--- a/src/domUI/boundDomRendererBase.js
+++ b/src/domUI/boundDomRendererBase.js
@@ -47,6 +47,23 @@ export class BoundDomRendererBase extends RendererBase {
   elements;
 
   /**
+   * Stores the default keys used when calling {@link BoundDomRendererBase#scrollToBottom}.
+   * These may be omitted if a subclass never needs the auto-scroll helper.
+   *
+   * @protected
+   * @type {string | null}
+   */
+  _defaultScrollContainerKey = null;
+
+  /**
+   * Stores the default content container key used when scrolling.
+   *
+   * @protected
+   * @type {string | null}
+   */
+  _defaultContentContainerKey = null;
+
+  /**
    * Initializes the base renderer and binds DOM elements.
    *
    * @param {object} params - The parameters object.
@@ -54,6 +71,8 @@ export class BoundDomRendererBase extends RendererBase {
    * @param {IDocumentContext} params.documentContext - The document context abstraction.
    * @param {IValidatedEventDispatcher} params.validatedEventDispatcher - The validated event dispatcher.
    * @param {ElementsConfig} params.elementsConfig - Configuration for binding DOM elements.
+   * @param {string} [params.scrollContainerKey] - Default key in `elementsConfig` used when scrolling.
+   * @param {string} [params.contentContainerKey] - Default content container key used when scrolling.
    * @throws {Error} If `elementsConfig` is not provided or is not an object.
    */
   constructor({
@@ -61,6 +80,8 @@ export class BoundDomRendererBase extends RendererBase {
     documentContext,
     validatedEventDispatcher,
     elementsConfig,
+    scrollContainerKey = null,
+    contentContainerKey = null,
   }) {
     super({ logger, documentContext, validatedEventDispatcher });
 
@@ -72,6 +93,8 @@ export class BoundDomRendererBase extends RendererBase {
 
     this.elements = {};
     this._bindElements(elementsConfig);
+    this._defaultScrollContainerKey = scrollContainerKey;
+    this._defaultContentContainerKey = contentContainerKey;
   }
 
   /**
@@ -207,7 +230,16 @@ export class BoundDomRendererBase extends RendererBase {
    * @param {string} scrollKey - Key for the scroll container in `this.elements`.
    * @param {string} contentKey - Key for the content container for fallback scrolling.
    */
-  scrollToBottom(scrollKey, contentKey) {
+  scrollToBottom(
+    scrollKey = this._defaultScrollContainerKey,
+    contentKey = this._defaultContentContainerKey
+  ) {
+    if (!scrollKey || !contentKey) {
+      this.logger.warn(
+        `${this._logPrefix} scrollToBottom called without valid keys.`
+      );
+      return;
+    }
     this._scrollToPanelBottom(scrollKey, contentKey);
   }
 

--- a/src/domUI/chatAlertRenderer.js
+++ b/src/domUI/chatAlertRenderer.js
@@ -73,6 +73,8 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
         scrollContainer: { selector: '#outputDiv', required: true },
         chatPanel: { selector: '#message-list', required: false },
       },
+      scrollContainerKey: 'scrollContainer',
+      contentContainerKey: 'chatPanel',
     });
 
     // --- Dependency Validation ---
@@ -135,15 +137,6 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
     );
 
     this.logger.debug(`${this._logPrefix} Initialized.`);
-  }
-
-  /**
-   * Scrolls the chat panel to the bottom to ensure the latest message is visible.
-   *
-   * @private
-   */
-  #scrollToBottom() {
-    this.scrollToBottom('scrollContainer', 'chatPanel');
   }
 
   /**
@@ -330,7 +323,7 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
 
     bubbleElement.appendChild(contentWrapper);
     this.elements.chatPanel.appendChild(bubbleElement);
-    this.#scrollToBottom();
+    this.scrollToBottom();
   }
 
   /**

--- a/src/domUI/speechBubbleRenderer.js
+++ b/src/domUI/speechBubbleRenderer.js
@@ -65,6 +65,8 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
       documentContext,
       validatedEventDispatcher,
       elementsConfig,
+      scrollContainerKey: 'outputDivElement',
+      contentContainerKey: 'speechContainer',
     });
 
     if (!entityManager)
@@ -278,12 +280,9 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
 
         // Wait for the image to load before scrolling to ensure the scroll height is correct.
         // Use a one-time listener for this.
-        this._addDomListener(
-          portraitImg,
-          'load',
-          () => this.#scrollToBottom(),
-          { once: true }
-        );
+        this._addDomListener(portraitImg, 'load', () => this.scrollToBottom(), {
+          once: true,
+        });
         this._addDomListener(
           portraitImg,
           'error',
@@ -291,7 +290,7 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
             this.logger.warn(
               `${this._logPrefix} Portrait image failed to load for ${speakerName}. Scrolling anyway.`
             );
-            this.#scrollToBottom();
+            this.scrollToBottom();
           },
           { once: true }
         );
@@ -314,22 +313,12 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
     // If there's no portrait, the layout is stable, so we can scroll immediately.
     // If there is a portrait, the 'onload' or 'onerror' handler will trigger the scroll.
     if (!hasPortrait) {
-      this.#scrollToBottom();
+      this.scrollToBottom();
     }
 
     this.logger.debug(
       `${this._logPrefix} Rendered speech for ${speakerName}${isPlayer ? ' (Player)' : ''}.`
     );
-  }
-
-  /**
-   * Scrolls the output/chat panel to the bottom.
-   * Uses the centralized method from BoundDomRendererBase.
-   *
-   * @private
-   */
-  #scrollToBottom() {
-    this.scrollToBottom('outputDivElement', 'speechContainer');
   }
 
   /**


### PR DESCRIPTION
Summary: Extend BoundDomRendererBase to store default scroll keys and expose a no-arg `scrollToBottom()` that uses them. Updated ChatAlertRenderer, ActionResultRenderer and SpeechBubbleRenderer to provide these keys at construction and call the new method directly.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684efb330354833192af708b10b39700