### PR TITLE
[Agent] implement reconstructEntity

### DIFF
--- a/src/interfaces/IEntityManager.js
+++ b/src/interfaces/IEntityManager.js
@@ -36,6 +36,17 @@ export class IEntityManager {
   }
 
   /**
+   * Reconstructs an entity instance from serialized persistence data.
+   *
+   * @param {{instanceId: string, definitionId: string, components: Record<string, any>}} serialized
+   *   Serialized representation produced by the save system.
+   * @returns {Entity | null} The reconstructed Entity instance or null on failure.
+   */
+  reconstructEntity(serialized) {
+    throw new Error('IEntityManager.reconstructEntity not implemented.');
+  }
+
+  /**
    * Retrieves the raw data object for a specific component type from an entity.
    *
    * @param {string} instanceId - The ID (UUID) of the entity.

--- a/tests/entities/entityManager.reconstructEntity.test.js
+++ b/tests/entities/entityManager.reconstructEntity.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import EntityManager from '../../src/entities/entityManager.js';
+import { POSITION_COMPONENT_ID } from '../../src/constants/componentIds.js';
+
+const makeStubs = () => {
+  const registry = { getEntityDefinition: jest.fn() };
+  const validator = { validate: jest.fn(() => ({ isValid: true })) };
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  const spatial = {
+    addEntity: jest.fn(),
+    removeEntity: jest.fn(),
+    updateEntityLocation: jest.fn(),
+    getEntitiesInLocation: jest.fn(() => new Set()),
+    buildIndex: jest.fn(),
+    clearIndex: jest.fn(),
+  };
+  return { registry, validator, logger, spatial };
+};
+
+describe('EntityManager.reconstructEntity', () => {
+  let stubs;
+  let manager;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+    manager = new EntityManager(
+      stubs.registry,
+      stubs.validator,
+      stubs.logger,
+      stubs.spatial
+    );
+  });
+
+  it('reconstructs entity and indexes position', () => {
+    const data = {
+      instanceId: 'e1',
+      definitionId: 'core:item',
+      components: {
+        [POSITION_COMPONENT_ID]: { x: 1, y: 2, locationId: 'loc1' },
+        'core:tag': { tag: 'a' },
+      },
+    };
+
+    const entity = manager.reconstructEntity(data);
+
+    expect(entity).not.toBeNull();
+    expect(manager.activeEntities.get('e1')).toBe(entity);
+    expect(stubs.spatial.addEntity).toHaveBeenCalledWith('e1', 'loc1');
+  });
+
+  it('returns null on validation failure', () => {
+    stubs.validator.validate.mockReturnValueOnce({
+      isValid: false,
+      errors: {},
+    });
+    const data = {
+      instanceId: 'e2',
+      definitionId: 'core:item',
+      components: { 'core:tag': { tag: 'b' } },
+    };
+
+    const entity = manager.reconstructEntity(data);
+
+    expect(entity).toBeNull();
+    expect(manager.activeEntities.has('e2')).toBe(false);
+    expect(stubs.spatial.addEntity).not.toHaveBeenCalled();
+    expect(stubs.logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement reconstructEntity in EntityManager
- expose reconstructEntity via IEntityManager interface
- add unit tests for reconstructEntity

## Testing Done
- [x] `npm run format`
- [ ] `npm run lint` *(fails: project has existing lint errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`
- [x] `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f0cd038f48331a0c8ed8d445dcba3