### PR TITLE
[Agent] add setContextValue helper and refactor handlers

### DIFF
--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -12,7 +12,7 @@
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
 import { wouldCreateCycle } from '../../utils/followUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /**
  * @typedef {object} CheckFollowCycleParams
@@ -86,8 +86,8 @@ class CheckFollowCycleHandler {
     const cycleDetected = wouldCreateCycle(fid, lid, this.#entityManager);
     const result = { success: true, cycleDetected };
 
-    const stored = storeResult(
-      result_variable.trim(),
+    const stored = setContextValue(
+      result_variable,
       result,
       execCtx,
       this.#dispatcher,

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -15,7 +15,7 @@
 import { NAME_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DEFAULT_FALLBACK_CHARACTER_NAME } from '../../constants/textDefaults.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
@@ -102,7 +102,7 @@ class GetNameHandler {
         `GET_NAME: Could not resolve entity from entity_ref. Storing fallback '${fallback}'.`,
         { entity_ref }
       );
-      storeResult(resultVar, fallback, executionContext, undefined, log);
+      setContextValue(resultVar, fallback, executionContext, undefined, log);
       return;
     }
 
@@ -123,7 +123,7 @@ class GetNameHandler {
       });
     }
 
-    storeResult(resultVar, name, executionContext, undefined, log);
+    setContextValue(resultVar, name, executionContext, undefined, log);
   }
 }
 

--- a/src/logic/operationHandlers/hasComponentHandler.js
+++ b/src/logic/operationHandlers/hasComponentHandler.js
@@ -13,7 +13,7 @@
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /**
  * Parameters accepted by {@link HasComponentHandler#execute}.
@@ -153,8 +153,8 @@ class HasComponentHandler {
     }
 
     // 4. Store the final boolean result in the context
-    storeResult(
-      trimmedResultVar,
+    setContextValue(
+      result_variable,
       result,
       executionContext,
       this.#dispatcher,

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -4,7 +4,7 @@
 
 import jsonLogic from 'json-logic-js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
@@ -77,8 +77,8 @@ class MathHandler {
     if (finalNumber === null) {
       log.warn('MATH: expression did not resolve to a numeric result.');
     }
-    const stored = storeResult(
-      result_variable.trim(),
+    const stored = setContextValue(
+      result_variable,
       finalNumber,
       executionContext,
       this.#dispatcher,

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -13,7 +13,7 @@ import { resolvePath } from '../../utils/objectUtils.js';
 import { cloneDeep } from 'lodash';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /**
  * @class ModifyArrayFieldHandler
@@ -237,7 +237,7 @@ class ModifyArrayFieldHandler {
 
     // 7. Store Result if requested
     if (result_variable) {
-      const stored = storeResult(
+      const stored = setContextValue(
         result_variable,
         result,
         executionContext,

--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -8,11 +8,12 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { resolvePath } from '../../utils/objectUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 import { cloneDeep } from 'lodash';
 
 /**
  * Safely sets a value on a nested object using a dot-notation path.
+ *
  * @param {object} obj The object to modify.
  * @param {string} path The dot-notation path (e.g., 'a.b.c').
  * @param {*} value The value to set at the path.
@@ -179,7 +180,7 @@ class ModifyContextArrayHandler {
     const resultForStorage = mode === 'pop' ? operationResult : finalArray;
 
     if (result_variable) {
-      storeResult(
+      setContextValue(
         result_variable,
         resultForStorage,
         executionContext,

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -23,7 +23,7 @@ import { safeDispatchError } from '../../utils/safeDispatchError.js';
  *   missing or an error occurs. Defaults to `undefined` if not provided.
  */
 
-import storeResult from '../../utils/contextVariableUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 class QueryComponentHandler {
   #entityManager;
@@ -151,8 +151,8 @@ class QueryComponentHandler {
 
       const valueToStore = result === undefined ? missing_value : result;
 
-      storeResult(
-        trimmedResultVariable,
+      setContextValue(
+        result_variable,
         valueToStore,
         executionContext,
         this.#dispatcher,
@@ -192,8 +192,8 @@ class QueryComponentHandler {
           resolvedEntityId: entityId,
         },
       });
-      const stored = storeResult(
-        trimmedResultVariable,
+      const stored = setContextValue(
+        result_variable,
         missing_value,
         executionContext,
         this.#dispatcher,

--- a/tests/utils/contextVariableUtils.test.js
+++ b/tests/utils/contextVariableUtils.test.js
@@ -1,5 +1,7 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import storeResult from '../../src/utils/contextVariableUtils.js';
+import storeResult, {
+  setContextValue,
+} from '../../src/utils/contextVariableUtils.js';
 import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
 
 describe('storeResult', () => {
@@ -55,5 +57,29 @@ describe('storeResult', () => {
       expect.any(Object)
     );
     expect(logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('setContextValue', () => {
+  test('trims variable name and stores value', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    const success = setContextValue('  myVar  ', 42, ctx, dispatcher, logger);
+    expect(success).toBe(true);
+    expect(ctx.evaluationContext.context.myVar).toBe(42);
+  });
+
+  test('returns false and dispatches error for invalid name', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = { warn: jest.fn() };
+    const success = setContextValue('   ', 1, ctx, dispatcher, logger);
+    expect(success).toBe(false);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    expect(Object.keys(ctx.evaluationContext.context)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- introduce `setContextValue` helper for context variable assignment
- update multiple operation handlers to use the new helper
- expand context variable utils test coverage

## Testing Done
- `npx prettier -w src/utils/contextVariableUtils.js src/logic/operationHandlers/queryComponentHandler.js src/logic/operationHandlers/hasComponentHandler.js src/logic/operationHandlers/mathHandler.js src/logic/operationHandlers/modifyContextArrayHandler.js src/logic/operationHandlers/modifyArrayFieldHandler.js src/logic/operationHandlers/checkFollowCycleHandler.js src/logic/operationHandlers/getNameHandler.js tests/utils/contextVariableUtils.test.js`
- `npm run lint` *(fails: many existing warnings & errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(proxy server start failed: missing express)*
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f06b511708331af7bfc68fa2939b1