### PR TITLE
[Agent] Add missing param checks in handlers

### DIFF
--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -16,6 +16,7 @@ import {
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import SystemMoveEntityHandler from './systemMoveEntityHandler.js';
 import BaseOperationHandler from './baseOperationHandler.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class AutoMoveFollowersHandler extends BaseOperationHandler {
   /** @type {EntityManager} */ #entityManager;
@@ -69,7 +70,10 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
    * @param {ExecutionContext} execCtx
    */
   execute(params, execCtx) {
-    const { leader_id, destination_id } = params || {};
+    const logger = execCtx?.logger ?? this.logger;
+    if (!assertParamsObject(params, logger, 'AUTO_MOVE_FOLLOWERS')) return;
+
+    const { leader_id, destination_id } = params;
     if (typeof leader_id !== 'string' || !leader_id.trim()) {
       this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
         message: 'AUTO_MOVE_FOLLOWERS: Invalid "leader_id" parameter',

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -12,6 +12,7 @@
 
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class BreakFollowRelationHandler {
   /** @type {ILogger} */
@@ -72,7 +73,10 @@ class BreakFollowRelationHandler {
    * @param {ExecutionContext} execCtx
    */
   execute(params, execCtx) {
-    const { follower_id } = params || {};
+    const logger = execCtx?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'BREAK_FOLLOW_RELATION')) return;
+
+    const { follower_id } = params;
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
       this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
         message: 'BREAK_FOLLOW_RELATION: Invalid "follower_id" parameter',

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -13,6 +13,7 @@ import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
 import { wouldCreateCycle } from '../../utils/followUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * @typedef {object} CheckFollowCycleParams
@@ -53,7 +54,9 @@ class CheckFollowCycleHandler {
    */
   execute(params, execCtx) {
     const log = this.#logger;
-    const { follower_id, leader_id, result_variable } = params || {};
+    if (!assertParamsObject(params, log, 'CHECK_FOLLOW_CYCLE')) return;
+
+    const { follower_id, leader_id, result_variable } = params;
 
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
       this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {

--- a/src/logic/operationHandlers/dispatchEventHandler.js
+++ b/src/logic/operationHandlers/dispatchEventHandler.js
@@ -4,6 +4,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */ // ** Corrected type for 2nd arg **
 /** @typedef {import('../../events/eventBus.js').default} EventBus */
 /** @typedef {import('../../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 // --- Handler Implementation ---
 /**
@@ -53,6 +54,7 @@ class DispatchEventHandler {
    */
   execute(params, _executionContext) {
     const logger = this.#logger; // Use the injected logger
+    if (!assertParamsObject(params, logger, 'DISPATCH_EVENT')) return;
 
     // 1. Validate resolved params and Trim eventType
     // Ensure params exists and eventType is a non-blank string *after* trimming.

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -10,6 +10,7 @@ import {
   DISPLAY_SPEECH_ID,
   DISPLAY_ERROR_ID,
 } from '../../constants/eventIds.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * Parameters accepted by {@link DispatchSpeechHandler#execute}.
@@ -55,8 +56,10 @@ class DispatchSpeechHandler {
    * @param {ExecutionContext} _ctx - Execution context (unused).
    */
   execute(params, _ctx) {
+    const logger = _ctx?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'DISPATCH_SPEECH')) return;
+
     if (
-      !params ||
       typeof params.entity_id !== 'string' ||
       !params.entity_id.trim() ||
       typeof params.speech_content !== 'string'

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -8,6 +8,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { TURN_ENDED_ID, DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * Parameters for {@link EndTurnHandler#execute}.
@@ -52,11 +53,10 @@ class EndTurnHandler {
    * @param {ExecutionContext} _executionContext - Execution context (unused).
    */
   execute(params, _executionContext) {
-    if (
-      !params ||
-      typeof params.entityId !== 'string' ||
-      !params.entityId.trim()
-    ) {
+    const logger = _executionContext?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'END_TURN')) return;
+
+    if (typeof params.entityId !== 'string' || !params.entityId.trim()) {
       this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
         message: 'END_TURN: Invalid or missing "entityId" parameter.',
         details: { params },

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -13,6 +13,7 @@
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { wouldCreateCycle } from '../../utils/followUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class EstablishFollowRelationHandler {
   /** @type {ILogger} */
@@ -75,7 +76,11 @@ class EstablishFollowRelationHandler {
    * @param {ExecutionContext} execCtx
    */
   execute(params, execCtx) {
-    const { follower_id, leader_id } = params || {};
+    const logger = execCtx?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'ESTABLISH_FOLLOW_RELATION'))
+      return;
+
+    const { follower_id, leader_id } = params;
     if (typeof follower_id !== 'string' || !follower_id.trim()) {
       this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
         message: 'ESTABLISH_FOLLOW_RELATION: Invalid "follower_id" parameter',

--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -4,6 +4,7 @@
  */
 
 import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class GetTimestampHandler {
   #logger;
@@ -14,6 +15,9 @@ class GetTimestampHandler {
   }
 
   execute(params, execCtx) {
+    const logger = execCtx?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
+
     const rv = params.result_variable.trim();
     const timestamp = new Date().toISOString();
     const stored = setContextValue(

--- a/src/logic/operationHandlers/logHandler.js
+++ b/src/logic/operationHandlers/logHandler.js
@@ -17,6 +17,7 @@
 
 const VALID_LOG_LEVELS = ['info', 'warn', 'error', 'debug'];
 const DEFAULT_LOG_LEVEL = 'info';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class LogHandler /* implements OperationHandler */ {
   #logger;
@@ -51,10 +52,13 @@ class LogHandler /* implements OperationHandler */ {
    * @returns {void}
    */
   execute(params, context) {
+    const logger = context?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'LOG')) return;
+
     // --- MODIFIED: Validate Parameters FIRST ---
     // Check if params exist and contain a non-null, non-undefined message.
-    if (!params || params.message === undefined || params.message === null) {
-      this.#logger.error(
+    if (params.message === undefined || params.message === null) {
+      logger.error(
         'LogHandler: Invalid or missing "message" parameter in LOG operation after resolution.',
         { paramsReceived: params }
       );

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -14,6 +14,7 @@ import { cloneDeep } from 'lodash';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * @class ModifyArrayFieldHandler
@@ -74,6 +75,9 @@ class ModifyArrayFieldHandler {
    */
   execute(params, executionContext) {
     const log = executionContext?.logger ?? this.#logger;
+    if (!assertParamsObject(params, log, 'MODIFY_ARRAY_FIELD')) {
+      return;
+    }
     // 1. Resolve Entity ID
     const entityId = resolveEntityId(params.entity_ref, executionContext);
     if (!entityId) {
@@ -133,7 +137,7 @@ class ModifyArrayFieldHandler {
         result = targetArray;
         break;
 
-      case 'push_unique':
+      case 'push_unique': {
         if (params.value === undefined) {
           log.warn(
             `MODIFY_ARRAY_FIELD: 'push_unique' mode requires a 'value' parameter.`
@@ -163,6 +167,7 @@ class ModifyArrayFieldHandler {
         }
         result = targetArray;
         break;
+      }
 
       case 'pop':
         if (targetArray.length > 0) {
@@ -175,7 +180,7 @@ class ModifyArrayFieldHandler {
         }
         break;
 
-      case 'remove_by_value':
+      case 'remove_by_value': {
         if (params.value === undefined) {
           log.warn(
             `MODIFY_ARRAY_FIELD: 'remove_by_value' mode requires a 'value' parameter.`
@@ -206,6 +211,7 @@ class ModifyArrayFieldHandler {
         }
         result = targetArray;
         break;
+      }
 
       default:
         log.warn(`MODIFY_ARRAY_FIELD: Unknown mode '${mode}'.`);

--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -10,6 +10,7 @@
 import { resolvePath } from '../../utils/objectUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 import { cloneDeep } from 'lodash';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * Safely sets a value on a nested object using a dot-notation path.
@@ -76,6 +77,10 @@ class ModifyContextArrayHandler {
   execute(params, executionContext) {
     const log = executionContext?.logger ?? this.#logger;
 
+    if (!assertParamsObject(params, log, 'MODIFY_CONTEXT_ARRAY')) {
+      return;
+    }
+
     const { variable_path, mode, value, result_variable } = params;
     if (!variable_path || !mode) {
       log.warn(
@@ -117,7 +122,7 @@ class ModifyContextArrayHandler {
         operationResult = clonedArray;
         break;
 
-      case 'push_unique':
+      case 'push_unique': {
         if (value === undefined) {
           log.warn(`'push_unique' mode requires a 'value' parameter.`);
           return;
@@ -136,6 +141,7 @@ class ModifyContextArrayHandler {
         }
         operationResult = clonedArray;
         break;
+      }
 
       case 'pop':
         if (clonedArray.length > 0) {
@@ -145,7 +151,7 @@ class ModifyContextArrayHandler {
         }
         break;
 
-      case 'remove_by_value':
+      case 'remove_by_value': {
         if (value === undefined) {
           log.warn(`'remove_by_value' mode requires a 'value' parameter.`);
           return;
@@ -164,6 +170,7 @@ class ModifyContextArrayHandler {
         }
         operationResult = clonedArray;
         break;
+      }
 
       default:
         log.warn(`MODIFY_CONTEXT_ARRAY: Unknown mode '${mode}'.`);

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -12,6 +12,7 @@
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * @class QueryEntitiesHandler
@@ -84,6 +85,10 @@ class QueryEntitiesHandler extends BaseOperationHandler {
    */
   execute(params, executionContext) {
     const log = this.getLogger(executionContext);
+
+    if (!assertParamsObject(params, log, 'QUERY_ENTITIES')) {
+      return;
+    }
 
     // 1. Parameter Validation
     if (

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -5,6 +5,7 @@
  */
 import { isNonBlankString } from '../../utils/textUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 /**
  * @class RebuildLeaderListCacheHandler
@@ -62,7 +63,11 @@ class RebuildLeaderListCacheHandler {
    * @param {import('../defs.js').ExecutionContext} nestedExecutionContext
    */
   execute(params, nestedExecutionContext) {
-    const { leaderIds } = params || {};
+    const logger = nestedExecutionContext?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'REBUILD_LEADER_LIST_CACHE'))
+      return;
+
+    const { leaderIds } = params;
     if (!Array.isArray(leaderIds) || leaderIds.length === 0) {
       this.#logger.debug(
         '[RebuildLeaderListCacheHandler] No leaderIds provided; skipping.'

--- a/src/logic/operationHandlers/resolveDirectionHandler.js
+++ b/src/logic/operationHandlers/resolveDirectionHandler.js
@@ -4,6 +4,7 @@
  */
 
 import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class ResolveDirectionHandler {
   #worldContext;
@@ -19,6 +20,9 @@ class ResolveDirectionHandler {
   }
 
   execute(params, execCtx) {
+    const logger = execCtx?.logger ?? this.#logger;
+    if (!assertParamsObject(params, logger, 'RESOLVE_DIRECTION')) return;
+
     // Safely destructure params, providing a default empty object to avoid errors if params is null/undefined.
     const { current_location_id, direction, result_variable } = params || {};
 

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -12,6 +12,7 @@
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { assertParamsObject } from '../../utils/handlerUtils.js';
 
 class SystemMoveEntityHandler {
   /** @type {ILogger} */ #logger;
@@ -56,11 +57,17 @@ class SystemMoveEntityHandler {
     const log = executionContext?.logger ?? this.#logger;
     const opName = 'SYSTEM_MOVE_ENTITY'; // Use a constant for the name
 
+    if (!assertParamsObject(params, log, opName)) return;
+
     // 1. Validate parameters
     const { entity_ref, target_location_id } = params;
     // **CORRECTED**: Check specifically for null/undefined instead of any falsy value for entity_ref.
     // An empty string is an invalid *value* (handled later), not a *missing parameter*.
-    if (entity_ref == null || !target_location_id) {
+    if (
+      entity_ref === null ||
+      entity_ref === undefined ||
+      !target_location_id
+    ) {
       log.warn(
         `${opName}: "entity_ref" and "target_location_id" are required.`
       );

--- a/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
+++ b/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
@@ -184,11 +184,9 @@ describe('CheckFollowCycleHandler', () => {
 
     test('should dispatch an error and return if params object itself is missing', () => {
       handler.execute(null, mockExecutionContext);
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
-        expect.objectContaining({
-          message: 'CHECK_FOLLOW_CYCLE: Invalid "follower_id" parameter',
-        })
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'CHECK_FOLLOW_CYCLE: params missing or invalid.',
+        { params: null }
       );
     });
   });

--- a/tests/logic/operationHandlers/dispatchEventHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchEventHandler.test.js
@@ -237,12 +237,12 @@ describe('DispatchEventHandler', () => {
   });
 
   // --- execute() Tests - Invalid Parameters ---
-  test('execute should log error and not dispatch if params is null', () => {
+  test('execute should log warn and not dispatch if params is null', () => {
     handler.execute(null, mockEvaluationContext);
-    expect(mockLogger.error).toHaveBeenCalledTimes(1);
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Invalid or missing "eventType" parameter'),
-      expect.anything()
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'DISPATCH_EVENT: params missing or invalid.',
+      { params: null }
     );
     expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
   });

--- a/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
@@ -81,12 +81,11 @@ describe('DispatchSpeechHandler', () => {
 
   test('dispatches error event on invalid parameters', () => {
     handler.execute(null, {});
-    expect(safeDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
-      expect.objectContaining({
-        message: 'DISPATCH_SPEECH: invalid parameters.',
-      })
+    expect(logger.warn).toHaveBeenCalledWith(
+      'DISPATCH_SPEECH: params missing or invalid.',
+      { params: null }
     );
+    expect(safeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 
   test('dispatches error event if underlying dispatch throws', () => {

--- a/tests/logic/operationHandlers/getTimestampHandler.test.js
+++ b/tests/logic/operationHandlers/getTimestampHandler.test.js
@@ -141,11 +141,11 @@ describe('GetTimestampHandler', () => {
   // 3. Error Handling and Edge Cases
   // -----------------------------------------------------------------------------
   describe('Error Handling and Edge Cases', () => {
-    test('should throw a TypeError if the params object is null', () => {
-      // The handler doesn't have explicit validation, so it relies on native JS behavior.
-      // This test captures that expected behavior.
-      expect(() => handler.execute(null, mockExecutionContext)).toThrow(
-        "Cannot read properties of null (reading 'result_variable')"
+    test('should warn and return if the params object is null', () => {
+      handler.execute(null, mockExecutionContext);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'GET_TIMESTAMP: params missing or invalid.',
+        { params: null }
       );
     });
 

--- a/tests/logic/operationHandlers/logHandler.test.js
+++ b/tests/logic/operationHandlers/logHandler.test.js
@@ -128,15 +128,15 @@ describe('LogHandler', () => {
   });
 
   // --- execute() Tests - Invalid Parameters --- (Keep As Is - These Passed Before)
-  test('execute should log error and not call log methods if params is null', () => {
+  test('execute should log warn and not call log methods if params is null', () => {
     logHandler.execute(null, baseMockContext);
-    expect(mockLogger.error).toHaveBeenCalledTimes(1);
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Invalid or missing "message" parameter'),
-      expect.anything()
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'LOG: params missing or invalid.',
+      { params: null }
     );
     expect(mockLogger.info).not.toHaveBeenCalled();
-    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
     expect(mockLogger.debug).not.toHaveBeenCalled();
   });
   test('execute should log error and not call log methods if params is empty object', () => {

--- a/tests/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
+++ b/tests/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
@@ -164,6 +164,16 @@ describe('RebuildLeaderListCacheHandler', () => {
     test.each([
       ['null params', null],
       ['undefined params', undefined],
+    ])('should warn and abort given %s', (caseName, params) => {
+      handler.execute(params, mockExecutionContext);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'REBUILD_LEADER_LIST_CACHE: params missing or invalid.',
+        { params }
+      );
+      expect(mockEntityManager.getEntitiesWithComponent).not.toHaveBeenCalled();
+    });
+
+    test.each([
       ['params with no leaderIds', {}],
       ['params with non-array leaderIds', { leaderIds: 'not-an-array' }],
       ['params with empty leaderIds array', { leaderIds: [] }],

--- a/tests/logic/operationHandlers/resolveDirectionHandler.test.js
+++ b/tests/logic/operationHandlers/resolveDirectionHandler.test.js
@@ -114,13 +114,18 @@ describe('ResolveDirectionHandler', () => {
       ['params with empty string result_variable', { result_variable: '' }],
       ['params with whitespace result_variable', { result_variable: '   ' }],
     ])('should log a warning and abort given %s', (caseName, params) => {
-      // Act
       handler.execute(params, mockExecCtx);
 
-      // Assert
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'RESOLVE_DIRECTION: Invalid or missing "result_variable" parameter. Operation aborted.'
-      );
+      if (params === null || params === undefined) {
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'RESOLVE_DIRECTION: params missing or invalid.',
+          { params }
+        );
+      } else {
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'RESOLVE_DIRECTION: Invalid or missing "result_variable" parameter. Operation aborted.'
+        );
+      }
       expect(
         mockWorldContext.getTargetLocationForDirection
       ).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary: 
- add `assertParamsObject` check as the first step of each operation handler
- update affected unit tests to expect new warning messages

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: many existing issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test` *(none needed)*
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f223cf35c833184a322fb0ccc4658