### PR TITLE
[Agent] centralize modal element config

### DIFF
--- a/src/domUI/helpers/buildModalElementsConfig.js
+++ b/src/domUI/helpers/buildModalElementsConfig.js
@@ -1,0 +1,33 @@
+/**
+ * @file Helper to build modal element configuration objects.
+ */
+
+/**
+ * @typedef {import('../boundDomRendererBase.js').ElementsConfig} ElementsConfig
+ */
+
+/**
+ * @description Creates an {@link ElementsConfig} object using selector strings.
+ * Values in `selectors` can be either a selector string or a tuple of
+ * `[selector, expectedType]` where `expectedType` is a constructor function used
+ * for type validation in {@link BoundDomRendererBase}.
+ * @param {Object.<string, string | [string, Function]>} selectors
+ * Map of element keys to selector values.
+ * @returns {ElementsConfig} Config object suitable for BoundDomRendererBase.
+ */
+export function buildModalElementsConfig(selectors) {
+  const config = {};
+  for (const [key, value] of Object.entries(selectors)) {
+    if (!value) continue;
+    if (typeof value === 'string') {
+      config[key] = { selector: value, required: true };
+    } else if (Array.isArray(value)) {
+      const [selector, expectedType] = value;
+      config[key] = { selector, required: true };
+      if (expectedType) {
+        config[key].expectedType = expectedType;
+      }
+    }
+  }
+  return config;
+}

--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -3,6 +3,7 @@
 
 import { SlotModalBase } from './slotModalBase.js';
 import { createSelectableItem } from './helpers/createSelectableItem.js';
+import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -23,19 +24,6 @@ import { createSelectableItem } from './helpers/createSelectableItem.js';
  * @property {LlmConfigOption[]} llmOptions - Array of LLM configuration options.
  * @property {string | null} currentActiveLlmId - The ID of the currently active LLM.
  */
-
-const LLM_SELECTION_MODAL_ELEMENTS_CONFIG = {
-  modalElement: { selector: '#llm-selection-modal', required: true },
-  closeButton: {
-    selector: '#llm-selection-modal-close-button',
-    required: true,
-  }, // Used by BaseModalRenderer
-  listContainerElement: { selector: '#llm-selection-list', required: true }, // For BaseListDisplayComponent pattern
-  statusMessageElement: {
-    selector: '#llm-selection-status-message',
-    required: false,
-  }, // For BaseModalRenderer status messages
-};
 
 /**
  * @class LlmSelectionModal
@@ -81,12 +69,18 @@ export class LlmSelectionModal extends SlotModalBase {
         'LlmSelectionModal: ValidatedEventDispatcher dependency is required for BaseModalRenderer.'
       );
 
+    const elementsConfig = buildModalElementsConfig({
+      modalElement: '#llm-selection-modal',
+      closeButton: '#llm-selection-modal-close-button',
+      listContainerElement: '#llm-selection-list',
+      statusMessageElement: '#llm-selection-status-message',
+    });
     super({
       datasetKey: 'llmId',
       logger,
       documentContext,
       validatedEventDispatcher,
-      elementsConfig: LLM_SELECTION_MODAL_ELEMENTS_CONFIG,
+      elementsConfig,
       domElementFactory,
     });
 

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -4,6 +4,7 @@ import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import { formatSaveFileMetadata } from './helpers/slotDataFormatter.js';
 import { renderSlotItem } from './helpers/renderSlotItem.js';
+import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -21,26 +22,6 @@ import { renderSlotItem } from './helpers/renderSlotItem.js';
  *
  * @typedef {SaveFileMetadata & { isCorrupted?: boolean }} LoadSlotDisplayData
  */
-
-const LOAD_GAME_UI_ELEMENTS_CONFIG = {
-  modalElement: { selector: '#load-game-screen', required: true },
-  closeButton: { selector: '#cancel-load-button', required: true },
-  listContainerElement: { selector: '#load-slots-container', required: true },
-  confirmLoadButtonEl: {
-    selector: '#confirm-load-button',
-    required: true,
-    expectedType: HTMLButtonElement,
-  },
-  deleteSaveButtonEl: {
-    selector: '#delete-save-button',
-    required: true,
-    expectedType: HTMLButtonElement,
-  },
-  statusMessageElement: {
-    selector: '#load-game-status-message',
-    required: true,
-  },
-};
 
 /**
  * @class LoadGameUI
@@ -70,11 +51,19 @@ class LoadGameUI extends SlotModalBase {
     saveLoadService,
     validatedEventDispatcher,
   }) {
+    const elementsConfig = buildModalElementsConfig({
+      modalElement: '#load-game-screen',
+      closeButton: '#cancel-load-button',
+      listContainerElement: '#load-slots-container',
+      confirmLoadButtonEl: ['#confirm-load-button', HTMLButtonElement],
+      deleteSaveButtonEl: ['#delete-save-button', HTMLButtonElement],
+      statusMessageElement: '#load-game-status-message',
+    });
     super({
       logger,
       documentContext,
       validatedEventDispatcher,
-      elementsConfig: LOAD_GAME_UI_ELEMENTS_CONFIG,
+      elementsConfig,
       domElementFactory,
       datasetKey: 'slotIdentifier',
       confirmButtonKey: 'confirmLoadButtonEl',

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -7,6 +7,7 @@ import {
   formatEmptySlot,
 } from './helpers/slotDataFormatter.js';
 import { renderSlotItem } from './helpers/renderSlotItem.js';
+import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -26,27 +27,6 @@ import { renderSlotItem } from './helpers/renderSlotItem.js';
  */
 
 const MAX_SAVE_SLOTS = 10;
-
-const SAVE_GAME_UI_ELEMENTS_CONFIG = {
-  modalElement: { selector: '#save-game-screen', required: true },
-  closeButton: { selector: '#cancel-save-button', required: true }, // Cancel button acts as close
-  listContainerElement: { selector: '#save-slots-container', required: true },
-  saveNameInputEl: {
-    selector: '#save-name-input',
-    required: true,
-    expectedType: HTMLInputElement,
-  },
-  confirmSaveButtonEl: {
-    selector: '#confirm-save-button',
-    required: true,
-    expectedType: HTMLButtonElement,
-  },
-  statusMessageElement: {
-    selector: '#save-game-status-message',
-    required: true,
-  },
-  // openSaveGameButtonEl is external and handled by main.js or equivalent
-};
 
 /**
  * @class SaveGameUI
@@ -83,11 +63,19 @@ export class SaveGameUI extends SlotModalBase {
     saveLoadService,
     validatedEventDispatcher,
   }) {
+    const elementsConfig = buildModalElementsConfig({
+      modalElement: '#save-game-screen',
+      closeButton: '#cancel-save-button',
+      listContainerElement: '#save-slots-container',
+      saveNameInputEl: ['#save-name-input', HTMLInputElement],
+      confirmSaveButtonEl: ['#confirm-save-button', HTMLButtonElement],
+      statusMessageElement: '#save-game-status-message',
+    });
     super({
       logger,
       documentContext,
       validatedEventDispatcher,
-      elementsConfig: SAVE_GAME_UI_ELEMENTS_CONFIG,
+      elementsConfig,
       domElementFactory,
       datasetKey: 'slotId',
       confirmButtonKey: 'confirmSaveButtonEl',


### PR DESCRIPTION
Summary:
- implement `buildModalElementsConfig` helper for DOM UI
- use this helper to configure SaveGameUI, LoadGameUI and LlmSelectionModal

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f21d9462883318d5bada64c3a2797