### PR TITLE
[Agent] Add handler utility module and refactor handlers

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -14,6 +14,11 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
+import {
+  initHandlerLogger,
+  validateDeps,
+  getExecLogger,
+} from './handlerUtils.js';
 
 /**
  * Parameters accepted by {@link AddComponentHandler#execute}.
@@ -42,30 +47,18 @@ class AddComponentHandler {
    * @throws {Error} If required dependencies are missing or invalid.
    */
   constructor({ entityManager, logger, safeEventDispatcher }) {
-    // Validate logger FIRST (consistent with ModifyComponentHandler)
-    if (
-      !logger ||
-      ['info', 'warn', 'error', 'debug'].some(
-        (m) => typeof logger[m] !== 'function'
-      )
-    ) {
-      throw new Error('AddComponentHandler requires a valid ILogger instance.');
-    }
-    if (!entityManager || typeof entityManager.addComponent !== 'function') {
-      throw new Error(
-        'AddComponentHandler requires a valid EntityManager instance with an addComponent method.'
-      );
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      throw new Error(
-        'AddComponentHandler requires a valid ISafeEventDispatcher instance.'
-      );
-    }
+    this.#logger = initHandlerLogger('AddComponentHandler', logger);
+    validateDeps('AddComponentHandler', this.#logger, {
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['addComponent'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#dispatcher = safeEventDispatcher;
-    this.#logger = logger;
     this.#entityManager = entityManager;
   }
 
@@ -79,7 +72,7 @@ class AddComponentHandler {
    * @implements {OperationHandler}
    */
   execute(params, executionContext) {
-    const log = executionContext?.logger ?? this.#logger;
+    const log = getExecLogger(this.#logger, executionContext);
 
     // 1. Validate Parameters
     if (!params || typeof params !== 'object') {

--- a/src/logic/operationHandlers/handlerUtils.js
+++ b/src/logic/operationHandlers/handlerUtils.js
@@ -1,0 +1,52 @@
+// src/logic/operationHandlers/handlerUtils.js
+
+/**
+ * @module HandlerUtils
+ * @description Utility helpers for operation handlers.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+
+import {
+  setupService,
+  validateServiceDeps,
+} from '../../utils/serviceInitializer.js';
+
+/**
+ * @description Initialize a handler logger using the standard service
+ * initializer utilities. Logs will automatically be prefixed with the
+ * handler name.
+ * @param {string} name - Name of the handler.
+ * @param {ILogger} logger - Base logger instance.
+ * @returns {ILogger} Prefixed logger instance.
+ */
+export function initHandlerLogger(name, logger) {
+  return setupService(name, logger);
+}
+
+/**
+ * @description Validate handler dependencies using the common service
+ * dependency validator.
+ * @param {string} name - Name used for validation messages.
+ * @param {ILogger} logger - Logger for validation output.
+ * @param {Record<string, import('../../utils/serviceInitializer.js').DependencySpec>} deps
+ *   - Map of dependency specs.
+ * @returns {void}
+ */
+export function validateDeps(name, logger, deps) {
+  validateServiceDeps(name, logger, deps);
+}
+
+/**
+ * @description Retrieve the logger to use during execution. If the
+ * execution context provides a logger, it takes precedence over the
+ * handler's default logger.
+ * @param {ILogger} defaultLogger - Default logger from the handler.
+ * @param {import('../defs.js').ExecutionContext} [execCtx] - Optional execution context.
+ * @returns {ILogger} Logger instance for execution.
+ */
+export function getExecLogger(defaultLogger, execCtx) {
+  return execCtx?.logger ?? defaultLogger;
+}
+
+// --- FILE END ---

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -12,6 +12,11 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
+import {
+  initHandlerLogger,
+  validateDeps,
+  getExecLogger,
+} from './handlerUtils.js';
 
 /**
  * @typedef {object} EntityRefObject
@@ -57,28 +62,18 @@ class ModifyComponentHandler {
   /** @type {ISafeEventDispatcher} */ #dispatcher;
 
   constructor({ entityManager, logger, safeEventDispatcher }) {
-    if (
-      !logger ||
-      ['info', 'warn', 'error', 'debug'].some(
-        (m) => typeof logger[m] !== 'function'
-      )
-    ) {
-      throw new Error('ModifyComponentHandler needs a valid ILogger.');
-    }
-    if (
-      !entityManager ||
-      typeof entityManager.getComponentData !== 'function' ||
-      typeof entityManager.addComponent !== 'function'
-    ) {
-      throw new Error(
-        'ModifyComponentHandler needs EntityManager#getComponentData & #addComponent.'
-      );
-    }
-    this.#logger = logger;
+    this.#logger = initHandlerLogger('ModifyComponentHandler', logger);
+    validateDeps('ModifyComponentHandler', this.#logger, {
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['getComponentData', 'addComponent'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#entityManager = entityManager;
-    if (!safeEventDispatcher?.dispatch) {
-      throw new Error('ModifyComponentHandler needs ISafeEventDispatcher');
-    }
     this.#dispatcher = safeEventDispatcher;
   }
 
@@ -89,7 +84,7 @@ class ModifyComponentHandler {
    * @param {ExecutionContext} execCtx
    */
   execute(params, execCtx) {
-    const log = execCtx?.logger ?? this.#logger;
+    const log = getExecLogger(this.#logger, execCtx);
 
     // ── validate base params ───────────────────────────────────────
     if (!params || typeof params !== 'object') {

--- a/src/logic/operationHandlers/removeComponentHandler.js
+++ b/src/logic/operationHandlers/removeComponentHandler.js
@@ -15,6 +15,11 @@
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import {
+  initHandlerLogger,
+  validateDeps,
+  getExecLogger,
+} from './handlerUtils.js';
 
 /**
  * Parameters accepted by {@link RemoveComponentHandler#execute}.
@@ -42,30 +47,18 @@ class RemoveComponentHandler {
    * @throws {Error} If entityManager or logger are missing or invalid.
    */
   constructor({ entityManager, logger, safeEventDispatcher }) {
-    // Validate logger FIRST
-    if (
-      !logger ||
-      ['info', 'warn', 'error', 'debug'].some(
-        (m) => typeof logger[m] !== 'function'
-      )
-    ) {
-      throw new Error(
-        'RemoveComponentHandler requires a valid ILogger instance.'
-      );
-    }
-    // Validate EntityManager dependency - needs removeComponent
-    if (!entityManager || typeof entityManager.removeComponent !== 'function') {
-      throw new Error(
-        'RemoveComponentHandler requires a valid EntityManager instance with a removeComponent method.'
-      );
-    }
-    if (!safeEventDispatcher?.dispatch) {
-      throw new Error(
-        'RemoveComponentHandler requires a valid ISafeEventDispatcher instance.'
-      );
-    }
+    this.#logger = initHandlerLogger('RemoveComponentHandler', logger);
+    validateDeps('RemoveComponentHandler', this.#logger, {
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['removeComponent'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#dispatcher = safeEventDispatcher;
-    this.#logger = logger;
     this.#entityManager = entityManager;
   }
 
@@ -89,7 +82,7 @@ class RemoveComponentHandler {
    * @implements {OperationHandler}
    */
   execute(params, executionContext) {
-    const log = executionContext?.logger ?? this.#logger;
+    const log = getExecLogger(this.#logger, executionContext);
 
     // 1. Validate Parameters
     if (!params || typeof params !== 'object') {

--- a/tests/integration/rules/thumbWipeCheekRule.integration.test.js
+++ b/tests/integration/rules/thumbWipeCheekRule.integration.test.js
@@ -5,7 +5,6 @@
 
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import Ajv from 'ajv';
-import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
@@ -241,7 +240,7 @@ describe.skip('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       (e) => e.eventType === 'core:perceptible_event'
     );
     expect(perceptibleEvent).toBeDefined();
-    
+
     expect(perceptibleEvent.payload.descriptionText).toBe(expectedMessage);
     expect(perceptibleEvent.payload.actorId).toBe('hero');
     expect(perceptibleEvent.payload.targetId).toBe('friend');
@@ -250,7 +249,7 @@ describe.skip('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       (e) => e.eventType === 'core:display_successful_action_result'
     );
     expect(uiEvent).toBeDefined();
-    
+
     expect(uiEvent.payload.message).toBeDefined();
 
     // Assert the turn ended correctly

--- a/tests/logic/operationHandlers/addComponentHandler.test.js
+++ b/tests/logic/operationHandlers/addComponentHandler.test.js
@@ -82,7 +82,7 @@ describe('AddComponentHandler', () => {
           logger: mockLogger,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/EntityManager/);
+    ).toThrow(/entityManager/);
     expect(
       () =>
         new AddComponentHandler({
@@ -90,14 +90,14 @@ describe('AddComponentHandler', () => {
           logger: mockLogger,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/addComponent method/);
+    ).toThrow(/addComponent/);
     expect(
       () =>
         new AddComponentHandler({
           entityManager: mockEntityManager,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/ILogger/);
+    ).toThrow(/logger/);
   });
 
   test('throws if safeEventDispatcher is missing or invalid', () => {
@@ -107,7 +107,7 @@ describe('AddComponentHandler', () => {
           entityManager: mockEntityManager,
           logger: mockLogger,
         })
-    ).toThrow(/ISafeEventDispatcher/);
+    ).toThrow(/safeEventDispatcher/);
     expect(
       () =>
         new AddComponentHandler({
@@ -115,7 +115,7 @@ describe('AddComponentHandler', () => {
           logger: mockLogger,
           safeEventDispatcher: {},
         })
-    ).toThrow(/ISafeEventDispatcher/);
+    ).toThrow(/safeEventDispatcher/);
   });
 
   // --- Happy Path - Basic Add/Replace ------------------------------------

--- a/tests/logic/operationHandlers/modifyComponentHandler.test.js
+++ b/tests/logic/operationHandlers/modifyComponentHandler.test.js
@@ -89,7 +89,7 @@ describe('ModifyComponentHandler', () => {
   // ---------------------------------------------------------------------------
   test('throws without valid dependencies', () => {
     expect(() => new ModifyComponentHandler({ logger: mockLogger })).toThrow(
-      /EntityManager/
+      /entityManager/
     );
     expect(
       () =>
@@ -102,14 +102,14 @@ describe('ModifyComponentHandler', () => {
     ).toThrow(/getComponentData/);
     expect(
       () => new ModifyComponentHandler({ entityManager: mockEntityManager })
-    ).toThrow(/ILogger/);
+    ).toThrow(/logger/);
     expect(
       () =>
         new ModifyComponentHandler({
           entityManager: mockEntityManager,
           logger: mockLogger,
         })
-    ).toThrow(/ISafeEventDispatcher/);
+    ).toThrow(/safeEventDispatcher/);
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/logic/operationHandlers/removeComponentHandler.test.js
+++ b/tests/logic/operationHandlers/removeComponentHandler.test.js
@@ -85,7 +85,7 @@ describe('RemoveComponentHandler', () => {
           logger: mockLogger,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/EntityManager/);
+    ).toThrow(/RemoveComponentHandler: entityManager/);
     // Check for specific method required by this handler
     expect(
       () =>
@@ -94,21 +94,21 @@ describe('RemoveComponentHandler', () => {
           logger: mockLogger,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/removeComponent method/);
+    ).toThrow(/removeComponent/);
     expect(
       () =>
         new RemoveComponentHandler({
           entityManager: mockEntityManager,
           safeEventDispatcher: mockDispatcher,
         })
-    ).toThrow(/ILogger/);
+    ).toThrow(/logger/);
     expect(
       () =>
         new RemoveComponentHandler({
           entityManager: mockEntityManager,
           logger: mockLogger,
         })
-    ).toThrow(/ISafeEventDispatcher/);
+    ).toThrow(/safeEventDispatcher/);
   });
 
   test('constructor initializes successfully with valid dependencies', () => {

--- a/tests/utils/loggerInitUsage.test.js
+++ b/tests/utils/loggerInitUsage.test.js
@@ -113,4 +113,27 @@ describe('initLogger usage in constructors', () => {
     jest.dontMock('../../src/utils/loggerUtils.js');
     jest.dontMock('../../src/utils/serviceInitializer.js');
   });
+
+  it('AddComponentHandler uses initHandlerLogger', () => {
+    jest.resetModules();
+    const initHandlerLogger = jest.fn(() => mockLogger);
+    jest.doMock('../../src/logic/operationHandlers/handlerUtils.js', () => {
+      const actual = jest.requireActual(
+        '../../src/logic/operationHandlers/handlerUtils.js'
+      );
+      return { ...actual, initHandlerLogger };
+    });
+    const AddComponentHandler =
+      require('../../src/logic/operationHandlers/addComponentHandler.js').default;
+    new AddComponentHandler({
+      entityManager: { addComponent: jest.fn() },
+      logger: mockLogger,
+      safeEventDispatcher: { dispatch: jest.fn() },
+    });
+    expect(initHandlerLogger).toHaveBeenCalledWith(
+      'AddComponentHandler',
+      mockLogger
+    );
+    jest.dontMock('../../src/logic/operationHandlers/handlerUtils.js');
+  });
 });


### PR DESCRIPTION
Summary: Adds a `handlerUtils` module providing standard logger initialization, dependency validation and execution context logger helpers. Refactors AddComponentHandler, RemoveComponentHandler, and ModifyComponentHandler to leverage these utilities. Updated tests accordingly and fixed a duplicate import in one integration test.

Changes Made:
- Introduced `src/logic/operationHandlers/handlerUtils.js` with `initHandlerLogger`, `validateDeps` and `getExecLogger`.
- Updated selected handlers to use the new helpers.
- Adjusted related unit tests and logger usage tests for the new initialization approach.
- Fixed duplicate import in `thumbWipeCheekRule.integration.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` – errors remain from unrelated files)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)


------
https://chatgpt.com/codex/tasks/task_e_684f095ed88c833189f1f215baa9493c