### PR TITLE
[Agent] add createMessageElement helper

### DIFF
--- a/src/domUI/helpers/createMessageElement.js
+++ b/src/domUI/helpers/createMessageElement.js
@@ -1,0 +1,22 @@
+/**
+ * @file Helper to generate a simple message element.
+ */
+
+/** @typedef {import('../domElementFactory.js').default} DomElementFactory */
+
+/**
+ * @description Creates a paragraph element containing a message using the
+ * provided {@link DomElementFactory}. Falls back to a Text node if the
+ * factory is unavailable or fails to create the element.
+ * @param {DomElementFactory} [domFactory] - Optional DOM element factory.
+ * @param {string} [cssClass] - CSS class to apply to the element.
+ * @param {string} text - The message text content.
+ * @returns {HTMLElement | Text} The created paragraph element or a Text node.
+ */
+export function createMessageElement(domFactory, cssClass, text) {
+  const p = domFactory?.p?.(cssClass, text) || null;
+  if (p) return p;
+  return document.createTextNode(text);
+}
+
+export default createMessageElement;

--- a/tests/domUI/helpers/createMessageElement.test.js
+++ b/tests/domUI/helpers/createMessageElement.test.js
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import DocumentContext from '../../../src/domUI/documentContext.js';
+import DomElementFactory from '../../../src/domUI/domElementFactory.js';
+import createMessageElement from '../../../src/domUI/helpers/createMessageElement.js';
+
+describe('createMessageElement', () => {
+  let factory;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const ctx = new DocumentContext(document);
+    factory = new DomElementFactory(ctx);
+  });
+
+  it('creates paragraph with class and text', () => {
+    const el = createMessageElement(factory, 'test-class', 'hello');
+    expect(el).toBeInstanceOf(HTMLElement);
+    expect(el.tagName).toBe('P');
+    expect(el.classList.contains('test-class')).toBe(true);
+    expect(el.textContent).toBe('hello');
+  });
+
+  it('returns text node when factory is missing', () => {
+    const node = createMessageElement(undefined, 'x', 'msg');
+    expect(node.nodeType).toBe(Node.TEXT_NODE);
+    expect(node.textContent).toBe('msg');
+  });
+
+  it('returns text node when factory fails to create', () => {
+    const badFactory = { p: () => null };
+    const node = createMessageElement(badFactory, 'x', 'msg');
+    expect(node.nodeType).toBe(Node.TEXT_NODE);
+    expect(node.textContent).toBe('msg');
+  });
+});


### PR DESCRIPTION
## Summary
- add `createMessageElement` helper for fallback text node creation
- test helper to ensure DOM factory optional behavior

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f73d0cc408331af8a3dc7a525aaa2