### PR TITLE
[Agent] warn when overwriting component cleaner

### DIFF
--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -66,6 +66,11 @@ class ComponentCleaningService {
    * @returns {void}
    */
   registerCleaner(componentId, cleanerFn) {
+    if (this.#cleaners.has(componentId)) {
+      this.#logger.warn(
+        `Cleaner for component '${componentId}' already registered. Overwriting.`
+      );
+    }
     this.#cleaners.set(componentId, cleanerFn);
   }
 

--- a/tests/services/componentCleaningService.test.js
+++ b/tests/services/componentCleaningService.test.js
@@ -32,7 +32,7 @@ describe('ComponentCleaningService', () => {
   });
 
   it('allows registering and executing custom cleaners', () => {
-    service.registerCleaner('test:comp', (d) => ({ cleaned: true }));
+    service.registerCleaner('test:comp', () => ({ cleaned: true }));
     const result = service.clean('test:comp', { foo: 'bar' });
     expect(result).toEqual({ cleaned: true });
   });
@@ -63,5 +63,21 @@ describe('ComponentCleaningService', () => {
         details: expect.objectContaining({ componentId: 'loop' }),
       })
     );
+  });
+
+  it('warns when registering a cleaner twice', () => {
+    const firstCleaner = jest.fn(() => ({ first: true }));
+    const secondCleaner = jest.fn(() => ({ second: true }));
+
+    service.registerCleaner('dup:comp', firstCleaner);
+    logger.warn.mockClear();
+    service.registerCleaner('dup:comp', secondCleaner);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "ComponentCleaningService: Cleaner for component 'dup:comp' already registered. Overwriting."
+    );
+
+    const result = service.clean('dup:comp', {});
+    expect(result).toEqual({ second: true });
   });
 });


### PR DESCRIPTION
## Summary
- log a warning if registering a cleaner for the same component twice
- test the warning and overwrite behavior in ComponentCleaningService

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f2b5a70b88331b8b12fed7a621e4f