### PR TITLE
[Agent] route errors via alert router

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -9,7 +9,6 @@
 
 // --- Dependency Imports ---
 import { getEntityDisplayName } from '../utils/entityUtils.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
 import { safeDispatchError } from '../utils/safeDispatchError.js';
 
 /**

--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -5,7 +5,7 @@
 
 import NotesService from './notesService.js';
 import { NOTES_COMPONENT_ID } from '../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
@@ -27,7 +27,7 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
 
   // If the 'notes' key exists but is not an array, dispatch an error and stop.
   if (!Array.isArray(notesArray)) {
-    dispatcher?.dispatch(DISPLAY_ERROR_ID, {
+    dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message:
         "NotesPersistenceHook: 'notes' field is not an array; skipping merge",
       details: { actorId: actorEntity?.id ?? 'UNKNOWN_ACTOR' },
@@ -46,7 +46,7 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
     if (isNonBlankString(noteText)) {
       validNotes.push(noteText);
     } else {
-      dispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'NotesPersistenceHook: Invalid note skipped',
         details: { note: noteText },
       });

--- a/src/configuration/httpConfigurationProvider.js
+++ b/src/configuration/httpConfigurationProvider.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 
 import { IConfigurationProvider } from '../interfaces/IConfigurationProvider.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -73,7 +73,9 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
     ) {
       const errorMessage =
         'HttpConfigurationProvider: sourceUrl must be a non-empty string.';
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, { message: errorMessage });
+      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+        message: errorMessage,
+      });
       throw new Error(errorMessage);
     }
 
@@ -87,7 +89,7 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
       if (!response.ok) {
         const errorStatusText =
           response.statusText || `HTTP status ${response.status}`;
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `HttpConfigurationProvider: Failed to fetch configuration from ${sourceUrl}. Status: ${response.status} ${errorStatusText}`,
           details: { status: response.status, statusText: errorStatusText },
         });
@@ -101,7 +103,7 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
       try {
         jsonData = await response.json();
       } catch (parseError) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `HttpConfigurationProvider: Failed to parse JSON response from ${sourceUrl}.`,
           details: {
             error:
@@ -136,7 +138,7 @@ export class HttpConfigurationProvider extends IConfigurationProvider {
 
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `HttpConfigurationProvider: Error loading or parsing configuration from ${sourceUrl}. Detail: ${errorMessage}`,
         details: {
           error: error instanceof Error ? error.message : String(error),

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -10,7 +10,7 @@ import {
   POSITION_COMPONENT_ID,
   CURRENT_ACTOR_COMPONENT_ID,
 } from '../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
 
 /**
@@ -106,7 +106,7 @@ class WorldContext extends IWorldContext {
 
     const errorMessage = `WorldContext: Expected exactly one entity with component '${CURRENT_ACTOR_COMPONENT_ID}', but found ${actorCount}.`;
 
-    this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+    this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: errorMessage,
       details: { actorCount },
     });
@@ -163,7 +163,9 @@ class WorldContext extends IWorldContext {
       !positionData.locationId
     ) {
       const msg = `WorldContext.getCurrentLocation: Current actor '${actor.id}' is missing a valid '${POSITION_COMPONENT_ID}' component or locationId.`;
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, { message: msg });
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+        message: msg,
+      });
       return null;
     }
 

--- a/src/data/providers/locationSummaryProvider.js
+++ b/src/data/providers/locationSummaryProvider.js
@@ -12,7 +12,7 @@ import {
   DEFAULT_FALLBACK_EXIT_DIRECTION,
   DEFAULT_FALLBACK_LOCATION_NAME,
 } from '../../constants/textDefaults.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -73,7 +73,7 @@ export class LocationSummaryProvider extends ILocationSummaryProvider {
               targetSummary?.name || DEFAULT_FALLBACK_LOCATION_NAME,
           };
         } catch (err) {
-          this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+          this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
             message: `LocationSummaryProvider: Error fetching exit target entity '${exitData.target}': ${err.message}`,
             details: { error: err.message, stack: err.stack, exitData },
           });
@@ -152,7 +152,7 @@ export class LocationSummaryProvider extends ILocationSummaryProvider {
         characters,
       };
     } catch (err) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `LocationSummaryProvider: Critical error generating summary for location '${position.locationId}': ${err.message}`,
         details: {
           error: err.message,

--- a/src/data/providers/perceptionLogProvider.js
+++ b/src/data/providers/perceptionLogProvider.js
@@ -6,7 +6,7 @@
 import { IPerceptionLogProvider } from '../../interfaces/IPerceptionLogProvider.js';
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DEFAULT_FALLBACK_EVENT_DESCRIPTION_RAW } from '../../constants/textDefaults.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -43,7 +43,7 @@ export class PerceptionLogProvider extends IPerceptionLogProvider {
         }
       }
     } catch (perceptionError) {
-      dispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `PerceptionLogProvider: Error retrieving perception log for ${actor.id}: ${perceptionError.message}`,
         details: { error: perceptionError },
       });

--- a/src/domUI/actionResultRenderer.js
+++ b/src/domUI/actionResultRenderer.js
@@ -26,7 +26,7 @@ import DomElementFactory from './domElementFactory.js';
 // Runtime imports
 // ────────────────────────────────────────────────────────────────────────────────
 import { BoundDomRendererBase } from './boundDomRendererBase.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {object} ActionResultPayload
@@ -165,7 +165,7 @@ export class ActionResultRenderer extends BoundDomRendererBase {
     const listEl = this.elements.listContainerElement;
 
     if (!listEl) {
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} listContainerElement not found – cannot render bubble.`,
         details: { message, cssClass },
       });
@@ -174,7 +174,7 @@ export class ActionResultRenderer extends BoundDomRendererBase {
 
     const li = this.domElementFactory?.li(cssClass);
     if (!li) {
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} DomElementFactory.li() returned null – cannot render bubble.`,
         details: { message, cssClass },
       });

--- a/src/domUI/inputStateController.js
+++ b/src/domUI/inputStateController.js
@@ -1,6 +1,6 @@
 // src/domUI/inputStateController.js
 import { RendererBase } from './rendererBase.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
@@ -48,7 +48,7 @@ export class InputStateController extends RendererBase {
     // --- Validate specific inputElement dependency ---
     if (!inputElement || inputElement.nodeType !== 1) {
       const errMsg = `${this._logPrefix} 'inputElement' dependency is missing or not a valid DOM element.`;
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
         details: { inputElement },
       });
@@ -57,7 +57,7 @@ export class InputStateController extends RendererBase {
     // Check specifically if it's an INPUT element
     if (inputElement.tagName !== 'INPUT') {
       const errMsg = `${this._logPrefix} 'inputElement' must be an HTMLInputElement (<input>), but received '${inputElement.tagName}'.`;
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
         details: { element: inputElement },
       });
@@ -182,7 +182,7 @@ export class InputStateController extends RendererBase {
   setEnabled(enabled, placeholderText = '') {
     if (!this.#inputElement) {
       const errMsg = `${this._logPrefix} Cannot set input state, internal #inputElement reference is missing.`;
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
         details: { element: this.#inputElement },
       });

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -3,7 +3,7 @@
 import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import {
   // POSITION_COMPONENT_ID, // No longer directly used for current location logic
   // NAME_COMPONENT_ID, // Handled by EntityDisplayDataProvider
@@ -121,7 +121,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       typeof entityManager.getEntitiesInLocation !== 'function'
     ) {
       const errMsg = `${this._logPrefix} 'entityManager' dependency is missing or invalid.`;
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
       });
       throw new Error(errMsg);
@@ -136,7 +136,9 @@ export class LocationRenderer extends BoundDomRendererBase {
       typeof entityDisplayDataProvider.getLocationPortraitData !== 'function' // IMPORTANT ASSUMPTION
     ) {
       const errMsg = `${this._logPrefix} 'entityDisplayDataProvider' dependency is missing or invalid (must include getLocationDetails, getEntityLocationId, and a new getLocationPortraitData).`;
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, { message: errMsg });
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+        message: errMsg,
+      });
       throw new Error(errMsg);
     }
     this.entityDisplayDataProvider = entityDisplayDataProvider;
@@ -151,7 +153,9 @@ export class LocationRenderer extends BoundDomRendererBase {
 
     if (!containerElement || containerElement.nodeType !== 1) {
       const errMsg = `${this._logPrefix} 'containerElement' dependency is missing or not a valid DOM element.`;
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, { message: errMsg });
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+        message: errMsg,
+      });
       throw new Error(errMsg);
     }
     this.baseContainerElement = containerElement;
@@ -165,7 +169,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       !this.elements.locationPortraitVisualsElement ||
       !this.elements.locationPortraitImageElement
     ) {
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} Location portrait DOM elements not bound. Portraits will not be displayed.`,
       });
       // Depending on strictness, you might throw an error or allow graceful degradation.
@@ -217,7 +221,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       );
 
       if (!locationDetails) {
-        this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `${this._logPrefix} Location details for ID '${currentLocationInstanceId}' not found.`,
         });
         this.#clearAllDisplaysOnErrorWithMessage(
@@ -272,7 +276,7 @@ export class LocationRenderer extends BoundDomRendererBase {
 
       this.render(displayPayload);
     } catch (error) {
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} Error processing '${event.type}' for entity '${currentActorEntityId}': ${error.message}`,
         details: { stack: error.stack },
       });
@@ -356,7 +360,7 @@ export class LocationRenderer extends BoundDomRendererBase {
     } else {
       const ul = this.domElementFactory.ul(undefined, 'location-detail-list');
       if (!ul) {
-        this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `${this._logPrefix} Failed to create UL for ${title}.`,
         });
         // Simplified fallback: render as paragraphs directly in targetElement
@@ -428,7 +432,7 @@ export class LocationRenderer extends BoundDomRendererBase {
 
   render(locationDto) {
     if (!this.baseContainerElement || !this.domElementFactory) {
-      this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} Cannot render, critical dependencies (baseContainerElement or domElementFactory) missing.`,
       });
       return;
@@ -444,7 +448,7 @@ export class LocationRenderer extends BoundDomRendererBase {
     ];
     for (const elKey of requiredElements) {
       if (!this.elements[elKey]) {
-        this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `${this._logPrefix} Cannot render, required DOM element '${elKey}' is missing.`,
         });
         // Potentially call #clearAllDisplaysOnErrorWithMessage or a similar specific error display

--- a/src/domUI/processingIndicatorController.js
+++ b/src/domUI/processingIndicatorController.js
@@ -6,7 +6,7 @@ import {
   AI_TURN_PROCESSING_ENDED,
   PLAYER_TURN_SUBMITTED_ID,
   // TEXT_UI_DISPLAY_SPEECH_ID // Not directly used for hiding in this version
-  DISPLAY_ERROR_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
 } from '../constants/eventIds.js'; // Assuming these constants are correctly named and exported
 
 /**
@@ -144,13 +144,13 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
           );
         } else {
           const errMsg = `${this._logPrefix} Failed to create #processing-indicator element using DomElementFactory.`;
-          this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+          this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
             message: errMsg,
           });
         }
       } else {
         const errMsg = `${this._logPrefix} Cannot create #processing-indicator: DomElementFactory or #outputDiv element missing.`;
-        this.safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: errMsg,
         });
       }

--- a/src/domUI/titleRenderer.js
+++ b/src/domUI/titleRenderer.js
@@ -1,9 +1,6 @@
 // src/dom-ui/titleRenderer.js
 import { RendererBase } from './rendererBase.js';
-import {
-  DISPLAY_ERROR_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
@@ -47,14 +44,14 @@ export class TitleRenderer extends RendererBase {
     // --- Validate specific titleElement dependency ---
     if (!titleElement || titleElement.nodeType !== 1) {
       const errMsg = `${this._logPrefix} 'titleElement' dependency is missing or not a valid DOM element.`;
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
       });
       throw new Error(errMsg);
     }
     if (titleElement.tagName !== 'H1') {
       const errMsg = `${this._logPrefix} 'titleElement' must be an H1 element, but received '${titleElement.tagName}'.`;
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errMsg,
         details: { element: titleElement },
       });
@@ -221,7 +218,7 @@ export class TitleRenderer extends RendererBase {
     const title = `Initialization Failed${payload?.worldName ? ` (World: ${payload.worldName})` : ''}`;
     this.set(title);
     // Dispatch error event for UI display
-    this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+    this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: `${this._logPrefix} Overall initialization failed. Error: ${payload?.error}`,
       details: payload,
     });
@@ -244,7 +241,7 @@ export class TitleRenderer extends RendererBase {
     }
     const title = `${stepName} Failed`;
     this.set(title);
-    this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+    this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: `${this._logPrefix} ${title}. Error: ${payload?.error}`,
       details: payload,
     });
@@ -290,7 +287,7 @@ export class TitleRenderer extends RendererBase {
       }
     } else {
       // Should not happen if constructor validation passed
-      this.validatedEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `${this._logPrefix} Cannot set title, internal #titleElement reference is lost.`,
       });
     }

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -1,7 +1,7 @@
 // src/services/playtimeTracker.js
 
 import IPlaytimeTracker from '../interfaces/IPlaytimeTracker.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
 
 /**
@@ -166,7 +166,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
   setAccumulatedPlaytime(seconds) {
     if (typeof seconds !== 'number') {
       const errorMessage = `PlaytimeTracker: setAccumulatedPlaytime expects a number, but received ${typeof seconds}.`;
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errorMessage,
         details: { receivedType: typeof seconds },
       });
@@ -174,7 +174,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
     }
     if (seconds < 0) {
       const errorMessage = `PlaytimeTracker: setAccumulatedPlaytime expects a non-negative number, but received ${seconds}.`;
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errorMessage,
         details: { seconds },
       });

--- a/src/interfaces/IPerceptionLogProvider.js
+++ b/src/interfaces/IPerceptionLogProvider.js
@@ -18,7 +18,7 @@ export class IPerceptionLogProvider {
    * @param {Entity} actor - The AI-controlled entity.
    * @param {ILogger} logger - An instance of the logger.
    * @param {import('./ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher -
-   * Safe dispatcher for DISPLAY_ERROR_ID events.
+   * Safe dispatcher for SYSTEM_ERROR_OCCURRED_ID events.
    * @returns {Promise<AIPerceptionLogEntryDTO[]>} A promise that resolves to an array of perception log entries.
    */
   async get(actor, logger, dispatcher) {

--- a/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
+++ b/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
@@ -4,7 +4,6 @@
  */
 
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import BaseOperationHandler from './baseOperationHandler.js';

--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -13,7 +13,6 @@ import {
   POSITION_COMPONENT_ID,
   LEADING_COMPONENT_ID,
 } from '../../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import SystemMoveEntityHandler from './systemMoveEntityHandler.js';
 import BaseOperationHandler from './baseOperationHandler.js';

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -10,7 +10,6 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 /** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { assertParamsObject } from '../../utils/handlerUtils';

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -9,7 +9,6 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 import { wouldCreateCycle } from '../../utils/followUtils.js';

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -9,7 +9,6 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -6,10 +6,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../events/safeEventDispatcher.js').SafeEventDispatcher} SafeEventDispatcher */
 
-import {
-  DISPLAY_SPEECH_ID,
-  DISPLAY_ERROR_ID,
-} from '../../constants/eventIds.js';
+import { DISPLAY_SPEECH_ID } from '../../constants/eventIds.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -7,7 +7,10 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { TURN_ENDED_ID, DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import {
+  TURN_ENDED_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
+} from '../../constants/eventIds.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
@@ -59,7 +62,7 @@ class EndTurnHandler {
     if (!assertParamsObject(params, logger, 'END_TURN')) return;
 
     if (typeof params.entityId !== 'string' || !params.entityId.trim()) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'END_TURN: Invalid or missing "entityId" parameter.',
         details: { params },
       });

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -10,7 +10,6 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 /** @typedef {import('./rebuildLeaderListCacheHandler.js').default} RebuildLeaderListCacheHandler */
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { wouldCreateCycle } from '../../utils/followUtils.js';

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -16,7 +16,6 @@ import { NAME_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DEFAULT_FALLBACK_CHARACTER_NAME } from '../../constants/textDefaults.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import BaseOperationHandler from './baseOperationHandler.js';

