### PR TITLE
[Agent] Add schema tests for core actions

### DIFF
--- a/tests/schemas/dismiss.schema.test.js
+++ b/tests/schemas/dismiss.schema.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import Ajv from 'ajv';
+import actionData from '../../data/mods/core/actions/dismiss.action.json';
+import actionSchema from '../../data/schemas/action-definition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+
+describe("Action Definition: 'core:dismiss'", () => {
+  /** @type {import('ajv').ValidateFunction} */
+  let validate;
+
+  beforeAll(() => {
+    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    validate = ajv.compile(actionSchema);
+  });
+
+  test('should be a valid action definition', () => {
+    const isValid = validate(actionData);
+    if (!isValid) {
+      console.error('Validation errors:', validate.errors);
+    }
+    expect(isValid).toBe(true);
+  });
+});

--- a/tests/schemas/follow.schema.test.js
+++ b/tests/schemas/follow.schema.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import Ajv from 'ajv';
+import actionData from '../../data/mods/core/actions/follow.action.json';
+import actionSchema from '../../data/schemas/action-definition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+
+describe("Action Definition: 'core:follow'", () => {
+  /** @type {import('ajv').ValidateFunction} */
+  let validate;
+
+  beforeAll(() => {
+    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    validate = ajv.compile(actionSchema);
+  });
+
+  test('should be a valid action definition', () => {
+    const isValid = validate(actionData);
+    if (!isValid) {
+      console.error('Validation errors:', validate.errors);
+    }
+    expect(isValid).toBe(true);
+  });
+});

--- a/tests/schemas/go.schema.test.js
+++ b/tests/schemas/go.schema.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import Ajv from 'ajv';
+import actionData from '../../data/mods/core/actions/go.action.json';
+import actionSchema from '../../data/schemas/action-definition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+
+describe("Action Definition: 'core:go'", () => {
+  /** @type {import('ajv').ValidateFunction} */
+  let validate;
+
+  beforeAll(() => {
+    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    validate = ajv.compile(actionSchema);
+  });
+
+  test('should be a valid action definition', () => {
+    const isValid = validate(actionData);
+    if (!isValid) {
+      console.error('Validation errors:', validate.errors);
+    }
+    expect(isValid).toBe(true);
+  });
+});

--- a/tests/schemas/stopFollowing.schema.test.js
+++ b/tests/schemas/stopFollowing.schema.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import Ajv from 'ajv';
+import actionData from '../../data/mods/core/actions/stop_following.action.json';
+import actionSchema from '../../data/schemas/action-definition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+
+describe("Action Definition: 'core:stop_following'", () => {
+  /** @type {import('ajv').ValidateFunction} */
+  let validate;
+
+  beforeAll(() => {
+    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    validate = ajv.compile(actionSchema);
+  });
+
+  test('should be a valid action definition', () => {
+    const isValid = validate(actionData);
+    if (!isValid) {
+      console.error('Validation errors:', validate.errors);
+    }
+    expect(isValid).toBe(true);
+  });
+});

--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -1,0 +1,24 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import Ajv from 'ajv';
+import actionData from '../../data/mods/core/actions/wait.action.json';
+import actionSchema from '../../data/schemas/action-definition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+
+describe("Action Definition: 'core:wait'", () => {
+  /** @type {import('ajv').ValidateFunction} */
+  let validate;
+
+  beforeAll(() => {
+    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    validate = ajv.compile(actionSchema);
+  });
+
+  test('should be a valid action definition', () => {
+    const isValid = validate(actionData);
+    if (!isValid) {
+      console.error('Validation errors:', validate.errors);
+    }
+    expect(isValid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add validation tests for core actions: dismiss, follow, go, stop_following and wait

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f7a11560883319a9364621ae94af1