### PR TITLE
[Agent] stop manual save deep clone

### DIFF
--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -136,6 +136,19 @@ describe('SaveLoadService additional coverage', () => {
     expect(res.success).toBe(true);
   });
 
+  it('does not mutate the provided game state object', async () => {
+    storageProvider.ensureDirectoryExists.mockResolvedValue();
+    storageProvider.writeFileAtomically.mockResolvedValue({ success: true });
+    const obj = {
+      metadata: {},
+      modManifest: {},
+      gameState: { level: 1 },
+    };
+    const original = JSON.stringify(obj);
+    await service.saveManualGame('NoMutate', obj);
+    expect(JSON.stringify(obj)).toBe(original);
+  });
+
   it('deepClone returns primitive values unchanged', async () => {
     storageProvider.ensureDirectoryExists.mockResolvedValue();
     let written;


### PR DESCRIPTION
## Summary
- simplify `saveManualGame` to avoid explicit cloning
- ensure the manual save input object stays immutable during save

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f20dabde483319e4c06a752ec2368