### PR TITLE
[Agent] export manual save regex

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -7,6 +7,7 @@ import {
   buildManualFileName,
   manualSavePath,
   FULL_MANUAL_SAVE_DIRECTORY_PATH,
+  MANUAL_SAVE_PATTERN,
 } from './savePathUtils.js';
 import { deserializeAndDecompress, parseManualSaveFile } from './saveFileIO.js';
 import { setupService } from '../utils/serviceInitializer.js';
@@ -32,8 +33,7 @@ import {
 // --- Constants ---
 // const MAX_MANUAL_SAVES = 10; // Not directly enforced by list/load, but by save UI/logic
 // Constants defining the manual save directory live in savePathUtils
-const MANUAL_SAVE_PATTERN = /^manual_save_.*\.sav$/; // Pattern to identify potential manual save files
-// const TEMP_SAVE_SUFFIX = '.tmp'; // // Defined in writeFileAtomically in IStorageProvider context
+// const TEMP_SAVE_SUFFIX = '.tmp'; // Defined in writeFileAtomically in IStorageProvider context
 
 /**
  * @implements {ISaveLoadService}

--- a/src/persistence/savePathUtils.js
+++ b/src/persistence/savePathUtils.js
@@ -22,6 +22,13 @@ export const MANUAL_SAVES_SUBDIRECTORY = 'manual_saves';
 export const FULL_MANUAL_SAVE_DIRECTORY_PATH = `${BASE_SAVE_DIRECTORY}/${MANUAL_SAVES_SUBDIRECTORY}`;
 
 /**
+ * Regular expression to match manual save filenames.
+ *
+ * @type {RegExp}
+ */
+export const MANUAL_SAVE_PATTERN = /^manual_save_.*\.sav$/;
+
+/**
  * Builds a sanitized manual save filename.
  *
  * @param {string} saveName - Raw save name input.


### PR DESCRIPTION
Summary:
- expose a manual save pattern constant from savePathUtils
- use MANUAL_SAVE_PATTERN in SaveLoadService

Testing Done:
- `npm run format`
- `npm run lint`
- `npm run test` (fails global coverage threshold)
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f8636553083319173907be15823ea