### PR TITLE
[Agent] standardize macro id field

### DIFF
--- a/data/mods/core/macros/autoMoveFollower.macro.json
+++ b/data/mods/core/macros/autoMoveFollower.macro.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://example.com/schemas/macro.schema.json",
-  "macro_id": "core:autoMoveFollower",
+  "id": "core:autoMoveFollower",
   "actions": [
     {
       "type": "SYSTEM_MOVE_ENTITY",

--- a/data/mods/core/macros/logFailureAndEndTurn.macro.json
+++ b/data/mods/core/macros/logFailureAndEndTurn.macro.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://example.com/schemas/macro.schema.json",
-  "macro_id": "core:logFailureAndEndTurn",
+  "id": "core:logFailureAndEndTurn",
   "actions": [
     {
       "type": "DISPATCH_EVENT",

--- a/data/mods/core/macros/logSuccessAndEndTurn.macro.json
+++ b/data/mods/core/macros/logSuccessAndEndTurn.macro.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://example.com/schemas/macro.schema.json",
-  "macro_id": "core:logSuccessAndEndTurn",
+  "id": "core:logSuccessAndEndTurn",
   "actions": [
     {
       "type": "GET_TIMESTAMP",

--- a/data/schemas/macro.schema.json
+++ b/data/schemas/macro.schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "description": "Optional schema reference for tooling."
     },
-    "macro_id": {
+    "id": {
       "type": "string",
       "description": "Unique identifier for this macro."
     },
@@ -26,6 +26,6 @@
       "description": "Optional note for modders. Ignored at runtime."
     }
   },
-  "required": ["macro_id", "actions"],
+  "required": ["id", "actions"],
   "additionalProperties": false
 }

--- a/docs/mods/macros.md
+++ b/docs/mods/macros.md
@@ -9,7 +9,7 @@ Create a file in your mod's `macros/` folder:
 ```json
 {
   "$schema": "http://example.com/schemas/macro.schema.json",
-  "macro_id": "core:say_hello",
+  "id": "core:say_hello",
   "actions": [{ "type": "DISPATCH_SPEECH", "parameters": { "text": "Hello!" } }]
 }
 ```

--- a/src/loaders/macroLoader.js
+++ b/src/loaders/macroLoader.js
@@ -68,7 +68,7 @@ class MacroLoader extends BaseManifestItemLoader {
 
     const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
       data,
-      'macro_id',
+      'id',
       'macros',
       modId,
       filename,


### PR DESCRIPTION
## Summary
- rename `macro_id` field to `id` across macro definitions
- update macro schema and loader accordingly
- fix docs and tests to reflect new field

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(manual smoke run)*

------
https://chatgpt.com/codex/tasks/task_e_684f7ae9c7dc8331be3776603f212fa4