### PR TITLE
[Agent] Add mod creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,15 @@ checks declared dependencies and conflicts, and verifies that all content files
 conform to their JSON schemas. If any problems are found they will be printed to
 the console; otherwise you will see **“All mods passed validation.”**
 
+### Creating a New Mod
+
+To scaffold a new mod directory with a starter `mod.manifest.json` run:
+
+    npm run create-mod -- <modId>
+
+Replace `<modId>` with your desired identifier. The script creates
+`data/mods/<modId>/` and populates a minimal manifest you can edit further.
+
 ### Documentation ▶️
 
 **JSON Logic – Composite Operators ➜ docs/json-logic/composite-logical-operators.md**  

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test": "jest --env=jsdom --updateSnapshot --silent --coverage",
     "test:single": "jest --env=jsdom --updateSnapshot",
     "validate-mods": "node scripts/validateMods.mjs",
+    "create-mod": "node scripts/createMod.mjs",
     "build": "esbuild src/main.js --bundle --outfile=dist/bundle.js --platform=browser --sourcemap && cpy index.html dist && cpy css dist && cpy data dist && cpy config dist && cpy favicon.ico dist",
     "start": "npm run build && http-server dist -o",
     "start:all": "concurrently \"npm run start\" \"npm run start --prefix llm-proxy-server\"",

--- a/scripts/createMod.mjs
+++ b/scripts/createMod.mjs
@@ -1,0 +1,55 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import StaticConfiguration from '../src/configuration/staticConfiguration.js';
+
+/**
+ * Creates a new mod directory with a starter manifest file.
+ *
+ * @param {string} modId - The ID of the mod to create.
+ * @param {object} [options] - Optional settings.
+ * @param {string} [options.baseDir] - Override base data directory.
+ * @returns {Promise<void>} Resolves when creation is complete.
+ */
+export async function createMod(modId, options = {}) {
+  if (typeof modId !== 'string' || !(modId = modId.trim())) {
+    throw new Error('modId must be a non-empty string');
+  }
+
+  const config = new StaticConfiguration();
+  if (options.baseDir) {
+    config.getBaseDataPath = () => options.baseDir;
+  }
+
+  const modsDir = path.join(config.getBaseDataPath(), config.getModsBasePath());
+  const modDir = path.join(modsDir, modId);
+  await fs.mkdir(modDir, { recursive: true });
+
+  const manifestPath = path.join(modDir, config.getModManifestFilename());
+  const manifest = {
+    $schema: 'http://example.com/schemas/mod.manifest.schema.json',
+    id: modId,
+    version: '1.0.0',
+    name: modId,
+    content: {},
+  };
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(manifest, null, 2) + '\n',
+    'utf8'
+  );
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const id = process.argv[2];
+  if (!id) {
+    console.error('Usage: node scripts/createMod.mjs <modId>');
+    process.exitCode = 1;
+  } else {
+    createMod(id, { baseDir: process.env.BASE_DATA_PATH }).catch((err) => {
+      console.error(err.message);
+      process.exitCode = 1;
+    });
+  }
+}

--- a/tests/scripts/createMod.test.js
+++ b/tests/scripts/createMod.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+let tempDir;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lne-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('createMod script', () => {
+  test('creates directory and manifest', async () => {
+    const modId = 'testmod';
+    await execFileAsync('node', ['scripts/createMod.mjs', modId], {
+      env: { ...process.env, BASE_DATA_PATH: tempDir },
+    });
+    const modDir = path.join(tempDir, 'mods', modId);
+    const manifestPath = path.join(modDir, 'mod.manifest.json');
+    const stat = await fs.stat(manifestPath);
+    expect(stat.isFile()).toBe(true);
+    const data = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    expect(data.id).toBe(modId);
+    expect(data.name).toBe(modId);
+  });
+
+  test('throws for blank modId', async () => {
+    await expect(
+      execFileAsync('node', ['scripts/createMod.mjs', '  '], {
+        env: { ...process.env, BASE_DATA_PATH: tempDir },
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Summary: Added a CLI script to scaffold a mod directory with a starter manifest. Updated package.json with a convenient npm command and documented usage in README. Introduced Jest tests verifying the script's functionality.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npx eslint scripts/createMod.mjs tests/scripts/createMod.test.js --fix`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f113139a0833183b48cc8086aa7c0