--- a/src/logic/operationHandlers/ifCoLocatedHandler.js
+++ b/src/logic/operationHandlers/ifCoLocatedHandler.js
@@ -10,7 +10,6 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -3,7 +3,6 @@
  */
 
 import jsonLogic from 'json-logic-js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 import storeResult from '../../utils/contextVariableUtils.js';

--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -8,7 +8,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import closenessCircleService from '../services/closenessCircleService.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
@@ -113,7 +113,7 @@ class MergeClosenessCircleHandler {
           partners,
         });
       } catch (err) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: 'MERGE_CLOSENESS_CIRCLE: failed updating closeness',
           details: { id, error: err.message, stack: err.stack },
         });
@@ -126,7 +126,7 @@ class MergeClosenessCircleHandler {
           locked: true,
         });
       } catch (err) {
-        this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: 'MERGE_CLOSENESS_CIRCLE: failed locking movement',
           details: { id, error: err.message, stack: err.stack },
         });

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -11,7 +11,6 @@
 
 import { resolvePath } from '../../utils/objectUtils.js';
 import { cloneDeep } from 'lodash';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -10,7 +10,6 @@
 /** @typedef {import('../../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import {

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -7,7 +7,6 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../defs.js').OperationParams} OperationParams */
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import { assertParamsObject } from '../../utils/handlerUtils/params.js';
 

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -9,7 +9,6 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -4,7 +4,6 @@
  * @see src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
  */
 import { isNonBlankString } from '../../utils/textUtils.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';

--- a/src/logic/operationHandlers/removeComponentHandler.js
+++ b/src/logic/operationHandlers/removeComponentHandler.js
@@ -14,7 +14,6 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 import {
   initHandlerLogger,

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -9,7 +9,7 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import ClosenessCircleService from '../services/closenessCircleService.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import {
   initHandlerLogger,
   validateDeps,
@@ -69,7 +69,7 @@ class RemoveFromClosenessCircleHandler {
     const { actor_id, result_variable } = params;
 
     if (typeof actor_id !== 'string' || !actor_id.trim()) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'REMOVE_FROM_CLOSENESS_CIRCLE: Invalid "actor_id" parameter',
         details: { params },
       });

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -11,7 +11,6 @@
 /** @typedef {import('../defs.js').EntityRefObject} EntityRefObject */
 
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils';
 

--- a/src/modding/modVersionValidator.js
+++ b/src/modding/modVersionValidator.js
@@ -3,7 +3,7 @@
 import engineVersionSatisfies from '../engine/engineVersionSatisfies.js';
 import ModDependencyError from '../errors/modDependencyError.js';
 import { ENGINE_VERSION } from '../engine/engineVersion.js'; // Import the actual engine version
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -111,7 +111,7 @@ export default function validateModEngineVersions(
   // --- Acceptance: Throws only ModDependencyError on failure (for incompatibility) ---
   if (fatals.length) {
     const errorMessage = fatals.join('\n');
-    safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+    safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: errorMessage,
       details: { incompatibilities: fatals, engineVersion: ENGINE_VERSION },
     });

--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -8,7 +8,7 @@ import {
   SHORT_TERM_MEMORY_COMPONENT_ID,
   PERCEPTION_LOG_COMPONENT_ID,
 } from '../constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * @class ComponentCleaningService
@@ -86,7 +86,7 @@ class ComponentCleaningService {
     try {
       dataToSave = deepClone(componentData);
     } catch (e) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: 'ComponentCleaningService.clean deepClone failed',
         details: {
           componentId,

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -8,10 +8,7 @@ import {
   manualSavePath,
   FULL_MANUAL_SAVE_DIRECTORY_PATH,
 } from './savePathUtils.js';
-import {
-  deserializeAndDecompress,
-  parseManualSaveFile,
-} from './saveFileIO.js';
+import { deserializeAndDecompress, parseManualSaveFile } from './saveFileIO.js';
 import { setupService } from '../utils/serviceInitializer.js';
 import { deepClone } from '../utils/objectUtils.js';
 import {

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -1,6 +1,6 @@
 // src/services/browserStorageProvider.js
 import { IStorageProvider } from '../interfaces/IStorageProvider.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
@@ -90,7 +90,7 @@ export class BrowserStorageProvider extends IStorageProvider {
             (await handle.requestPermission({ mode: 'readwrite' })) !==
             'granted'
           ) {
-            this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+            this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
               message:
                 'BrowserStorageProvider: Permission explicitly denied after selecting directory.',
             });
@@ -105,7 +105,7 @@ export class BrowserStorageProvider extends IStorageProvider {
           this.#logger.warn('User aborted root directory selection.');
           // Let the error propagate so the caller knows the operation can't proceed.
         } else {
-          this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+          this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
             message: 'BrowserStorageProvider: Error selecting root directory.',
             details: { error: error.message, stack: error.stack },
           });
@@ -157,7 +157,7 @@ export class BrowserStorageProvider extends IStorageProvider {
           );
         } else {
           // Log as error for other types of errors, or if create was true and it still failed.
-          this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+          this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
             message: `BrowserStorageProvider: Failed to get/create directory handle for "${part}" in path "${normalizedDirectoryPath}" (options.create: ${isCreateTrue}).`,
             details: { error: error.message, stack: error.stack },
           });
