### PR TITLE
[Refactor] Remove preposition parsing from CommandParser

### DIFF
--- a/tests/commands/commandParser.parse.basic.test.js
+++ b/tests/commands/commandParser.parse.basic.test.js
@@ -194,9 +194,9 @@ describe('CommandParser.parse() - Basic & Whitespace Tests', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key',
-      preposition: 'on',
-      indirectObjectPhrase: 'table',
+      directObjectPhrase: 'key on table',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -213,9 +213,9 @@ describe('CommandParser.parse() - Basic & Whitespace Tests', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:go',
-      directObjectPhrase: null, // No DO before preposition
-      preposition: '>',
-      indirectObjectPhrase: 'north',
+      directObjectPhrase: '> north',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };

--- a/tests/commands/commandParser.parse.direction.test.js
+++ b/tests/commands/commandParser.parse.direction.test.js
@@ -155,9 +155,9 @@ describe('CommandParser.parse() - Direction Handling Tests', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'book',
-      preposition: 'on',
-      indirectObjectPhrase: 'table',
+      directObjectPhrase: 'book on table',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -187,9 +187,9 @@ describe('CommandParser.parse() - Direction Handling Tests', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:take',
-      directObjectPhrase: 'note',
-      preposition: 'with',
-      indirectObjectPhrase: 'feather',
+      directObjectPhrase: 'note with feather',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };

--- a/tests/commands/commandParser.parse.originalInput.test.js
+++ b/tests/commands/commandParser.parse.originalInput.test.js
@@ -109,9 +109,9 @@ describe('CommandParser.parse() - Original Input Preservation Tests (Ticket 8)',
 
     // Optional: Verify the rest of the parsing for context
     expect(result.actionId).toBe('core:put'); // Verb matched case-insensitively
-    expect(result.directObjectPhrase).toBe('Key'); // DO preserves original case
-    expect(result.preposition).toBe('on'); // Preposition stored lowercase
-    expect(result.indirectObjectPhrase).toBe('Table'); // IO preserves original case
+    expect(result.directObjectPhrase).toBe('Key ON Table');
+    expect(result.preposition).toBeNull();
+    expect(result.indirectObjectPhrase).toBeNull();
     expect(result.error).toBeNull();
     expect(mockGetAllActionDefinitions).toHaveBeenCalledTimes(1);
   });

--- a/tests/commands/commandParser.parse.prepositionEdgeCases.test.js
+++ b/tests/commands/commandParser.parse.prepositionEdgeCases.test.js
@@ -101,9 +101,9 @@ describe('CommandParser.parse() - Preposition Handling Edge Cases', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:give',
-      directObjectPhrase: 'scroll',
-      preposition: 'to', // First supported preposition
-      indirectObjectPhrase: 'wizard with staff', // Remainder including "with"
+      directObjectPhrase: 'scroll to wizard with staff',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null, // Structurally valid
     };
@@ -121,9 +121,9 @@ describe('CommandParser.parse() - Preposition Handling Edge Cases', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null, // V+P+IO structure
-      preposition: 'at', // Matched case-insensitively, stored lowercase
-      indirectObjectPhrase: 'map',
+      directObjectPhrase: 'aT map',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null, // Structurally valid
     };
@@ -161,9 +161,9 @@ describe('CommandParser.parse() - Preposition Handling Edge Cases', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null,
-      preposition: 'on',
-      indirectObjectPhrase: 'table',
+      directObjectPhrase: 'on table',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -180,9 +180,9 @@ describe('CommandParser.parse() - Preposition Handling Edge Cases', () => {
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key',
-      preposition: 'on',
-      indirectObjectPhrase: null, // Missing IO
+      directObjectPhrase: 'key on',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };

--- a/tests/commands/commandParser.parse.prepositional.test.js
+++ b/tests/commands/commandParser.parse.prepositional.test.js
@@ -80,9 +80,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key',
-      preposition: 'in',
-      indirectObjectPhrase: 'box',
+      directObjectPhrase: 'key in box',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -101,9 +101,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'the blue gem',
-      preposition: 'on',
-      indirectObjectPhrase: 'stone altar',
+      directObjectPhrase: 'the blue gem on stone altar',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -123,9 +123,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null, // V+P+IO has null DO
-      preposition: 'at',
-      indirectObjectPhrase: 'door',
+      directObjectPhrase: 'at door',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -144,9 +144,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:go',
-      directObjectPhrase: null, // V+P+IO has null DO
-      preposition: '>',
-      indirectObjectPhrase: 'the dark cave',
+      directObjectPhrase: '> the dark cave',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -166,9 +166,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:use',
-      directObjectPhrase: 'key',
-      preposition: '>',
-      indirectObjectPhrase: 'lock',
+      directObjectPhrase: 'key > lock',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -188,9 +188,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:talk',
-      directObjectPhrase: 'guard',
-      preposition: 'with', // First preposition found
-      indirectObjectPhrase: 'helmet about task', // Remainder after 'with'
+      directObjectPhrase: 'guard with helmet about task',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -210,9 +210,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null, // V+P+IO has null DO
-      preposition: 'in', // First preposition found
-      indirectObjectPhrase: 'box with lid', // Remainder after 'in'
+      directObjectPhrase: 'in box with lid',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -232,9 +232,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null, // V+P structure
-      preposition: 'in',
-      indirectObjectPhrase: null, // IO is missing
+      directObjectPhrase: 'in',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -254,9 +254,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key',
-      preposition: 'on',
-      indirectObjectPhrase: null, // IO is missing
+      directObjectPhrase: 'key on',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -277,9 +277,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key', // Assumes internal spaces before prep are trimmed as part of DO
-      preposition: 'on',
-      indirectObjectPhrase: 'table', // Assumes leading spaces before IO are trimmed
+      directObjectPhrase: 'key   on   table',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -306,9 +306,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null,
-      preposition: 'at',
-      indirectObjectPhrase: 'door',
+      directObjectPhrase: 'at   door',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -331,9 +331,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:put',
-      directObjectPhrase: 'key',
-      preposition: 'with',
-      indirectObjectPhrase: null, // IO is missing
+      directObjectPhrase: 'key with',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };
@@ -349,9 +349,9 @@ describe('CommandParser.parse() - Prepositional Structure Tests (V+P+IO, V+DO+P+
     /** @type {ParsedCommand} */
     const expectedOutput = {
       actionId: 'core:look',
-      directObjectPhrase: null,
-      preposition: 'at',
-      indirectObjectPhrase: null, // IO is missing
+      directObjectPhrase: 'at',
+      preposition: null,
+      indirectObjectPhrase: null,
       originalInput: input,
       error: null,
     };


### PR DESCRIPTION
Summary: Simplified CommandParser by dropping legacy preposition handling and updating related tests.

Changes Made:
- Removed SUPPORTED_PREPOSITIONS logic and associated parsing code.
- Updated parse() to always return remaining text as direct object phrase.
- Adjusted tests for new parser behavior across all suites.

Testing Done:
- [x] Code formatted (`npm run format` in root and proxy)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684f0b74db8483318e769c62a04d1532