### PR TITLE
[Agent] rename resolve stage

### DIFF
--- a/src/bootstrapper/stages.js
+++ b/src/bootstrapper/stages.js
@@ -103,7 +103,12 @@ export async function setupDIContainerStage(
 }
 
 /**
- * Bootstrap Stage: Resolves essential core services, particularly the logger.
+ * Bootstrap Stage: Resolves core services.
+ * Currently only the logger is required, but additional core services will be added soon.
+ *
+ * Upcoming core services:
+ * - Event bus
+ * - Configuration access
  *
  * @async
  * @param {AppContainer} container - The configured AppContainer instance.
@@ -111,8 +116,8 @@ export async function setupDIContainerStage(
  * @returns {Promise<{logger: ILogger}>} An object containing the resolved logger.
  * @throws {Error} If the ILogger service cannot be resolved or is invalid. The error will have a `phase` property set to 'Core Services Resolution'.
  */
-export async function resolveCoreServicesStage(container, diTokens) {
-  console.log('Bootstrap Stage: Resolving core services (Logger)...');
+export async function resolveLoggerStage(container, diTokens) {
+  console.log('Bootstrap Stage: Resolving logger service...');
   /** @type {ILogger} */
   let logger;
 
@@ -126,13 +131,13 @@ export async function resolveCoreServicesStage(container, diTokens) {
     const stageError = new Error(errorMsg, { cause: resolveError });
     stageError.phase = 'Core Services Resolution';
     console.error(
-      `Bootstrap Stage: resolveCoreServicesStage failed. ${errorMsg}`,
+      `Bootstrap Stage: resolveLoggerStage failed. ${errorMsg}`,
       resolveError
     );
     throw stageError;
   }
   logger.debug(
-    'Bootstrap Stage: Resolving core services (Logger)... DONE. Logger resolved successfully.'
+    'Bootstrap Stage: Resolving logger service... DONE. Logger resolved successfully.'
   );
   return { logger };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import GameEngine from './engine/gameEngine.js';
 import {
   ensureCriticalDOMElementsStage,
   setupDIContainerStage,
-  resolveCoreServicesStage,
+  resolveLoggerStage,
   initializeGameEngineStage,
   setupMenuButtonListenersStage,
   setupGlobalEventListenersStage,
@@ -56,7 +56,7 @@ export async function bootstrapApp() {
 
     // STAGE 3: Resolve Core Services (Logger)
     currentPhaseForError = 'Core Services Resolution';
-    const coreServices = await resolveCoreServicesStage(container, tokens);
+    const coreServices = await resolveLoggerStage(container, tokens);
     logger = coreServices.logger; // Assign the resolved logger
     logger.debug(
       `main.js: ${currentPhaseForError} stage completed. Logger is now available.`

--- a/tests/bootstrapper/stages.additional.test.js
+++ b/tests/bootstrapper/stages.additional.test.js
@@ -10,7 +10,7 @@ jest.mock('../../src/engine/gameEngine.js', () => {
 import GameEngine from '../../src/engine/gameEngine.js';
 import {
   setupDIContainerStage,
-  resolveCoreServicesStage,
+  resolveLoggerStage,
   initializeGameEngineStage,
   setupGlobalEventListenersStage,
   startGameStage,
@@ -45,12 +45,12 @@ describe('setupDIContainerStage', () => {
   });
 });
 
-describe('resolveCoreServicesStage', () => {
+describe('resolveLoggerStage', () => {
   it('resolves logger from container', async () => {
     const logger = createLogger();
     const container = { resolve: jest.fn().mockReturnValue(logger) };
     const tokens = { ILogger: 'LOGGER' };
-    const result = await resolveCoreServicesStage(container, tokens);
+    const result = await resolveLoggerStage(container, tokens);
     expect(container.resolve).toHaveBeenCalledWith(tokens.ILogger);
     expect(result.logger).toBe(logger);
   });
@@ -62,9 +62,9 @@ describe('resolveCoreServicesStage', () => {
       }),
     };
     const tokens = { ILogger: 'LOGGER' };
-    await expect(
-      resolveCoreServicesStage(container, tokens)
-    ).rejects.toMatchObject({ phase: 'Core Services Resolution' });
+    await expect(resolveLoggerStage(container, tokens)).rejects.toMatchObject({
+      phase: 'Core Services Resolution',
+    });
   });
 });
 

--- a/tests/main/main.bootstrapFlow.test.js
+++ b/tests/main/main.bootstrapFlow.test.js
@@ -14,7 +14,7 @@ jest.mock('../../src/bootstrapper/stages.js', () => ({
   __esModule: true,
   ensureCriticalDOMElementsStage: (...args) => mockEnsure(...args),
   setupDIContainerStage: (...args) => mockSetupDI(...args),
-  resolveCoreServicesStage: (...args) => mockResolveCore(...args),
+  resolveLoggerStage: (...args) => mockResolveCore(...args),
   initializeGameEngineStage: (...args) => mockInitEngine(...args),
   setupMenuButtonListenersStage: (...args) => mockMenu(...args),
   setupGlobalEventListenersStage: (...args) => mockGlobal(...args),

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -14,7 +14,7 @@ jest.mock('../../src/bootstrapper/stages.js', () => ({
   __esModule: true,
   ensureCriticalDOMElementsStage: (...args) => mockEnsure(...args),
   setupDIContainerStage: (...args) => mockSetupDI(...args),
-  resolveCoreServicesStage: (...args) => mockResolveCore(...args),
+  resolveLoggerStage: (...args) => mockResolveCore(...args),
   initializeGameEngineStage: (...args) => mockInitEngine(...args),
   setupMenuButtonListenersStage: (...args) => mockMenu(...args),
   setupGlobalEventListenersStage: (...args) => mockGlobal(...args),


### PR DESCRIPTION
Summary: rename resolveCoreServicesStage to resolveLoggerStage and update imports/tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f8350fa6c83318dc03baa9b54ad3a