### PR TITLE
[Agent] adopt success/failure macros in rules

### DIFF
--- a/data/mods/core/rules/follow.rule.json
+++ b/data/mods/core/rules/follow.rule.json
@@ -30,23 +30,23 @@
         },
         "then_actions": [
           {
-            "type": "DISPATCH_EVENT",
-            "comment": "Dispatch a decoupled event to the UI indicating the failure.",
+            "type": "GET_NAME",
+            "comment": "Fetch the leader's name for the failure message.",
             "parameters": {
-              "eventType": "core:display_error",
-              "payload": {
-                "message": "You cannot follow {target.name}; this would create a follow cycle (e.g. A follows B, B follows A)."
-              }
+              "entity_ref": {
+                "entityId": "{event.payload.targetId}"
+              },
+              "result_variable": "targetName"
             }
           },
           {
-            "type": "END_TURN",
-            "comment": "Signal to the Turn Manager that the actor's turn is over (and was unsuccessful).",
+            "type": "SET_VARIABLE",
             "parameters": {
-              "entityId": "{event.payload.actorId}",
-              "success": false
+              "variable_name": "logMessage",
+              "value": "You cannot follow {context.targetName}; this would create a follow cycle (e.g. A follows B, B follows A)."
             }
-          }
+          },
+          { "macro": "core:logFailureAndEndTurn" }
         ]
       }
     },

--- a/data/mods/intimacy/rules/thumb_wipe_cheek.rule.json
+++ b/data/mods/intimacy/rules/thumb_wipe_cheek.rule.json
@@ -54,33 +54,19 @@
       }
     },
     {
-      "type": "DISPATCH_PERCEPTIBLE_EVENT",
-      "comment": "Dispatch an event for other characters to observe.",
+      "type": "SET_VARIABLE",
       "parameters": {
-        "location_id": "{context.locationId}",
-        "description_text": "{context.logMessage}",
-        "perception_type": "action_target_general",
-        "actor_id": "{event.payload.actorId}",
-        "target_id": "{event.payload.targetId}"
+        "variable_name": "perceptionType",
+        "value": "action_target_general"
       }
     },
     {
-      "type": "DISPATCH_EVENT",
-      "comment": "Notify the actor's client with a third-person success message.",
+      "type": "SET_VARIABLE",
       "parameters": {
-        "eventType": "core:display_successful_action_result",
-        "payload": {
-          "message": "{context.logMessage}"
-        }
+        "variable_name": "targetId",
+        "value": "{event.payload.targetId}"
       }
     },
-    {
-      "type": "END_TURN",
-      "comment": "Signal to the Turn Manager that the actor's turn is over.",
-      "parameters": {
-        "entityId": "{event.payload.actorId}",
-        "success": true
-      }
-    }
+    { "macro": "core:logSuccessAndEndTurn" }
   ]
 }


### PR DESCRIPTION
## Summary
- replace manual failure logging in `follow.rule.json` with `core:logFailureAndEndTurn`
- use `core:logSuccessAndEndTurn` in intimacy thumb wipe rule

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 543 errors)*
- `npm run test` *(passes with coverage warnings)*
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f1ac62bbc8331a89e4b6509ca838a