### PR TITLE
[Agent] add ui assets loader tests

### DIFF
--- a/src/domUI/helpers/buildSpeechMeta.js
+++ b/src/domUI/helpers/buildSpeechMeta.js
@@ -2,7 +2,7 @@
  * @file Helper function to build the speech metadata block (thoughts, notes icons).
  */
 
-import { THOUGHT_SVG, NOTES_SVG } from '../icons.js';
+import { getIcon } from '../icons.js';
 
 /**
  * @typedef {import('../domElementFactory.js').default} DomElementFactory
@@ -37,7 +37,7 @@ export function buildSpeechMeta(document, domFactory, { thoughts, notes }) {
       attrs: { 'aria-label': 'View inner thoughts' },
     });
     btn.style.setProperty('--clr', 'var(--thoughts-icon-color)');
-    btn.innerHTML = THOUGHT_SVG;
+    btn.innerHTML = getIcon('thoughts');
 
     const tooltip = domFactory.create('div', { cls: 'meta-tooltip' });
     tooltip.textContent = thoughts;
@@ -52,7 +52,7 @@ export function buildSpeechMeta(document, domFactory, { thoughts, notes }) {
       attrs: { 'aria-label': 'View private notes' },
     });
     btn.style.setProperty('--clr', 'var(--notes-icon-color)');
-    btn.innerHTML = NOTES_SVG;
+    btn.innerHTML = getIcon('notes');
 
     const tooltip = domFactory.create('div', { cls: 'meta-tooltip' });
     tooltip.textContent = notes;

--- a/src/domUI/icons.js
+++ b/src/domUI/icons.js
@@ -1,7 +1,11 @@
 /**
- * @file Contains inline SVG icon definitions for the UI.
- * Using inline SVGs avoids extra network requests and allows for easy styling with CSS (e.g., 'currentColor').
+ * @file Contains inline SVG icon definitions for the UI and helper functions
+ * to override them at runtime.
+ * Using inline SVGs avoids extra network requests and allows for easy styling
+ * with CSS (e.g., 'currentColor').
  */
+
+/** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 
 /**
  * SVG icon for "thoughts" bubble. Sized 20x20.
@@ -16,3 +20,40 @@ export const THOUGHT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" h
  * @type {string}
  */
 export const NOTES_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828a2 2 0 0 0-.586-1.414l-4.414-4.414A2 2 0 0 0 11.172 2H4zm5.5 2.5a.5.5 0 0 0-.5-.5H5a.5.5 0 0 0-.5.5v11a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V9.5a.5.5 0 0 0-.5-.5h-4a.5.5 0 0 0-.5.5V11H6V9h3.5V6.5zM11 5H6V4h5v1z" clip-rule="evenodd"/></svg>`;
+
+const DEFAULT_ICONS = {
+  thoughts: THOUGHT_SVG,
+  notes: NOTES_SVG,
+};
+
+let iconRegistry = null;
+
+/**
+ * @description Registers an IDataRegistry providing custom icons.
+ * @param {IDataRegistry|null} registry - Registry containing 'ui-icons' entries or null to clear.
+ */
+export function setIconRegistry(registry) {
+  iconRegistry = registry;
+}
+
+/**
+ * @description Retrieves an icon by name, falling back to defaults.
+ * @param {string} name - Icon identifier.
+ * @returns {string} SVG markup for the icon.
+ */
+export function getIcon(name) {
+  if (iconRegistry && typeof iconRegistry.get === 'function') {
+    const custom = iconRegistry.get('ui-icons', name);
+    if (typeof custom === 'string') {
+      return custom;
+    }
+    if (
+      custom &&
+      typeof custom === 'object' &&
+      typeof custom.markup === 'string'
+    ) {
+      return custom.markup;
+    }
+  }
+  return DEFAULT_ICONS[name] || '';
+}

