### PR TITLE
[Feat] Add displaySuccessAndEndTurn macro

### DIFF
--- a/data/mods/core/macros/displaySuccessAndEndTurn.macro.json
+++ b/data/mods/core/macros/displaySuccessAndEndTurn.macro.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://example.com/schemas/macro.schema.json",
+  "id": "core:displaySuccessAndEndTurn",
+  "actions": [
+    {
+      "type": "DISPATCH_EVENT",
+      "parameters": {
+        "eventType": "core:display_successful_action_result",
+        "payload": {
+          "message": "{context.successMessage}"
+        }
+      }
+    },
+    {
+      "type": "END_TURN",
+      "parameters": {
+        "entityId": "{event.payload.actorId}",
+        "success": true
+      }
+    }
+  ]
+}

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -57,7 +57,8 @@
     "macros": [
       "logSuccessAndEndTurn.macro.json",
       "logFailureAndEndTurn.macro.json",
-      "autoMoveFollower.macro.json"
+      "autoMoveFollower.macro.json",
+      "displaySuccessAndEndTurn.macro.json"
     ],
     "events": [
       "action_decided.event.json",

--- a/data/mods/core/rules/dismiss.rule.json
+++ b/data/mods/core/rules/dismiss.rule.json
@@ -84,22 +84,13 @@
       }
     },
     {
-      "type": "DISPATCH_EVENT",
-      "comment": "Step 3: Notify the actor's client that the action was successful.",
+      "type": "SET_VARIABLE",
+      "comment": "Prepare success message for the UI.",
       "parameters": {
-        "eventType": "core:display_successful_action_result",
-        "payload": {
-          "message": "{context.actorName} dismisses {context.targetName}."
-        }
+        "variable_name": "successMessage",
+        "value": "{context.actorName} dismisses {context.targetName}."
       }
     },
-    {
-      "type": "END_TURN",
-      "comment": "Step 4: Signal to the Turn Manager that the actor's turn is over.",
-      "parameters": {
-        "entityId": "{event.payload.actorId}",
-        "success": true
-      }
-    }
+    { "macro": "core:displaySuccessAndEndTurn" }
   ]
 }

--- a/data/mods/core/rules/go.rule.json
+++ b/data/mods/core/rules/go.rule.json
@@ -166,23 +166,14 @@
                   }
                 },
                 {
-                  "type": "DISPATCH_EVENT",
-                  "comment": "Dispatch a UI event indicating the successful move.",
+                  "type": "SET_VARIABLE",
+                  "comment": "Prepare success message for the UI.",
                   "parameters": {
-                    "eventType": "core:display_successful_action_result",
-                    "payload": {
-                      "message": "{context.actorNameComponent.text} arrives at {context.targetLocationNameComponent.text}."
-                    }
+                    "variable_name": "successMessage",
+                    "value": "{context.actorNameComponent.text} arrives at {context.targetLocationNameComponent.text}."
                   }
                 },
-                {
-                  "type": "END_TURN",
-                  "comment": "End the turn successfully.",
-                  "parameters": {
-                    "entityId": "{event.payload.actorId}",
-                    "success": true
-                  }
-                }
+                { "macro": "core:displaySuccessAndEndTurn" }
               ],
               "else_actions": [
                 {

--- a/data/mods/core/rules/stop_following.rule.json
+++ b/data/mods/core/rules/stop_following.rule.json
@@ -97,23 +97,14 @@
             }
           },
           {
-            "type": "DISPATCH_EVENT",
-            "comment": "Dispatch a UI event indicating the successful unfollow action.",
+            "type": "SET_VARIABLE",
+            "comment": "Prepare success message for the UI.",
             "parameters": {
-              "eventType": "core:display_successful_action_result",
-              "payload": {
-                "message": "{context.actorName.text} stops following {context.oldLeaderName.text}."
-              }
+              "variable_name": "successMessage",
+              "value": "{context.actorName.text} stops following {context.oldLeaderName.text}."
             }
           },
