### PR TITLE
[Feat] Refine component capture filtering

### DIFF
--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -73,6 +73,20 @@ class GameStateCaptureService {
   }
 
   /**
+   * Determines if cleaned component data should be saved.
+   *
+   * @param {*} data - Component data after cleaning.
+   * @returns {boolean} True if data is non-null and either not an object or an
+   *   object with at least one key.
+   * @private
+   */
+  #hasMeaningfulData(data) {
+    return (
+      data != null && (typeof data !== 'object' || Object.keys(data).length > 0)
+    );
+  }
+
+  /**
    * Cleans and prepares component data for serialization.
    *
    * @param {Map<string, any>} componentEntries - Raw component map from the entity.
@@ -95,9 +109,7 @@ class GameStateCaptureService {
         componentData
       );
 
-      if (dataToSave !== null && typeof dataToSave !== 'object') {
-        components[componentTypeId] = dataToSave;
-      } else if (Object.keys(dataToSave).length > 0) {
+      if (this.#hasMeaningfulData(dataToSave)) {
         components[componentTypeId] = dataToSave;
       } else {
         this.#logger.debug(

--- a/tests/services/gameStateCaptureService.test.js
+++ b/tests/services/gameStateCaptureService.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
+import { CURRENT_ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
+import { createMockLogger } from '../testUtils.js';
+
+describe('GameStateCaptureService', () => {
+  let logger;
+  let entityManager;
+  let dataRegistry;
+  let playtimeTracker;
+  let componentCleaningService;
+  let metadataBuilder;
+  let captureService;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    entityManager = { activeEntities: new Map() };
+    dataRegistry = { getAll: jest.fn().mockReturnValue([]) };
+    playtimeTracker = { getTotalPlaytime: jest.fn().mockReturnValue(0) };
+    componentCleaningService = { clean: jest.fn() };
+    metadataBuilder = {
+      build: jest.fn(() => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: 'Test',
+        timestamp: 't',
+        playtimeSeconds: 0,
+        saveName: '',
+      })),
+    };
+    captureService = new GameStateCaptureService({
+      logger,
+      entityManager,
+      dataRegistry,
+      playtimeTracker,
+      componentCleaningService,
+      metadataBuilder,
+    });
+  });
+
+  it('skips empty object components and keeps meaningful data', () => {
+    const entity = {
+      id: 'e1',
+      definitionId: 'core:test',
+      componentEntries: new Map(
+        Object.entries({
+          empty: { foo: 'bar' },
+          object: { val: 1 },
+          primitive: 7,
+          nullComp: null,
+          [CURRENT_ACTOR_COMPONENT_ID]: { active: true },
+        })
+      ),
+    };
+    entityManager.activeEntities.set('e1', entity);
+
+    componentCleaningService.clean.mockImplementation((id, data) => {
+      if (id === 'empty') return {};
+      if (id === 'object') return { val: 1 };
+      if (id === 'primitive') return 7;
+      if (id === 'nullComp') return null;
+      return data;
+    });
+
+    const result = captureService.captureCurrentGameState('World');
+    const comps = result.gameState.entities[0].components;
+
+    expect(comps).not.toHaveProperty('empty');
+    expect(comps).toHaveProperty('object', { val: 1 });
+    expect(comps).toHaveProperty('primitive', 7);
+    expect(comps).not.toHaveProperty('nullComp');
+    expect(comps).not.toHaveProperty(CURRENT_ACTOR_COMPONENT_ID);
+  });
+});


### PR DESCRIPTION
Summary: Improve readability and behavior of GameStateCaptureService by introducing a helper to check if cleaned component data should be saved. Added dedicated tests for skipping empty objects.

Changes Made:
- Added private `#hasMeaningfulData` method for data checks
- Updated `#applyComponentCleaners` to use helper
- Created `gameStateCaptureService.test.js` covering new logic

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_684f71847d10833181671bc11e5cd73c