### PR TITLE
[Agent] Remove unused _handleSlotNavigation override

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -415,16 +415,6 @@ class LoadGameUI extends SlotModalBase {
   }
 
   /**
-   * Keyboard navigation handler for the save slot list.
-   *
-   * @param {KeyboardEvent} event - The key event.
-   * @private
-   */
-  _handleSlotNavigation(event) {
-    super._handleSlotNavigation(event);
-  }
-
-  /**
    * Handles the "Load" button click.
    *
    * @private


### PR DESCRIPTION
Summary:
- remove redundant `_handleSlotNavigation` from `LoadGameUI`

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f15c85a588331a05910cda6e8e0d5