### PR TITLE
[Agent] Add JSON prompt templates

### DIFF
--- a/data/prompts/targetMessages.json
+++ b/data/prompts/targetMessages.json
@@ -1,0 +1,13 @@
+/*
+  Placeholder variables:
+  ${targetName} - name or description of the target entity
+  ${actionVerb} - verb phrase describing the action on the target
+  ${names} - comma-separated list of candidate entity names
+  ${directionInput} - ambiguous direction entered by the user
+  ${namesList} - comma-separated list of matching connection names
+*/
+{
+  "TARGET_NOT_FOUND_CONTEXT": "Could not find '${targetName}' nearby to target.",
+  "TARGET_AMBIGUOUS_CONTEXT": "Which '${targetName}' did you want to ${actionVerb}? (${names})",
+  "AMBIGUOUS_DIRECTION": "There are multiple ways to go '${directionInput}'. Which one did you mean: ${namesList}?"
+}


### PR DESCRIPTION
Summary: Added new `targetMessages.json` file containing target resolution messages with placeholder variables for use in prompts. Included brief documentation comments for each placeholder.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (errors remain but pre-existing)
- [x] Root tests `npx jest --runInBand --silent`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f17c1ac1c8331aaad90174d6c54f1