### PR TITLE
[Agent] Document mod manifest format

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ Complete operator list, context explanation, and many ready-made patterns.
 **Mod Manifest Loader Usage ➜ docs/mods/modManifestLoader.md**
 How to use the ModManifestLoader service and handle potential errors.
 
+**Mod Manifest Format ➜ docs/mods/mod_manifest_format.md**
+Details of every allowed field with a sample manifest.
+
 **Display Error Event Payload ➜ docs/events/display_error_payload.md**
 Overview of the payload structure emitted when dispatching `core:display_error` events.
 

--- a/docs/mods/loader.md
+++ b/docs/mods/loader.md
@@ -4,7 +4,7 @@ This document details aspects of how the Living Narrative Engine loads mods.
 
 ## Mod Manifests
 
-(Future content about `mod.manifest.json` structure and discovery might go here).
+See [Mod Manifest Format](mod_manifest_format.md) for details on every allowed field and an example manifest. The engine automatically discovers each `mod.manifest.json` within a mod's directory during startup.
 
 ## Dependency & Conflict Validation
 

--- a/docs/mods/mod_manifest_format.md
+++ b/docs/mods/mod_manifest_format.md
@@ -1,0 +1,62 @@
+# Mod Manifest Format
+
+Every mod requires a `mod.manifest.json` file describing its metadata and the content files it provides. The following fields are recognized:
+
+## `id` (required)
+
+Unique identifier for the mod. Case-insensitive for lookups and used as the namespace for its content.
+
+## `version` (required)
+
+Semantic version string of the mod (e.g., `"1.0.0"`).
+
+## `name` (required)
+
+Human-friendly display name.
+
+## `description`
+
+Optional short summary of what the mod does.
+
+## `author`
+
+Optional string naming the author or team.
+
+## `gameVersion`
+
+Optional [SemVer](https://semver.org/) range specifying compatible engine versions. If provided, the engine will refuse to load the mod when the running version falls outside this range or the value is not a valid range.
+
+## `dependencies`
+
+Optional array of objects declaring required mods. Each entry has:
+
+- `id`: ID of the dependency mod.
+- `version`: SemVer range that the dependency must satisfy.
+
+## `conflicts`
+
+Optional array of mod IDs that cannot be loaded alongside this mod.
+
+## `content`
+
+Object mapping content categories to arrays of JSON definition files. Paths are relative to the mod's root directory. Predefined categories include `actions`, `characters`, `components`, `items`, `locations`, `rules`, `macros`, and `events`. Additional categories are allowed for custom systems.
+
+### Sample Manifest
+
+```json
+{
+  "$schema": "http://example.com/schemas/mod.manifest.schema.json",
+  "id": "ExampleMod",
+  "version": "1.0.0",
+  "name": "Example Mod",
+  "description": "Adds sample items and characters.",
+  "author": "ACME Studios",
+  "gameVersion": ">=1.0.0",
+  "dependencies": [{ "id": "core", "version": ">=1.0.0" }],
+  "conflicts": ["OldExampleMod"],
+  "content": {
+    "characters": ["hero.character.json"],
+    "locations": ["town.location.json"]
+  }
+}
+```


### PR DESCRIPTION
Summary: Added documentation for the `mod.manifest.json` format, including a sample manifest. Linked the new guide from `README.md` and `docs/mods/loader.md`.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npx eslint README.md docs/mods/loader.md docs/mods/mod_manifest_format.md`
- [x] Root tests         `npm test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f11112ec88331b1c8e5b67def1986