### PR TITLE
[Feat] add identifier assertion method

### DIFF
--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import { encode, decode } from '@msgpack/msgpack';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 
@@ -88,6 +89,7 @@ describe('SaveLoadService additional coverage', () => {
   it('loadGameData validates identifier', async () => {
     const res = await service.loadGameData('');
     expect(res.success).toBe(false);
+    expect(res.error.code).toBe(PersistenceErrorCodes.INVALID_SAVE_IDENTIFIER);
     expect(res.data).toBeNull();
     expect(logger.error).toHaveBeenCalled();
   });

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -8,6 +8,7 @@ import {
 } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import { encode } from '@msgpack/msgpack';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 
@@ -178,6 +179,9 @@ describe('SaveLoadService edge cases', () => {
     it('fails on invalid identifier', async () => {
       const res = await service.loadGameData('');
       expect(res.success).toBe(false);
+      expect(res.error.code).toBe(
+        PersistenceErrorCodes.INVALID_SAVE_IDENTIFIER
+      );
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -317,6 +321,9 @@ describe('SaveLoadService edge cases', () => {
     it('rejects invalid identifier', async () => {
       const res = await service.deleteManualSave('');
       expect(res.success).toBe(false);
+      expect(res.error.code).toBe(
+        PersistenceErrorCodes.INVALID_SAVE_IDENTIFIER
+      );
       expect(logger.error).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Summary: Implemented a reusable identifier validation helper and updated tests.

Changes Made:
- Added `#assertValidIdentifier` private method in `SaveLoadService`.
- Replaced inline identifier checks in `loadGameData` and `deleteManualSave`.
- Updated tests to assert error codes on invalid identifiers.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`) – fails due to existing repo issues
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test (skipped)


------
https://chatgpt.com/codex/tasks/task_e_684f2b6f4468833190e586bde19b1e0c