### PR TITLE
[Agent] Add bootstrap helper utilities

### DIFF
--- a/src/bootstrapper/auxiliaryStages.js
+++ b/src/bootstrapper/auxiliaryStages.js
@@ -5,6 +5,7 @@
  *
  * @module auxiliaryStages
  */
+import { resolveAndInitialize } from './helpers.js';
 
 /**
  * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer
@@ -30,23 +31,7 @@
  * @returns {void}
  */
 export function initEngineUIManager({ container, logger, tokens }) {
-  const stage = 'EngineUIManager Init';
-  try {
-    logger.debug(`${stage}: Resolving EngineUIManager...`);
-    const eum = container.resolve(tokens.EngineUIManager);
-    if (!eum) {
-      throw new Error(
-        'EngineUIManager instance could not be resolved from container.'
-      );
-    }
-    if (typeof eum.initialize !== 'function') {
-      throw new Error('EngineUIManager does not expose initialize()');
-    }
-    eum.initialize();
-    logger.debug(`${stage}: Initialized successfully.`);
-  } catch (err) {
-    logger.error(`${stage}: Failed to initialize.`, err);
-  }
+  resolveAndInitialize(container, tokens.EngineUIManager, 'initialize', logger);
 }
 
 /**
@@ -56,22 +41,13 @@ export function initEngineUIManager({ container, logger, tokens }) {
  * @returns {void}
  */
 export function initSaveGameUI({ container, gameEngine, logger, tokens }) {
-  const stage = 'SaveGameUI Init';
-  try {
-    logger.debug(`${stage}: Resolving SaveGameUI...`);
-    const ui = container.resolve(tokens.SaveGameUI);
-    if (ui) {
-      if (typeof ui.init !== 'function') {
-        throw new Error('SaveGameUI missing init(gameEngine)');
-      }
-      ui.init(gameEngine);
-      logger.debug(`${stage}: Initialized with GameEngine.`);
-    } else {
-      logger.warn(`${stage}: SaveGameUI could not be resolved.`);
-    }
-  } catch (err) {
-    logger.error(`${stage}: Error during initialization.`, err);
-  }
+  resolveAndInitialize(
+    container,
+    tokens.SaveGameUI,
+    'init',
+    logger,
+    gameEngine
+  );
 }
 
 /**
@@ -81,22 +57,13 @@ export function initSaveGameUI({ container, gameEngine, logger, tokens }) {
  * @returns {void}
  */
 export function initLoadGameUI({ container, gameEngine, logger, tokens }) {
-  const stage = 'LoadGameUI Init';
-  try {
-    logger.debug(`${stage}: Resolving LoadGameUI...`);
-    const ui = container.resolve(tokens.LoadGameUI);
-    if (ui) {
-      if (typeof ui.init !== 'function') {
-        throw new Error('LoadGameUI missing init(gameEngine)');
-      }
-      ui.init(gameEngine);
-      logger.debug(`${stage}: Initialized with GameEngine.`);
-    } else {
-      logger.warn(`${stage}: LoadGameUI could not be resolved.`);
-    }
-  } catch (err) {
-    logger.error(`${stage}: Error during initialization.`, err);
-  }
+  resolveAndInitialize(
+    container,
+    tokens.LoadGameUI,
+    'init',
+    logger,
+    gameEngine
+  );
 }
 
 /**

--- a/src/bootstrapper/helpers.js
+++ b/src/bootstrapper/helpers.js
@@ -1,0 +1,80 @@
+// src/bootstrapper/helpers.js
+
+/**
+ * @file Utility helpers used during application bootstrap stages.
+ */
+
+/**
+ * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+/**
+ * Resolves a service from the container and invokes its initialization method.
+ * Logs success or failure for easier debugging during bootstrap.
+ *
+ * @param {AppContainer} container - The dependency injection container.
+ * @param {string} token - The DI token used to resolve the service.
+ * @param {string} initFnName - Name of the initialization method to invoke.
+ * @param {ILogger} logger - Logger used for debug/warn/error output.
+ * @param {...any} args - Arguments forwarded to the initialization method.
+ * @returns {void}
+ */
+export function resolveAndInitialize(
+  container,
+  token,
+  initFnName,
+  logger,
+  ...args
+) {
+  const stage = `${token} Init`;
+  try {
+    logger.debug(`${stage}: Resolving ${token}...`);
+    const service = container.resolve(token);
+    if (!service) {
+      logger.warn(`${stage}: ${token} could not be resolved.`);
+      return;
+    }
+    const initFn = service[initFnName];
+    if (typeof initFn !== 'function') {
+      throw new Error(`${token} missing ${initFnName}()`);
+    }
+    initFn.apply(service, args);
+    logger.debug(`${stage}: Initialized successfully.`);
+  } catch (err) {
+    logger.error(`${stage}: Failed to initialize.`, err);
+  }
+}
+
+/**
+ * Attaches a click listener to a DOM button element if it exists.
+ * Logs warnings when the element is missing.
+ *
+ * @param {Document} documentRef - Document to query for the button element.
+ * @param {string} buttonId - Element ID of the button.
+ * @param {Function} handler - Click handler function.
+ * @param {ILogger} logger - Logger used for debug/warn output.
+ * @param {string} stageName - Name of the bootstrap stage for log context.
+ * @returns {void}
+ */
+export function setupButtonListener(
+  documentRef,
+  buttonId,
+  handler,
+  logger,
+  stageName
+) {
+  const button = documentRef.getElementById(buttonId);
+  if (button) {
+    button.addEventListener('click', handler);
+    logger.debug(
+      `${stageName}: ${buttonId} listener attached to #${buttonId}.`
+    );
+  } else {
+    logger.warn(
+      `${stageName}: Could not find #${buttonId}. Listener not attached.`
+    );
+  }
+}
+
+// --- FILE END ---

