### PR TITLE
[Agent] update game page path in accessibility test

### DIFF
--- a/tests/accessibility/indext.test.js
+++ b/tests/accessibility/indext.test.js
@@ -9,7 +9,7 @@ describe('Accessibility: <ul id="message-list">', () => {
 
   beforeAll(() => {
     // Adjust path if your game.html lives elsewhere
-    const htmlPath = path.resolve(__dirname, '../../game.html');
+    const htmlPath = path.join(__dirname, '..', '..', 'game.html');
     const html = fs.readFileSync(htmlPath, 'utf-8');
     const dom = new JSDOM(html);
     document = dom.window.document;


### PR DESCRIPTION
Summary: adjust the accessibility test to load `game.html` using `path.join` for clarity.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f7901c2d0833182c7e7a053a4ef72