### PR TITLE
[Agent] Increase serviceInitializer test coverage

### DIFF
--- a/tests/utils/serviceInitializer.test.js
+++ b/tests/utils/serviceInitializer.test.js
@@ -93,6 +93,26 @@ describe('serviceInitializer utilities', () => {
         { requiredMethods: ['x'], isFunction: undefined }
       );
     });
+
+    it('does nothing when deps is falsy', () => {
+      validateServiceDeps('Svc', baseLogger, null);
+      expect(validateDependency).not.toHaveBeenCalled();
+    });
+
+    it('skips entries with falsy spec objects', () => {
+      const deps = {
+        a: null,
+        b: { value: {} },
+      };
+      validateServiceDeps('Svc', baseLogger, deps);
+      expect(validateDependency).toHaveBeenCalledTimes(1);
+      expect(validateDependency).toHaveBeenCalledWith(
+        deps.b.value,
+        'Svc: b',
+        baseLogger,
+        { requiredMethods: undefined, isFunction: undefined }
+      );
+    });
   });
 
   describe('setupService', () => {


### PR DESCRIPTION
## Summary
- extend serviceInitializer tests for missing branches

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f10b6ff3c83319107d16725bbebce