### PR TITLE
[Agent] Inject dependencies for bootstrap stages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,9 @@
 import { configureContainer } from './dependencyInjection/containerConfig.js';
 import { tokens } from './dependencyInjection/tokens.js';
 import { displayFatalStartupError } from './bootstrapper/errorUtils.js';
+import { UIBootstrapper } from './bootstrapper/UIBootstrapper.js';
+import AppContainer from './dependencyInjection/appContainer.js';
+import GameEngine from './engine/gameEngine.js';
 // Import all necessary stages
 import {
   ensureCriticalDOMElementsStage,
@@ -38,11 +41,18 @@ export async function bootstrapApp() {
   try {
     // STAGE 1: Ensure Critical DOM Elements
     currentPhaseForError = 'UI Element Validation';
-    uiElements = await ensureCriticalDOMElementsStage(document);
+    uiElements = await ensureCriticalDOMElementsStage(
+      document,
+      () => new UIBootstrapper()
+    );
 
     // STAGE 2: Setup DI Container
     currentPhaseForError = 'DI Container Setup';
-    container = await setupDIContainerStage(uiElements, configureContainer);
+    container = await setupDIContainerStage(
+      uiElements,
+      configureContainer,
+      () => new AppContainer()
+    );
 
     // STAGE 3: Resolve Core Services (Logger)
     currentPhaseForError = 'Core Services Resolution';
@@ -55,7 +65,7 @@ export async function bootstrapApp() {
     // STAGE 4: Initialize Game Engine
     currentPhaseForError = 'Game Engine Initialization';
     logger.debug(`main.js: Executing ${currentPhaseForError} stage...`);
-    gameEngine = await initializeGameEngineStage(container, logger);
+    gameEngine = await initializeGameEngineStage(container, logger, GameEngine);
     logger.debug(`main.js: ${currentPhaseForError} stage completed.`);
 
     // STAGE 5: Initialize Auxiliary Services

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -1,16 +1,6 @@
-import {
-  ensureCriticalDOMElementsStage,
-  setupGlobalEventListenersStage,
-  startGameStage,
-} from '../../src/bootstrapper/stages.js';
+import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages.js';
 import { UIBootstrapper } from '../../src/bootstrapper/UIBootstrapper.js';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
-
-const createLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-});
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -19,22 +9,20 @@ afterEach(() => {
 describe('ensureCriticalDOMElementsStage', () => {
   it('returns elements from UIBootstrapper', async () => {
     const mockElements = { root: document.body };
-    jest
-      .spyOn(UIBootstrapper.prototype, 'gatherEssentialElements')
-      .mockReturnValue(mockElements);
-    const result = await ensureCriticalDOMElementsStage(document);
+    const uiBoot = new UIBootstrapper();
+    jest.spyOn(uiBoot, 'gatherEssentialElements').mockReturnValue(mockElements);
+    const result = await ensureCriticalDOMElementsStage(document, uiBoot);
     expect(result).toBe(mockElements);
   });
 
   it('wraps errors with phase', async () => {
     const error = new Error('fail');
-    jest
-      .spyOn(UIBootstrapper.prototype, 'gatherEssentialElements')
-      .mockImplementation(() => {
-        throw error;
-      });
+    const uiBoot = new UIBootstrapper();
+    jest.spyOn(uiBoot, 'gatherEssentialElements').mockImplementation(() => {
+      throw error;
+    });
     await expect(
-      ensureCriticalDOMElementsStage(document)
+      ensureCriticalDOMElementsStage(document, uiBoot)
     ).rejects.toMatchObject({ phase: 'UI Element Validation' });
   });
 });


### PR DESCRIPTION
Summary: Refactors bootstrap stages to allow dependency injection of UI bootstrapper, DI container, and GameEngine. Updates main.js to supply these instances and adapts related tests.

Changes Made:
- `ensureCriticalDOMElementsStage` now accepts a bootstrapper instance or factory.
- `setupDIContainerStage` takes an optional container instance or factory.
- `initializeGameEngineStage` can receive a GameEngine constructor or factory.
- main bootstrap process updated to pass the required objects.
- Tests updated for new parameters.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)



------
https://chatgpt.com/codex/tasks/task_e_684f2bb755808331afdca4dca6c25bd0