### PR TITLE
[Agent] simplify beforeunload handler

### DIFF
--- a/src/bootstrapper/helpers.js
+++ b/src/bootstrapper/helpers.js
@@ -77,4 +77,27 @@ export function setupButtonListener(
   }
 }
 
+/**
+ * @description Determines if the game engine should be stopped based on its current status.
+ * @param {import('../engine/gameEngine.js').default} gameEngine - The game engine instance to inspect.
+ * @returns {boolean} True if the engine is running and should be stopped.
+ */
+export function shouldStopEngine(gameEngine) {
+  return (
+    !!gameEngine &&
+    typeof gameEngine.getEngineStatus === 'function' &&
+    gameEngine.getEngineStatus().isLoopRunning === true
+  );
+}
+
+/**
+ * @description Attaches a 'beforeunload' event handler to the provided window reference.
+ * @param {Window} windowRef - The window object on which to listen for 'beforeunload'.
+ * @param {Function} handler - The event handler function.
+ * @returns {void}
+ */
+export function attachBeforeUnload(windowRef, handler) {
+  windowRef.addEventListener('beforeunload', handler);
+}
+
 // --- FILE END ---


### PR DESCRIPTION
Summary: refactored setupGlobalEventListenersStage with helper functions to simplify the beforeunload event listener.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing repo issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f7e83a2a083318464aed18cceb6fd