### PR TITLE
[Agent] restore perceptible event dispatch in macros

### DIFF
--- a/data/mods/core/macros/autoMoveFollower.macro.json
+++ b/data/mods/core/macros/autoMoveFollower.macro.json
@@ -6,9 +6,7 @@
       "type": "SYSTEM_MOVE_ENTITY",
       "comment": "Move the follower directly without using a turn-based action.",
       "parameters": {
-        "entity_ref": {
-          "entityId": "{context.followerId}"
-        },
+        "entity_ref": { "entityId": "{context.followerId}" },
         "target_location_id": "{event.payload.currentLocationId}"
       }
     },
@@ -16,28 +14,24 @@
       "type": "QUERY_COMPONENT",
       "comment": "Get the follower's name for event messages.",
       "parameters": {
-        "entity_ref": {
-          "entityId": "{context.followerId}"
-        },
+        "entity_ref": { "entityId": "{context.followerId}" },
         "component_type": "core:name",
         "result_variable": "followerName"
       }
     },
     {
-      "type": "ADD_PERCEPTION_LOG_ENTRY",
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
       "comment": "Send a perceptible event to the new location.",
       "parameters": {
         "location_id": "{event.payload.currentLocationId}",
-        "entry": {
-          "description_text": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}.",
-          "perception_type": "character_enter",
-          "actor_id": "{context.followerId}",
-          "target_id": "{event.payload.entityId}",
-          "involved_entities": [],
-          "contextual_data": {
-            "leaderId": "{event.payload.entityId}",
-            "originLocationId": "{event.payload.previousLocationId}"
-          }
+        "description_text": "{context.followerName.text} follows {context.leaderName.text} to {context.newLocationName.text}.",
+        "perception_type": "character_enter",
+        "actor_id": "{context.followerId}",
+        "target_id": "{event.payload.entityId}",
+        "involved_entities": [],
+        "contextual_data": {
+          "leaderId": "{event.payload.entityId}",
+          "originLocationId": "{event.payload.previousLocationId}"
         }
       }
     },

--- a/data/mods/core/macros/logSuccessAndEndTurn.macro.json
+++ b/data/mods/core/macros/logSuccessAndEndTurn.macro.json
@@ -9,15 +9,17 @@
       }
     },
     {
-      "type": "ADD_PERCEPTION_LOG_ENTRY",
+      "type": "DISPATCH_EVENT",
       "parameters": {
-        "location_id": "{context.locationId}",
-        "entry": {
+        "eventType": "core:perceptible_event",
+        "payload": {
+          "eventName": "core:perceptible_event",
+          "locationId": "{context.locationId}",
+          "descriptionText": "{context.logMessage}",
           "timestamp": "{context.nowIso}",
-          "description_text": "{context.logMessage}",
-          "perception_type": "{context.perceptionType}",
-          "actor_id": "{event.payload.actorId}",
-          "target_id": "{context.targetId}"
+          "perceptionType": "{context.perceptionType}",
+          "actorId": "{event.payload.actorId}",
+          "targetId": "{context.targetId}"
         }
       }
     },


### PR DESCRIPTION
## Summary
- fix autoMoveFollower macro to dispatch perceptible events
- update logSuccessAndEndTurn macro to emit core:perceptible_event

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 535 errors)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f760c3fc48331a0169fdc564ee07f