### PR TITLE
[Agent] add tests for errors, event bus, logger utils

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -8,10 +8,7 @@ import {
   manualSavePath,
   FULL_MANUAL_SAVE_DIRECTORY_PATH,
 } from './savePathUtils.js';
-import {
-  deserializeAndDecompress,
-  parseManualSaveFile,
-} from './saveFileIO.js';
+import { deserializeAndDecompress, parseManualSaveFile } from './saveFileIO.js';
 import { setupService } from '../utils/serviceInitializer.js';
 import { deepClone } from '../utils/objectUtils.js';
 import {

--- a/tests/errors/errorClasses.test.js
+++ b/tests/errors/errorClasses.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ActorError } from '../../src/errors/actorError.js';
+import { ActorMismatchError } from '../../src/errors/actorMismatchError.js';
+import ModDependencyError from '../../src/errors/modDependencyError.js';
+import WorldLoaderError from '../../src/errors/worldLoaderError.js';
+import PromptTooLongError from '../../src/errors/promptTooLongError.js';
+import {
+  LLMInteractionError,
+  ApiKeyError,
+  InsufficientCreditsError,
+  ContentPolicyError,
+  PermissionError,
+  BadRequestError,
+  MalformedResponseError,
+} from '../../src/errors/llmInteractionErrors.js';
+
+describe('custom error classes', () => {
+  let original;
+  beforeEach(() => {
+    original = Error.captureStackTrace;
+  });
+  afterEach(() => {
+    Error.captureStackTrace = original;
+  });
+
+  it('ActorError handles missing captureStackTrace', () => {
+    Error.captureStackTrace = undefined;
+    const err = new ActorError('a');
+    expect(err.name).toBe('ActorError');
+    expect(err.message).toBe('a');
+    expect(err.stack).toBeDefined();
+  });
+
+  it('ActorMismatchError stores context', () => {
+    const err = new ActorMismatchError('mismatch', {
+      expectedActorId: 'e',
+      actualActorId: 'a',
+      operation: 'op',
+    });
+    expect(err.expectedActorId).toBe('e');
+    expect(err.actualActorId).toBe('a');
+    expect(err.operation).toBe('op');
+  });
+
+  it('ModDependencyError and WorldLoaderError support causes', () => {
+    const cause = new Error('root');
+    const modErr = new ModDependencyError('mod', cause);
+    const worldErr = new WorldLoaderError('world', cause);
+    expect(modErr.cause).toBe(cause);
+    expect(worldErr.cause).toBe(cause);
+  });
+
+  it('PromptTooLongError stores token details', () => {
+    const err = new PromptTooLongError('too long', {
+      estimatedTokens: 10,
+      promptTokenSpace: 5,
+    });
+    expect(err.estimatedTokens).toBe(10);
+    expect(err.promptTokenSpace).toBe(5);
+  });
+
+  it('LLMInteractionError subclasses set names correctly', () => {
+    const base = new LLMInteractionError('base', {
+      status: 400,
+      llmId: 'x',
+      responseBody: {},
+    });
+    expect(base.status).toBe(400);
+    expect(base.llmId).toBe('x');
+    const classes = [
+      ApiKeyError,
+      InsufficientCreditsError,
+      ContentPolicyError,
+      PermissionError,
+      BadRequestError,
+      MalformedResponseError,
+    ];
+    for (const Cls of classes) {
+      const e = new Cls('msg');
+      expect(e).toBeInstanceOf(LLMInteractionError);
+      expect(e.name).toBe(Cls.name);
+    }
+  });
+});

--- a/tests/events/eventBus.errors.test.js
+++ b/tests/events/eventBus.errors.test.js
@@ -1,0 +1,55 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
+import EventBus from '../../src/events/eventBus.js';
+
+describe('EventBus error handling', () => {
+  let bus;
+  let errorSpy;
+  beforeEach(() => {
+    bus = new EventBus();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs for invalid subscribe arguments', () => {
+    bus.subscribe('', () => {});
+    bus.subscribe('test', null);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs for invalid unsubscribe arguments', () => {
+    bus.unsubscribe('', () => {});
+    bus.unsubscribe('a', null);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs for invalid dispatch name', async () => {
+    await bus.dispatch('');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles listener errors gracefully', async () => {
+    bus.subscribe('x', () => {
+      throw new Error('oops');
+    });
+    await bus.dispatch('x');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('EventBus: Error executing listener'),
+      expect.any(Error)
+    );
+  });
+
+  it('listenerCount logs and returns 0 for invalid name', () => {
+    const count = bus.listenerCount('');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(count).toBe(0);
+  });
+});

--- a/tests/utils/loggerUtils.test.js
+++ b/tests/utils/loggerUtils.test.js
@@ -1,0 +1,86 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  afterEach,
+  beforeEach,
+} from '@jest/globals';
+import {
+  ensureValidLogger,
+  createPrefixedLogger,
+  getPrefixedLogger,
+  initLogger,
+} from '../../src/utils/loggerUtils.js';
+import { validateDependency } from '../../src/utils/validationUtils.js';
+
+jest.mock('../../src/utils/validationUtils.js');
+
+describe('loggerUtils', () => {
+  const valid = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  let consoleSpies;
+
+  beforeEach(() => {
+    consoleSpies = {
+      info: jest.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: jest.spyOn(console, 'error').mockImplementation(() => {}),
+      debug: jest.spyOn(console, 'debug').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    Object.values(consoleSpies).forEach((s) => s.mockRestore());
+  });
+
+  it('ensureValidLogger returns original logger when valid', () => {
+    const result = ensureValidLogger(valid, 'Pfx');
+    expect(result).toBe(valid);
+    expect(consoleSpies.warn).not.toHaveBeenCalled();
+  });
+
+  it('ensureValidLogger provides fallback and warns when logger invalid', () => {
+    const invalid = {};
+    const result = ensureValidLogger(invalid, 'Bad');
+    expect(result).not.toBe(invalid);
+    expect(typeof result.warn).toBe('function');
+    expect(consoleSpies.warn).toHaveBeenCalledWith(
+      'Bad: ',
+      `An invalid logger instance was provided. Falling back to console logging with prefix "Bad".`
+    );
+  });
+
+  it('createPrefixedLogger prefixes messages', () => {
+    const prefixed = createPrefixedLogger(valid, 'X: ');
+    prefixed.info('hello');
+    expect(valid.info).toHaveBeenCalledWith('X: hello');
+  });
+
+  it('getPrefixedLogger returns prefixed fallback when logger missing', () => {
+    const logger = getPrefixedLogger(null, 'GP: ');
+    logger.debug('a');
+    expect(consoleSpies.debug).toHaveBeenCalledWith('GP: : ', 'GP: a');
+  });
+
+  it('initLogger validates when not optional and returns logger', () => {
+    const spy = validateDependency;
+    const logger = initLogger('Svc', valid);
+    expect(spy).toHaveBeenCalledWith(valid, 'logger', console, {
+      requiredMethods: ['info', 'warn', 'error', 'debug'],
+    });
+    expect(logger).toBe(valid);
+  });
+
+  it('initLogger skips validation when optional and logger missing', () => {
+    const logger = initLogger('Svc', null, { optional: true });
+    expect(validateDependency).not.toHaveBeenCalled();
+    logger.error('oops');
+    expect(consoleSpies.error).toHaveBeenCalledWith('Svc: ', 'oops');
+  });
+});


### PR DESCRIPTION
## Summary
- extend coverage for custom error classes
- test logger utility helpers
- add negative path tests for EventBus

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test` *(fails coverage threshold)*
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f7f698ea48331af4d120eaef0afbf