### PR TITLE
[Agent] fix esbuild cross-platform test

### DIFF
--- a/src/engine/engineVersion.js
+++ b/src/engine/engineVersion.js
@@ -1,11 +1,7 @@
 // src/engine/engineVersion.js
-/* eslint-env node */
-/* global process */
+/* eslint-env browser */
 
-import { readFileSync } from 'fs';
-import path from 'path';
-const pkgPath = path.resolve(process.cwd(), 'package.json');
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+import pkg from '../../package.json';
 import semver from 'semver';
 import { freeze } from '../utils/objectUtils.js';
 

--- a/tests/integration/browserBuild.integration.test.js
+++ b/tests/integration/browserBuild.integration.test.js
@@ -1,0 +1,25 @@
+/* eslint-disable jsdoc/check-tag-names */
+/** @jest-environment node */
+
+import { tmpdir } from 'os';
+import { join } from 'path';
+import fs from 'fs';
+import { TextEncoder } from 'util';
+import { execFileSync } from 'child_process';
+
+describe('Browser build', () => {
+  it('bundles main entry without node built-ins', () => {
+    const outfile = join(tmpdir(), 'bundle.js');
+    // esbuild relies on a native TextEncoder implementation
+    global.TextEncoder = TextEncoder;
+    const esbuildPath = require.resolve('esbuild/bin/esbuild');
+    execFileSync(esbuildPath, [
+      'src/main.js',
+      '--bundle',
+      '--platform=browser',
+      `--outfile=${outfile}`,
+    ]);
+    expect(fs.existsSync(outfile)).toBe(true);
+    fs.unlinkSync(outfile);
+  });
+});


### PR DESCRIPTION
## Summary
- use esbuild binary in integration test
- ensure TextEncoder is set for esbuild

## Testing Done
- `npm run format`
- `npx eslint src/engine/engineVersion.js tests/integration/browserBuild.integration.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f2caa254c8331bc9aa0671272f5c5