### PR TITLE
[Agent] add slot data formatter

### DIFF
--- a/src/domUI/helpers/slotDataFormatter.js
+++ b/src/domUI/helpers/slotDataFormatter.js
@@ -1,0 +1,64 @@
+/**
+ * @file Utility for formatting save file metadata for UI slot rendering.
+ */
+
+import { formatPlaytime, formatTimestamp } from '../../utils/textUtils.js';
+
+/** @typedef {import('../interfaces/ISaveLoadService.js').SaveFileMetadata} SaveFileMetadata */
+
+/**
+ * @typedef {object} SlotItemMetadata
+ * @property {string} name - Display name for the slot.
+ * @property {string} timestamp - Timestamp label for the slot.
+ * @property {string} playtime - Playtime label for the slot.
+ * @property {boolean} isEmpty - Whether the slot is empty.
+ * @property {boolean} isCorrupted - Whether the slot is corrupted.
+ */
+
+/**
+ * @description Converts a {@link SaveFileMetadata} record into the metadata object
+ * expected by {@link renderSlotItem}.
+ * @param {SaveFileMetadata} metadata - Save file metadata to convert.
+ * @returns {SlotItemMetadata} Formatted slot item metadata.
+ */
+export function formatSaveFileMetadata(metadata) {
+  const name = metadata.saveName || metadata.identifier;
+  let timestamp = '';
+  if (
+    metadata.timestamp &&
+    metadata.timestamp !== 'N/A' &&
+    !metadata.isCorrupted
+  ) {
+    const formatted = formatTimestamp(metadata.timestamp);
+    timestamp = `Saved: ${formatted}`;
+  } else if (metadata.isCorrupted) {
+    timestamp = 'Timestamp: N/A';
+  }
+
+  const playtime = !metadata.isCorrupted
+    ? `Playtime: ${formatPlaytime(metadata.playtimeSeconds)}`
+    : '';
+
+  return {
+    name,
+    timestamp,
+    playtime,
+    isEmpty: false,
+    isCorrupted: !!metadata.isCorrupted,
+  };
+}
+
+/**
+ * @description Creates metadata representing an empty slot.
+ * @param {string} name - Name label for the empty slot.
+ * @returns {SlotItemMetadata} Metadata for an empty slot.
+ */
+export function formatEmptySlot(name) {
+  return {
+    name,
+    timestamp: '',
+    playtime: '',
+    isEmpty: true,
+    isCorrupted: false,
+  };
+}

--- a/tests/domUI/loadGameUI.test.js
+++ b/tests/domUI/loadGameUI.test.js
@@ -2,6 +2,7 @@ import { JSDOM } from 'jsdom';
 import { LoadGameUI } from '../../src/domUI/index.js';
 import DomElementFactory from '../../src/domUI/domElementFactory.js';
 import * as renderSlotItemModule from '../../src/domUI/helpers/renderSlotItem.js';
+import { formatSaveFileMetadata } from '../../src/domUI/helpers/slotDataFormatter.js';
 import {
   beforeEach,
   afterEach,
@@ -110,6 +111,7 @@ describe('LoadGameUI basic behaviors', () => {
     const result = await loadGameUI._getLoadSlotsData();
 
     expect(result.map((s) => s.identifier)).toEqual(['b', 'a', 'c']);
+    expect(result[0].slotItemMeta).toEqual(formatSaveFileMetadata(result[0]));
     expect(loadGameUI.currentSlotsDisplayData).toEqual(result);
   });
 

--- a/tests/domUI/saveGameUI.test.js
+++ b/tests/domUI/saveGameUI.test.js
@@ -5,6 +5,10 @@ import { JSDOM } from 'jsdom';
 import { SaveGameUI } from '../../src/domUI/index.js'; // Adjust path if necessary
 import DomElementFactory from '../../src/domUI/domElementFactory.js';
 import * as renderSlotItemModule from '../../src/domUI/helpers/renderSlotItem.js';
+import {
+  formatSaveFileMetadata,
+  formatEmptySlot,
+} from '../../src/domUI/helpers/slotDataFormatter.js';
 
 import {
   afterEach,
@@ -172,6 +176,33 @@ describe('SaveGameUI', () => {
     }
     await awaitTick();
   }
+
+  describe('_getSaveSlotsData', () => {
+    it('should build slot metadata with helper', async () => {
+      mockSaveLoadService.listManualSaveSlots.mockResolvedValueOnce([
+        {
+          identifier: 'id1',
+          saveName: 'Slot One',
+          timestamp: '2023-01-01T00:00:00Z',
+          playtimeSeconds: 5,
+          isCorrupted: false,
+        },
+      ]);
+
+      const result = await saveGameUI._getSaveSlotsData();
+
+      expect(result[0].slotItemMeta).toEqual(
+        formatSaveFileMetadata({
+          identifier: 'id1',
+          saveName: 'Slot One',
+          timestamp: '2023-01-01T00:00:00Z',
+          playtimeSeconds: 5,
+          isCorrupted: false,
+        })
+      );
+      expect(result[1].slotItemMeta).toEqual(formatEmptySlot('Empty Slot 2'));
+    });
+  });
 
   describe('populateSlotsList integration', () => {
     it('should populate the save slots container with slot items', async () => {


### PR DESCRIPTION
Summary: Added slotDataFormatter helper to prepare save metadata for renderSlotItem and refactored save/load UI modules to use it. Updated associated unit tests.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint run           `npm run lint` *(fails: existing repo issues)*
- [x] Root tests         `npm run test` *(fails coverage thresholds only)*
- [x] Proxy tests        `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f15cfa7b08331b1d9b94d8da0c781