### PR TITLE
[Agent] extract entity context helper

### DIFF
--- a/src/actions/validation/contextBuilders.js
+++ b/src/actions/validation/contextBuilders.js
@@ -6,6 +6,7 @@
 import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
 import { getExitByDirection } from '../../utils/locationUtils.js';
 import { createComponentAccessor } from '../../logic/componentAccessor.js';
+import { createEntityContext } from '../../logic/contextAssembler.js';
 
 /**
  * @description Build the actor portion of an action validation context.
@@ -15,10 +16,7 @@ import { createComponentAccessor } from '../../logic/componentAccessor.js';
  * @returns {{id: string, components: object}} Actor context object.
  */
 export function buildActorContext(entityId, entityManager, logger) {
-  return {
-    id: entityId,
-    components: createComponentAccessor(entityId, entityManager, logger),
-  };
+  return createEntityContext(entityId, entityManager, logger);
 }
 
 /**

--- a/src/logic/contextAssembler.js
+++ b/src/logic/contextAssembler.js
@@ -17,6 +17,20 @@ import { createComponentAccessor } from './componentAccessor.js';
 /** @typedef {string | number | null | undefined} EntityId */
 
 /**
+ * @description Create a basic context object for an entity.
+ * @param {EntityId} entityId - Identifier of the entity.
+ * @param {EntityManager} entityManager - Manager used to access components.
+ * @param {ILogger} logger - Logger instance for diagnostics.
+ * @returns {JsonLogicEntityContext} Context object with id and component accessor.
+ */
+export function createEntityContext(entityId, entityManager, logger) {
+  return {
+    id: entityId,
+    components: createComponentAccessor(entityId, entityManager, logger),
+  };
+}
+
+/**
  * Populates either the `actor` or `target` field on the provided evaluation
  * context by retrieving the entity and creating a component accessor.
  *
@@ -46,10 +60,11 @@ export function populateParticipant(
         logger.debug(
           `Found ${fieldName} entity [${entityId}]. Creating context entry.`
         );
-        evaluationContext[fieldName] = {
-          id: entityId,
-          components: createComponentAccessor(entity.id, entityManager, logger),
-        };
+        evaluationContext[fieldName] = createEntityContext(
+          entityId,
+          entityManager,
+          logger
+        );
       } else {
         logger.warn(
           `${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)} entity not found for ID [${entityId}]. Setting ${fieldName} context to null.`


### PR DESCRIPTION
## Summary
- add `createEntityContext` helper
- refactor `populateParticipant` and `buildActorContext` to use the helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm run test` *(fails: coverage threshold unmet)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f1cab73bc8331905cdcd6df9d8131