### PR TITLE
[Fix] Register missing RemoveFromClosenessCircleHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -44,6 +44,7 @@ import IfCoLocatedHandler from '../../logic/operationHandlers/ifCoLocatedHandler
 import ModifyContextArrayHandler from '../../logic/operationHandlers/modifyContextArrayHandler.js';
 import AutoMoveFollowersHandler from '../../logic/operationHandlers/autoMoveFollowersHandler.js';
 import MergeClosenessCircleHandler from '../../logic/operationHandlers/mergeClosenessCircleHandler.js';
+import RemoveFromClosenessCircleHandler from '../../logic/operationHandlers/removeFromClosenessCircleHandler.js';
 
 /**
  * Registers all interpreter-layer services in the DI container.
@@ -334,6 +335,16 @@ export function registerInterpreters(container) {
     [
       tokens.MergeClosenessCircleHandler,
       MergeClosenessCircleHandler,
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          entityManager: c.resolve(tokens.IEntityManager),
+          safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        }),
+    ],
+    [
+      tokens.RemoveFromClosenessCircleHandler,
+      RemoveFromClosenessCircleHandler,
       (c, Handler) =>
         new Handler({
           logger: c.resolve(tokens.ILogger),

--- a/tests/dependencyInjection/registrations/interpreterRegistrations.removeFromClosenessCircleHandler.test.js
+++ b/tests/dependencyInjection/registrations/interpreterRegistrations.removeFromClosenessCircleHandler.test.js
@@ -1,0 +1,66 @@
+/**
+ * @file Tests for RemoveFromClosenessCircleHandler DI registration.
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../../src/dependencyInjection/appContainer';
+import { Registrar } from '../../../src/dependencyInjection/registrarHelpers';
+import { tokens } from '../../../src/dependencyInjection/tokens';
+import { registerInterpreters } from '../../../src/dependencyInjection/registrations/interpreterRegistrations';
+import RemoveFromClosenessCircleHandler from '../../../src/logic/operationHandlers/removeFromClosenessCircleHandler.js';
+
+describe('interpreterRegistrations', () => {
+  describe('RemoveFromClosenessCircleHandler Registration', () => {
+    it('resolves RemoveFromClosenessCircleHandler with dependencies', () => {
+      const container = new AppContainer();
+      const registrar = new Registrar(container);
+
+      const mockLogger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const mockEntityManager = {
+        getComponentData: jest.fn(),
+        addComponent: jest.fn(),
+        removeComponent: jest.fn(),
+      };
+      const mockSafeEventDispatcher = { dispatch: jest.fn() };
+      const mockValidatedEventDispatcher = {};
+      const mockWorldContext = {};
+      const mockJsonLogicService = {};
+      const mockOperationRegistry = {};
+      const mockEventBus = {};
+      const mockDataRegistry = {};
+
+      registrar.instance(tokens.ILogger, mockLogger);
+      registrar.instance(tokens.IEntityManager, mockEntityManager);
+      registrar.instance(tokens.ISafeEventDispatcher, mockSafeEventDispatcher);
+      registrar.instance(
+        tokens.IValidatedEventDispatcher,
+        mockValidatedEventDispatcher
+      );
+      registrar.instance(tokens.IWorldContext, mockWorldContext);
+      registrar.instance(
+        tokens.JsonLogicEvaluationService,
+        mockJsonLogicService
+      );
+      registrar.instance(tokens.OperationRegistry, mockOperationRegistry);
+      registrar.instance(tokens.EventBus, mockEventBus);
+      registrar.instance(tokens.IDataRegistry, mockDataRegistry);
+
+      registerInterpreters(container);
+
+      let handler;
+      let resolutionError;
+      try {
+        handler = container.resolve(tokens.RemoveFromClosenessCircleHandler);
+      } catch (err) {
+        resolutionError = err;
+      }
+
+      expect(resolutionError).toBeUndefined();
+      expect(handler).toBeInstanceOf(RemoveFromClosenessCircleHandler);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Fixes a crash when executing the intimacy:step_back rule by registering `RemoveFromClosenessCircleHandler` in the interpreter DI configuration. Added an integration test to verify the handler resolves correctly.

Changes Made:
- imported and bound `RemoveFromClosenessCircleHandler` within interpreter registrations
- added corresponding unit test for DI resolution

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for changed files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (skipped in CI)


------
https://chatgpt.com/codex/tasks/task_e_684f856dfaf083318e003689d5393b5a