### PR TITLE
[Agent] dispatch display_error in BrowserStorageProvider

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -40,7 +40,10 @@ export function registerPersistence(container) {
   const logger = container.resolve(tokens.ILogger);
   logger.debug('Persistence Registration: Starting...');
 
-  r.single(tokens.IStorageProvider, BrowserStorageProvider, [tokens.ILogger]);
+  r.single(tokens.IStorageProvider, BrowserStorageProvider, [
+    tokens.ILogger,
+    tokens.ISafeEventDispatcher,
+  ]);
   logger.debug(
     `Persistence Registration: Registered ${String(tokens.IStorageProvider)}.`
   );

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -97,7 +97,7 @@ describe('registerPersistence', () => {
         token: tokens.IStorageProvider,
         Class: BrowserStorageProvider,
         lifecycle: 'singleton',
-        deps: [tokens.ILogger],
+        deps: [tokens.ILogger, tokens.ISafeEventDispatcher],
       },
       {
         token: tokens.ISaveLoadService,


### PR DESCRIPTION
## Summary
- inject SafeEventDispatcher into `BrowserStorageProvider`
- dispatch `DISPLAY_ERROR_ID` instead of using `logger.error`
- update persistence registrations and tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f02b877fc8331a1e9bd90a4296134