### PR TITLE
[Agent] normalize error dispatch across handlers

### DIFF
--- a/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
+++ b/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
@@ -5,6 +5,7 @@
 
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 const DEFAULT_MAX_LOG_ENTRIES = 50;
@@ -49,17 +50,19 @@ class AddPerceptionLogEntryHandler {
     }
     const { location_id, entry } = params;
     if (typeof location_id !== 'string' || !location_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'ADD_PERCEPTION_LOG_ENTRY: location_id is required',
-        details: { location_id },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'ADD_PERCEPTION_LOG_ENTRY: location_id is required',
+        { location_id }
+      );
       return;
     }
     if (!entry || typeof entry !== 'object') {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'ADD_PERCEPTION_LOG_ENTRY: entry object is required',
-        details: { entry },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'ADD_PERCEPTION_LOG_ENTRY: entry object is required',
+        { entry }
+      );
       return;
     }
 
@@ -112,10 +115,11 @@ class AddPerceptionLogEntryHandler {
         this.#entityManager.addComponent(id, PERCEPTION_LOG_COMPONENT_ID, next);
         updated++;
       } catch (e) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-          message: `ADD_PERCEPTION_LOG_ENTRY: failed to update ${id}: ${e.message}`,
-          details: { stack: e.stack, entityId: id },
-        });
+        safeDispatchError(
+          this.#dispatcher,
+          `ADD_PERCEPTION_LOG_ENTRY: failed to update ${id}: ${e.message}`,
+          { stack: e.stack, entityId: id }
+        );
       }
     }
 

--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -14,6 +14,7 @@ import {
   LEADING_COMPONENT_ID,
 } from '../../constants/componentIds.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import SystemMoveEntityHandler from './systemMoveEntityHandler.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 
@@ -71,17 +72,19 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
   execute(params, execCtx) {
     const { leader_id, destination_id } = params || {};
     if (typeof leader_id !== 'string' || !leader_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'AUTO_MOVE_FOLLOWERS: Invalid "leader_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'AUTO_MOVE_FOLLOWERS: Invalid "leader_id" parameter',
+        { params }
+      );
       return;
     }
     if (typeof destination_id !== 'string' || !destination_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'AUTO_MOVE_FOLLOWERS: Invalid "destination_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'AUTO_MOVE_FOLLOWERS: Invalid "destination_id" parameter',
+        { params }
+      );
       return;
     }
 
@@ -140,10 +143,11 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
           message,
         });
       } catch (err) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-          message: 'AUTO_MOVE_FOLLOWERS: Error moving follower',