--- a/src/bootstrapper/stages.js
+++ b/src/bootstrapper/stages.js
@@ -6,6 +6,7 @@ import AppContainer from '../dependencyInjection/appContainer.js'; // Corrected 
 import GameEngine from '../engine/gameEngine.js';
 
 import { initializeAuxiliaryServicesStage } from './auxiliaryStages.js';
+import { setupButtonListener } from './helpers.js';
 export { initializeAuxiliaryServicesStage };
 // eslint-disable-next-line no-unused-vars
 import { tokens } from '../dependencyInjection/tokens.js'; // Corrected path assuming tokens.js is in ../dependencyInjection/
@@ -204,48 +205,49 @@ export async function setupMenuButtonListenersStage(
   logger.debug(`Bootstrap Stage: Starting ${stageName}...`);
 
   try {
-    const openSaveGameButton = documentRef.getElementById(
-      'open-save-game-button'
-    );
-    if (openSaveGameButton && gameEngine) {
-      openSaveGameButton.addEventListener('click', () => {
-        logger.debug(`${stageName}: "Open Save Game UI" button clicked.`);
-        gameEngine.showSaveGameUI();
-      });
-      logger.debug(
-        `${stageName}: Save Game UI button listener attached to #open-save-game-button.`
+    if (gameEngine) {
+      setupButtonListener(
+        documentRef,
+        'open-save-game-button',
+        () => {
+          logger.debug(`${stageName}: "Open Save Game UI" button clicked.`);
+          gameEngine.showSaveGameUI();
+        },
+        logger,
+        stageName
       );
-    } else {
-      if (!openSaveGameButton)
-        logger.warn(
-          `${stageName}: Could not find #open-save-game-button. Save listener not attached.`
-        );
-      if (!gameEngine)
-        logger.warn(
-          `${stageName}: GameEngine not available for #open-save-game-button listener.`
-        );
-    }
 
-    const openLoadGameButton = documentRef.getElementById(
-      'open-load-game-button'
-    );
-    if (openLoadGameButton && gameEngine) {
-      openLoadGameButton.addEventListener('click', () => {
-        logger.debug(`${stageName}: "Open Load Game UI" button clicked.`);
-        gameEngine.showLoadGameUI();
-      });
-      logger.debug(
-        `${stageName}: Load Game UI button listener attached to #open-load-game-button.`
+      setupButtonListener(
+        documentRef,
+        'open-load-game-button',
+        () => {
+          logger.debug(`${stageName}: "Open Load Game UI" button clicked.`);
+          gameEngine.showLoadGameUI();
+        },
+        logger,
+        stageName
       );
     } else {
-      if (!openLoadGameButton)
-        logger.warn(
-          `${stageName}: Could not find #open-load-game-button. Load listener not attached.`
-        );
-      if (!gameEngine)
-        logger.warn(
-          `${stageName}: GameEngine not available for #open-load-game-button listener.`
-        );
+      setupButtonListener(
+        documentRef,
+        'open-save-game-button',
+        () => {},
+        logger,
+        stageName
+      );
+      logger.warn(
+        `${stageName}: GameEngine not available for #open-save-game-button listener.`
+      );
+      setupButtonListener(
+        documentRef,
+        'open-load-game-button',
+        () => {},
+        logger,
+        stageName
+      );
+      logger.warn(
+        `${stageName}: GameEngine not available for #open-load-game-button listener.`
+      );
     }
     logger.debug(`Bootstrap Stage: ${stageName} completed successfully.`);
   } catch (error) {


### PR DESCRIPTION
Summary: Introduced reusable helpers for bootstrap stages and refactored menu/button setup.

Changes Made:
- Added `resolveAndInitialize` and `setupButtonListener` helpers.
- Updated auxiliary service initializers to use `resolveAndInitialize`.
- Refactored `setupMenuButtonListenersStage` with `setupButtonListener`.
- Updated imports and created new helper module.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_684f2e5be98c8331bf82542c14ad3720