### PR TITLE
[Agent] dispatch error events in LocationSummaryProvider

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -309,14 +309,13 @@ export function registerAI(container) {
         entityManager: c.resolve(tokens.IEntityManager),
       })
   );
-  r.singletonFactory(
-    tokens.ILocationSummaryProvider,
-    (c) =>
-      new LocationSummaryProvider({
-        entityManager: c.resolve(tokens.IEntityManager),
-        summaryProvider: c.resolve(tokens.IEntitySummaryProvider),
-      })
-  );
+  r.singletonFactory(tokens.ILocationSummaryProvider, (c) => {
+    return new LocationSummaryProvider({
+      entityManager: c.resolve(tokens.IEntityManager),
+      summaryProvider: c.resolve(tokens.IEntitySummaryProvider),
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+    });
+  });
 
   r.singletonFactory(tokens.IAIGameStateProvider, (c) => {
     return new AIGameStateProvider({

--- a/tests/turns/services/AIGameStateProvider.bugFixes.test.js
+++ b/tests/turns/services/AIGameStateProvider.bugFixes.test.js
@@ -105,11 +105,12 @@ describe('AIGameStateProvider', () => {
     const actorDataExtractor = new ActorDataExtractor();
     const perceptionLogProvider = new PerceptionLogProvider();
     const entitySummaryProvider = new EntitySummaryProvider();
+    const safeEventDispatcher = { dispatch: jest.fn() };
     const locationSummaryProvider = new LocationSummaryProvider({
       entityManager,
       summaryProvider: entitySummaryProvider,
+      safeEventDispatcher,
     });
-    const safeEventDispatcher = { dispatch: jest.fn() };
 
     provider = new AIGameStateProvider({
       actorStateProvider,

--- a/tests/turns/services/AIGameStateProvider.test.js
+++ b/tests/turns/services/AIGameStateProvider.test.js
@@ -100,12 +100,12 @@ describe('AIGameStateProvider Integration Tests', () => {
     actorDataExtractor = new ActorDataExtractor();
     perceptionLogProvider = new PerceptionLogProvider();
     entitySummaryProvider = new EntitySummaryProvider();
+    safeEventDispatcher = { dispatch: jest.fn() };
     locationSummaryProvider = new LocationSummaryProvider({
       entityManager: deps.entityManager,
       summaryProvider: entitySummaryProvider,
+      safeEventDispatcher,
     });
-
-    safeEventDispatcher = { dispatch: jest.fn() };
 
     return new AIGameStateProvider({
       actorStateProvider,
@@ -224,7 +224,10 @@ describe('AIGameStateProvider Integration Tests', () => {
           logger
         );
         expect(currentLocation).toBeNull();
-        expect(logger.error).toHaveBeenCalled();
+        expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+          DISPLAY_ERROR_ID,
+          expect.any(Object)
+        );
       });
 
       test('should return null for location if location entity not found', async () => {


### PR DESCRIPTION
## Summary
- use SafeEventDispatcher in LocationSummaryProvider
- update aiRegistrations to supply SafeEventDispatcher
- adjust AIGameStateProvider tests for dispatcher usage

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2331 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684efe20d0788331b38e703e888a3be0