### PR TITLE
[Agent] implement deferred game start

### DIFF
--- a/game.html
+++ b/game.html
@@ -285,5 +285,13 @@
     </div>
 
     <script src="bundle.js"></script>
+    <script>
+      window.bootstrapApp().then(() => {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('start') !== 'false') {
+          window.beginGame(params.get('load') === 'true');
+        }
+      });
+    </script>
   </body>
 </html>

--- a/tests/main/main.bootstrapFlow.test.js
+++ b/tests/main/main.bootstrapFlow.test.js
@@ -40,6 +40,7 @@ describe('main.js bootstrap extended coverage', () => {
   });
 
   it('executes all bootstrap stages successfully', async () => {
+    window.history.pushState({}, '', '?start=false');
     document.body.innerHTML = `
       <div id="outputDiv"></div>
       <div id="error-output"></div>
@@ -64,7 +65,10 @@ describe('main.js bootstrap extended coverage', () => {
     mockGlobal.mockResolvedValue();
     mockStartGame.mockResolvedValue();
 
-    await import('../../src/main.js');
+    const main = await import('../../src/main.js');
+    await main.bootstrapApp();
+    await new Promise((r) => setTimeout(r, 0));
+    await window.beginGame();
     await new Promise((r) => setTimeout(r, 0));
 
     expect(mockEnsure).toHaveBeenCalledTimes(1);
@@ -92,6 +96,7 @@ describe('main.js bootstrap extended coverage', () => {
   });
 
   it('displays fatal error when game engine fails to initialize', async () => {
+    window.history.pushState({}, '', '?start=false');
     document.body.innerHTML = `<div id="outputDiv"></div>`;
     const uiElements = {
       outputDiv: document.querySelector('#outputDiv'),
@@ -107,7 +112,10 @@ describe('main.js bootstrap extended coverage', () => {
     mockResolveCore.mockResolvedValue({ logger });
     mockInitEngine.mockResolvedValue(null);
 
-    await import('../../src/main.js');
+    const main = await import('../../src/main.js');
+    await main.bootstrapApp();
+    await new Promise((r) => setTimeout(r, 0));
+    await expect(window.beginGame()).rejects.toThrow();
     await new Promise((r) => setTimeout(r, 0));
 
     expect(mockStartGame).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary: Implemented bootstrapApp and beginGame functions without automatic execution, updated game.html to bootstrap and optionally start the game based on URL params. Adjusted tests to call bootstrapApp directly and ensure deferred start behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(warnings remain)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f1597b6288331b91c63820bf6ae31