@@ -200,7 +200,7 @@ export class BrowserStorageProvider extends IStorageProvider {
     try {
       return await directoryHandle.getFileHandle(fileName, options);
     } catch (error) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Failed to get/create file handle for "${fileName}" in directory path "${pathParts.join('/')}" (original: ${filePath}).`,
         details: { error: error.message, stack: error.stack },
       });
@@ -233,7 +233,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         `BrowserStorageProvider: Successfully wrote ${data.byteLength} bytes to temporary file ${tempFilePath}.`
       );
     } catch (error) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Error writing to temporary file ${tempFilePath}: ${error.message}`,
         details: { error: error.message, stack: error.stack },
       });
@@ -272,7 +272,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         `BrowserStorageProvider: Successfully replaced/wrote final file ${normalizedFilePath}.`
       );
     } catch (error) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Error writing to final file ${normalizedFilePath} (replacing original): ${error.message}`,
         details: { error: error.message, stack: error.stack },
       });
@@ -343,7 +343,7 @@ export class BrowserStorageProvider extends IStorageProvider {
         );
         return [];
       }
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Error listing files in "${directoryPath}": ${error.message}`,
         details: { error: error.message, stack: error.stack },
       });
@@ -364,7 +364,7 @@ export class BrowserStorageProvider extends IStorageProvider {
       );
       return new Uint8Array(contents);
     } catch (error) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Error reading file ${filePath}: ${error.message}`,
         details: { error: error.message, stack: error.stack },
       });
@@ -418,7 +418,7 @@ export class BrowserStorageProvider extends IStorageProvider {
       );
       return { success: true };
     } catch (error) {
-      this.#safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: `BrowserStorageProvider: Error deleting file ${filePath}: ${error.message}`,
         details: { error: error.message, stack: error.stack },
       });

--- a/src/turns/adapters/eventBusTurnEndAdapter.js
+++ b/src/turns/adapters/eventBusTurnEndAdapter.js
@@ -5,7 +5,6 @@ import { ITurnEndPort } from '../ports/ITurnEndPort.js';
 import {
   TURN_ENDED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
-  DISPLAY_ERROR_ID,
 } from '../../constants/eventIds.js';
 
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeDispatcher */
@@ -58,7 +57,7 @@ export default class EventBusTurnEndAdapter extends ITurnEndPort {
           },
         });
       } catch (dispatchErr) {
-        await this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `EventBusTurnEndAdapter: Error dispatching ${SYSTEM_ERROR_OCCURRED_ID} about invalid entityId.`,
           details: {
             error: dispatchErr.message,
@@ -103,7 +102,7 @@ export default class EventBusTurnEndAdapter extends ITurnEndPort {
           },
         });
       } catch (dispatchErr) {
-        await this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+        await this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `EventBusTurnEndAdapter: Error dispatching ${SYSTEM_ERROR_OCCURRED_ID} after failing ${TURN_ENDED_ID} for ${entityId}.`,
           details: {
             error: dispatchErr.message,

--- a/src/turns/services/LLMResponseProcessor.js
+++ b/src/turns/services/LLMResponseProcessor.js
@@ -4,7 +4,6 @@
 import { ILLMResponseProcessor } from '../interfaces/ILLMResponseProcessor.js';
 import { parseAndRepairJson } from '../../utils/llmUtils.js';
 import { LLM_TURN_ACTION_RESPONSE_SCHEMA_ID } from '../schemas/llmOutputSchemas.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchError.js';
 
 /**

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -11,7 +11,10 @@
 
 import { AbstractTurnState } from './abstractTurnState.js';
 
-import { TURN_ENDED_ID, DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import {
+  TURN_ENDED_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
+} from '../../constants/eventIds.js';
 
 /* global process */
 
@@ -147,7 +150,7 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     );
 
     // 1) tell the UI / console
-    ctx.getSafeEventDispatcher?.().dispatch(DISPLAY_ERROR_ID, {
+    ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: msg,
       details: {
         code: err.code,

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -11,7 +11,7 @@
  */
 
 import { AbstractTurnState } from './abstractTurnState.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 export class TurnEndingState extends AbstractTurnState {
   /** @type {string}     */ #actorToEndId;
@@ -28,7 +28,7 @@ export class TurnEndingState extends AbstractTurnState {
     if (!actorToEndId) {
       const message =
         'TurnEndingState Constructor: actorToEndId must be provided.';
-      dispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message,
         details: { providedActorId: actorToEndId ?? null },
       });
@@ -63,7 +63,7 @@ export class TurnEndingState extends AbstractTurnState {
       try {
         await ctx.getTurnEndPort().notifyTurnEnded(this.#actorToEndId, success);
       } catch (err) {
-        ctx.getSafeEventDispatcher?.().dispatch(DISPLAY_ERROR_ID, {
+        ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `TurnEndingState: Failed notifying TurnEndPort for actor ${this.#actorToEndId}: ${err.message}`,
           details: {
             actorId: this.#actorToEndId,
@@ -146,7 +146,7 @@ export class TurnEndingState extends AbstractTurnState {
       try {
         await ctx.requestIdleStateTransition();
       } catch (err) {
-        ctx.getSafeEventDispatcher?.().dispatch(DISPLAY_ERROR_ID, {
+        ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `TurnEndingState: Failed forced transition to TurnIdleState during destroy for actor ${this.#actorToEndId}: ${err.message}`,
           details: {
             actorId: this.#actorToEndId,

--- a/src/turns/strategies/repromptStrategy.js
+++ b/src/turns/strategies/repromptStrategy.js
@@ -11,7 +11,7 @@
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
 import { AwaitingActorDecisionState } from '../states/awaitingActorDecisionState.js';
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 /**
  * Handles TurnDirective.RE_PROMPT by requesting a transition to AwaitingActorDecisionState.
@@ -41,7 +41,7 @@ export default class RepromptStrategy extends ITurnDirectiveStrategy {
 
     if (directive !== TurnDirective.RE_PROMPT) {
       const errorMsg = `${className}: Received non-RE_PROMPT directive (${directive}). Aborting.`;
-      safeEventDispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      safeEventDispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errorMsg,
         details: { directive },
       });
@@ -54,7 +54,7 @@ export default class RepromptStrategy extends ITurnDirectiveStrategy {
 
     if (!contextActor) {
       const errorMsg = `${className}: No actor found in ITurnContext. Cannot re-prompt.`;
-      safeEventDispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      safeEventDispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errorMsg,
         details: { directive },
       });
@@ -83,7 +83,7 @@ export default class RepromptStrategy extends ITurnDirectiveStrategy {
       );
     } catch (transitionError) {
       const errorMsg = `${className}: Failed to request transition to AwaitingActorDecisionState for actor ${contextActor.id}. Error: ${transitionError.message}`;
-      safeEventDispatcher?.dispatch(DISPLAY_ERROR_ID, {
+      safeEventDispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message: errorMsg,
         details: {
           actorId: contextActor.id,

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 import { getPrefixedLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchError.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 const RETRYABLE_HTTP_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
@@ -35,7 +35,7 @@ function _calculateRetryDelay(currentAttempt, baseDelayMs, maxDelayMs) {
  * @param {number} maxRetries Maximum number of retry attempts before failing.
  * @param {number} baseDelayMs Initial delay in milliseconds for the first retry.
  * @param {number} maxDelayMs Maximum delay in milliseconds between retries, capping the exponential backoff.
- * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} safeEventDispatcher Dispatcher for DISPLAY_ERROR_ID events.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} safeEventDispatcher Dispatcher for SYSTEM_ERROR_OCCURRED_ID events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] Optional logger instance.
  * @returns {Promise<any>} A promise that resolves with the parsed JSON response on success.
  * @throws {Error} Throws an error if all retries fail, a non-retryable HTTP error occurs,
@@ -119,7 +119,7 @@ export async function Workspace_retry(
         } else {
           // Non-retryable HTTP error or max retries reached for an HTTP error
           const errorMessage = `API request to ${url} failed after ${currentAttempt} attempt(s) with status ${response.status}: ${errorBodyText}`;
-          await safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+          await safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
             message: `Workspace_retry: ${errorMessage} (Attempt ${currentAttempt}/${maxRetries}, Non-retryable or max retries reached)`,
             details: {
               status: response.status,
@@ -173,7 +173,7 @@ export async function Workspace_retry(
         } else {
           finalErrorMessage = `Workspace_retry: Failed for ${url} after ${currentAttempt} attempt(s). Unexpected error: ${error.message}`;
         }
-        await safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, {
+        await safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: finalErrorMessage,
           details: {
             originalErrorName: error.name,

--- a/src/utils/entityAssertions.js
+++ b/src/utils/entityAssertions.js
@@ -11,7 +11,7 @@
 
 import { isNonBlankString } from './textUtils.js';
 import { getPrefixedLogger } from './loggerUtils.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
  * Throws an error if the provided entity is invalid.
@@ -20,7 +20,7 @@ import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
  * @param {Entity} entity - The entity to validate.
  * @param {ILogger} [logger] - Optional logger for warnings.
  * @param {string} [contextName] - Name of the calling context.
- * @param {ISafeEventDispatcher} [safeEventDispatcher] - Optional dispatcher for DISPLAY_ERROR_ID events.
+ * @param {ISafeEventDispatcher} [safeEventDispatcher] - Optional dispatcher for SYSTEM_ERROR_OCCURRED_ID events.
  * @throws {Error} If the entity is invalid.
  */
 export function assertValidEntity(
@@ -37,7 +37,7 @@ export function assertValidEntity(
       details: { contextName, entityId: entity?.id ?? null, entity },
     };
     if (safeEventDispatcher?.dispatch) {
-      safeEventDispatcher.dispatch(DISPLAY_ERROR_ID, payload);
+      safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, payload);
     } else {
       log.warn(`${errMsg} - SafeEventDispatcher missing.`, { entity });
     }
@@ -51,7 +51,7 @@ export function assertValidEntity(
  * @param {Entity} actor - Actor entity being validated.
  * @param {ILogger} [logger] - Logger used for warnings when dispatcher missing.
  * @param {string} [contextName] - Calling context for clearer error messages.
- * @param {ISafeEventDispatcher} [safeEventDispatcher] - Dispatcher for DISPLAY_ERROR_ID events.
+ * @param {ISafeEventDispatcher} [safeEventDispatcher] - Dispatcher for SYSTEM_ERROR_OCCURRED_ID events.
  * @deprecated Use {@link assertValidEntity} instead.
  * @throws {Error}
  */

--- a/src/utils/handlerUtils/params.js
+++ b/src/utils/handlerUtils/params.js
@@ -1,6 +1,6 @@
 // src/utils/handlerUtils/params.js
 
-import { DISPLAY_ERROR_ID } from '../../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 /**
  * @description Ensures an operation handler received a valid parameters object.
@@ -22,7 +22,7 @@ export function assertParamsObject(params, logger, opName) {
   if (logger && typeof logger.warn === 'function') {
     logger.warn(message, { params });
   } else if (logger && typeof logger.dispatch === 'function') {
-    logger.dispatch(DISPLAY_ERROR_ID, { message, details: { params } });
+    logger.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details: { params } });
   } else {
     console.warn(message, { params });
   }

--- a/src/utils/safeDispatchError.js
+++ b/src/utils/safeDispatchError.js
@@ -7,10 +7,10 @@
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
- * Sends a `core:display_error` event with a consistent payload structure.
+ * Sends a `core:system_error_occurred` event with a consistent payload structure.
  * The dispatcher is validated before dispatching.
  *
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
@@ -30,7 +30,7 @@ export function safeDispatchError(dispatcher, message, details = {}) {
     throw new Error(errorMsg);
   }
 
-  dispatcher.dispatch(DISPLAY_ERROR_ID, { message, details });
+  dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });
 }
 
 // --- FILE END ---

--- a/src/validation/gameStateValidationServiceForPrompting.js
+++ b/src/validation/gameStateValidationServiceForPrompting.js
@@ -7,7 +7,7 @@
 /** @typedef {import('../interfaces/IGameStateValidationServiceForPrompting.js').IGameStateValidationServiceForPrompting} IGameStateValidationServiceForPrompting_Interface */
 
 import { ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING } from '../constants/textDefaults.js';
-import { DISPLAY_ERROR_ID } from '../constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { IGameStateValidationServiceForPrompting } from '../interfaces/IGameStateValidationServiceForPrompting.js';
 
 /**
@@ -57,7 +57,7 @@ export class GameStateValidationServiceForPrompting extends IGameStateValidation
    */
   validate(gameStateDto) {
     if (!gameStateDto) {
-      this.#dispatcher.dispatch(DISPLAY_ERROR_ID, {
+      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
         message:
           'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
         details: {},

--- a/tests/actions/actionFormatter.additional.test.js
+++ b/tests/actions/actionFormatter.additional.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import { formatActionCommand } from '../../src/actions/actionFormatter.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 jest.mock('../../src/utils/entityUtils.js', () => ({
   getEntityDisplayName: jest.fn(),
@@ -87,7 +87,7 @@ describe('formatActionCommand additional cases', () => {
 
     expect(result).toBeNull();
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('placeholder substitution'),
       })

--- a/tests/actions/actionFormatter.test.js
+++ b/tests/actions/actionFormatter.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { formatActionCommand } from '../../src/actions/actionFormatter.js';
 import { getEntityDisplayName } from '../../src/utils/entityUtils.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 jest.mock('../../src/utils/entityUtils.js', () => ({
   getEntityDisplayName: jest.fn(),
@@ -82,7 +82,7 @@ describe('formatActionCommand', () => {
     );
     expect(result).toBeNull();
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message:
           'formatActionCommand: Invalid or missing actionDefinition or template.',

--- a/tests/ai/notesPersistenceHook.test.js
+++ b/tests/ai/notesPersistenceHook.test.js
@@ -3,7 +3,7 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { persistNotes } from '../../src/ai/notesPersistenceHook.js';
 import { NOTES_COMPONENT_ID } from '../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
   error: jest.fn(),
@@ -105,21 +105,21 @@ describe('persistNotes', () => {
 
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(3);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'NotesPersistenceHook: Invalid note skipped',
         details: { note: '' },
       })
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'NotesPersistenceHook: Invalid note skipped',
         details: { note: 123 },
       })
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'NotesPersistenceHook: Invalid note skipped',
         details: { note: null },

--- a/tests/alerting/throttler.test.js
+++ b/tests/alerting/throttler.test.js
@@ -116,11 +116,14 @@ describe('Throttler', () => {
 
     // Assert
     expect(mockDispatcher.dispatch).toHaveBeenCalledTimes(1);
-    expect(mockDispatcher.dispatch).toHaveBeenCalledWith('core:display_error', {
-      message:
-        "Error: 'Critical failure' occurred 1 more times in the last 10 seconds.",
-      details: errorPayload.details,
-    });
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      'core:display_error',
+      {
+        message:
+          "Error: 'Critical failure' occurred 1 more times in the last 10 seconds.",
+        details: errorPayload.details,
+      }
+    );
   });
 
   /**

--- a/tests/context/worldContext.edgeCases.test.js
+++ b/tests/context/worldContext.edgeCases.test.js
@@ -33,7 +33,7 @@ import {
   POSITION_COMPONENT_ID,
   CURRENT_ACTOR_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('WorldContext Edge Cases', () => {
   let worldContext;
@@ -89,7 +89,7 @@ describe('WorldContext Edge Cases', () => {
     // #assertSingleCurrentActor logs the error in production mode
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Expected exactly one entity with component '${CURRENT_ACTOR_COMPONENT_ID}', but found 0.`
@@ -123,7 +123,7 @@ describe('WorldContext Edge Cases', () => {
     // #assertSingleCurrentActor logs the error in production mode
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Expected exactly one entity with component '${CURRENT_ACTOR_COMPONENT_ID}', but found 2.`
@@ -168,7 +168,7 @@ describe('WorldContext Edge Cases', () => {
     );
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Current actor 'player1' is missing a valid '${POSITION_COMPONENT_ID}' component or locationId.`
@@ -209,7 +209,7 @@ describe('WorldContext Edge Cases', () => {
     );
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Current actor 'player1' is missing a valid '${POSITION_COMPONENT_ID}' component or locationId.`

--- a/tests/context/worldContext.test.js
+++ b/tests/context/worldContext.test.js
@@ -15,7 +15,7 @@ import {
   POSITION_COMPONENT_ID,
   CURRENT_ACTOR_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 const createMockEntityManager = () => ({
   getEntitiesWithComponent: jest.fn(),
@@ -144,7 +144,7 @@ describe('WorldContext (Stateless)', () => {
       process.env.NODE_ENV = 'test';
       expect(() => worldContext.getCurrentActor()).toThrow(`but found 0`);
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('found 0'),
         })
@@ -152,7 +152,7 @@ describe('WorldContext (Stateless)', () => {
       process.env.NODE_ENV = 'production';
       expect(worldContext.getCurrentActor()).toBeNull();
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('found 0'),
         })
@@ -167,7 +167,7 @@ describe('WorldContext (Stateless)', () => {
       process.env.NODE_ENV = 'test';
       expect(() => worldContext.getCurrentActor()).toThrow(`but found 2`);
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('found 2'),
         })
@@ -175,7 +175,7 @@ describe('WorldContext (Stateless)', () => {
       process.env.NODE_ENV = 'production';
       expect(worldContext.getCurrentActor()).toBeNull();
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('found 2'),
         })
@@ -226,7 +226,7 @@ describe('WorldContext (Stateless)', () => {
       const location = worldContext.getCurrentLocation();
       expect(location).toBeNull();
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             `Current actor '${PLAYER_ID}' is missing a valid '${POSITION_COMPONENT_ID}' component`
@@ -242,7 +242,7 @@ describe('WorldContext (Stateless)', () => {
       const location = worldContext.getCurrentLocation();
       expect(location).toBeNull();
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             `Current actor '${PLAYER_ID}' is missing a valid '${POSITION_COMPONENT_ID}' component or locationId`

--- a/tests/domUI/actionResultRenderer.test.js
+++ b/tests/domUI/actionResultRenderer.test.js
@@ -14,7 +14,7 @@ import {
 
 // Class under test
 import { ActionResultRenderer } from '../../src/domUI/actionResultRenderer.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock dependencies
 const mockLogger = {
@@ -258,7 +258,7 @@ describe('ActionResultRenderer', () => {
   });
 
   describe('Test Case: Error dispatching', () => {
-    it('dispatches core:display_error when message list is missing', () => {
+    it('dispatches core:system_error_occurred when message list is missing', () => {
       // Reconfigure DocumentContext to omit the message list element
       mockDocumentContext.query = jest.fn((selector) => {
         if (selector === '#outputDiv') {
@@ -280,7 +280,7 @@ describe('ActionResultRenderer', () => {
       handler({ payload: { message: 'hi' } });
 
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('listContainerElement not found'),
         })
@@ -288,14 +288,14 @@ describe('ActionResultRenderer', () => {
       expect(mockDomElementFactory.li).not.toHaveBeenCalled();
     });
 
-    it('dispatches core:display_error when DomElementFactory returns null', () => {
+    it('dispatches core:system_error_occurred when DomElementFactory returns null', () => {
       mockDomElementFactory.li.mockReturnValue(null);
 
       const handler = eventListeners['core:display_successful_action_result'];
       handler({ payload: { message: 'Boom' } });
 
       expect(mockValidatedEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             'DomElementFactory.li() returned null'

--- a/tests/domUI/chatAlertRenderer.a11y.test.js
+++ b/tests/domUI/chatAlertRenderer.a11y.test.js
@@ -76,7 +76,10 @@ describe('ChatAlertRenderer ARIA behavior', () => {
   });
 
   it('renders error bubble with proper aria attributes and icon label', () => {
-    fire(dispatcher, 'core:display_error', { message: 'Boom', details: {} });
+    fire(dispatcher, 'core:display_error', {
+      message: 'Boom',
+      details: {},
+    });
     const bubble = chatPanel.firstElementChild;
     expect(bubble.getAttribute('role')).toBe('alert');
     expect(bubble.getAttribute('aria-live')).toBe('assertive');

--- a/tests/domUI/inputStateController.test.js
+++ b/tests/domUI/inputStateController.test.js
@@ -11,7 +11,7 @@ import { JSDOM } from 'jsdom';
 import { InputStateController } from '../../src/domUI'; // Assuming index exports it
 import DocumentContext from '../../src/domUI/documentContext.js';
 import ConsoleLogger from '../../src/logging/consoleLogger.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock dependencies
 jest.mock('../../src/logging/consoleLogger.js');
@@ -109,7 +109,7 @@ describe('InputStateController', () => {
         "'inputElement' dependency is missing or not a valid DOM element."
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             "'inputElement' dependency is missing or not a valid DOM element."
@@ -128,7 +128,7 @@ describe('InputStateController', () => {
         "'inputElement' dependency is missing or not a valid DOM element."
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             "'inputElement' dependency is missing or not a valid DOM element."
@@ -143,7 +143,7 @@ describe('InputStateController', () => {
         "'inputElement' must be an HTMLInputElement (<input>), but received 'DIV'."
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             "'inputElement' must be an HTMLInputElement (<input>), but received 'DIV'."

--- a/tests/domUI/locationRenderer.test.js
+++ b/tests/domUI/locationRenderer.test.js
@@ -31,7 +31,7 @@ import {
   EXITS_COMPONENT_ID,
   ACTOR_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 /** @returns {import('../../src/interfaces/ILogger.js').ILogger} */
 const createMockLogger = () => ({
@@ -535,7 +535,7 @@ describe('LocationRenderer', () => {
         mockEntityDisplayDataProvider.getLocationDetails
       ).toHaveBeenCalledWith(MOCK_LOCATION_ID);
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             `Location details for ID '${MOCK_LOCATION_ID}' not found.`
@@ -895,10 +895,13 @@ describe('LocationRenderer', () => {
           );
         }
       }
-      expect(specificMockVed.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
-        message:
-          "[LocationRenderer] Cannot render, required DOM element 'charactersDisplay' is missing.",
-      });
+      expect(specificMockVed.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            "[LocationRenderer] Cannot render, required DOM element 'charactersDisplay' is missing.",
+        }
+      );
       mockDocumentContext.query = originalQuery; // Restore original mock
     });
   });