--- a/src/loaders/uiAssetsLoader.js
+++ b/src/loaders/uiAssetsLoader.js
@@ -1,0 +1,127 @@
+// src/loaders/uiAssetsLoader.js
+
+/**
+ * @file Loader for UI asset files such as icons.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
+/** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
+/** @typedef {import('../interfaces/coreServices.js').IDataFetcher} IDataFetcher */
+/** @typedef {import('../interfaces/coreServices.js').ISchemaValidator} ISchemaValidator */
+/** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../interfaces/coreServices.js').ModManifest} ModManifest */
+
+import AbstractLoader from './abstractLoader.js';
+
+/**
+ * Simple loader that processes `icons.json` files for a mod and stores the
+ * icon markup in the provided {@link IDataRegistry}. Icons are stored under the
+ * `ui-icons` category using their icon name as the key. When multiple mods
+ * provide the same icon name, the last loaded mod wins.
+ *
+ * @class UiAssetsLoader
+ * @augments AbstractLoader
+ */
+class UiAssetsLoader extends AbstractLoader {
+  #config;
+  #resolver;
+  #fetcher;
+  #validator;
+  #registry;
+
+  /**
+   * @description Creates an instance of UiAssetsLoader.
+   * @param {IConfiguration} config - Configuration service.
+   * @param {IPathResolver} pathResolver - Path resolver service.
+   * @param {IDataFetcher} dataFetcher - Data fetching service.
+   * @param {ISchemaValidator} schemaValidator - Schema validation service.
+   * @param {IDataRegistry} dataRegistry - Data registry for storing icons.
+   * @param {ILogger} logger - Logger instance.
+   */
+  constructor(
+    config,
+    pathResolver,
+    dataFetcher,
+    schemaValidator,
+    dataRegistry,
+    logger
+  ) {
+    super(logger, [
+      {
+        dependency: config,
+        name: 'IConfiguration',
+        methods: ['getContentTypeSchemaId'],
+      },
+      {
+        dependency: pathResolver,
+        name: 'IPathResolver',
+        methods: ['resolveModContentPath'],
+      },
+      { dependency: dataFetcher, name: 'IDataFetcher', methods: ['fetch'] },
+      {
+        dependency: schemaValidator,
+        name: 'ISchemaValidator',
+        methods: ['validate'],
+      },
+      {
+        dependency: dataRegistry,
+        name: 'IDataRegistry',
+        methods: ['store', 'get'],
+      },
+    ]);
+
+    this.#config = config;
+    this.#resolver = pathResolver;
+    this.#fetcher = dataFetcher;
+    this.#validator = schemaValidator;
+    this.#registry = dataRegistry;
+  }
+
+  /**
+   * @description Loads icon definitions for a mod.
+   * @param {string} modId - The mod identifier.
+   * @param {ModManifest} manifest - The mod manifest.
+   * @returns {Promise<{count:number, overrides:number, errors:number}>} Result summary.
+   */
+  async loadIconsForMod(modId, manifest) {
+    const uiFiles = manifest?.content?.ui || [];
+    const iconsFiles = uiFiles.filter((f) => f.endsWith('icons.json'));
+
+    let count = 0;
+    let overrides = 0;
+    let errors = 0;
+
+    for (const filename of iconsFiles) {
+      try {
+        const path = this.#resolver.resolveModContentPath(
+          modId,
+          'ui',
+          filename
+        );
+        const data = await this.#fetcher.fetch(path);
+        const schemaId = this.#config.getContentTypeSchemaId('ui-icons');
+        const res = this.#validator.validate(schemaId, data);
+        if (!res.isValid) {
+          throw new Error('Icon schema validation failed');
+        }
+        for (const [name, svg] of Object.entries(data)) {
+          if (this.#registry.get('ui-icons', name) !== undefined) {
+            overrides++;
+          }
+          this.#registry.store('ui-icons', name, { markup: svg });
+        }
+        count++;
+      } catch (e) {
+        errors++;
+        this._logger.error(
+          `UiAssetsLoader [${modId}]: Failed to process ${filename}: ${e.message}`
+        );
+      }
+    }
+
+    return { count, overrides, errors };
+  }
+}
+
+export default UiAssetsLoader;

--- a/tests/domUI/helpers/buildSpeechMeta.test.js
+++ b/tests/domUI/helpers/buildSpeechMeta.test.js
@@ -2,6 +2,8 @@ import { buildSpeechMeta } from '../../../src/domUI/helpers/buildSpeechMeta.js';
 import { JSDOM } from 'jsdom';
 import { getByLabelText, getByText, queryByText } from '@testing-library/dom';
 import { describe, beforeEach, it, expect } from '@jest/globals';