-          details: { error: err.message, stack: err.stack, followerId: fid },
-        });
+        safeDispatchError(
+          this.#dispatcher,
+          'AUTO_MOVE_FOLLOWERS: Error moving follower',
+          { error: err.message, stack: err.stack, followerId: fid }
+        );
       }
     }
     this.logger.debug(

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -11,6 +11,7 @@
 /** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 
 class BreakFollowRelationHandler {
@@ -74,10 +75,11 @@ class BreakFollowRelationHandler {
   execute(params, execCtx) {
     const { follower_id } = params || {};
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'BREAK_FOLLOW_RELATION: Invalid "follower_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'BREAK_FOLLOW_RELATION: Invalid "follower_id" parameter',
+        { params }
+      );
       return;
     }
     const fid = follower_id.trim();
@@ -94,10 +96,11 @@ class BreakFollowRelationHandler {
     try {
       this.#entityManager.removeComponent(fid, FOLLOWING_COMPONENT_ID);
     } catch (err) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'BREAK_FOLLOW_RELATION: Failed removing following component',
-        details: { error: err.message, stack: err.stack, follower_id: fid },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'BREAK_FOLLOW_RELATION: Failed removing following component',
+        { error: err.message, stack: err.stack, follower_id: fid }
+      );
       return;
     }
     if (currentData.leaderId) {

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 import { wouldCreateCycle } from '../../utils/followUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
@@ -56,24 +57,27 @@ class CheckFollowCycleHandler {
     const { follower_id, leader_id, result_variable } = params || {};
 
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'CHECK_FOLLOW_CYCLE: Invalid "follower_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'CHECK_FOLLOW_CYCLE: Invalid "follower_id" parameter',
+        { params }
+      );
       return;
     }
     if (typeof leader_id !== 'string' || !leader_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'CHECK_FOLLOW_CYCLE: Invalid "leader_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'CHECK_FOLLOW_CYCLE: Invalid "leader_id" parameter',
+        { params }
+      );
       return;
     }
     if (typeof result_variable !== 'string' || !result_variable.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'CHECK_FOLLOW_CYCLE: Invalid "result_variable" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'CHECK_FOLLOW_CYCLE: Invalid "result_variable" parameter',
+        { params }
+      );
       return;
     }
 

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 const EVENT_ID = 'core:perceptible_event';
@@ -92,31 +93,35 @@ class DispatchPerceptibleEventHandler {
     } = params;
 
     if (typeof location_id !== 'string' || !location_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_PERCEPTIBLE_EVENT: location_id required',
-        details: { location_id },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_PERCEPTIBLE_EVENT: location_id required',
+        { location_id }
+      );
       return;
     }
     if (typeof description_text !== 'string' || !description_text.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_PERCEPTIBLE_EVENT: description_text required',
-        details: { description_text },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_PERCEPTIBLE_EVENT: description_text required',
+        { description_text }
+      );
       return;
     }
     if (typeof perception_type !== 'string' || !perception_type.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_PERCEPTIBLE_EVENT: perception_type required',
-        details: { perception_type },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_PERCEPTIBLE_EVENT: perception_type required',
+        { perception_type }
+      );
       return;
     }
     if (typeof actor_id !== 'string' || !actor_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_PERCEPTIBLE_EVENT: actor_id required',
-        details: { actor_id },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_PERCEPTIBLE_EVENT: actor_id required',
+        { actor_id }
+      );
       return;
     }
 

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -10,6 +10,7 @@ import {
   DISPLAY_SPEECH_ID,
   DISPLAY_ERROR_ID,
 } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 /**
  * Parameters accepted by {@link DispatchSpeechHandler#execute}.
@@ -61,10 +62,11 @@ class DispatchSpeechHandler {
       !params.entity_id.trim() ||
       typeof params.speech_content !== 'string'
     ) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_SPEECH: invalid parameters.',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_SPEECH: invalid parameters.',
+        { params }
+      );
       return;
     }
 
@@ -89,10 +91,11 @@ class DispatchSpeechHandler {
     try {
       this.#dispatcher.dispatch(DISPLAY_SPEECH_ID, payload);
     } catch (err) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'DISPATCH_SPEECH: Error dispatching display_speech.',
-        details: { errorMessage: err.message, stack: err.stack },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'DISPATCH_SPEECH: Error dispatching display_speech.',
+        { errorMessage: err.message, stack: err.stack }
+      );
     }
   }
 }

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -8,6 +8,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { TURN_ENDED_ID, DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 /**
  * Parameters for {@link EndTurnHandler#execute}.
@@ -57,10 +58,11 @@ class EndTurnHandler {
       typeof params.entityId !== 'string' ||
       !params.entityId.trim()
     ) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'END_TURN: Invalid or missing "entityId" parameter.',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#safeEventDispatcher,
+        'END_TURN: Invalid or missing "entityId" parameter.',
+        { params }
+      );
       return;
     }
 
@@ -85,17 +87,19 @@ class EndTurnHandler {
     if (dispatchResult && typeof dispatchResult.then === 'function') {
       dispatchResult.then((success) => {
         if (!success) {
-          this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-            message: 'END_TURN: Failed to dispatch turn ended event.',
-            details: { payload },
-          });
+          safeDispatchError(
+            this.#safeEventDispatcher,
+            'END_TURN: Failed to dispatch turn ended event.',
+            { payload }
+          );
         }
       });
     } else if (dispatchResult === false) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'END_TURN: Failed to dispatch turn ended event.',
-        details: { payload },
-      });
+      safeDispatchError(
+        this.#safeEventDispatcher,
+        'END_TURN: Failed to dispatch turn ended event.',
+        { payload }
+      );
     }
   }
 }

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -11,6 +11,7 @@
 /** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { wouldCreateCycle } from '../../utils/followUtils.js';
 
@@ -77,17 +78,19 @@ class EstablishFollowRelationHandler {
   execute(params, execCtx) {
     const { follower_id, leader_id } = params || {};
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'ESTABLISH_FOLLOW_RELATION: Invalid "follower_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'ESTABLISH_FOLLOW_RELATION: Invalid "follower_id" parameter',
+        { params }
+      );
       return;
     }
     if (typeof leader_id !== 'string' || !leader_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'ESTABLISH_FOLLOW_RELATION: Invalid "leader_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'ESTABLISH_FOLLOW_RELATION: Invalid "leader_id" parameter',
+        { params }
+      );
       return;
     }
 
@@ -98,10 +101,11 @@ class EstablishFollowRelationHandler {
     );
 
     if (wouldCreateCycle(fid, lid, this.#entityManager)) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'ESTABLISH_FOLLOW_RELATION: Following would create a cycle',
-        details: { follower_id: fid, leader_id: lid },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'ESTABLISH_FOLLOW_RELATION: Following would create a cycle',
+        { follower_id: fid, leader_id: lid }
+      );
       return;
     }
 
@@ -114,16 +118,16 @@ class EstablishFollowRelationHandler {
         leaderId: lid,
       });
     } catch (err) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message:
-          'ESTABLISH_FOLLOW_RELATION: Failed updating follower component',
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        'ESTABLISH_FOLLOW_RELATION: Failed updating follower component',
+        {
           error: err.message,
           stack: err.stack,
           follower_id: fid,
           leader_id: lid,
-        },
-      });
+        }
+      );
       return;
     }
 

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -112,10 +112,11 @@ class GetNameHandler extends BaseOperationHandler {
       }
       log.debug(`GET_NAME: Resolved name for '${entityId}' -> '${name}'.`);
     } catch (e) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `GET_NAME: Error retrieving '${NAME_COMPONENT_ID}' from '${entityId}'. Using fallback.`,
-        details: { error: e.message, stack: e.stack },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        `GET_NAME: Error retrieving '${NAME_COMPONENT_ID}' from '${entityId}'. Using fallback.`,
+        { error: e.message, stack: e.stack }
+      );
     }
 
     setContextValue(resultVar, name, executionContext, undefined, log);

--- a/src/logic/operationHandlers/hasComponentHandler.js
+++ b/src/logic/operationHandlers/hasComponentHandler.js
@@ -12,6 +12,7 @@
 /** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 import storeResult from '../../utils/contextVariableUtils.js';
@@ -139,16 +140,17 @@ class HasComponentHandler {
           } component "${trimmedComponentType}". Storing result in "${trimmedResultVar}".`
         );
       } catch (e) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-          message: `HAS_COMPONENT: An error occurred while checking for component "${trimmedComponentType}" on entity "${entityId}". Storing 'false'.`,
-          details: {
+        safeDispatchError(
+          this.#dispatcher,
+          `HAS_COMPONENT: An error occurred while checking for component "${trimmedComponentType}" on entity "${entityId}". Storing 'false'.`,
+          {
             error: e.message,
             stack: e.stack,
             entityId,
             componentType: trimmedComponentType,
             resultVariable: trimmedResultVar,
-          },
-        });
+          }
+        );
         result = false; // Ensure result is false on error
       }
     }

--- a/src/logic/operationHandlers/ifCoLocatedHandler.js
+++ b/src/logic/operationHandlers/ifCoLocatedHandler.js
@@ -110,10 +110,11 @@ class IfCoLocatedHandler {
         posB?.locationId &&
         posA.locationId === posB.locationId;
     } catch (e) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `IF_CO_LOCATED: error reading positions for '${idA}' or '${idB}'`,
-        details: { error: e.message, stack: e.stack },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        `IF_CO_LOCATED: error reading positions for '${idA}' or '${idB}'`,
+        { error: e.message, stack: e.stack }
+      );
       same = false;
     }
 
@@ -126,14 +127,15 @@ class IfCoLocatedHandler {
       try {
         this.#opInterpreter.execute(op, execCtx);
       } catch (err) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-          message: 'IF_CO_LOCATED: nested operation threw',
-          details: {
+        safeDispatchError(
+          this.#dispatcher,
+          'IF_CO_LOCATED: nested operation threw',
+          {
             error: err?.message,
             stack: err?.stack,
             op,
-          },
-        });
+          }
+        );
         break;
       }
     }

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -4,6 +4,7 @@
 
 import jsonLogic from 'json-logic-js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 import storeResult from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils.js';
@@ -158,10 +159,11 @@ class MathHandler {
           const num = Number(raw);
           return Number.isNaN(num) ? NaN : num;
         } catch (e) {
-          this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-            message: 'MATH: Error resolving variable operand.',
-            details: { error: e.message, stack: e.stack },
-          });
+          safeDispatchError(
+            this.#dispatcher,
+            'MATH: Error resolving variable operand.',
+            { error: e.message, stack: e.stack }
+          );
           return NaN;
         }
       }

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -12,6 +12,7 @@
 import { resolvePath } from '../../utils/objectUtils.js';
 import { cloneDeep } from 'lodash';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 
@@ -223,15 +224,15 @@ class ModifyArrayFieldHandler {
         `MODIFY_ARRAY_FIELD: Successfully committed changes to component '${component_type}' on entity '${entityId}'.`
       );
     } catch (error) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message:
-          'MODIFY_ARRAY_FIELD: Failed to commit changes via addComponent.',
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        'MODIFY_ARRAY_FIELD: Failed to commit changes via addComponent.',
+        {
           error: error.message,
           entityId,
           componentType: component_type,
-        },
-      });
+        }
+      );
       return; // Abort if the update fails
     }
 

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -11,6 +11,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import {
   initHandlerLogger,
@@ -171,15 +172,16 @@ class ModifyComponentHandler {
         );
       }
     } catch (e) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: 'MODIFY_COMPONENT: Error during EntityManager.addComponent.',
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        'MODIFY_COMPONENT: Error during EntityManager.addComponent.',
+        {
           error: e.message,
           stack: e.stack,
           entityId,
           componentType: compType,
-        },
-      });
+        }
+      );
     }
   }
 }

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -181,15 +181,16 @@ class QueryComponentHandler {
         );
       }
     } catch (error) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `QueryComponentHandler: Error during EntityManager.getComponentData for component "${trimmedComponentType}" on entity "${entityId}".`,
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        `QueryComponentHandler: Error during EntityManager.getComponentData for component "${trimmedComponentType}" on entity "${entityId}".`,
+        {
           error: error.message,
           stack: error.stack,
           params: params,
           resolvedEntityId: entityId,
-        },
-      });
+        }
+      );
       const stored = setContextValue(
         result_variable,
         missing_value,

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 
@@ -228,11 +229,11 @@ class QueryEntitiesHandler extends BaseOperationHandler {
         `QUERY_ENTITIES: Stored ${finalIds.length} entity IDs in context variable "${resultVariable}".`
       );
     } else {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message:
-          'QUERY_ENTITIES: Cannot store result. `executionContext.evaluationContext.context` is not available.',
-        details: { resultVariable },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'QUERY_ENTITIES: Cannot store result. `executionContext.evaluationContext.context` is not available.',
+        { resultVariable }
+      );
     }
   }
 }

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -5,6 +5,7 @@
  */
 import { isNonBlankString } from '../../utils/textUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 /**
  * @class RebuildLeaderListCacheHandler
@@ -114,10 +115,11 @@ class RebuildLeaderListCacheHandler {
         }
         updated++;
       } catch (err) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-          message: `[RebuildLeaderListCacheHandler] Failed updating 'core:leading' for '${leaderId}': ${err.message || err}`,
