### PR TITLE
[Agent] fix browser build and add build test

### DIFF
--- a/src/engine/engineVersion.js
+++ b/src/engine/engineVersion.js
@@ -1,11 +1,7 @@
 // src/engine/engineVersion.js
-/* eslint-env node */
-/* global process */
+/* eslint-env browser */
 
-import { readFileSync } from 'fs';
-import path from 'path';
-const pkgPath = path.resolve(process.cwd(), 'package.json');
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+import pkg from '../../package.json';
 import semver from 'semver';
 import { freeze } from '../utils/objectUtils.js';
 

--- a/tests/integration/browserBuild.integration.test.js
+++ b/tests/integration/browserBuild.integration.test.js
@@ -1,0 +1,14 @@
+import { execFileSync } from 'child_process';
+
+const ESBUILD_PATH = './node_modules/.bin/esbuild';
+
+describe('Browser build', () => {
+  it('bundles main entry without node built-ins', () => {
+    execFileSync(ESBUILD_PATH, [
+      'src/main.js',
+      '--bundle',
+      '--platform=browser',
+      '--outfile=/tmp/out.js',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- make browser build use JSON import instead of Node `fs`
- ensure esbuild can bundle main entry

## Testing Done
- `npm run format`
- `npx eslint src/engine/engineVersion.js tests/integration/browserBuild.integration.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f2caa254c8331bc9aa0671272f5c5