--- a/tests/domUI/titleRenderer.subscriptions.test.js
+++ b/tests/domUI/titleRenderer.subscriptions.test.js
@@ -2,10 +2,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { TitleRenderer } from '../../src/domUI/index.js'; // Corrected import path if needed
 import { RendererBase } from '../../src/domUI/index.js';
-import {
-  SYSTEM_ERROR_OCCURRED_ID,
-  DISPLAY_ERROR_ID,
-} from '../../src/constants/eventIds.js'; // Needed for checking super.dispose
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js'; // Needed for checking super.dispose
 
 // --- Mock Dependencies ---
 
@@ -114,7 +111,7 @@ describe('TitleRenderer', () => {
       );
       expect(mockSafeEventDispatcher.subscribe).toHaveBeenCalledTimes(14);
       expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.any(Object)
       );
     });
@@ -131,7 +128,7 @@ describe('TitleRenderer', () => {
         "[TitleRenderer] 'titleElement' dependency is missing or not a valid DOM element."
       );
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             'missing or not a valid DOM element'
@@ -153,7 +150,7 @@ describe('TitleRenderer', () => {
         "[TitleRenderer] 'titleElement' dependency is missing or not a valid DOM element."
       );
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             'missing or not a valid DOM element'
@@ -175,7 +172,7 @@ describe('TitleRenderer', () => {
         "[TitleRenderer] 'titleElement' must be an H1 element, but received 'DIV'."
       );
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('must be an H1 element'),
         })
@@ -243,7 +240,7 @@ describe('TitleRenderer', () => {
       );
       expect(mockLogger.warn).not.toHaveBeenCalled();
       expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.any(Object)
       );
     });
