### PR TITLE
[Agent] Add PromptTextLoader

### DIFF
--- a/src/loaders/promptTextLoader.js
+++ b/src/loaders/promptTextLoader.js
@@ -1,0 +1,112 @@
+// src/loaders/promptTextLoader.js
+
+/**
+ * @file Loader for the core prompt text used by the AI system.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
+/** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
+/** @typedef {import('../interfaces/coreServices.js').IDataFetcher} IDataFetcher */
+/** @typedef {import('../interfaces/coreServices.js').ISchemaValidator} ISchemaValidator */
+/** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+
+import AbstractLoader from './abstractLoader.js';
+
+/**
+ * Handles loading and validation of the game's core prompt text file.
+ *
+ * @class PromptTextLoader
+ * @augments AbstractLoader
+ */
+class PromptTextLoader extends AbstractLoader {
+  #configuration;
+  #pathResolver;
+  #dataFetcher;
+  #schemaValidator;
+  #dataRegistry;
+
+  /**
+   * Creates a new PromptTextLoader instance.
+   *
+   * @param {object} deps - Dependency injection object.
+   * @param {IConfiguration} deps.configuration - Configuration service.
+   * @param {IPathResolver} deps.pathResolver - Path resolver service.
+   * @param {IDataFetcher} deps.dataFetcher - Data fetching service.
+   * @param {ISchemaValidator} deps.schemaValidator - Schema validator service.
+   * @param {IDataRegistry} deps.dataRegistry - Data registry service.
+   * @param {ILogger} deps.logger - Logger service.
+   */
+  constructor({
+    configuration,
+    pathResolver,
+    dataFetcher,
+    schemaValidator,
+    dataRegistry,
+    logger,
+  }) {
+    super(logger, [
+      {
+        dependency: configuration,
+        name: 'IConfiguration',
+        methods: ['getContentTypeSchemaId'],
+      },
+      {
+        dependency: pathResolver,
+        name: 'IPathResolver',
+        methods: ['resolveContentPath'],
+      },
+      { dependency: dataFetcher, name: 'IDataFetcher', methods: ['fetch'] },
+      {
+        dependency: schemaValidator,
+        name: 'ISchemaValidator',
+        methods: ['validate'],
+      },
+      { dependency: dataRegistry, name: 'IDataRegistry', methods: ['store'] },
+    ]);
+
+    this.#configuration = configuration;
+    this.#pathResolver = pathResolver;
+    this.#dataFetcher = dataFetcher;
+    this.#schemaValidator = schemaValidator;
+    this.#dataRegistry = dataRegistry;
+  }
+
+  /**
+   * Loads the core prompt text, validates it against the configured schema, and stores it in the registry.
+   *
+   * @returns {Promise<object>} The validated prompt text object.
+   * @public
+   * @async
+   */
+  async loadPromptText() {
+    const filePath = this.#pathResolver.resolveContentPath(
+      'prompts',
+      'corePromptText.json'
+    );
+    this._logger.debug(
+      `PromptTextLoader: Loading prompt text from ${filePath}.`
+    );
+
+    const data = await this.#dataFetcher.fetch(filePath);
+
+    const schemaId = this.#configuration.getContentTypeSchemaId('prompt-text');
+    const validationResult = this.#schemaValidator.validate(schemaId, data);
+    if (!validationResult.isValid) {
+      this._logger.error(
+        `PromptTextLoader: Validation failed for ${filePath} using schema '${schemaId}'.`,
+        { errors: validationResult.errors }
+      );
+      throw new Error('Prompt text validation failed.');
+    }
+
+    this.#dataRegistry.store('prompt_text', 'core', data);
+    this._logger.debug(
+      'PromptTextLoader: Stored prompt text under type \u2018prompt_text\u2019 with id \u2018core\u2019.'
+    );
+
+    return data;
+  }
+}
+
+export default PromptTextLoader;

--- a/tests/loaders/promptTextLoader.test.js
+++ b/tests/loaders/promptTextLoader.test.js
@@ -1,0 +1,104 @@
+// tests/loaders/promptTextLoader.test.js
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import PromptTextLoader from '../../src/loaders/promptTextLoader.js';
+
+/** @typedef {import('../../src/interfaces/coreServices.js').IConfiguration} IConfiguration */
+/** @typedef {import('../../src/interfaces/coreServices.js').IPathResolver} IPathResolver */
+/** @typedef {import('../../src/interfaces/coreServices.js').IDataFetcher} IDataFetcher */
+/** @typedef {import('../../src/interfaces/coreServices.js').ISchemaValidator} ISchemaValidator */
+/** @typedef {import('../../src/interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../../src/interfaces/coreServices.js').ILogger} ILogger */
+
+const createMockConfiguration = (overrides = {}) => ({
+  getContentTypeSchemaId: jest
+    .fn()
+    .mockReturnValue('http://example.com/schemas/prompt-text.schema.json'),
+  ...overrides,
+});
+
+const createMockPathResolver = (overrides = {}) => ({
+  resolveContentPath: jest.fn(() => '/path/prompts/corePromptText.json'),
+  ...overrides,
+});
+
+const createMockDataFetcher = (overrides = {}) => ({
+  fetch: jest.fn().mockResolvedValue({ example: true }),
+  ...overrides,
+});
+
+const createMockSchemaValidator = (overrides = {}) => ({
+  validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
+  ...overrides,
+});
+
+const createMockDataRegistry = (overrides = {}) => ({
+  store: jest.fn(),
+  ...overrides,
+});
+
+const createMockLogger = (overrides = {}) => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  ...overrides,
+});
+
+/** @type {IConfiguration} */
+let configuration;
+/** @type {IPathResolver} */
+let pathResolver;
+/** @type {IDataFetcher} */
+let dataFetcher;
+/** @type {ISchemaValidator} */
+let schemaValidator;
+/** @type {IDataRegistry} */
+let dataRegistry;
+/** @type {ILogger} */
+let logger;
+/** @type {PromptTextLoader} */
+let loader;
+
+beforeEach(() => {
+  configuration = createMockConfiguration();
+  pathResolver = createMockPathResolver();
+  dataFetcher = createMockDataFetcher();
+  schemaValidator = createMockSchemaValidator();
+  dataRegistry = createMockDataRegistry();
+  logger = createMockLogger();
+
+  loader = new PromptTextLoader({
+    configuration,
+    pathResolver,
+    dataFetcher,
+    schemaValidator,
+    dataRegistry,
+    logger,
+  });
+});
+
+describe('PromptTextLoader', () => {
+  it('loads, validates, stores, and returns the prompt text', async () => {
+    const result = await loader.loadPromptText();
+
+    expect(pathResolver.resolveContentPath).toHaveBeenCalledWith(
+      'prompts',
+      'corePromptText.json'
+    );
+    expect(dataFetcher.fetch).toHaveBeenCalledWith(
+      '/path/prompts/corePromptText.json'
+    );
+    expect(configuration.getContentTypeSchemaId).toHaveBeenCalledWith(
+      'prompt-text'
+    );
+    expect(schemaValidator.validate).toHaveBeenCalledWith(
+      'http://example.com/schemas/prompt-text.schema.json',
+      { example: true }
+    );
+    expect(dataRegistry.store).toHaveBeenCalledWith('prompt_text', 'core', {
+      example: true,
+    });
+    expect(result).toEqual({ example: true });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `PromptTextLoader` to fetch and validate core prompt text
- add matching Jest tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm run test` *(fails coverage threshold)*
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f1640dec88331aa2e45cc42f1b022