-          {
-            "type": "END_TURN",
-            "comment": "Signal to the Turn Manager that the actor's turn is over.",
-            "parameters": {
-              "entityId": "{event.payload.actorId}",
-              "success": true
-            }
-          }
+          { "macro": "core:displaySuccessAndEndTurn" }
         ],
         "else_actions": [
           {

--- a/data/mods/intimacy/rules/adjust_clothing.rule.json
+++ b/data/mods/intimacy/rules/adjust_clothing.rule.json
@@ -63,22 +63,6 @@
         "target_id": "{event.payload.targetId}"
       }
     },
-    {
-      "type": "DISPATCH_EVENT",
-      "comment": "Dispatch the success message to the actor's UI.",
-      "parameters": {
-        "eventType": "core:display_successful_action_result",
-        "payload": {
-          "message": "{context.successMessage}"
-        }
-      }
-    },
-    {
-      "type": "END_TURN",
-      "parameters": {
-        "entityId": "{event.payload.actorId}",
-        "success": true
-      }
-    }
+    { "macro": "core:displaySuccessAndEndTurn" }
   ]
 }

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -11,6 +11,8 @@ import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import dismissRule from '../../../data/mods/core/rules/dismiss.rule.json';
+import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
+import { expandMacros } from '../../../src/utils/macroUtils.js';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
@@ -244,8 +246,20 @@ describe('core_handle_dismiss rule integration', () => {
       }),
     };
 
+    const macroRegistry = {
+      get: (type, id) =>
+        type === 'macros'
+          ? { 'core:displaySuccessAndEndTurn': displaySuccessAndEndTurn }[id]
+          : undefined,
+    };
+
+    const expandedRule = {
+      ...dismissRule,
+      actions: expandMacros(dismissRule.actions, macroRegistry),
+    };
+
     dataRegistry = {
-      getAllSystemRules: jest.fn().mockReturnValue([dismissRule]),
+      getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
     };
 
     init([]);

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -10,6 +10,8 @@ import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import goRule from '../../../data/mods/core/rules/go.rule.json';
+import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
+import { expandMacros } from '../../../src/utils/macroUtils.js';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
@@ -254,8 +256,20 @@ describe('core_handle_go rule integration', () => {
       listenerCount: jest.fn().mockReturnValue(1),
     };
 
+    const macroRegistry = {
+      get: (type, id) =>
+        type === 'macros'
+          ? { 'core:displaySuccessAndEndTurn': displaySuccessAndEndTurn }[id]
+          : undefined,
+    };
+
+    const expandedRule = {
+      ...goRule,
+      actions: expandMacros(goRule.actions, macroRegistry),
+    };
+
     dataRegistry = {
-      getAllSystemRules: jest.fn().mockReturnValue([goRule]),
+      getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
     };
 
     init([]);

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -12,7 +12,9 @@ import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import stopFollowingRule from '../../../data/mods/core/rules/stop_following.rule.json';
 import logFailureAndEndTurn from '../../../data/mods/core/macros/logFailureAndEndTurn.macro.json';
+import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
+import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
@@ -171,6 +173,7 @@ function init(entities) {
       safeEventDispatcher: safeDispatcher,
     }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({
       safeEventDispatcher: safeDispatcher,
@@ -248,7 +251,10 @@ describe('core_handle_stop_following rule integration', () => {
     const macroRegistry = {
       get: (type, id) =>
         type === 'macros'
-          ? { 'core:logFailureAndEndTurn': logFailureAndEndTurn }[id]
+          ? {
+              'core:logFailureAndEndTurn': logFailureAndEndTurn,
+              'core:displaySuccessAndEndTurn': displaySuccessAndEndTurn,
+            }[id]
           : undefined,
     };
 


### PR DESCRIPTION
Summary: Adds a reusable macro for displaying success messages and ending turns. Updated rules to use this macro and adjusted integration tests accordingly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint run (`npm run lint` - fails due to existing issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_684f7dd4161c8331a186882f8d9fc894