+import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
+import { setIconRegistry } from '../../../src/domUI/icons.js';
 
 // A mock DomElementFactory that creates real DOM nodes using the provided document
 const createMockDomFactory = (document) => ({
@@ -125,5 +127,25 @@ describe('buildSpeechMeta', () => {
 
     // JSDOM adds a :focus pseudo-class, which is sufficient for this test
     expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  it('renders custom icons provided via the registry', () => {
+    const registry = new InMemoryDataRegistry();
+    setIconRegistry(registry);
+    registry.store('ui-icons', 'thoughts', { markup: '<svg id="t"></svg>' });
+    registry.store('ui-icons', 'notes', { markup: '<svg id="n"></svg>' });
+
+    const fragment = buildSpeechMeta(doc, mockDomFactory, {
+      thoughts: 'Hi',
+      notes: 'Note',
+    });
+    container.appendChild(fragment.cloneNode(true));
+
+    const thoughtsButton = getByLabelText(container, 'View inner thoughts');
+    const notesButton = getByLabelText(container, 'View private notes');
+    expect(thoughtsButton.querySelector('svg').id).toBe('t');
+    expect(notesButton.querySelector('svg').id).toBe('n');
+
+    setIconRegistry(null);
   });
 });

--- a/tests/loaders/uiAssetsLoader.integration.override.test.js
+++ b/tests/loaders/uiAssetsLoader.integration.override.test.js
@@ -1,0 +1,103 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import path from 'path';
+import UiAssetsLoader from '../../src/loaders/uiAssetsLoader.js';
+import InMemoryDataRegistry from '../../src/data/inMemoryDataRegistry.js';
+
+/**
+ * Creates a minimal mock configuration service.
+ *
+ * @returns {IConfiguration}
+ */
+const createMockConfig = () => ({
+  getContentTypeSchemaId: jest
+    .fn()
+    .mockImplementation((type) =>
+      type === 'ui-icons' ? 'http://example.com/ui-icons.schema.json' : ''
+    ),
+});
+
+/**
+ * Creates a mock path resolver service.
+ *
+ * @returns {IPathResolver}
+ */
+const createMockResolver = () => ({
+  resolveModContentPath: jest.fn((modId, dir, file) =>
+    path.join('/mods', modId, dir, file)
+  ),
+});
+
+/**
+ * Creates a mock data fetcher service from a map of path->data.
+ *
+ * @param {Record<string,any>} dataMap
+ * @returns {IDataFetcher}
+ */
+const createMockFetcher = (dataMap) => ({
+  fetch: jest.fn((p) => Promise.resolve(dataMap[p])),
+});
+
+/**
+ * Creates a simple schema validator mock always returning valid.
+ *
+ * @returns {ISchemaValidator}
+ */
+const createMockValidator = () => ({
+  validate: jest.fn(() => ({ isValid: true })),
+});
+
+const createMockLogger = () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('UiAssetsLoader integration - overrides', () => {
+  let registry;
+  let loader;
+  let resolver;
+  let fetcher;
+
+  const baseModId = 'BaseMod';
+  const overrideModId = 'OverrideMod';
+  const iconFile = 'icons.json';
+  const basePath = path.join('/mods', baseModId, 'ui', iconFile);
+  const overridePath = path.join('/mods', overrideModId, 'ui', iconFile);
+
+  const baseData = { heart: '<svg>base</svg>' };
+  const overrideData = { heart: '<svg>override</svg>' };
+
+  beforeEach(() => {
+    registry = new InMemoryDataRegistry();
+    resolver = createMockResolver();
+    fetcher = createMockFetcher({
+      [basePath]: baseData,
+      [overridePath]: overrideData,
+    });
+    loader = new UiAssetsLoader(
+      createMockConfig(),
+      resolver,
+      fetcher,
+      createMockValidator(),
+      registry,
+      createMockLogger()
+    );
+  });
+
+  it('last loaded icon wins when mods define the same name', async () => {
+    await loader.loadIconsForMod(baseModId, {
+      id: baseModId,
+      content: { ui: [iconFile] },
+    });
+    await loader.loadIconsForMod(overrideModId, {
+      id: overrideModId,
+      content: { ui: [iconFile] },
+    });
+
+    const stored = registry.get('ui-icons', 'heart');
+    expect(stored).toEqual({ markup: '<svg>override</svg>' });
+    expect(resolver.resolveModContentPath).toHaveBeenCalledTimes(2);
+    expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Summary:
- add UiAssetsLoader with icon registry support
- support overriding UI icons in buildSpeechMeta via getIcon
- test registry-based icon overrides
- integration test for UiAssetsLoader overrides

Testing Done:
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f2e89891c8331b127e753ae11ddf0