### PR TITLE
[Agent] implement follower auto-move macro

### DIFF
--- a/data/mods/core/macros/autoMoveFollower.macro.json
+++ b/data/mods/core/macros/autoMoveFollower.macro.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://example.com/schemas/macro.schema.json",
+  "macro_id": "core:autoMoveFollower",
+  "actions": [
+    {
+      "type": "SYSTEM_MOVE_ENTITY",
+      "comment": "Move the follower directly without using a turn-based action.",
+      "parameters": {
+        "entity_ref": { "entityId": "{context.followerId}" },
+        "target_location_id": "{event.payload.currentLocationId}"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Get the follower's name for event messages.",
+      "parameters": {
+        "entity_ref": { "entityId": "{context.followerId}" },
+        "component_type": "core:name",
+        "result_variable": "followerName"
+      }
+    },
+    {
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
+      "comment": "Send a perceptible event to the new location.",
+      "parameters": {
+        "location_id": "{event.payload.currentLocationId}",
+        "description_text": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}.",
+        "perception_type": "character_enter",
+        "actor_id": "{context.followerId}",
+        "target_id": "{event.payload.entityId}",
+        "involved_entities": [],
+        "contextual_data": {
+          "leaderId": "{event.payload.entityId}",
+          "originLocationId": "{event.payload.previousLocationId}"
+        }
+      }
+    },
+    {
+      "type": "DISPATCH_EVENT",
+      "comment": "Inform the follower's UI that they automatically moved.",
+      "parameters": {
+        "eventType": "core:display_successful_action_result",
+        "payload": {
+          "message": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}."
+        }
+      }
+    }
+  ]
+}

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -56,7 +56,8 @@
     ],
     "macros": [
       "logSuccessAndEndTurn.macro.json",
-      "logFailureAndEndTurn.macro.json"
+      "logFailureAndEndTurn.macro.json",
+      "autoMoveFollower.macro.json"
     ],
     "events": [
       "action_decided.event.json",

--- a/data/mods/core/rules/follow_auto_move.rule.json
+++ b/data/mods/core/rules/follow_auto_move.rule.json
@@ -4,12 +4,7 @@
   "comment": "After a leader moves, find co-located followers using QUERY_ENTITIES and move them, dispatching events to log the auto-move and inform the UI.",
   "event_type": "core:entity_moved",
   "condition": {
-    "!==": [
-      {
-        "var": "actor"
-      },
-      null
-    ]
+    "!==": [{ "var": "actor" }, null]
   },
   "actions": [
     {
@@ -20,10 +15,62 @@
       }
     },
     {
-      "type": "AUTO_MOVE_FOLLOWERS",
+      "type": "QUERY_ENTITIES",
+      "comment": "Step 1: Efficiently find all followers who were in the same starting location as the leader.",
       "parameters": {
-        "leader_id": "{event.payload.entityId}",
-        "destination_id": "{event.payload.currentLocationId}"
+        "result_variable": "followersToMove",
+        "filters": [
+          { "by_location": "{event.payload.previousLocationId}" },
+          {
+            "with_component_data": {
+              "component_type": "core:following",
+              "condition": {
+                "==": [{ "var": "leaderId" }, "{event.payload.entityId}"]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "IF",
+      "comment": "Step 2: If any followers were found, proceed to move them.",
+      "parameters": {
+        "condition": { ">": [{ "var": "context.followersToMove.length" }, 0] },
+        "then_actions": [
+          {
+            "type": "QUERY_COMPONENT",
+            "comment": "Get the leader's name for event messages.",
+            "parameters": {
+              "entity_ref": "actor",
+              "component_type": "core:name",
+              "result_variable": "leaderName"
+            }
+          },
+          {
+            "type": "QUERY_COMPONENT",
+            "comment": "Get the destination location's name for event messages.",
+            "parameters": {
+              "entity_ref": { "entityId": "{event.payload.currentLocationId}" },
+              "component_type": "core:name",
+              "result_variable": "newLocationName"
+            }
+          },
+          {
+            "type": "GET_TIMESTAMP",
+            "comment": "Get a single timestamp for all resulting perception logs.",
+            "parameters": { "result_variable": "nowIso" }
+          },
+          {
+            "type": "FOR_EACH",
+            "comment": "For each follower that needs to move, update their state and dispatch events.",
+            "parameters": {
+              "collection": "context.followersToMove",
+              "item_variable": "followerId",
+              "actions": [{ "macro": "core:autoMoveFollower" }]
+            }
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Summary
- add `core:autoMoveFollower` macro for moving followers
- use macro in `follow_auto_move.rule.json`
- register new macro in core mod manifest
- update followAutoMoveRule integration test for macro expansion

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f219b84a88331a10f1bdb65d32945