### PR TITLE
[Agent] Add queryComponents operation

### DIFF
--- a/data/mods/core/rules/entity_speech.rule.json
+++ b/data/mods/core/rules/entity_speech.rule.json
@@ -5,23 +5,20 @@
   "event_type": "core:entity_spoke",
   "actions": [
     {
-      "type": "QUERY_COMPONENT",
-      "comment": "Step 1.1: Attempt to get the speaker's name component.",
+      "type": "QUERY_COMPONENTS",
+      "comment": "Fetch required speaker components in bulk.",
       "parameters": {
         "entity_ref": "actor",
-        "component_type": "core:name",
-        "result_variable": "speakerNameComponent",
-        "missing_value": null
-      }
-    },
-    {
-      "type": "QUERY_COMPONENT",
-      "comment": "Step 1.2: Attempt to get the speaker's position component.",
-      "parameters": {
-        "entity_ref": "actor",
-        "component_type": "core:position",
-        "result_variable": "speakerPositionComponent",
-        "missing_value": null
+        "pairs": [
+          {
+            "component_type": "core:name",
+            "result_variable": "speakerNameComponent"
+          },
+          {
+            "component_type": "core:position",
+            "result_variable": "speakerPositionComponent"
+          }
+        ]
       }
     },
     {

--- a/data/mods/core/rules/go.rule.json
+++ b/data/mods/core/rules/go.rule.json
@@ -13,23 +13,20 @@
   },
   "actions": [
     {
-      "type": "QUERY_COMPONENT",
-      "comment": "Step 1.1: Attempt to fetch the actor's name component.",
+      "type": "QUERY_COMPONENTS",
+      "comment": "Fetch actor name and position components in bulk.",
       "parameters": {
         "entity_ref": "actor",
-        "component_type": "core:name",
-        "result_variable": "actorNameComponent",
-        "missing_value": null
-      }
-    },
-    {
-      "type": "QUERY_COMPONENT",
-      "comment": "Step 1.2: Attempt to fetch the actor's position component.",
-      "parameters": {
-        "entity_ref": "actor",
-        "component_type": "core:position",
-        "result_variable": "actorPositionComponentPreMove",
-        "missing_value": null
+        "pairs": [
+          {
+            "component_type": "core:name",
+            "result_variable": "actorNameComponent"
+          },
+          {
+            "component_type": "core:position",
+            "result_variable": "actorPositionComponentPreMove"
+          }
+        ]
       }
     },
     {

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -39,6 +39,9 @@
           "$ref": "./operations/queryComponent.schema.json"
         },
         {
+          "$ref": "./operations/queryComponents.schema.json"
+        },
+        {
           "$ref": "./operations/modifyComponent.schema.json"
         },
         {

--- a/data/schemas/operations/queryComponents.schema.json
+++ b/data/schemas/operations/queryComponents.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/schemas/operations/queryComponents.schema.json",
+  "title": "QUERY_COMPONENTS Operation",
+  "type": "object",
+  "properties": {
+    "type": { "const": "QUERY_COMPONENTS" },
+    "comment": {
+      "type": "string",
+      "description": "Optional. A human-readable description or note; ignored at runtime."
+    },
+    "condition": {
+      "$ref": "../json-logic.schema.json#",
+      "description": "Optional. If present, execute only when the JSON-Logic condition evaluates to true."
+    },
+    "parameters": { "$ref": "#/$defs/Parameters" }
+  },
+  "required": ["type", "parameters"],
+  "additionalProperties": false,
+  "$defs": {
+    "Parameters": {
+      "type": "object",
+      "description": "Parameters for the QUERY_COMPONENTS operation.",
+      "properties": {
+        "entity_ref": {
+          "$ref": "../common.schema.json#/definitions/entityReference"
+        },
+        "pairs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/Pair" }
+        }
+      },
+      "required": ["entity_ref", "pairs"],
+      "additionalProperties": false
+    },
+    "Pair": {
+      "type": "object",
+      "properties": {
+        "component_type": {
+          "$ref": "../common.schema.json#/definitions/namespacedId"
+        },
+        "result_variable": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\S(.*\\S)?$"
+        }
+      },
+      "required": ["component_type", "result_variable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -23,6 +23,7 @@ import LogHandler from '../../logic/operationHandlers/logHandler.js';
 import ModifyComponentHandler from '../../logic/operationHandlers/modifyComponentHandler.js';
 import AddComponentHandler from '../../logic/operationHandlers/addComponentHandler.js';
 import QueryComponentHandler from '../../logic/operationHandlers/queryComponentHandler.js';
+import QueryComponentsHandler from '../../logic/operationHandlers/queryComponentsHandler.js';
 import RemoveComponentHandler from '../../logic/operationHandlers/removeComponentHandler.js';
 import SetVariableHandler from '../../logic/operationHandlers/setVariableHandler.js';
 import EndTurnHandler from '../../logic/operationHandlers/endTurnHandler.js';
@@ -136,6 +137,16 @@ export function registerInterpreters(container) {
     [
       tokens.QueryComponentHandler,
       QueryComponentHandler,
+      (c, Handler) =>
+        new Handler({
+          entityManager: c.resolve(tokens.IEntityManager),
+          logger: c.resolve(tokens.ILogger),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        }),
+    ],
+    [
+      tokens.QueryComponentsHandler,
+      QueryComponentsHandler,
       (c, Handler) =>
         new Handler({
           entityManager: c.resolve(tokens.IEntityManager),
@@ -362,6 +373,7 @@ export function registerInterpreters(container) {
     registry.register('ADD_COMPONENT', bind(tokens.AddComponentHandler));
     registry.register('REMOVE_COMPONENT', bind(tokens.RemoveComponentHandler));
     registry.register('QUERY_COMPONENT', bind(tokens.QueryComponentHandler));
+    registry.register('QUERY_COMPONENTS', bind(tokens.QueryComponentsHandler));
     registry.register('QUERY_ENTITIES', bind(tokens.QueryEntitiesHandler));
     registry.register('SET_VARIABLE', bind(tokens.SetVariableHandler));
     registry.register('END_TURN', bind(tokens.EndTurnHandler));

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -125,6 +125,7 @@ import { freeze } from '../utils/objectUtils.js';
  * @property {DiToken} AddComponentHandler - Token for the 'ADD_COMPONENT' operation handler.
  * @property {DiToken} RemoveComponentHandler - Token for the 'REMOVE_COMPONENT' operation handler.
  * @property {DiToken} QueryComponentHandler - Token for the 'QUERY_COMPONENT' operation handler.
+ * @property {DiToken} QueryComponentsHandler - Token for the 'QUERY_COMPONENTS' operation handler.
  * @property {DiToken} SetVariableHandler - Token for the 'SET_VARIABLE' operation handler.
  * @property {DiToken} EndTurnHandler - Token for the 'END_TURN' operation handler.
  * @property {DiToken} ModifyContextArrayHandler - Token for the 'MODIFY_CONTEXT_ARRAY' operation handler.
@@ -310,6 +311,7 @@ export const tokens = freeze({
   AddComponentHandler: 'AddComponentHandler',
   RemoveComponentHandler: 'RemoveComponentHandler',
   QueryComponentHandler: 'QueryComponentHandler',
+  QueryComponentsHandler: 'QueryComponentsHandler',
   SetVariableHandler: 'SetVariableHandler',
   EndTurnHandler: 'EndTurnHandler',
   SystemMoveEntityHandler: 'SystemMoveEntityHandler',

--- a/src/logic/operationHandlers/queryComponentsHandler.js
+++ b/src/logic/operationHandlers/queryComponentsHandler.js
@@ -1,0 +1,173 @@
+// src/logic/operationHandlers/queryComponentsHandler.js
+
+/**
+ * @file Handles the QUERY_COMPONENTS operation which retrieves multiple
+ * components from an entity at once.
+ */
+
+/** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
+import { resolveEntityId } from '../../utils/entityRefUtils.js';
+import { setContextValue } from '../../utils/contextVariableUtils.js';
+import { safeDispatchError } from '../../utils/safeDispatchError.js';
+import { assertParamsObject } from '../../utils/handlerUtils/params.js';
+
+/**
+ * Parameters for the QUERY_COMPONENTS operation.
+ *
+ * @typedef {object} QueryComponentsParams
+ * @property {'actor'|'target'|string|import('./modifyComponentHandler.js').EntityRefObject} entity_ref
+ *   Reference to the entity from which to fetch components.
+ * @property {Array<{component_type: string, result_variable: string}>} pairs
+ *   Array of component/result variable pairs.
+ */
+
+class QueryComponentsHandler {
+  /** @type {IEntityManager} */ #entityManager;
+  /** @type {ILogger} */ #logger;
+  /** @type {ISafeEventDispatcher} */ #dispatcher;
+
+  /**
+   * @param {object} deps
+   * @param {IEntityManager} deps.entityManager
+   * @param {ILogger} deps.logger
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
+   */
+  constructor({ entityManager, logger, safeEventDispatcher }) {
+    if (!entityManager?.getComponentData) {
+      throw new Error('QueryComponentsHandler requires a valid IEntityManager');
+    }
+    if (!logger || typeof logger.debug !== 'function') {
+      throw new Error('QueryComponentsHandler requires a valid ILogger');
+    }
+    if (!safeEventDispatcher?.dispatch) {
+      throw new Error('QueryComponentsHandler requires ISafeEventDispatcher');
+    }
+    this.#entityManager = entityManager;
+    this.#logger = logger;
+    this.#dispatcher = safeEventDispatcher;
+  }
+
+  /**
+   * Execute the QUERY_COMPONENTS operation.
+   *
+   * @param {QueryComponentsParams} params
+   * @param {ExecutionContext} executionContext
+   */
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
+
+    if (
+      !assertParamsObject(params, this.#dispatcher, 'QueryComponentsHandler')
+    ) {
+      return;
+    }
+
+    if (
+      !executionContext?.evaluationContext?.context ||
+      typeof executionContext.evaluationContext.context !== 'object'
+    ) {
+      safeDispatchError(
+        this.#dispatcher,
+        'QueryComponentsHandler: executionContext.evaluationContext.context is missing or invalid.',
+        { executionContext }
+      );
+      return;
+    }
+
+    const { entity_ref, pairs } = params;
+
+    if (!entity_ref) {
+      safeDispatchError(
+        this.#dispatcher,
+        'QueryComponentsHandler: Missing required "entity_ref" parameter.',
+        { params }
+      );
+      return;
+    }
+    if (!Array.isArray(pairs) || pairs.length === 0) {
+      safeDispatchError(
+        this.#dispatcher,
+        'QueryComponentsHandler: "pairs" must be a non-empty array.',
+        { params }
+      );
+      return;
+    }
+
+    const entityId = resolveEntityId(entity_ref, executionContext);
+    if (!entityId) {
+      safeDispatchError(
+        this.#dispatcher,
+        'QueryComponentsHandler: Could not resolve entity id from entity_ref.',
+        { entityRef: entity_ref }
+      );
+      return;
+    }
+
+    for (const pair of pairs) {
+      if (!pair || typeof pair !== 'object') continue;
+      const { component_type, result_variable } = pair;
+      if (
+        !component_type ||
+        typeof component_type !== 'string' ||
+        !component_type.trim()
+      ) {
+        safeDispatchError(
+          this.#dispatcher,
+          'QueryComponentsHandler: Invalid component_type in pair.',
+          { pair }
+        );
+        continue;
+      }
+      if (
+        !result_variable ||
+        typeof result_variable !== 'string' ||
+        !result_variable.trim()
+      ) {
+        safeDispatchError(
+          this.#dispatcher,
+          'QueryComponentsHandler: Invalid result_variable in pair.',
+          { pair }
+        );
+        continue;
+      }
+      const trimmedType = component_type.trim();
+      const trimmedVar = result_variable.trim();
+      let result;
+      try {
+        result = this.#entityManager.getComponentData(entityId, trimmedType);
+      } catch (e) {
+        safeDispatchError(
+          this.#dispatcher,
+          `QueryComponentsHandler: Error retrieving component "${trimmedType}" from entity "${entityId}"`,
+          { error: e.message, stack: e.stack }
+        );
+        result = undefined;
+      }
+
+      const valueToStore = result === undefined ? null : result;
+      setContextValue(
+        trimmedVar,
+        valueToStore,
+        executionContext,
+        this.#dispatcher,
+        logger
+      );
+
+      if (result !== undefined) {
+        logger.debug(
+          `QueryComponentsHandler: Stored component "${trimmedType}" value in "${trimmedVar}".`
+        );
+      } else {
+        logger.debug(
+          `QueryComponentsHandler: Component "${trimmedType}" not found on entity "${entityId}". Stored null in "${trimmedVar}".`
+        );
+      }
+    }
+  }
+}
+
+export default QueryComponentsHandler;

--- a/tests/config/registrations/interpreterRegistrations.test.js
+++ b/tests/config/registrations/interpreterRegistrations.test.js
@@ -413,6 +413,10 @@ describe('registerInterpreters', () => {
       expect.any(Function)
     );
     expect(mockInstance.register).toHaveBeenCalledWith(
+      'QUERY_COMPONENTS',
+      expect.any(Function)
+    );
+    expect(mockInstance.register).toHaveBeenCalledWith(
       'SET_VARIABLE',
       expect.any(Function)
     );

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -82,6 +82,11 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
+    QUERY_COMPONENTS: new (require('../../../src/logic/operationHandlers/queryComponentsHandler.js').default)({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
       dispatcher: eventBus,

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -165,6 +165,11 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
+    QUERY_COMPONENTS: new (require('../../../src/logic/operationHandlers/queryComponentsHandler.js').default)({
+      entityManager,
+      logger,
+      safeEventDispatcher: safeDispatcher,
+    }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     SET_VARIABLE: new SetVariableHandler({ logger }),
     RESOLVE_DIRECTION: new ResolveDirectionHandler({

--- a/tests/logic/operationHandlers/queryComponentsHandler.test.js
+++ b/tests/logic/operationHandlers/queryComponentsHandler.test.js
@@ -1,0 +1,97 @@
+// tests/logic/operationHandlers/queryComponentsHandler.test.js
+
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+import QueryComponentsHandler from '../../../src/logic/operationHandlers/queryComponentsHandler.js';
+import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('QueryComponentsHandler', () => {
+  let entityManager;
+  let logger;
+  let dispatcher;
+  let handler;
+
+  const actorId = 'actor-1';
+  const execCtx = {
+    evaluationContext: { actor: { id: actorId }, target: null, context: {} },
+    logger: makeLogger(),
+  };
+
+  beforeEach(() => {
+    entityManager = { getComponentData: jest.fn() };
+    logger = makeLogger();
+    dispatcher = { dispatch: jest.fn() };
+    handler = new QueryComponentsHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher: dispatcher,
+    });
+    jest.clearAllMocks();
+    execCtx.evaluationContext.context = {};
+  });
+
+  test('fetches each component and stores results', () => {
+    entityManager.getComponentData.mockImplementation((id, type) => {
+      if (type === 'core:name') return { text: 'Hero' };
+      if (type === 'core:pos') return { locationId: 'room1' };
+      return undefined;
+    });
+
+    const params = {
+      entity_ref: 'actor',
+      pairs: [
+        { component_type: 'core:name', result_variable: 'nameComp' },
+        { component_type: 'core:pos', result_variable: 'posComp' },
+      ],
+    };
+
+    handler.execute(params, execCtx);
+
+    expect(entityManager.getComponentData).toHaveBeenCalledWith(
+      actorId,
+      'core:name'
+    );
+    expect(entityManager.getComponentData).toHaveBeenCalledWith(
+      actorId,
+      'core:pos'
+    );
+    expect(execCtx.evaluationContext.context.nameComp).toEqual({
+      text: 'Hero',
+    });
+    expect(execCtx.evaluationContext.context.posComp).toEqual({
+      locationId: 'room1',
+    });
+  });
+
+  test('stores null when a component is missing', () => {
+    entityManager.getComponentData.mockReturnValue(undefined);
+
+    const params = {
+      entity_ref: 'actor',
+      pairs: [{ component_type: 'core:missing', result_variable: 'miss' }],
+    };
+
+    handler.execute(params, execCtx);
+
+    expect(execCtx.evaluationContext.context.miss).toBeNull();
+    expect(execCtx.logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Stored null in "miss"')
+    );
+  });
+
+  test('logs error when params invalid', () => {
+    handler.execute(null, execCtx);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      DISPLAY_ERROR_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('params missing'),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Implemented a bulk component query operation. Added schema and handler, registered in DI, updated tests and core rules to use QUERY_COMPONENTS.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f2bfe19dc83319eb9109c85d62d49