### PR TITLE
[Agent] freeze persistence error codes

### DIFF
--- a/src/persistence/persistenceErrors.js
+++ b/src/persistence/persistenceErrors.js
@@ -17,6 +17,11 @@ export const PersistenceErrorCodes = {
   UNEXPECTED_ERROR: 'UNEXPECTED_ERROR',
 };
 
+// Freeze to prevent accidental modification of error codes
+Object.freeze(PersistenceErrorCodes);
+
+export default PersistenceErrorCodes;
+
 /**
  * Custom error class for persistence-related operations.
  *


### PR DESCRIPTION
Summary: freeze PersistenceErrorCodes and export as default so other modules can't mutate them.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 540 errors, 1829 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f228c8b2883319d08dac27d4c7b92