### PR TITLE
[Agent] ensure perceptible_event macro sets involvedEntities

### DIFF
--- a/data/mods/core/macros/logSuccessAndEndTurn.macro.json
+++ b/data/mods/core/macros/logSuccessAndEndTurn.macro.json
@@ -19,7 +19,8 @@
           "timestamp": "{context.nowIso}",
           "perceptionType": "{context.perceptionType}",
           "actorId": "{event.payload.actorId}",
-          "targetId": "{context.targetId}"
+          "targetId": "{context.targetId}",
+          "involvedEntities": []
         }
       }
     },

--- a/tests/schemas/logSuccessAndEndTurnMacro.schema.test.js
+++ b/tests/schemas/logSuccessAndEndTurnMacro.schema.test.js
@@ -60,4 +60,16 @@ describe("Macro Definition: 'core:logSuccessAndEndTurn'", () => {
 
     expect(isValid).toBe(true);
   });
+
+  test('perceptible_event payload includes involvedEntities array', () => {
+    const dispatchAction = macroData.actions.find(
+      (a) =>
+        a.type === 'DISPATCH_EVENT' &&
+        a.parameters?.eventType === 'core:perceptible_event'
+    );
+    expect(dispatchAction).toBeDefined();
+    expect(
+      Array.isArray(dispatchAction.parameters.payload.involvedEntities)
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- include `involvedEntities` when dispatching perceptible events in `logSuccessAndEndTurn` macro
- assert that macro JSON contains the new field

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors)*
- `npm run test`
- `npm install && npm run lint` in `llm-proxy-server`
- `npm run test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_684f7cbcf5cc8331a795092dcdd19812