### PR TITLE
[Agent] add ui content category

### DIFF
--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -86,6 +86,7 @@
       "set_title.event.json",
       "update_available_actions.event.json",
       "entity_moved.event.json"
-    ]
+    ],
+    "ui": ["icons.json", "labels.json"]
   }
 }

--- a/data/mods/core/ui/icons.json
+++ b/data/mods/core/ui/icons.json
@@ -1,0 +1,4 @@
+{
+  "thoughts": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>",
+  "notes": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>"
+}

--- a/data/mods/core/ui/labels.json
+++ b/data/mods/core/ui/labels.json
@@ -1,0 +1,4 @@
+{
+  "save": "Save",
+  "load": "Load"
+}

--- a/data/mods/intimacy/mod.manifest.json
+++ b/data/mods/intimacy/mod.manifest.json
@@ -22,6 +22,7 @@
       "intimacy_show_onlookers.rule.json",
       "thumb_wipe_cheek.rule.json"
     ],
-    "events": []
+    "events": [],
+    "ui": ["icons.json", "labels.json"]
   }
 }

--- a/data/mods/intimacy/ui/icons.json
+++ b/data/mods/intimacy/ui/icons.json
@@ -1,0 +1,4 @@
+{
+  "thoughts": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>",
+  "notes": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>"
+}

--- a/data/mods/intimacy/ui/labels.json
+++ b/data/mods/intimacy/ui/labels.json
@@ -1,0 +1,4 @@
+{
+  "save": "Save",
+  "load": "Load"
+}

--- a/data/mods/isekai/mod.manifest.json
+++ b/data/mods/isekai/mod.manifest.json
@@ -13,6 +13,7 @@
     "locations": ["adventurers_guild.location.json", "town.location.json"],
     "actions": [],
     "rules": [],
-    "events": []
+    "events": [],
+    "ui": ["icons.json", "labels.json"]
   }
 }

--- a/data/mods/isekai/ui/icons.json
+++ b/data/mods/isekai/ui/icons.json
@@ -1,0 +1,4 @@
+{
+  "thoughts": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>",
+  "notes": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\"></svg>"
+}

--- a/data/mods/isekai/ui/labels.json
+++ b/data/mods/isekai/ui/labels.json
@@ -1,0 +1,4 @@
+{
+  "save": "Save",
+  "load": "Load"
+}

--- a/data/schemas/ui-icons.schema.json
+++ b/data/schemas/ui-icons.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/schemas/ui-icons.schema.json",
+  "title": "UI Icons",
+  "description": "Mapping of icon names to SVG markup or asset paths.",
+  "type": "object",
+  "additionalProperties": { "type": "string" }
+}

--- a/data/schemas/ui-labels.schema.json
+++ b/data/schemas/ui-labels.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/schemas/ui-labels.schema.json",
+  "title": "UI Labels",
+  "description": "Mapping of UI label keys to display strings.",
+  "type": "object",
+  "additionalProperties": { "type": "string" }
+}

--- a/docs/mods/mod_manifest_format.md
+++ b/docs/mods/mod_manifest_format.md
@@ -60,3 +60,20 @@ Object mapping content categories to arrays of JSON definition files. Paths are 
   }
 }
 ```
+
+### `ui` Category
+
+Mods may supply user-interface resources using a `ui` content category. Typical files include:
+
+- `icons.json` – conforms to `ui-icons.schema.json` and maps icon names to SVG markup or image paths.
+- `labels.json` – conforms to `ui-labels.schema.json` and maps label keys to display text.
+
+Example snippet:
+
+```json
+{
+  "content": {
+    "ui": ["icons.json", "labels.json"]
+  }
+}
+```

--- a/src/configuration/staticConfiguration.js
+++ b/src/configuration/staticConfiguration.js
@@ -107,6 +107,8 @@ class StaticConfiguration {
       'llm-configs.schema.json',
       'prompt-text.schema.json',
       'macro.schema.json',
+      'ui-icons.schema.json',
+      'ui-labels.schema.json',
       ...OPERATION_SCHEMA_FILES,
     ];
   }
@@ -134,6 +136,8 @@ class StaticConfiguration {
       rules: 'http://example.com/schemas/rule.schema.json',
       'llm-configs': 'http://example.com/schemas/llm-configs.schema.json',
       'prompt-text': 'http://example.com/schemas/prompt-text.schema.json',
+      'ui-icons': 'http://example.com/schemas/ui-icons.schema.json',
+      'ui-labels': 'http://example.com/schemas/ui-labels.schema.json',
     };
     return map[typeName];
   }

--- a/tests/services/staticConfiguration.test.js
+++ b/tests/services/staticConfiguration.test.js
@@ -23,6 +23,8 @@ const EXPECTED_SCHEMA_FILES = [
   'llm-configs.schema.json',
   'prompt-text.schema.json',
   'macro.schema.json',
+  'ui-icons.schema.json',
+  'ui-labels.schema.json',
   'addComponent.schema.json',
   'addPerceptionLogEntry.schema.json',
   'autoMoveFollowers.schema.json',
@@ -67,6 +69,8 @@ const EXPECTED_CONTENT_TYPE_SCHEMAS = {
   operations: 'http://example.com/schemas/operation.schema.json',
   rules: 'http://example.com/schemas/rule.schema.json',
   'prompt-text': 'http://example.com/schemas/prompt-text.schema.json',
+  'ui-icons': 'http://example.com/schemas/ui-icons.schema.json',
+  'ui-labels': 'http://example.com/schemas/ui-labels.schema.json',
 };
 
 // Source: this.#manifestSchemaId = CONTENT_TYPE_SCHEMAS.manifest;


### PR DESCRIPTION
Summary:
- add `ui` category to mod manifests with new `icons.json` and `labels.json`
- add schemas for ui icons and labels
- extend `StaticConfiguration` with schema IDs
- document new category in mod manifest docs
- update configuration tests

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 540 errors)*
- [x] `npm run test --silent`
- [x] `cd llm-proxy-server && npm run test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f20625d7c8331ab8e7a14028a8b9b