### PR TITLE
[Agent] document ui loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ implementation).
 
 The formal structure of this file is defined by the `game.schema.json` schema file. The engine validates `game.json`
 against this schema during startup. You can refer to `data/schemas/game.schema.json` for the precise definition.
+UI icons and labels are validated against `ui-icons.schema.json` and `ui-labels.schema.json` and loaded by the new **UiLoader**. Definitions from later mods override earlier ones.
 
 ## Dependency & Conflict Validation
 
@@ -376,6 +377,8 @@ How to use the ModManifestLoader service and handle potential errors.
 **Mod Manifest Format ➜ docs/mods/mod_manifest_format.md**
 Details of every allowed field with a sample manifest.
 
+**UI Icons & Labels ➜ docs/mods/loader.md#ui-directory-structure**
+Overview of the `ui/` folder and how icons/labels are merged.
 **Display Error Event Payload ➜ docs/events/display_error_payload.md**
 Overview of the payload structure emitted when dispatching `core:display_error` events.
 

--- a/docs/mods/loader.md
+++ b/docs/mods/loader.md
@@ -62,3 +62,19 @@ needs a policy to decide which definition takes precedence.
 
 By understanding the `game.json` ordering and the "Last Mod Wins" policy, modders can better predict how their mods will
 interact and override content from core game files or other mods.
+
+## UI Directory Structure
+
+Mods can include a `ui/` folder containing optional `icons.json` and `labels.json` files. These files are simple key/value objects validated against the `ui-icons.schema.json` and `ui-labels.schema.json` schemas.
+
+Reference them in the manifest using a `ui` content category:
+
+```json
+{
+  "content": {
+    "ui": ["icons.json", "labels.json"]
+  }
+}
+```
+
+During loading, the UiLoader merges icon and label definitions from all mods. If multiple mods define the same key, the entry from the mod loaded last overrides earlier ones, following the same "last mod wins" rule used for other content.

--- a/docs/mods/mod_manifest_format.md
+++ b/docs/mods/mod_manifest_format.md
@@ -77,3 +77,5 @@ Example snippet:
   }
 }
 ```
+
+The UiLoader validates these files against their schemas and merges the results across all mods. When multiple mods provide the same icon or label key, the version from the mod loaded last overrides earlier ones.


### PR DESCRIPTION
## Summary
- document `ui/` directory and UiLoader behavior
- mention ui JSON schemas in README
- link to new docs in README

## Testing
- `npm run format`
- `npm run lint` *(fails: jsdoc/require-... etc.)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f2e8084988331979c60234dd256e6