### PR TITLE
[Agent] refactor handlers to use BaseOperationHandler

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -14,11 +14,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import {
-  initHandlerLogger,
-  validateDeps,
-  getExecLogger,
-} from '../../utils/handlerUtils/service.js';
+import BaseOperationHandler from './baseOperationHandler.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 
 /**
@@ -33,8 +29,7 @@ import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 // -----------------------------------------------------------------------------
 //  Handler implementation
 // -----------------------------------------------------------------------------
-class AddComponentHandler {
-  /** @type {ILogger} */ #logger;
+class AddComponentHandler extends BaseOperationHandler {
   /** @type {EntityManager} */ #entityManager;
   /** @type {ISafeEventDispatcher} */ #dispatcher;
 
@@ -48,8 +43,8 @@ class AddComponentHandler {
    * @throws {Error} If required dependencies are missing or invalid.
    */
   constructor({ entityManager, logger, safeEventDispatcher }) {
-    this.#logger = initHandlerLogger('AddComponentHandler', logger);
-    validateDeps('AddComponentHandler', this.#logger, {
+    super('AddComponentHandler', {
+      logger: { value: logger },
       entityManager: {
         value: entityManager,
         requiredMethods: ['addComponent'],
@@ -73,7 +68,7 @@ class AddComponentHandler {
    * @implements {OperationHandler}
    */
   execute(params, executionContext) {
-    const log = getExecLogger(this.#logger, executionContext);
+    const log = this.getLogger(executionContext);
 
     // 1. Validate Parameters
     if (!assertParamsObject(params, log, 'ADD_COMPONENT')) {

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -14,10 +14,9 @@ import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { assertParamsObject } from '../../utils/handlerUtils';
+import BaseOperationHandler from './baseOperationHandler.js';
 
-class BreakFollowRelationHandler {
-  /** @type {ILogger} */
-  #logger;
+class BreakFollowRelationHandler extends BaseOperationHandler {
   /** @type {EntityManager} */
   #entityManager;
   /** @type {RebuildLeaderListCacheHandler} */
@@ -62,11 +61,25 @@ class BreakFollowRelationHandler {
         'BreakFollowRelationHandler requires a valid ISafeEventDispatcher'
       );
     }
-    this.#logger = logger;
+    super('BreakFollowRelationHandler', {
+      logger: { value: logger },
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['removeComponent', 'getComponentData'],
+      },
+      rebuildLeaderListCacheHandler: {
+        value: rebuildLeaderListCacheHandler,
+        requiredMethods: ['execute'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#entityManager = entityManager;
     this.#rebuildHandler = rebuildLeaderListCacheHandler;
     this.#dispatcher = safeEventDispatcher;
-    this.#logger.debug('[BreakFollowRelationHandler] Initialized');
+    this.logger.debug('[BreakFollowRelationHandler] Initialized');
   }
 
   /**
@@ -74,7 +87,7 @@ class BreakFollowRelationHandler {
    * @param {ExecutionContext} execCtx
    */
   execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.#logger;
+    const logger = this.getLogger(execCtx);
     if (!assertParamsObject(params, logger, 'BREAK_FOLLOW_RELATION')) return;
 
     const { follower_id } = params;
@@ -92,7 +105,7 @@ class BreakFollowRelationHandler {
       FOLLOWING_COMPONENT_ID
     );
     if (!currentData) {
-      this.#logger.debug(
+      this.logger.debug(
         `[BreakFollowRelationHandler] ${fid} is not following anyone.`
       );
       return;

--- a/tests/logic/operationHandlers/addPerceptionLogEntryHandler.test.js
+++ b/tests/logic/operationHandlers/addPerceptionLogEntryHandler.test.js
@@ -89,21 +89,21 @@ describe('AddPerceptionLogEntryHandler', () => {
     test('throws if logger is missing or incomplete', () => {
       expect(
         () => new AddPerceptionLogEntryHandler({ entityManager: em })
-      ).toThrow(/ILogger/);
+      ).toThrow(/logger/);
       expect(
         () =>
           new AddPerceptionLogEntryHandler({ logger: {}, entityManager: em })
-      ).toThrow(/ILogger/);
+      ).toThrow(/logger/);
     });
 
     test('throws if entityManager is missing or incomplete', () => {
       expect(() => new AddPerceptionLogEntryHandler({ logger: log })).toThrow(
-        /IEntityManager/
+        /entityManager/
       );
       expect(
         () =>
           new AddPerceptionLogEntryHandler({ logger: log, entityManager: {} })
-      ).toThrow(/IEntityManager/);
+      ).toThrow(/entityManager/);
     });
 
     test('throws if safeEventDispatcher is missing or invalid', () => {
@@ -113,7 +113,7 @@ describe('AddPerceptionLogEntryHandler', () => {
             logger: log,
             entityManager: em,
           })
-      ).toThrow(/ISafeEventDispatcher/);
+      ).toThrow(/safeEventDispatcher/);
       expect(
         () =>
           new AddPerceptionLogEntryHandler({
@@ -121,7 +121,7 @@ describe('AddPerceptionLogEntryHandler', () => {
             entityManager: em,
             safeEventDispatcher: {},
           })
-      ).toThrow(/ISafeEventDispatcher/);
+      ).toThrow(/safeEventDispatcher/);
     });
   });
 
@@ -202,7 +202,9 @@ describe('AddPerceptionLogEntryHandler', () => {
       expect(em.hasComponent).not.toHaveBeenCalled();
       expect(em.addComponent).not.toHaveBeenCalled();
       expect(log.debug).toHaveBeenCalledWith(
-        `ADD_PERCEPTION_LOG_ENTRY: No entities in location ${LOC}`
+        expect.stringContaining(
+          `ADD_PERCEPTION_LOG_ENTRY: No entities in location ${LOC}`
+        )
       );
     });
 
@@ -279,7 +281,9 @@ describe('AddPerceptionLogEntryHandler', () => {
       ).toBe(true);
 
       expect(log.debug).toHaveBeenCalledWith(
-        `ADD_PERCEPTION_LOG_ENTRY: wrote entry to 2/3 perceivers in ${LOC}`
+        expect.stringContaining(
+          `ADD_PERCEPTION_LOG_ENTRY: wrote entry to 2/3 perceivers in ${LOC}`
+        )
       );
     });
   });


### PR DESCRIPTION
## Summary
- derive several operation handlers from `BaseOperationHandler`
- update constructor dependency validation
- adjust logger usage in tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 534 errors, 1912 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f7a255b888331912f3dcb8c3fcdc7