### PR TITLE
[Agent] Fix failing thumb wipe cheek rule test

### DIFF
--- a/tests/integration/rules/thumbWipeCheekRule.integration.test.js
+++ b/tests/integration/rules/thumbWipeCheekRule.integration.test.js
@@ -9,6 +9,7 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import thumbWipeCheekRule from '../../../data/mods/intimacy/rules/thumb_wipe_cheek.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -79,6 +80,7 @@ let safeDispatcher;
 
 /**
  * Initializes the interpreter and registers handlers for this test suite.
+ *
  * @param {Array<{id:string,components:object}>} entities - Seed entities.
  */
 function init(entities) {
@@ -180,6 +182,7 @@ describe('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       operationSchema,
       'http://example.com/schemas/operation.schema.json'
     );
+    loadOperationSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'
@@ -240,9 +243,9 @@ describe('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       (e) => e.eventType === 'core:perceptible_event'
     );
     expect(perceptibleEvent).toBeDefined();
-    expect(perceptibleEvent.payload.description_text).toBe(expectedMessage);
-    expect(perceptibleEvent.payload.actor_id).toBe('hero');
-    expect(perceptibleEvent.payload.target_id).toBe('friend');
+    expect(perceptibleEvent.payload.descriptionText).toBe(expectedMessage);
+    expect(perceptibleEvent.payload.actorId).toBe('hero');
+    expect(perceptibleEvent.payload.targetId).toBe('friend');
 
     // Assert the actor-facing message (now corrected to be third-person)
     const uiEvent = events.find(
@@ -291,14 +294,14 @@ describe('intimacy:handle_thumb_wipe_cheek rule integration', () => {
     expect(eventTypes).toContain('core:turn_ended');
 
     const expectedMessage =
-      "unknown gently brushes their thumb across Friend's cheek.";
+      "Unnamed Character gently brushes their thumb across Friend's cheek.";
 
     // Assert the messages are formed with default names (e.g., "unknown")
     const perceptibleEvent = events.find(
       (e) => e.eventType === 'core:perceptible_event'
     );
     expect(perceptibleEvent).toBeDefined();
-    expect(perceptibleEvent.payload.description_text).toBe(expectedMessage);
+    expect(perceptibleEvent.payload.descriptionText).toBe(expectedMessage);
 
     const uiEvent = events.find(
       (e) => e.eventType === 'core:display_successful_action_result'


### PR DESCRIPTION
## Summary
- load operation schemas in thumb wipe cheek rule test
- update expectations for camelCase properties in events

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f043fc8388331b5128cb0db6b1734