### PR TITLE
[Feat] Introduce PersistenceResult typedef

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -150,7 +150,7 @@ class GameStateSerializer {
    * Decompresses Gzip-compressed data.
    *
    * @param {Uint8Array} data - Compressed data.
-   * @returns {{success: boolean, data?: Uint8Array, error?: PersistenceError, userFriendlyError?: string}} Outcome of decompression.
+   * @returns {import('./persistenceTypes.js').PersistenceResult<Uint8Array>} Outcome of decompression.
    */
   decompress(data) {
     try {
@@ -178,7 +178,7 @@ class GameStateSerializer {
    * Deserializes MessagePack data.
    *
    * @param {Uint8Array} buffer - Data to deserialize.
-   * @returns {{success: boolean, data?: object, error?: PersistenceError, userFriendlyError?: string}} Outcome of deserialization.
+   * @returns {import('./persistenceTypes.js').PersistenceResult<object>} Outcome of deserialization.
    */
   deserialize(buffer) {
     try {

--- a/src/persistence/persistenceTypes.js
+++ b/src/persistence/persistenceTypes.js
@@ -1,0 +1,17 @@
+// src/persistence/persistenceTypes.js
+
+/**
+ * @file JSDoc typedefs used across persistence services.
+ */
+
+/**
+ * Generic result returned by persistence operations.
+ *
+ * @template T
+ * @typedef {object} PersistenceResult
+ * @property {boolean} success - Indicates if the operation succeeded.
+ * @property {T} [data] - Optional data returned on success.
+ * @property {import('./persistenceErrors.js').PersistenceError} [error] - Error instance when the operation fails.
+ * @property {string} [userFriendlyError] - Message safe to display to users.
+ */
+export {};

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -96,7 +96,7 @@ class SaveLoadService extends ISaveLoadService {
    *
    * @param {SaveGameStructure} obj - The deserialized save object.
    * @param {string} identifier - Identifier used for logging.
-   * @returns {{success: boolean, error?: PersistenceError}} Result.
+   * @returns {import('./persistenceTypes.js').PersistenceResult<null>} Result.
    * @private
    */
   #validateStructure(obj, identifier) {
@@ -136,7 +136,7 @@ class SaveLoadService extends ISaveLoadService {
    *
    * @param {SaveGameStructure} obj - The deserialized save object.
    * @param {string} identifier - Identifier used for logging.
-   * @returns {Promise<{success: boolean, error?: PersistenceError}>} Result.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result.
    * @private
    */
   async #verifyChecksum(obj, identifier) {
@@ -197,7 +197,7 @@ class SaveLoadService extends ISaveLoadService {
    *
    * @param {SaveGameStructure} obj - The deserialized save object.
    * @param {string} identifier - Identifier used for logging.
-   * @returns {Promise<{success: boolean, error?: PersistenceError}>} Result.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result.
    * @private
    */
   async #validateLoadedSaveObject(obj, identifier) {

--- a/tests/integration/rules/thumbWipeCheekRule.integration.test.js
+++ b/tests/integration/rules/thumbWipeCheekRule.integration.test.js
@@ -10,7 +10,6 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
-import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import thumbWipeCheekRule from '../../../data/mods/intimacy/rules/thumb_wipe_cheek.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -241,7 +240,7 @@ describe.skip('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       (e) => e.eventType === 'core:perceptible_event'
     );
     expect(perceptibleEvent).toBeDefined();
-    
+
     expect(perceptibleEvent.payload.descriptionText).toBe(expectedMessage);
     expect(perceptibleEvent.payload.actorId).toBe('hero');
     expect(perceptibleEvent.payload.targetId).toBe('friend');
@@ -250,7 +249,7 @@ describe.skip('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       (e) => e.eventType === 'core:display_successful_action_result'
     );
     expect(uiEvent).toBeDefined();
-    
+
     expect(uiEvent.payload.message).toBeDefined();
 
     // Assert the turn ended correctly

--- a/tests/services/gameStateSerializer.test.js
+++ b/tests/services/gameStateSerializer.test.js
@@ -9,6 +9,10 @@ import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { createMockLogger } from '../testUtils.js';
 
+/**
+ * @typedef {import('../../src/persistence/persistenceTypes.js').PersistenceResult<any>} PersistenceResult
+ */
+
 beforeAll(() => {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'crypto', {
@@ -35,15 +39,18 @@ describe('GameStateSerializer', () => {
     const obj = { a: 1, nested: { b: 'c' } };
     const compressed = pako.gzip(encode(obj));
 
+    /** @type {PersistenceResult<Uint8Array>} */
     const decResult = serializer.decompress(compressed);
     expect(decResult.success).toBe(true);
 
+    /** @type {PersistenceResult<object>} */
     const deserResult = serializer.deserialize(decResult.data);
     expect(deserResult.success).toBe(true);
     expect(deserResult.data).toEqual(obj);
   });
 
   it('decompress fails on invalid gzip data', () => {
+    /** @type {PersistenceResult<Uint8Array>} */
     const result = serializer.decompress(new Uint8Array([1, 2, 3]));
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.DECOMPRESSION_ERROR);
@@ -51,9 +58,11 @@ describe('GameStateSerializer', () => {
 
   it('deserialize fails on malformed MessagePack', () => {
     const malformed = pako.gzip(new Uint8Array([1, 2, 3]));
+    /** @type {PersistenceResult<Uint8Array>} */
     const dec = serializer.decompress(malformed);
     expect(dec.success).toBe(true);
 
+    /** @type {PersistenceResult<object>} */
     const desRes = serializer.deserialize(dec.data);
     expect(desRes.success).toBe(false);
     expect(desRes.error.code).toBe(PersistenceErrorCodes.DESERIALIZATION_ERROR);

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -11,6 +11,10 @@ import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { TextEncoder, TextDecoder } from 'util';
 
+/**
+ * @typedef {import('../../src/persistence/persistenceTypes.js').PersistenceResult<any>} PersistenceResult
+ */
+
 jest.mock('@msgpack/msgpack', () => {
   global.encodeMock = jest.fn();
   global.decodeMock = jest.fn();
@@ -81,6 +85,7 @@ describe('SaveLoadService error paths', () => {
   it('handles deleteFile throwing exception', async () => {
     storageProvider.fileExists.mockResolvedValue(true);
     storageProvider.deleteFile.mockRejectedValue(new Error('fs failure'));
+    /** @type {PersistenceResult<any>} */
     const res = await service.deleteManualSave('saves/manual_saves/bad.sav');
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/unexpected error/i);
@@ -111,6 +116,7 @@ describe('SaveLoadService error paths', () => {
       gameState: { isGameState: true },
       integrityChecks: {},
     };
+    /** @type {PersistenceResult<any>} */
     const result = await service.saveManualGame('Slot', obj);
     expect(result.success).toBe(true);
 
@@ -135,6 +141,7 @@ describe('SaveLoadService error paths', () => {
       integrityChecks: {},
     };
     cyc.self = cyc;
+    /** @type {PersistenceResult<any>} */
     const res = await service.saveManualGame('Loop', cyc);
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/deep clone/i);

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -10,6 +10,10 @@ import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 
+/**
+ * @typedef {import('../../src/persistence/persistenceTypes.js').PersistenceResult<any>} PersistenceResult
+ */
+
 beforeAll(() => {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'crypto', {
@@ -63,6 +67,7 @@ describe('SaveLoadService private helper error propagation', () => {
 
   it('propagates readSaveFile errors', async () => {
     storageProvider.readFile.mockRejectedValue(new Error('read fail'));
+    /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/Could not access/);
@@ -70,6 +75,7 @@ describe('SaveLoadService private helper error propagation', () => {
 
   it('propagates empty file error', async () => {
     storageProvider.readFile.mockResolvedValue(new Uint8Array());
+    /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/empty or cannot be read/);
@@ -77,6 +83,7 @@ describe('SaveLoadService private helper error propagation', () => {
 
   it('propagates decompression errors', async () => {
     storageProvider.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/could not decompress/);
@@ -85,6 +92,7 @@ describe('SaveLoadService private helper error propagation', () => {
   it('propagates deserialization errors', async () => {
     const badGzip = pako.gzip(new Uint8Array([1, 2, 3]));
     storageProvider.readFile.mockResolvedValue(badGzip);
+    /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
     expect(res.error.message).toMatch(/could not understand/);


### PR DESCRIPTION
Summary: Adds a reusable PersistenceResult typedef for persistence modules and updates relevant JSDoc comments and tests.

Changes Made:
- Created `src/persistence/persistenceTypes.js` exporting the generic `PersistenceResult<T>` typedef.
- Replaced inline return type objects in `saveLoadService.js` and `gameStateSerializer.js` with references to `PersistenceResult`.
- Updated related unit tests to import and annotate with this new type.
- Fixed a duplicate import in `thumbWipeCheekRule.integration.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` — warnings present but no new errors)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_684f0991977483319dc60ce45abedba8