@@ -367,7 +364,7 @@ describe('TitleRenderer', () => {
         'Initialization Failed (World: BrokenWorld)'
       );
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('Overall initialization failed'),
         })
@@ -404,7 +401,7 @@ describe('TitleRenderer', () => {
       simulateEvent('initialization:world_loader:failed', payload);
       expect(renderer.set).toHaveBeenCalledWith('world loader Failed');
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             'world loader Failed. Error: File not found'
@@ -418,7 +415,7 @@ describe('TitleRenderer', () => {
       simulateEvent('initialization:input_setup_service:failed', payload);
       expect(renderer.set).toHaveBeenCalledWith('input setup service Failed');
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             'input setup service Failed. Error: Keybindings conflict'

--- a/tests/domUI/titleRenderer.test.js
+++ b/tests/domUI/titleRenderer.test.js
@@ -1,7 +1,7 @@
 // tests/domUI/titleRenderer.test.js
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'; // Use if needed for mocking
 import { TitleRenderer } from '../../src/domUI/index.js'; // Adjust path as necessary
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock dependencies
 const mockLogger = {
@@ -63,7 +63,7 @@ describe('TitleRenderer', () => {
       expect.stringContaining('[TitleRenderer] Attached to H1 element.')
     );
     expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.any(Object)
     );
   });
@@ -80,7 +80,7 @@ describe('TitleRenderer', () => {
       "'titleElement' dependency is missing or not a valid DOM element."
     );
     expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('missing or not a valid DOM element'),
       })
@@ -100,7 +100,7 @@ describe('TitleRenderer', () => {
       "'titleElement' dependency is missing or not a valid DOM element."
     );
     expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('missing or not a valid DOM element'),
       })
@@ -118,7 +118,7 @@ describe('TitleRenderer', () => {
       });
     }).toThrow("'titleElement' must be an H1 element, but received 'DIV'.");
     expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('must be an H1 element'),
       })

--- a/tests/integration/LLMResponseProcessor.e2e.test.js
+++ b/tests/integration/LLMResponseProcessor.e2e.test.js
@@ -8,7 +8,7 @@ import {
   LLMResponseProcessor,
   LLMProcessingError,
 } from '../../src/turns/services/LLMResponseProcessor.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mocked logger for capturing logs
 const makeLogger = () => ({
@@ -122,7 +122,7 @@ describe('LLMResponseProcessor', () => {
     });
 
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message: `LLMResponseProcessor: schema invalid for actor ${actorId}`,
         details: { errors: mockErrors, parsed: JSON.parse(invalidJson) },
@@ -150,7 +150,7 @@ describe('LLMResponseProcessor', () => {
     await processor.processResponse(nonJson, actorId).catch(() => {});
 
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `LLMResponseProcessor: JSON could not be parsed for actor ${actorId}`

--- a/tests/llms/clientApiKeyProvider.test.js
+++ b/tests/llms/clientApiKeyProvider.test.js
@@ -4,7 +4,7 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ClientApiKeyProvider } from '../../src/llms/clientApiKeyProvider.js';
 import { EnvironmentContext } from '../../src/llms/environmentContext.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 /**
  * @typedef {import('../../src/llms/interfaces/ILogger.js').ILogger} ILogger
@@ -110,7 +110,7 @@ describe('ClientApiKeyProvider', () => {
       );
       // Ensure no other checks (like api key var) are made if not client
       expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('missing both'),
         })
@@ -121,7 +121,7 @@ describe('ClientApiKeyProvider', () => {
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
@@ -140,7 +140,7 @@ describe('ClientApiKeyProvider', () => {
       );
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
@@ -152,7 +152,7 @@ describe('ClientApiKeyProvider', () => {
       const key = await provider.getKey(null, environmentContext);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'ClientApiKeyProvider.getKey (UnknownLLM): llmConfig is null or undefined.',
@@ -172,7 +172,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: expect.stringContaining('missing both'),
             })
@@ -192,7 +192,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: expect.stringContaining('missing both'),
             })
@@ -212,7 +212,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: expect.stringContaining('missing both'),
             })
@@ -232,7 +232,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: `ClientApiKeyProvider.getKey (test-llm): Configuration for cloud service '${apiType}' is missing both 'apiKeyEnvVar' and 'apiKeyFileName'. The proxy server will be unable to retrieve the API key. This is a configuration issue.`,
             })
@@ -247,7 +247,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: `ClientApiKeyProvider.getKey (test-llm): Configuration for cloud service '${apiType}' is missing both 'apiKeyEnvVar' and 'apiKeyFileName'. The proxy server will be unable to retrieve the API key. This is a configuration issue.`,
             })
@@ -262,7 +262,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: `ClientApiKeyProvider.getKey (test-llm): Configuration for cloud service '${apiType}' is missing both 'apiKeyEnvVar' and 'apiKeyFileName'. The proxy server will be unable to retrieve the API key. This is a configuration issue.`,
             })
@@ -282,7 +282,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: expect.stringContaining('missing both'),
             })