-          details: { stack: err.stack, leaderId },
-        });
+        safeDispatchError(
+          this.#dispatcher,
+          `[RebuildLeaderListCacheHandler] Failed updating 'core:leading' for '${leaderId}': ${err.message || err}`,
+          { stack: err.stack, leaderId }
+        );
       }
     }
 

--- a/src/logic/operationHandlers/removeComponentHandler.js
+++ b/src/logic/operationHandlers/removeComponentHandler.js
@@ -15,6 +15,7 @@
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import {
   initHandlerLogger,
   validateDeps,
@@ -142,15 +143,16 @@ class RemoveComponentHandler {
       }
     } catch (e) {
       // Catch potential errors from removeComponent (e.g., entity not found by EntityManager)
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `REMOVE_COMPONENT: Failed to remove component "${trimmedComponentType}" from entity "${entityId}". Error: ${e.message}`,
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        `REMOVE_COMPONENT: Failed to remove component "${trimmedComponentType}" from entity "${entityId}". Error: ${e.message}`,
+        {
           error: e.message,
           stack: e.stack,
           entityId,
           componentType: trimmedComponentType,
-        },
-      });
+        }
+      );
     }
   }
 }

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -12,6 +12,7 @@
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 class SystemMoveEntityHandler {
   /** @type {ILogger} */ #logger;
@@ -128,16 +129,17 @@ class SystemMoveEntityHandler {
         originalCommand: 'system:follow', // A sensible default for system-initiated actions
       });
     } catch (e) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
-        message: `${opName}: Failed to move entity "${entityId}". Error: ${e.message}`,
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        `${opName}: Failed to move entity "${entityId}". Error: ${e.message}`,
+        {
           error: e.message,
           stack: e.stack,
           entityId,
           fromLocationId,
           targetLocationId: target_location_id,
-        },
-      });
+        }
+      );
     }
   }
 }


### PR DESCRIPTION
Summary: use `safeDispatchError` helper in all operation handlers to standardize error event payloads.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 540 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start` *(fails: esbuild could not resolve fs/path)*

------
https://chatgpt.com/codex/tasks/task_e_684f224691c0833196c9f31f72ff459b