### PR TITLE
[Agent] use helper for message elements

### DIFF
--- a/src/domUI/baseListDisplayComponent.js
+++ b/src/domUI/baseListDisplayComponent.js
@@ -2,6 +2,7 @@
 
 import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
+import createMessageElement from './helpers/createMessageElement.js';
 
 /**
  * @typedef {import('../interfaces/ILogger.js').ILogger} ILogger
@@ -190,14 +191,11 @@ export class BaseListDisplayComponent extends BoundDomRendererBase {
         error
       );
       DomUtils.clearElement(this.elements.listContainerElement);
-      const errorMsg =
-        this.domElementFactory?.p(
-          'error-message',
-          'Error loading list data.'
-        ) ||
-        this.documentContext.document.createTextNode(
-          'Error loading list data.'
-        );
+      const errorMsg = createMessageElement(
+        this.domElementFactory,
+        'error-message',
+        'Error loading list data.'
+      );
       this.elements.listContainerElement.appendChild(errorMsg);
       this._onListRendered(null, this.elements.listContainerElement);
       return;
@@ -213,16 +211,13 @@ export class BaseListDisplayComponent extends BoundDomRendererBase {
       const emptyMessage = this._getEmptyListMessage();
       if (typeof emptyMessage === 'string') {
         if (this.domElementFactory) {
-          const pEmpty = this.domElementFactory.p(
-            'empty-list-message',
-            emptyMessage
+          this.elements.listContainerElement.appendChild(
+            createMessageElement(
+              this.domElementFactory,
+              'empty-list-message',
+              emptyMessage
+            )
           );
-          if (pEmpty) {
-            this.elements.listContainerElement.appendChild(pEmpty);
-          } else {
-            // Fallback if p creation fails
-            this.elements.listContainerElement.textContent = emptyMessage;
-          }
         } else {
           this.elements.listContainerElement.textContent = emptyMessage;
         }
@@ -233,10 +228,16 @@ export class BaseListDisplayComponent extends BoundDomRendererBase {
           `${this._logPrefix} _getEmptyListMessage() returned an invalid type. Expected string or HTMLElement.`,
           { type: typeof emptyMessage }
         );
-        const fallbackEmptyMsg =
-          this.domElementFactory?.p('empty-list-message', 'List is empty.') ||
-          this.documentContext.document.createTextNode('List is empty.');
-        this.elements.listContainerElement.appendChild(fallbackEmptyMsg);
+        if (this.domElementFactory) {
+          const fallbackEmptyMsg = createMessageElement(
+            this.domElementFactory,
+            'empty-list-message',
+            'List is empty.'
+          );
+          this.elements.listContainerElement.appendChild(fallbackEmptyMsg);
+        } else {
+          this.elements.listContainerElement.textContent = 'List is empty.';
+        }
       }
       this.logger.debug(`${this._logPrefix} Empty list message displayed.`);
     } else {

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -5,6 +5,7 @@ import { DomUtils } from '../utils/domUtils.js';
 import { formatSaveFileMetadata } from './helpers/slotDataFormatter.js';
 import { renderSlotItem } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
+import createMessageElement from './helpers/createMessageElement.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -305,9 +306,10 @@ class LoadGameUI extends SlotModalBase {
   _getEmptyLoadSlotsMessage() {
     const message = 'No saved games found.';
     if (this.domElementFactory) {
-      return (
-        this.domElementFactory.p('empty-slot-message', message) ||
-        this.documentContext.document.createTextNode(message)
+      return createMessageElement(
+        this.domElementFactory,
+        'empty-slot-message',
+        message
       );
     }
     return message;

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
+import createMessageElement from './helpers/createMessageElement.js';
 import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 import {
   // POSITION_COMPONENT_ID, // No longer directly used for current location logic
@@ -295,12 +296,12 @@ export class LocationRenderer extends BoundDomRendererBase {
       if (element) {
         DomUtils.clearElement(element);
         const text = key === 'descriptionDisplay' ? message : defaultText;
-        const pError = this.domElementFactory.p('error-message', text);
-        if (pError) {
-          element.appendChild(pError);
-        } else {
-          element.textContent = text;
-        }
+        const pError = createMessageElement(
+          this.domElementFactory,
+          'error-message',
+          text
+        );
+        element.appendChild(pError);
       } else {
         this.logger.warn(
           `${this._logPrefix} Could not find element this.elements.${key} to clear on error.`
@@ -345,14 +346,13 @@ export class LocationRenderer extends BoundDomRendererBase {
     }
 
     if (!dataArray || dataArray.length === 0) {
-      const pEmpty = this.domElementFactory.p('empty-list-message', emptyText);
-      if (pEmpty) {
-        targetElement.appendChild(pEmpty);
-      } else {
-        targetElement.appendChild(
-          this.documentContext.document.createTextNode(emptyText)
-        );
-      }
+      targetElement.appendChild(
+        createMessageElement(
+          this.domElementFactory,
+          'empty-list-message',
+          emptyText
+        )
+      );
     } else {
       const ul = this.domElementFactory.ul(undefined, 'location-detail-list');
       if (!ul) {
@@ -365,12 +365,9 @@ export class LocationRenderer extends BoundDomRendererBase {
             item && typeof item === 'object' && item[itemTextProperty]
               ? String(item[itemTextProperty])
               : '(Invalid item)';
-          const pItem = this.domElementFactory.p(itemClassName, text);
-          if (pItem) targetElement.appendChild(pItem);
-          else
-            targetElement.appendChild(
-              this.documentContext.document.createTextNode(text)
-            );
+          targetElement.appendChild(
+            createMessageElement(this.domElementFactory, itemClassName, text)
+          );
         });
         return;
       }
@@ -386,8 +383,12 @@ export class LocationRenderer extends BoundDomRendererBase {
             `${this._logPrefix} Failed to create LI for ${title}.`
           );
           ul.appendChild(
-            this.documentContext.document.createTextNode(primaryText)
-          ); // Fallback text in UL
+            createMessageElement(
+              this.domElementFactory,
+              itemClassName,
+              primaryText
+            )
+          );
           return;
         }
 
@@ -396,8 +397,8 @@ export class LocationRenderer extends BoundDomRendererBase {
           li.appendChild(nameSpan);
         } else {
           li.appendChild(
-            this.documentContext.document.createTextNode(primaryText)
-          ); // Fallback text in LI
+            createMessageElement(this.domElementFactory, undefined, primaryText)
+          );
         }
 
         if (
@@ -408,19 +409,15 @@ export class LocationRenderer extends BoundDomRendererBase {
           typeof item.description === 'string' &&
           item.description.trim() !== ''
         ) {
-          const descP = this.domElementFactory.p(
+          const descP = createMessageElement(
+            this.domElementFactory,
             'character-description',
             item.description
           );
-          if (descP) {
+          if (descP instanceof HTMLElement) {
             li.appendChild(descP);
           } else if (nameSpan) {
-            // Fallback: append to nameSpan's parent (li)
-            li.appendChild(
-              this.documentContext.document.createTextNode(
-                ` (${item.description})`
-              )
-            );
+            li.appendChild(descP);
           }
         }
         ul.appendChild(li);

--- a/src/domUI/perceptionLogRenderer.js
+++ b/src/domUI/perceptionLogRenderer.js
@@ -3,6 +3,7 @@
 import { BaseListDisplayComponent } from './baseListDisplayComponent.js';
 import { PERCEPTION_LOG_COMPONENT_ID } from '../constants/componentIds.js';
 import { TURN_STARTED_ID } from '../constants/eventIds.js';
+import createMessageElement from './helpers/createMessageElement.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -340,15 +341,14 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
         `${this._logPrefix} Error during refreshList in #handleTurnStarted:`,
         error
       );
-      if (this.elements.listContainerElement && this.domElementFactory) {
-        const pError = this.domElementFactory.p(
+      if (this.elements.listContainerElement) {
+        const pError = createMessageElement(
+          this.domElementFactory,
           'error-message',
           'Error updating perception log.'
         );
-        if (pError) {
-          this.elements.listContainerElement.innerHTML = '';
-          this.elements.listContainerElement.appendChild(pError);
-        }
+        this.elements.listContainerElement.innerHTML = '';
+        this.elements.listContainerElement.appendChild(pError);
       }
     });
   }

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -8,6 +8,7 @@ import {
 } from './helpers/slotDataFormatter.js';
 import { renderSlotItem } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
+import createMessageElement from './helpers/createMessageElement.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -317,7 +318,8 @@ export class SaveGameUI extends SlotModalBase {
    */
   _getEmptySaveSlotsMessage() {
     if (this.domElementFactory) {
-      return this.domElementFactory.p(
+      return createMessageElement(
+        this.domElementFactory,
         'empty-slot-message',
         'No save slots available to display.'
       );

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -7,6 +7,7 @@
 import { BaseModalRenderer } from './baseModalRenderer.js';
 import { setupRadioListNavigation } from '../utils/listNavigation.js';
 import { DomUtils } from '../utils/domUtils.js';
+import createMessageElement from './helpers/createMessageElement.js';
 
 /**
  * @class SlotModalBase
@@ -218,14 +219,9 @@ export class SlotModalBase extends BaseModalRenderer {
     if (this.currentSlotsDisplayData.length === 0) {
       const emptyMessage = getEmptyMessageFn();
       if (typeof emptyMessage === 'string') {
-        if (this.domElementFactory) {
-          const p =
-            this.domElementFactory.p(undefined, emptyMessage) ||
-            this.documentContext.document.createTextNode(emptyMessage);
-          this.elements.listContainerElement?.appendChild(p);
-        } else if (this.elements.listContainerElement) {
-          this.elements.listContainerElement.textContent = emptyMessage;
-        }
+        this.elements.listContainerElement?.appendChild(
+          createMessageElement(this.domElementFactory, undefined, emptyMessage)
+        );
       } else if (
         emptyMessage instanceof
         this.documentContext.document.defaultView.HTMLElement


### PR DESCRIPTION
Summary: 
- import `createMessageElement` in various UI components
- replace manual `<p>` creation and fallback logic with `createMessageElement`

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 534 errors, 1913 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format`
- [x] `cd llm-proxy-server && npm run lint`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f7a9fb7208331bf495fb6bbea66d3