### PR TITLE
[Agent] Introduce _subscribe helper for UI

### DIFF
--- a/src/domUI/actionButtonsRenderer.js
+++ b/src/domUI/actionButtonsRenderer.js
@@ -183,14 +183,12 @@ export class ActionButtonsRenderer extends BaseListDisplayComponent {
       );
     }
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        this._EVENT_TYPE_SUBSCRIBED,
-        this.#handleUpdateActions.bind(this)
-      )
+    this._subscribe(
+      this._EVENT_TYPE_SUBSCRIBED,
+      this.#handleUpdateActions.bind(this)
     );
     this.logger.debug(
-      `${this._logPrefix} Subscribed to VED event '${this._EVENT_TYPE_SUBSCRIBED}' via _addSubscription.`
+      `${this._logPrefix} Subscribed to VED event '${this._EVENT_TYPE_SUBSCRIBED}' via _subscribe.`
     );
   }
 

--- a/src/domUI/actionResultRenderer.js
+++ b/src/domUI/actionResultRenderer.js
@@ -111,18 +111,14 @@ export class ActionResultRenderer extends BoundDomRendererBase {
    * @private
    */
   #subscribeToEvents() {
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        'core:display_successful_action_result',
-        this.#handleSuccess.bind(this)
-      )
+    this._subscribe(
+      'core:display_successful_action_result',
+      this.#handleSuccess.bind(this)
     );
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        'core:display_failed_action_result',
-        this.#handleFailure.bind(this)
-      )
+    this._subscribe(
+      'core:display_failed_action_result',
+      this.#handleFailure.bind(this)
     );
 
     this.logger.debug(

--- a/src/domUI/chatAlertRenderer.js
+++ b/src/domUI/chatAlertRenderer.js
@@ -123,18 +123,8 @@ export class ChatAlertRenderer extends BoundDomRendererBase {
     }
 
     // --- Event Subscriptions ---
-    this._addSubscription(
-      this.#safeEventDispatcher.subscribe(
-        'core:display_warning',
-        this.#handleWarning.bind(this)
-      )
-    );
-    this._addSubscription(
-      this.#safeEventDispatcher.subscribe(
-        'core:display_error',
-        this.#handleError.bind(this)
-      )
-    );
+    this._subscribe('core:display_warning', this.#handleWarning.bind(this));
+    this._subscribe('core:display_error', this.#handleError.bind(this));
 
     this.logger.debug(`${this._logPrefix} Initialized.`);
   }

--- a/src/domUI/currentTurnActorRenderer.js
+++ b/src/domUI/currentTurnActorRenderer.js
@@ -91,13 +91,8 @@ export class CurrentTurnActorRenderer extends BoundDomRendererBase {
     this.#resetPanel(); // Initialize to default state
 
     try {
-      // Use _addSubscription from RendererBase (via BoundDomRendererBase)
-      this._addSubscription(
-        this.validatedEventDispatcher.subscribe(
-          TURN_STARTED_ID,
-          this.handleTurnStarted.bind(this)
-        )
-      );
+      // Subscribe using helper method
+      this._subscribe(TURN_STARTED_ID, this.handleTurnStarted.bind(this));
       this.logger.debug(
         `${this._logPrefix} Initialized and subscribed to ${TURN_STARTED_ID}.`
       );

--- a/src/domUI/inputStateController.js
+++ b/src/domUI/inputStateController.js
@@ -91,14 +91,10 @@ export class InputStateController extends RendererBase {
   #subscribeToEvents() {
     const ved = this.validatedEventDispatcher; // Alias for brevity
 
-    // Use _addSubscription from RendererBase
-    this._addSubscription(
-      ved.subscribe('core:disable_input', this.#handleDisableInput.bind(this))
-    );
+    // Subscribe to events using helper
+    this._subscribe('core:disable_input', this.#handleDisableInput.bind(this));
 
-    this._addSubscription(
-      ved.subscribe('core:enable_input', this.#handleEnableInput.bind(this))
-    );
+    this._subscribe('core:enable_input', this.#handleEnableInput.bind(this));
 
     this.logger.debug(
       `${this._logPrefix} Subscribed to VED events 'core:disable_input' and 'core:enable_input'.`

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -179,11 +179,9 @@ export class LocationRenderer extends BoundDomRendererBase {
       // Depending on strictness, you might throw an error or allow graceful degradation.
     }
 
-    this._addSubscription(
-      this.safeEventDispatcher.subscribe(
-        this._EVENT_TYPE_SUBSCRIBED,
-        this.#handleTurnStarted.bind(this)
-      )
+    this._subscribe(
+      this._EVENT_TYPE_SUBSCRIBED,
+      this.#handleTurnStarted.bind(this)
     );
     this.logger.debug(
       `${this._logPrefix} Subscribed to VED event '${this._EVENT_TYPE_SUBSCRIBED}'.`

--- a/src/domUI/perceptionLogRenderer.js
+++ b/src/domUI/perceptionLogRenderer.js
@@ -114,12 +114,7 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
 
     this.#currentActorId = null;
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        TURN_STARTED_ID,
-        this.#handleTurnStarted.bind(this)
-      )
-    );
+    this._subscribe(TURN_STARTED_ID, this.#handleTurnStarted.bind(this));
     this.logger.debug(
       `${this._logPrefix} Subscribed to VED event '${TURN_STARTED_ID}'.`
     );

--- a/src/domUI/processingIndicatorController.js
+++ b/src/domUI/processingIndicatorController.js
@@ -186,20 +186,14 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
    */
   #subscribeToEvents() {
     // AI Processing Indicator
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(AI_TURN_PROCESSING_STARTED, () =>
-        this.#showIndicator('ai')
-      )
+    this._subscribe(AI_TURN_PROCESSING_STARTED, () =>
+      this.#showIndicator('ai')
     );
     this.logger.debug(
       `${this._logPrefix} Subscribed to ${AI_TURN_PROCESSING_STARTED}.`
     );
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(AI_TURN_PROCESSING_ENDED, () =>
-        this.#hideIndicator('ai')
-      )
-    );
+    this._subscribe(AI_TURN_PROCESSING_ENDED, () => this.#hideIndicator('ai'));
     this.logger.debug(
       `${this._logPrefix} Subscribed to ${AI_TURN_PROCESSING_ENDED}.`
     );
@@ -219,11 +213,9 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
       );
     }
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        PLAYER_TURN_SUBMITTED_ID,
-        () => this.#hideIndicator('player_input') // Hide player input indicator on submit
-      )
+    this._subscribe(
+      PLAYER_TURN_SUBMITTED_ID,
+      () => this.#hideIndicator('player_input') // Hide player input indicator on submit
     );
     this.logger.debug(
       `${this._logPrefix} Subscribed to ${PLAYER_TURN_SUBMITTED_ID} for hiding player indicator.`

--- a/src/domUI/rendererBase.js
+++ b/src/domUI/rendererBase.js
@@ -130,6 +130,22 @@ export class RendererBase {
   }
 
   /**
+   * Subscribes to an event via {@link IValidatedEventDispatcher#subscribe} and
+   * automatically tracks the unsubscribe function for disposal.
+   *
+   * @protected
+   * @param {string} eventName - The event name to subscribe to.
+   * @param {Function} handler - The event handler to invoke.
+   * @returns {(() => void) | { unsubscribe: Function } | undefined} The value
+   *  returned by `subscribe`, typically an unsubscribe function or object.
+   */
+  _subscribe(eventName, handler) {
+    const unsub = this.validatedEventDispatcher.subscribe(eventName, handler);
+    this._addSubscription(unsub);
+    return unsub;
+  }
+
+  /**
    * Adds a DOM event listener and stores its details for automatic removal on dispose.
    * The component should provide a pre-bound handler if its `this` context is needed.
    *

--- a/src/domUI/speechBubbleRenderer.js
+++ b/src/domUI/speechBubbleRenderer.js
@@ -100,12 +100,7 @@ export class SpeechBubbleRenderer extends BoundDomRendererBase {
       this.effectiveSpeechContainer = null;
     }
 
-    this._addSubscription(
-      this.validatedEventDispatcher.subscribe(
-        DISPLAY_SPEECH_ID,
-        this.#onDisplaySpeech.bind(this)
-      )
-    );
+    this._subscribe(DISPLAY_SPEECH_ID, this.#onDisplaySpeech.bind(this));
     this.logger.debug(
       `${this._logPrefix} Initialized and subscribed to ${DISPLAY_SPEECH_ID}.`
     );

--- a/src/domUI/titleRenderer.js
+++ b/src/domUI/titleRenderer.js
@@ -77,91 +77,66 @@ export class TitleRenderer extends RendererBase {
     const ved = this.validatedEventDispatcher; // Alias for brevity
 
     // Direct title setting
-    this._addSubscription(
-      ved.subscribe('core:set_title', this.#handleSetTitle.bind(this))
-    );
+    this._subscribe('core:set_title', this.#handleSetTitle.bind(this));
 
     // Initialization Events
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:initialization_service:completed',
-        this.#handleInitializationCompleted.bind(this)
-      )
+    this._subscribe(
+      'initialization:initialization_service:completed',
+      this.#handleInitializationCompleted.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:initialization_service:failed',
-        this.#handleInitializationFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:initialization_service:failed',
+      this.#handleInitializationFailed.bind(this)
     );
 
     // Initialization Steps Started
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:world_loader:started',
-        this.#handleInitializationStepStarted.bind(this)
-      )
+    this._subscribe(
+      'initialization:world_loader:started',
+      this.#handleInitializationStepStarted.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:system_initializer:started',
-        this.#handleInitializationStepStarted.bind(this)
-      )
+    this._subscribe(
+      'initialization:system_initializer:started',
+      this.#handleInitializationStepStarted.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:game_state_initializer:started',
-        this.#handleInitializationStepStarted.bind(this)
-      )
+    this._subscribe(
+      'initialization:game_state_initializer:started',
+      this.#handleInitializationStepStarted.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:world_initializer:started',
-        this.#handleInitializationStepStarted.bind(this)
-      )
+    this._subscribe(
+      'initialization:world_initializer:started',
+      this.#handleInitializationStepStarted.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:input_setup_service:started',
-        this.#handleInitializationStepStarted.bind(this)
-      )
+    this._subscribe(
+      'initialization:input_setup_service:started',
+      this.#handleInitializationStepStarted.bind(this)
     );
 
     // Initialization Steps Failed
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:world_loader:failed',
-        this.#handleInitializationStepFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:world_loader:failed',
+      this.#handleInitializationStepFailed.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:system_initializer:failed',
-        this.#handleInitializationStepFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:system_initializer:failed',
+      this.#handleInitializationStepFailed.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:game_state_initializer:failed',
-        this.#handleInitializationStepFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:game_state_initializer:failed',
+      this.#handleInitializationStepFailed.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:world_initializer:failed',
-        this.#handleInitializationStepFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:world_initializer:failed',
+      this.#handleInitializationStepFailed.bind(this)
     );
-    this._addSubscription(
-      ved.subscribe(
-        'initialization:input_setup_service:failed',
-        this.#handleInitializationStepFailed.bind(this)
-      )
+    this._subscribe(
+      'initialization:input_setup_service:failed',
+      this.#handleInitializationStepFailed.bind(this)
     );
 
     // System Fatal Error (Could also trigger title change)
-    this._addSubscription(
-      ved.subscribe(SYSTEM_ERROR_OCCURRED_ID, this.#handleFatalError.bind(this))
+    this._subscribe(
+      SYSTEM_ERROR_OCCURRED_ID,
+      this.#handleFatalError.bind(this)
     );
 
     this.logger.debug(

--- a/tests/domUI/actionButtonsRenderer.constructor.test.js
+++ b/tests/domUI/actionButtonsRenderer.constructor.test.js
@@ -231,7 +231,7 @@ describe('ActionButtonsRenderer', () => {
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
-          "[ActionButtonsRenderer] Subscribed to VED event 'core:update_available_actions' via _addSubscription."
+          "[ActionButtonsRenderer] Subscribed to VED event 'core:update_available_actions' via _subscribe."
         )
       );
     });

--- a/tests/domUI/actionButtonsRenderer.eventHandling.test.js
+++ b/tests/domUI/actionButtonsRenderer.eventHandling.test.js
@@ -387,7 +387,7 @@ describe('ActionButtonsRenderer', () => {
     expect(capturedEventHandler).toBeInstanceOf(Function);
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        `${CLASS_PREFIX} Subscribed to VED event 'core:update_available_actions' via _addSubscription.`
+        `${CLASS_PREFIX} Subscribed to VED event 'core:update_available_actions' via _subscribe.`
       )
     );
   });


### PR DESCRIPTION
Summary: Adds a protected `_subscribe` helper to `RendererBase` so subclasses can easily register and track VED subscriptions. Updated all UI renderers to use this new method and adjusted related tests.

Changes Made:
- Implemented `_subscribe` in `src/domUI/rendererBase.js`.
- Refactored all renderer subclasses to replace direct `subscribe` calls with `_subscribe`.
- Updated debug log wording in `ActionButtonsRenderer` and updated its tests accordingly.
- Ensured formatting and ran all test suites for root and proxy projects.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684f15d4e18c83318347b7f96d958f48