@@ -300,7 +300,7 @@ describe('ClientApiKeyProvider', () => {
           const key = await provider.getKey(llmConfig, environmentContext);
           expect(key).toBeNull();
           expect(dispatcher.dispatch).not.toHaveBeenCalledWith(
-            DISPLAY_ERROR_ID,
+            SYSTEM_ERROR_OCCURRED_ID,
             expect.objectContaining({
               message: expect.stringContaining('missing both'),
             })

--- a/tests/llms/serverApiKeyProvider.test.js
+++ b/tests/llms/serverApiKeyProvider.test.js
@@ -4,7 +4,7 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ServerApiKeyProvider } from '../../src/llms/serverApiKeyProvider.js';
 import { EnvironmentContext } from '../../src/llms/environmentContext.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 // Import the actual interfaces to ensure mocks align if needed, though not strictly used for type in JS tests
 // import { IFileSystemReader, IEnvironmentVariableReader } from '../../src/llms/interfaces/IServerUtils.js';
 
@@ -195,7 +195,7 @@ describe('ServerApiKeyProvider', () => {
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'ServerApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
@@ -280,7 +280,7 @@ describe('ServerApiKeyProvider', () => {
 
         expect(key).toBe('file_key_after_env_error');
         expect(dispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message:
               "ServerApiKeyProvider.getKey (test-llm): Error while reading environment variable 'ERROR_KEY_ENV'. Error: Hypothetical permission denied reading env",
@@ -338,7 +338,7 @@ describe('ServerApiKeyProvider', () => {
 
         expect(key).toBeNull();
         expect(dispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message:
               "ServerApiKeyProvider.getKey (test-llm): Cannot retrieve key from file 'keyfile.txt' because projectRootPath is missing or invalid in EnvironmentContext.",
@@ -403,7 +403,7 @@ describe('ServerApiKeyProvider', () => {
 
         expect(key).toBeNull();
         expect(dispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message:
               "ServerApiKeyProvider.getKey (test-llm): Unexpected error while reading API key file '/project/root/error_file.txt'. Error: Disk read error (unexpected)",

--- a/tests/logic/operationHandlers/addPerceptionLogEntryHandler.test.js
+++ b/tests/logic/operationHandlers/addPerceptionLogEntryHandler.test.js
@@ -19,7 +19,7 @@ import {
 // ─── Function Under Test ──────────────────────────────────────────────────────
 import AddPerceptionLogEntryHandler from '../../../src/logic/operationHandlers/addPerceptionLogEntryHandler.js';
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // ─── JSDoc Types (optional) ───────────────────────────────────────────────────
 /** @typedef {import('../../src/interfaces/coreServices.js').ILogger}  ILogger */
@@ -140,7 +140,7 @@ describe('AddPerceptionLogEntryHandler', () => {
       [null, undefined, 42, 'str'].forEach((bad) => {
         h.execute(/** @type {any} */ (bad));
         expect(dispatcher.dispatch).toHaveBeenLastCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message: 'ADD_PERCEPTION_LOG_ENTRY: params missing or invalid.',
           })
@@ -156,7 +156,7 @@ describe('AddPerceptionLogEntryHandler', () => {
           entry: makeEntry(),
         });
         expect(dispatcher.dispatch).toHaveBeenLastCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message: 'ADD_PERCEPTION_LOG_ENTRY: location_id is required',
           })
@@ -169,7 +169,7 @@ describe('AddPerceptionLogEntryHandler', () => {
       [null, undefined, 999, 'bad'].forEach((ent) => {
         h.execute({ location_id: 'loc:test', entry: /** @type {any} */ (ent) });
         expect(dispatcher.dispatch).toHaveBeenLastCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message: 'ADD_PERCEPTION_LOG_ENTRY: entry object is required',
           })

--- a/tests/logic/operationHandlers/breakFollowRelationHandler.test.js
+++ b/tests/logic/operationHandlers/breakFollowRelationHandler.test.js
@@ -3,7 +3,7 @@
  */
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import BreakFollowRelationHandler from '../../../src/logic/operationHandlers/breakFollowRelationHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { FOLLOWING_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 
 const makeMockLogger = () => ({
@@ -65,7 +65,7 @@ describe('BreakFollowRelationHandler', () => {
   test('validates parameters', () => {
     handler.execute({}, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('follower_id'),
       })

--- a/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
+++ b/tests/logic/operationHandlers/checkFollowCycleHandler.test.js
@@ -14,7 +14,7 @@ import {
 import CheckFollowCycleHandler from '../../../src/logic/operationHandlers/checkFollowCycleHandler.js';
 // Assuming the constant is exported from a known path
 import { FOLLOWING_COMPONENT_ID } from '../../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 /**
  * Creates a mock ILogger.
@@ -173,7 +173,7 @@ describe('CheckFollowCycleHandler', () => {
       (paramName, params) => {
         handler.execute(params, mockExecutionContext);
         expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message: `CHECK_FOLLOW_CYCLE: Invalid "${paramName}" parameter`,
           })
@@ -370,7 +370,7 @@ describe('CheckFollowCycleHandler', () => {
 
       // Assert
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('cannot store result'),
         })

--- a/tests/logic/operationHandlers/dispatchPerceptibleEventHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchPerceptibleEventHandler.test.js
@@ -4,7 +4,7 @@
 
 import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
   debug: jest.fn(),
@@ -75,7 +75,7 @@ describe('DispatchPerceptibleEventHandler', () => {
   test('dispatches error when params missing', () => {
     handler.execute(null, {});
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('params missing'),
       })

--- a/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
+++ b/tests/logic/operationHandlers/dispatchSpeechHandler.test.js
@@ -5,7 +5,7 @@ import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import DispatchSpeechHandler from '../../../src/logic/operationHandlers/dispatchSpeechHandler.js';
 import {
   DISPLAY_SPEECH_ID,
-  DISPLAY_ERROR_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
@@ -95,7 +95,7 @@ describe('DispatchSpeechHandler', () => {
     const params = { entity_id: 'e1', speech_content: 'oops' };
     handler.execute(params, {});
     expect(safeDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'DISPATCH_SPEECH: Error dispatching display_speech.',
       })

--- a/tests/logic/operationHandlers/endTurnHandler.test.js
+++ b/tests/logic/operationHandlers/endTurnHandler.test.js
@@ -5,7 +5,7 @@ import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import {
   TURN_ENDED_ID,
-  DISPLAY_ERROR_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
@@ -49,7 +49,7 @@ describe('EndTurnHandler', () => {
 
   test('execute logs error and does not dispatch when entityId is invalid', () => {
     handler.execute({ entityId: '   ', success: true }, {});
-    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message: 'END_TURN: Invalid or missing "entityId" parameter.',
       details: { params: { entityId: '   ', success: true } },
     });

--- a/tests/logic/operationHandlers/establishFollowRelationHandler.test.js
+++ b/tests/logic/operationHandlers/establishFollowRelationHandler.test.js
@@ -3,7 +3,7 @@
  */
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import EstablishFollowRelationHandler from '../../../src/logic/operationHandlers/establishFollowRelationHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { FOLLOWING_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 
 const makeMockLogger = () => ({
@@ -69,7 +69,7 @@ describe('EstablishFollowRelationHandler', () => {
     wouldCreateCycle.mockReturnValueOnce(true);
     handler.execute({ follower_id: 'A', leader_id: 'B' }, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.stringContaining('cycle') })
     );
     expect(em.addComponent).not.toHaveBeenCalled();
@@ -78,7 +78,7 @@ describe('EstablishFollowRelationHandler', () => {
   test('validates parameters', () => {
     handler.execute({}, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('follower_id'),
       })

--- a/tests/logic/operationHandlers/hasComponentHandler.test.js
+++ b/tests/logic/operationHandlers/hasComponentHandler.test.js
@@ -4,7 +4,7 @@
  */
 
 import HasComponentHandler from '../../../src/logic/operationHandlers/hasComponentHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import {
   jest,
   describe,
@@ -239,7 +239,7 @@ describe('HasComponentHandler', () => {
       'core:failing_component'
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'An error occurred while checking for component "core:failing_component"'

--- a/tests/logic/operationHandlers/mergeClosenessCircleHandler.test.js
+++ b/tests/logic/operationHandlers/mergeClosenessCircleHandler.test.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import MergeClosenessCircleHandler from '../../../src/logic/operationHandlers/mergeClosenessCircleHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
   debug: jest.fn(),
@@ -72,7 +72,7 @@ describe('MergeClosenessCircleHandler', () => {
   test('validates parameters', () => {
     handler.execute({}, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.stringContaining('actor_id') })
     );
   });

--- a/tests/logic/operationHandlers/modifyComponentHandler.test.js
+++ b/tests/logic/operationHandlers/modifyComponentHandler.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Type-hints (for editors only) ------------------------------------------
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -388,7 +388,7 @@ describe('ModifyComponentHandler', () => {
       { stats: { hp: 25 } }
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         details: expect.objectContaining({ error: testError.message }),
       })

--- a/tests/logic/operationHandlers/queryComponentHandler.context.test.js
+++ b/tests/logic/operationHandlers/queryComponentHandler.context.test.js
@@ -2,7 +2,7 @@
 
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const getLoggerMock = () => ({
   info: jest.fn(),
@@ -155,7 +155,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     handler.execute(params, executionContext);
 
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'executionContext.evaluationContext.context is missing'
@@ -179,7 +179,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     handler.execute(params, executionContext);
 
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'executionContext.evaluationContext.context is missing'
@@ -200,7 +200,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     };
     handler.execute(params, executionContext);
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Missing required "entity_ref"'),
       })
@@ -217,7 +217,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     };
     handler.execute(params, executionContext);
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"component_type"'),
       })
@@ -234,7 +234,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     };
     handler.execute(params, executionContext);
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"result_variable"'),
       })
@@ -263,7 +263,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     handler.execute(params, executionContext);
 
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'Error during EntityManager.getComponentData'
@@ -289,7 +289,7 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     };
     handler.execute(params, executionContext);
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })

--- a/tests/logic/operationHandlers/queryComponentHandler.test.js
+++ b/tests/logic/operationHandlers/queryComponentHandler.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js'; // Adjust path
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- JSDoc Imports ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -276,7 +276,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext({ evaluationContext: { actor: null } }); // Actor missing
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })
@@ -296,7 +296,7 @@ describe('QueryComponentHandler', () => {
     }); // Target ID missing
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })
@@ -314,7 +314,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext();
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })
@@ -332,7 +332,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext();
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })
@@ -350,7 +350,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext();
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Could not resolve entity id'),
       })
@@ -364,7 +364,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext();
     handler.execute(null, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'QueryComponentHandler: params missing or invalid.',
       })
@@ -374,7 +374,7 @@ describe('QueryComponentHandler', () => {
 
     handler.execute('invalid', context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: 'QueryComponentHandler: params missing or invalid.',
       })
@@ -385,7 +385,7 @@ describe('QueryComponentHandler', () => {
     const context = getMockContext();
     handler.execute({ entity_ref: 'actor', result_variable: 'res' }, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"component_type" parameter'),
       })
@@ -398,7 +398,7 @@ describe('QueryComponentHandler', () => {
       context
     );
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"component_type" parameter'),
       })
@@ -414,7 +414,7 @@ describe('QueryComponentHandler', () => {
       context
     );
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"result_variable" parameter'),
       })
@@ -431,7 +431,7 @@ describe('QueryComponentHandler', () => {
       context
     );
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('"result_variable" parameter'),
       })
@@ -451,7 +451,7 @@ describe('QueryComponentHandler', () => {
 
     handler.execute(params, context);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'evaluationContext.context is missing'
@@ -639,7 +639,7 @@ describe('QueryComponentHandler', () => {
 
     expect(mockEntityManager.getComponentData).toHaveBeenCalledTimes(1);
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           'Error during EntityManager.getComponentData'
@@ -671,7 +671,7 @@ describe('QueryComponentHandler', () => {
     );
 
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.anything()
     );
     expect(specificLogger.error).not.toHaveBeenCalled();

--- a/tests/logic/operationHandlers/queryComponentsHandler.test.js
+++ b/tests/logic/operationHandlers/queryComponentsHandler.test.js
@@ -2,7 +2,7 @@
 
 import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import QueryComponentsHandler from '../../../src/logic/operationHandlers/queryComponentsHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
   info: jest.fn(),
@@ -88,7 +88,7 @@ describe('QueryComponentsHandler', () => {
   test('logs error when params invalid', () => {
     handler.execute(null, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('params missing'),
       })

--- a/tests/logic/operationHandlers/queryEntitiesHandler.test.js
+++ b/tests/logic/operationHandlers/queryEntitiesHandler.test.js
@@ -12,7 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import QueryEntitiesHandler from '../../../src/logic/operationHandlers/queryEntitiesHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // 1. Test Harness Setup
 /**
@@ -381,7 +381,7 @@ describe('QueryEntitiesHandler', () => {
       handler.execute(params, mockExecutionContext);
 
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining('Cannot store result'),
           details: { resultVariable: 'x' },

--- a/tests/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
+++ b/tests/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
@@ -12,7 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import RebuildLeaderListCacheHandler from '../../../src/logic/operationHandlers/rebuildLeaderListCacheHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Constants ---
 const FOLLOWING_COMPONENT_ID = 'core:following';
@@ -476,7 +476,7 @@ describe('RebuildLeaderListCacheHandler', () => {
       // Assert
       expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             "[RebuildLeaderListCacheHandler] Failed updating 'core:leading' for 'leader1': EntityManager failed",
@@ -517,7 +517,7 @@ describe('RebuildLeaderListCacheHandler', () => {
       // Assert
       expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             "[RebuildLeaderListCacheHandler] Failed updating 'core:leading' for 'leader1': EntityManager remove failed",

--- a/tests/logic/operationHandlers/removeComponentHandler.test.js
+++ b/tests/logic/operationHandlers/removeComponentHandler.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import RemoveComponentHandler from '../../../src/logic/operationHandlers/removeComponentHandler.js'; // Adjust path if needed
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Type-hints (for editors only) ------------------------------------------
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -356,7 +356,7 @@ describe('RemoveComponentHandler', () => {
       'problem:comp'
     );
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining('Failed to remove component'),
       })

--- a/tests/logic/operationHandlers/removeFromClosenessCircleHandler.test.js
+++ b/tests/logic/operationHandlers/removeFromClosenessCircleHandler.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import RemoveFromClosenessCircleHandler from '../../../src/logic/operationHandlers/removeFromClosenessCircleHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const makeLogger = () => ({
   debug: jest.fn(),
@@ -48,7 +48,7 @@ describe('RemoveFromClosenessCircleHandler', () => {
   test('validates parameters', () => {
     handler.execute({}, execCtx);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.stringContaining('actor_id') })
     );
   });

--- a/tests/logic/operationHandlers/systemMoveEntityHandler.test.js
+++ b/tests/logic/operationHandlers/systemMoveEntityHandler.test.js
@@ -12,7 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import SystemMoveEntityHandler from '../../../src/logic/operationHandlers/systemMoveEntityHandler.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Mocks ---
 
@@ -324,7 +324,7 @@ describe('SystemMoveEntityHandler', () => {
       // Assert
       expect(execCtx.logger.error).not.toHaveBeenCalled();
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `SYSTEM_MOVE_ENTITY: Failed to move entity "player". Error: ${error.message}`,
         })
@@ -349,7 +349,7 @@ describe('SystemMoveEntityHandler', () => {
       // Assert
       expect(execCtx.logger.error).not.toHaveBeenCalled();
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `SYSTEM_MOVE_ENTITY: Failed to move entity "player". Error: ${error.message}`,
         })

--- a/tests/services/browserStorageProvider.test.js
+++ b/tests/services/browserStorageProvider.test.js
@@ -11,7 +11,7 @@ import {
   afterEach,
   test,
 } from '@jest/globals';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 import { BrowserStorageProvider } from '../../src/storage/browserStorageProvider'; // Adjust path as needed
 
 // --- Mock ILogger ---
@@ -313,7 +313,7 @@ describe('BrowserStorageProvider - writeFileAtomically', () => {
       'Failed to write to temporary file: Failed to create temp writable'
     );
     expect(storageProvider._testDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Error writing to temporary file ${tempFilePath}`
@@ -368,7 +368,7 @@ describe('BrowserStorageProvider - writeFileAtomically', () => {
     );
     expect(mockTempStreamWithError.write).toHaveBeenCalledWith(data);
     expect(storageProvider._testDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Error writing to temporary file ${tempFilePath}`
@@ -441,7 +441,7 @@ describe('BrowserStorageProvider - writeFileAtomically', () => {
     ); // Crucial check
 
     expect(storageProvider._testDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.stringContaining(
           `Error writing to final file ${filePath} (replacing original): Final write failed`

--- a/tests/services/componentCleaningService.test.js
+++ b/tests/services/componentCleaningService.test.js
@@ -57,7 +57,7 @@ describe('ComponentCleaningService', () => {
       'Failed to deep clone object data.'
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      'core:display_error',
+      'core:system_error_occurred',
       expect.objectContaining({
         message: 'ComponentCleaningService.clean deepClone failed',
         details: expect.objectContaining({ componentId: 'loop' }),

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -83,7 +83,7 @@ describe('GamePersistenceService error paths', () => {
         'Failed to deep clone object data.'
       );
       expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        'core:display_error',
+        'core:system_error_occurred',
         expect.objectContaining({
           message: 'ComponentCleaningService.clean deepClone failed',
           details: expect.objectContaining({ componentId: 'loop' }),

--- a/tests/services/gameStateValidationServiceForPrompting.test.js
+++ b/tests/services/gameStateValidationServiceForPrompting.test.js
@@ -3,7 +3,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { GameStateValidationServiceForPrompting } from '../../src/validation/gameStateValidationServiceForPrompting.js';
 import { ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING } from '../../src/constants/textDefaults.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock ILogger dependency
 const mockLogger = {
@@ -77,11 +77,14 @@ describe('GameStateValidationServiceForPrompting', () => {
       expect(result.errorContent).toBe(
         ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING
       );
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
-        message:
-          'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
-        details: {},
-      });
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
+          details: {},
+        }
+      );
     });
 
     it('should return invalid if gameStateDto is undefined', () => {
@@ -90,11 +93,14 @@ describe('GameStateValidationServiceForPrompting', () => {
       expect(result.errorContent).toBe(
         ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING
       );
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
-        message:
-          'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
-        details: {},
-      });
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            'GameStateValidationServiceForPrompting.validate: AIGameStateDTO is null or undefined.',
+          details: {},
+        }
+      );
     });
 
     it('should return valid and warn if actorState is missing', () => {

--- a/tests/services/httpConfigurationProvider.test.js
+++ b/tests/services/httpConfigurationProvider.test.js
@@ -10,7 +10,7 @@ import {
 } from '@jest/globals';
 import { HttpConfigurationProvider } from '../../src/configuration/httpConfigurationProvider.js'; // Adjust path as needed
 import { createMockLogger } from '../testUtils.js'; // Path updated as per your usage
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('HttpConfigurationProvider', () => {
   let mockLogger;
@@ -92,7 +92,7 @@ describe('HttpConfigurationProvider', () => {
         'HttpConfigurationProvider: sourceUrl must be a non-empty string.'
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'HttpConfigurationProvider: sourceUrl must be a non-empty string.',
@@ -113,7 +113,7 @@ describe('HttpConfigurationProvider', () => {
         'HttpConfigurationProvider: sourceUrl must be a non-empty string.'
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message:
             'HttpConfigurationProvider: sourceUrl must be a non-empty string.',
@@ -141,7 +141,7 @@ describe('HttpConfigurationProvider', () => {
         'Failed to fetch configuration file from http://example.com/nonexistent.json: Not Found'
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `HttpConfigurationProvider: Failed to fetch configuration from ${url}. Status: 404 Not Found`,
         })
@@ -168,7 +168,7 @@ describe('HttpConfigurationProvider', () => {
         `Failed to fetch configuration file from ${url}: Internal Server Error`
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `HttpConfigurationProvider: Failed to fetch configuration from ${url}. Status: 500 Internal Server Error`,
         })
@@ -197,7 +197,7 @@ describe('HttpConfigurationProvider', () => {
         `Failed to parse configuration data from ${url} as JSON: ${parseError.message}`
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `HttpConfigurationProvider: Failed to parse JSON response from ${url}.`,
         })
@@ -219,7 +219,7 @@ describe('HttpConfigurationProvider', () => {
         `Could not load configuration from ${url}: ${networkError.message}`
       );
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `HttpConfigurationProvider: Error loading or parsing configuration from ${url}. Detail: ${networkError.message}`,
         })

--- a/tests/services/modVersionValidator.test.js
+++ b/tests/services/modVersionValidator.test.js
@@ -8,7 +8,7 @@ import { cloneDeep } from 'lodash'; // Using lodash cloneDeep as requested
 import validateModEngineVersions from '../../src/modding/modVersionValidator.js';
 import ModDependencyError from '../../src/errors/modDependencyError.js';
 import { ENGINE_VERSION } from '../../src/engine/engineVersion.js'; // Use the actual engine version
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Mock Logger Factory
 const createMockLogger = () => ({
@@ -148,7 +148,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(mockDispatcher.dispatch).toHaveBeenCalledTimes(1);
       // Assertion 3: dispatcher called with correct payload
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({ message: expectedErrorMsg })
       );
       // Assertion 4: Logger info not called
@@ -186,7 +186,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(mockDispatcher.dispatch).toHaveBeenCalledTimes(1);
       // Assertion 3: dispatcher called with correct payload
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({ message: expectedFullErrorMsg })
       );
       // Assertion 4: Logger info not called
@@ -206,7 +206,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).toThrow(new ModDependencyError(expectedErrorMsg));
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({ message: expectedErrorMsg })
       );
       expect.assertions(2);

--- a/tests/services/promptElementAssemblers/standardElementAssembler.test.js
+++ b/tests/services/promptElementAssemblers/standardElementAssembler.test.js
@@ -12,7 +12,7 @@ import { StandardElementAssembler } from '../../../src/prompting/assembling/stan
 import { createMockLogger } from '../../testUtils.js'; // Adjust path for your test utils
 // We will use the actual snakeToCamel from textUtils since it's a utility function
 import { snakeToCamel } from '../../../src/utils/textUtils.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // Mock PlaceholderResolver
 const mockPlaceholderResolverInstance = {
@@ -53,7 +53,7 @@ describe('StandardElementAssembler', () => {
       // Indirectly check dispatcher by causing an error in assemble
       assembler.assemble(null, {}, activeMockPlaceholderResolver);
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.any(Object)
       );
     });
@@ -76,7 +76,7 @@ describe('StandardElementAssembler', () => {
       );
       expect(result).toBe('');
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.any(String),
           details: expect.objectContaining({ elementConfigProvided: false }),
@@ -94,7 +94,7 @@ describe('StandardElementAssembler', () => {
       );
       expect(result).toBe('');
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.any(String),
           details: expect.objectContaining({ promptDataProvider: false }),
@@ -112,7 +112,7 @@ describe('StandardElementAssembler', () => {
       );
       expect(result).toBe('');
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.any(String),
           details: expect.objectContaining({

--- a/tests/turns/providers/humanDecisionProvider.test.js
+++ b/tests/turns/providers/humanDecisionProvider.test.js
@@ -3,7 +3,7 @@
 import { jest, describe, beforeEach, expect, test } from '@jest/globals';
 import { HumanDecisionProvider } from '../../../src/turns/providers/humanDecisionProvider.js';
 import { ITurnDecisionProvider } from '../../../src/turns/interfaces/ITurnDecisionProvider.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // Mock dependencies
 const mockPromptCoordinator = {
@@ -127,7 +127,7 @@ describe('HumanDecisionProvider', () => {
 
       // Assert that an error event was dispatched
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             "Did not receive a valid integer 'chosenIndex'"

--- a/tests/turns/providers/llmDecisionProvider.test.js
+++ b/tests/turns/providers/llmDecisionProvider.test.js
@@ -1,6 +1,6 @@
 import { jest, describe, expect } from '@jest/globals';
 import { LLMDecisionProvider } from '../../../src/turns/providers/llmDecisionProvider.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const mockLogger = {
   error: jest.fn(),
@@ -58,7 +58,7 @@ describe('LLMDecisionProvider', () => {
       provider.decide('actor', 'context', ['a'], null)
     ).rejects.toThrow('Could not resolve the chosen action to a valid index.');
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.any(Object)
     );
   });

--- a/tests/turns/services/AIGameStateProvider.test.js
+++ b/tests/turns/services/AIGameStateProvider.test.js
@@ -14,7 +14,7 @@ import {
   POSITION_COMPONENT_ID,
   PERCEPTION_LOG_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import {
   DEFAULT_FALLBACK_LOCATION_NAME,
   DEFAULT_FALLBACK_CHARACTER_NAME,
@@ -225,7 +225,7 @@ describe('AIGameStateProvider Integration Tests', () => {
         );
         expect(currentLocation).toBeNull();
         expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.any(Object)
         );
       });
@@ -303,7 +303,7 @@ describe('AIGameStateProvider Integration Tests', () => {
         );
         expect(perceptionLog).toEqual([]);
         expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-          DISPLAY_ERROR_ID,
+          SYSTEM_ERROR_OCCURRED_ID,
           expect.objectContaining({
             message: expect.stringContaining('Test error'),
           })

--- a/tests/turns/services/LLMResponseProcessor.goals.test.js
+++ b/tests/turns/services/LLMResponseProcessor.goals.test.js
@@ -6,7 +6,7 @@
 import { LLMResponseProcessor } from '../../../src/turns/services/LLMResponseProcessor.js';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { LLMProcessingError } from '../../../src/turns/services/LLMResponseProcessor.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 describe('LLMResponseProcessor – Handling of disallowed properties', () => {
   let mockLogger;
@@ -66,7 +66,7 @@ describe('LLMResponseProcessor – Handling of disallowed properties', () => {
     // We must run the method again to inspect the logger, as `rejects` consumes the error.
     await processor.processResponse(jsonPayload, actorId).catch(() => {});
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message: `LLMResponseProcessor: schema invalid for actor ${actorId}`,
         details: {

--- a/tests/turns/services/LLMResponseProcessor.notesGuards.test.js
+++ b/tests/turns/services/LLMResponseProcessor.notesGuards.test.js
@@ -6,7 +6,7 @@
 import { LLMResponseProcessor } from '../../../src/turns/services/LLMResponseProcessor.js';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { LLMProcessingError } from '../../../src/turns/services/LLMResponseProcessor.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Mocks & Helpers ---
 
@@ -122,7 +122,7 @@ describe('LLMResponseProcessor - notes data extraction', () => {
     // We need to run it again because the `expect().rejects` consumes the error.
     await processor.processResponse(jsonString, actorId).catch(() => {});
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message: `LLMResponseProcessor: schema invalid for actor ${actorId}`,
         details: {

--- a/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -33,7 +33,7 @@ jest.mock('../../../src/turns/states/turnIdleState.js', () => ({
 import { AwaitingExternalTurnEndState } from '../../../src/turns/states/awaitingExternalTurnEndState.js';
 import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js'; // This resolves to our mock above.
 import {
-  DISPLAY_ERROR_ID,
+  SYSTEM_ERROR_OCCURRED_ID,
   TURN_ENDED_ID,
 } from '../../../src/constants/eventIds.js';
 
@@ -347,7 +347,7 @@ describe('AwaitingExternalTurnEndState', () => {
       // 1. A display error event is dispatched.
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         {
           message:
             "No rule ended the turn for actor player-1 after action 'test-action'. The engine timed out after 3000 ms.",

--- a/tests/turns/states/awaitingExternalTurnEndState.test.js
+++ b/tests/turns/states/awaitingExternalTurnEndState.test.js
@@ -2,7 +2,7 @@
 // ****** MODIFIED FILE ******
 
 import { AwaitingExternalTurnEndState } from '../../../src/turns/states/awaitingExternalTurnEndState.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import {
   afterEach,
   beforeEach,
@@ -75,7 +75,7 @@ describe('AwaitingExternalTurnEndState – action-definition propagation', () =>
     jest.clearAllTimers();
   });
 
-  it('dispatches core:display_error with the *definition* id on timeout', async () => {
+  it('dispatches core:system_error_occurred with the *definition* id on timeout', async () => {
     // prime the state
     await state.enterState(mockHandler, /* prev */ null);
 
@@ -83,7 +83,7 @@ describe('AwaitingExternalTurnEndState – action-definition propagation', () =>
     jest.advanceTimersByTime(TIMEOUT_MS + 1);
 
     expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         details: expect.objectContaining({
           actorId: 'hero-123',
@@ -102,7 +102,7 @@ describe('AwaitingExternalTurnEndState – action-definition propagation', () =>
     jest.advanceTimersByTime(TIMEOUT_MS + 1);
 
     expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         details: expect.objectContaining({
           actionId: 'use-potion',

--- a/tests/turns/states/turnEndingState.test.js
+++ b/tests/turns/states/turnEndingState.test.js
@@ -26,7 +26,7 @@ import { TurnEndingState } from '../../../src/turns/states/turnEndingState.js';
 // Dependencies
 import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js';
 import { AbstractTurnState } from '../../../src/turns/states/abstractTurnState.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 // --- Mocks & Test Utilities ---
 
@@ -312,7 +312,7 @@ describe('TurnEndingState', () => {
       await turnEndingState.enterState(mockHandler, null);
 
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: `TurnEndingState: Failed notifying TurnEndPort for actor ${actorId}: ${notifyError.message}`,
         })
@@ -398,7 +398,7 @@ describe('TurnEndingState', () => {
       await turnEndingState.destroy(mockHandler);
 
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        DISPLAY_ERROR_ID,
+        SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
           message: expect.stringContaining(
             `Failed forced transition to TurnIdleState during destroy for actor ${actorId}: ${transitionError.message}`

--- a/tests/turns/strategies/repromptStrategy.test.js
+++ b/tests/turns/strategies/repromptStrategy.test.js
@@ -2,7 +2,7 @@
 
 import RepromptStrategy from '../../../src/turns/strategies/repromptStrategy.js';
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
-import { DISPLAY_ERROR_ID } from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { AwaitingActorDecisionState } from '../../../src/turns/states/awaitingActorDecisionState.js';
 import {
   afterEach,
@@ -119,7 +119,7 @@ describe('RepromptStrategy', () => {
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getSafeEventDispatcher).toHaveBeenCalledTimes(1);
     expect(mockTurnContext._safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message:
           'RepromptStrategy: Received non-RE_PROMPT directive (END_TURN_SUCCESS). Aborting.',
@@ -142,7 +142,7 @@ describe('RepromptStrategy', () => {
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getSafeEventDispatcher).toHaveBeenCalledTimes(1);
     expect(mockTurnContext._safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message:
           'RepromptStrategy: No actor found in ITurnContext. Cannot re-prompt.',
@@ -180,7 +180,7 @@ describe('RepromptStrategy', () => {
     const expectedOverallErrorMessage = `RepromptStrategy: Failed to request transition to AwaitingActorDecisionState for actor ${mockActor.id}. Error: ${transitionErrorMessage}`;
     expect(mockTurnContext.getSafeEventDispatcher).toHaveBeenCalledTimes(1);
     expect(mockTurnContext._safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message: expectedOverallErrorMessage,
         details: {
@@ -206,7 +206,7 @@ describe('RepromptStrategy', () => {
     expect(mockTurnContext.getLogger).toHaveBeenCalled(); // Should be called to get the logger
     expect(mockTurnContext.getSafeEventDispatcher).toHaveBeenCalledTimes(1);
     expect(mockTurnContext._safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       {
         message:
           'RepromptStrategy: No actor found in ITurnContext. Cannot re-prompt.',

--- a/tests/utils/contextVariableUtils.test.js
+++ b/tests/utils/contextVariableUtils.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals';
 import storeResult, {
   setContextValue,
 } from '../../src/utils/contextVariableUtils.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('storeResult', () => {
   test('stores value when context exists', () => {
@@ -27,7 +27,7 @@ describe('storeResult', () => {
     const success = storeResult('bar', 5, ctx, dispatcher, logger);
     expect(success).toBe(false);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.any(String) })
     );
   });
@@ -52,7 +52,7 @@ describe('storeResult', () => {
     await Promise.resolve();
     expect(success).toBe(false);
     expect(validated.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.any(String) }),
       expect.any(Object)
     );
@@ -77,7 +77,7 @@ describe('setContextValue', () => {
     const success = setContextValue('   ', 1, ctx, dispatcher, logger);
     expect(success).toBe(false);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({ message: expect.any(String) })
     );
     expect(Object.keys(ctx.evaluationContext.context)).toHaveLength(0);

--- a/tests/utils/entityAssertions.test.js
+++ b/tests/utils/entityAssertions.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import { assertValidEntity } from '../../src/utils/entityAssertions.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('assertValidEntity', () => {
   test('dispatches error and throws when actor invalid', () => {
@@ -16,7 +16,7 @@ describe('assertValidEntity', () => {
       assertValidEntity(badActor, logger, 'TestCtx', dispatcher)
     ).toThrow('TestCtx: entity is required and must have a valid id.');
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
-      DISPLAY_ERROR_ID,
+      SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
         message: expect.any(String),
         details: expect.objectContaining({ contextName: 'TestCtx' }),

--- a/tests/utils/handlerUtils.test.js
+++ b/tests/utils/handlerUtils.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { assertParamsObject } from '../../src/utils/handlerUtils/params.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('assertParamsObject', () => {
   it('logs a warning and returns false when params are invalid', () => {
@@ -17,7 +17,7 @@ describe('assertParamsObject', () => {
     const dispatcher = { dispatch: jest.fn() };
     const result = assertParamsObject(undefined, dispatcher, 'TEST_OP');
     expect(result).toBe(false);
-    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message: 'TEST_OP: params missing or invalid.',
       details: { params: undefined },
     });

--- a/tests/utils/safeDispatchError.test.js
+++ b/tests/utils/safeDispatchError.test.js
@@ -1,12 +1,12 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { safeDispatchError } from '../../src/utils/safeDispatchError.js';
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('safeDispatchError', () => {
   it('dispatches the display error event', () => {
     const dispatcher = { dispatch: jest.fn() };
     safeDispatchError(dispatcher, 'boom', { a: 1 });
-    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message: 'boom',
       details: { a: 1 },
     });

--- a/tests/utils/validationUtils.additional.test.js
+++ b/tests/utils/validationUtils.additional.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import * as validationUtils from '../../src/utils/validationUtils.js';
 const { validateLoaderDeps, assertValidActionIndex } = validationUtils;
-import { DISPLAY_ERROR_ID } from '../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 // Tests for validateLoaderDeps and assertValidActionIndex
 
@@ -30,7 +30,7 @@ describe('assertValidActionIndex', () => {
     expect(() =>
       assertValidActionIndex(1.5, 3, 'Prov', 'actor1', dispatcher, {})
     ).toThrow('Could not resolve the chosen action to a valid index.');
-    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message:
         "Prov: Did not receive a valid integer 'chosenIndex' for actor actor1.",
       details: {},
@@ -50,7 +50,7 @@ describe('assertValidActionIndex', () => {
         { extra: 'data' }
       )
     ).toThrow('Player chose an index that does not exist for this turn.');
-    expect(dispatcher.dispatch).toHaveBeenCalledWith(DISPLAY_ERROR_ID, {
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
       message: 'Prov: invalid chosenIndex (5) for actor actor2.',
       details: { extra: 'data', actionsCount: 3 },
     });


### PR DESCRIPTION
Summary: Replaced direct `core:display_error` dispatches with `core:system_error_occurred` so AlertRouter can throttle messages. Updated tests and utility functions accordingly.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- [ ] Root tests `npm test` *(fails coverage threshold but tests pass)*
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_684f816efb9883318f882023781f15ac