### PR TITLE
[Agent] use setContextValue for context writes

### DIFF
--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -3,6 +3,8 @@
  * @see src/logic/operationHandlers/getTimestampHandler.js
  */
 
+import { setContextValue } from '../../utils/contextVariableUtils.js';
+
 class GetTimestampHandler {
   #logger;
 
@@ -13,10 +15,17 @@ class GetTimestampHandler {
 
   execute(params, execCtx) {
     const rv = params.result_variable.trim();
-    execCtx.evaluationContext.context[rv] = new Date().toISOString();
-    this.#logger.debug(
-      `GET_TIMESTAMP → ${rv} = ${execCtx.evaluationContext.context[rv]}`
+    const timestamp = new Date().toISOString();
+    const stored = setContextValue(
+      rv,
+      timestamp,
+      execCtx,
+      undefined,
+      this.#logger
     );
+    if (stored) {
+      this.#logger.debug(`GET_TIMESTAMP → ${rv} = ${timestamp}`);
+    }
   }
 }
 

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -11,6 +11,7 @@
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import BaseOperationHandler from './baseOperationHandler.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /**
  * @class QueryEntitiesHandler
@@ -215,8 +216,14 @@ class QueryEntitiesHandler extends BaseOperationHandler {
     }
 
     const resultVariable = params.result_variable;
-    if (executionContext?.evaluationContext?.context) {
-      executionContext.evaluationContext.context[resultVariable] = finalIds;
+    const stored = setContextValue(
+      resultVariable,
+      finalIds,
+      executionContext,
+      this.#dispatcher,
+      log
+    );
+    if (stored) {
       log.debug(
         `QUERY_ENTITIES: Stored ${finalIds.length} entity IDs in context variable "${resultVariable}".`
       );

--- a/src/logic/operationHandlers/resolveDirectionHandler.js
+++ b/src/logic/operationHandlers/resolveDirectionHandler.js
@@ -3,6 +3,8 @@
  * @see src/logic/operationHandlers/resolveDirectionHandler.js
  */
 
+import { setContextValue } from '../../utils/contextVariableUtils.js';
+
 class ResolveDirectionHandler {
   #worldContext;
   #logger;
@@ -38,8 +40,16 @@ class ResolveDirectionHandler {
     });
 
     const trimmedVar = result_variable.trim();
-    execCtx.evaluationContext.context[trimmedVar] = target;
-    this.#logger.debug(`RESOLVE_DIRECTION → ${trimmedVar} = ${target}`);
+    const stored = setContextValue(
+      trimmedVar,
+      target,
+      execCtx,
+      undefined,
+      this.#logger
+    );
+    if (stored) {
+      this.#logger.debug(`RESOLVE_DIRECTION → ${trimmedVar} = ${target}`);
+    }
   }
 }
 

--- a/src/logic/operationHandlers/setVariableHandler.js
+++ b/src/logic/operationHandlers/setVariableHandler.js
@@ -11,6 +11,7 @@
 // <<< ADDED Import: jsonLogic directly >>>
 import jsonLogic from 'json-logic-js';
 import { assertParamsObject } from '../../utils/handlerUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 /**
  * Parameters expected by the SetVariableHandler#execute method.
@@ -259,22 +260,20 @@ class SetVariableHandler {
       `SET_VARIABLE: Setting context variable "${trimmedVariableName}" in evaluationContext.context to value: ${finalValueStringForLog}`
     );
 
-    try {
-      // Assign the final determined value to the correct context (variableStore)
-      variableStore[trimmedVariableName] = finalValue;
-    } catch (assignmentError) {
+    const stored = setContextValue(
+      trimmedVariableName,
+      finalValue,
+      executionContext,
+      undefined,
+      logger
+    );
+    if (!stored) {
       logger.error(
         `SET_VARIABLE: Unexpected error during assignment for variable "${trimmedVariableName}" into evaluationContext.context.`,
         {
-          error:
-            assignmentError instanceof Error
-              ? assignmentError.message
-              : String(assignmentError),
           variableName: trimmedVariableName,
-          // Do not log finalValue again if it's complex and caused stringify issues above
         }
       );
-      // Depending on desired behavior, you might want to re-throw or simply return here
     }
   }
 }

--- a/tests/logic/operationHandlers/getTimestampHandler.test.js
+++ b/tests/logic/operationHandlers/getTimestampHandler.test.js
@@ -159,7 +159,7 @@ describe('GetTimestampHandler', () => {
       );
     });
 
-    test('should throw a TypeError if the execution context is malformed', () => {
+    test('should handle a malformed execution context gracefully', () => {
       // Arrange
       const params = { result_variable: 'any_var' };
       const malformedExecCtx = {
@@ -168,10 +168,11 @@ describe('GetTimestampHandler', () => {
         },
       };
 
-      // Act & Assert
-      expect(() => handler.execute(params, malformedExecCtx)).toThrow(
-        "Cannot set properties of undefined (setting 'any_var')"
-      );
+      // Act
+      expect(() => handler.execute(params, malformedExecCtx)).not.toThrow();
+
+      // Assert
+      expect(mockLogger.debug).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Summary: Replace direct context assignments with `setContextValue` util and update affected tests.

Changes Made:
- Updated queryEntities, resolveDirection, getTimestamp, and setVariable handlers to use `setContextValue`.
- Adjusted malformed context test for GetTimestampHandler.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on touched files (`npx eslint src/logic/operationHandlers/queryEntitiesHandler.js src/logic/operationHandlers/resolveDirectionHandler.js src/logic/operationHandlers/getTimestampHandler.js src/logic/operationHandlers/setVariableHandler.js --fix`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_684f15facf348331b27ddc90520628d4