### PR TITLE
[Agent] verify MacroLoader schema ID use

### DIFF
--- a/tests/services/macroLoader.happyPath.core.test.js
+++ b/tests/services/macroLoader.happyPath.core.test.js
@@ -1,6 +1,7 @@
 import MacroLoader from '../../src/loaders/macroLoader.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { CORE_MOD_ID } from '../../src/constants/core';
+import StaticConfiguration from '../../src/configuration/staticConfiguration.js';
 
 const createMockConfiguration = (overrides = {}) => ({
   getModsBasePath: jest.fn(() => './data/mods'),
@@ -108,5 +109,26 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
     );
 
     expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('uses StaticConfiguration to obtain the macro schema ID', () => {
+    const realConfig = new StaticConfiguration();
+    const tempLogger = createMockLogger();
+
+    const loader = new MacroLoader(
+      realConfig,
+      createMockPathResolver(),
+      createMockDataFetcher({}),
+      createMockSchemaValidator(),
+      mockRegistry,
+      tempLogger
+    );
+
+    const expectedId = realConfig.getContentTypeSchemaId('macros');
+    expect(loader._primarySchemaId).toBe(expectedId);
+    expect(tempLogger.warn).not.toHaveBeenCalled();
+    expect(tempLogger.debug).toHaveBeenCalledWith(
+      `MacroLoader: Primary schema ID for content type 'macros' found: '${expectedId}'`
+    );
   });
 });


### PR DESCRIPTION
## Summary
- confirm that MacroLoader grabs the macros schema ID

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f2c660bb88331afe380093c2a8d78