### PR TITLE
[Agent] Add tests for interface stubs

### DIFF
--- a/tests/llms/interfaces/interfaces.test.js
+++ b/tests/llms/interfaces/interfaces.test.js
@@ -1,0 +1,40 @@
+// tests/llms/interfaces/interfaces.test.js
+// -----------------------------------------------------------------------------
+// Tests for basic interface classes exported in src/llms/interfaces.
+// These classes are minimal and simply throw errors if their methods are called.
+// These tests ensure that calling the interface methods results in the expected
+// error being thrown so they contribute to coverage totals.
+// -----------------------------------------------------------------------------
+
+import { describe, it, expect } from '@jest/globals';
+import { IApiKeyProvider } from '../../../src/llms/interfaces/IApiKeyProvider.js';
+import { IHttpClient } from '../../../src/llms/interfaces/IHttpClient.js';
+import { ILLMStrategy } from '../../../src/llms/interfaces/ILLMStrategy.js';
+
+/** Dummy objects for method arguments */
+const dummyConfig = {};
+const dummyEnv = {};
+const dummyOptions = { method: 'GET' };
+
+describe('LLM interface base classes', () => {
+  it('IApiKeyProvider.getKey should reject with not implemented error', async () => {
+    const provider = new IApiKeyProvider();
+    await expect(provider.getKey(dummyConfig, dummyEnv)).rejects.toThrow(
+      'IApiKeyProvider.getKey method not implemented.'
+    );
+  });
+
+  it('IHttpClient.request should reject with not implemented error', async () => {
+    const client = new IHttpClient();
+    await expect(
+      client.request('http://example.com', dummyOptions)
+    ).rejects.toThrow('IHttpClient.request method not implemented.');
+  });
+
+  it('ILLMStrategy.execute should reject with not implemented error', async () => {
+    const strategy = new ILLMStrategy();
+    await expect(strategy.execute({})).rejects.toThrow(
+      'ILLMStrategy.execute method not implemented.'
+    );
+  });
+});

--- a/tests/services/browserStorageProvider.files.test.js
+++ b/tests/services/browserStorageProvider.files.test.js
@@ -1,0 +1,101 @@
+// tests/services/browserStorageProvider.files.test.js
+// -----------------------------------------------------------------------------
+// Focused tests for BrowserStorageProvider readFile, deleteFile and fileExists
+// which were previously uncovered. These tests mock the File System Access API
+// enough to exercise the different code paths without performing real IO.
+// -----------------------------------------------------------------------------
+
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import { BrowserStorageProvider } from '../../src/storage/browserStorageProvider.js';
+
+// Helper to create a minimal mock directory handle with an in-memory file map.
+const createMockRootHandle = (fileMap) => {
+  const handle = {
+    name: 'root',
+    kind: 'directory',
+    getFileHandle: jest.fn(async (name, opts) => {
+      if (fileMap[name]) {
+        return {
+          name,
+          getFile: async () => ({
+            arrayBuffer: async () => fileMap[name].buffer,
+          }),
+        };
+      }
+      const err = new Error('Not found');
+      err.name = 'NotFoundError';
+      throw err;
+    }),
+    getDirectoryHandle: jest.fn(async () => handle),
+    removeEntry: jest.fn(async (name) => {
+      if (fileMap[name]) {
+        delete fileMap[name];
+        return;
+      }
+      const err = new Error('NotFoundError');
+      err.name = 'NotFoundError';
+      throw err;
+    }),
+    values: jest.fn().mockImplementation(async function* () {
+      for (const name of Object.keys(fileMap)) {
+        yield { kind: 'file', name };
+      }
+    }),
+    queryPermission: jest.fn().mockResolvedValue('granted'),
+    requestPermission: jest.fn().mockResolvedValue('granted'),
+  };
+  return handle;
+};
+
+describe('BrowserStorageProvider file operations', () => {
+  /** @type {BrowserStorageProvider} */
+  let provider;
+  /** @type {ReturnType<typeof createMockRootHandle>} */
+  let rootHandle;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const dispatcher = { dispatch: jest.fn() };
+    const files = { 'read.sav': new Uint8Array([1, 2, 3]) };
+    rootHandle = createMockRootHandle(files);
+    global.window.showDirectoryPicker = jest.fn(async () => rootHandle);
+    provider = new BrowserStorageProvider({
+      logger: mockLogger,
+      safeEventDispatcher: dispatcher,
+    });
+  });
+
+  it('readFile returns contents when file exists', async () => {
+    const data = await provider.readFile('read.sav');
+    expect(Array.from(data)).toEqual([1, 2, 3]);
+  });
+
+  it('fileExists returns false when file missing', async () => {
+    const exists = await provider.fileExists('missing.sav');
+    expect(exists).toBe(false);
+  });
+
+  it('fileExists returns true when file exists', async () => {
+    const exists = await provider.fileExists('read.sav');
+    expect(exists).toBe(true);
+  });
+
+  it('readFile throws when file missing', async () => {
+    await expect(provider.readFile('missing.sav')).rejects.toThrow(
+      'File not found'
+    );
+  });
+
+  it('deleteFile succeeds when file present', async () => {
+    const result = await provider.deleteFile('read.sav');
+    expect(result.success).toBe(true);
+  });
+
+  it('deleteFile returns success false when root selection aborted', async () => {
+    rootHandle.queryPermission.mockResolvedValue('denied');
+    rootHandle.requestPermission.mockResolvedValue('denied');
+    const result = await provider.deleteFile('read.sav');
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/turns/builders/turnContextBuilder.test.js
+++ b/tests/turns/builders/turnContextBuilder.test.js
@@ -1,0 +1,72 @@
+// tests/turns/builders/turnContextBuilder.test.js
+// -----------------------------------------------------------------------------
+// Unit tests for TurnContextBuilder ensuring constructor validations and basic
+// build operation work as expected.
+// -----------------------------------------------------------------------------
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { TurnContextBuilder } from '../../../src/turns/builders/turnContextBuilder.js';
+
+const logger = { debug: jest.fn() };
+const factory = { create: jest.fn(() => ({ id: 'ctx' })) };
+const assertValidEntity = jest.fn();
+
+describe('TurnContextBuilder constructor validation', () => {
+  it('throws if logger is missing', () => {
+    expect(
+      () =>
+        new TurnContextBuilder({
+          turnContextFactory: factory,
+          assertValidEntity,
+        })
+    ).toThrow('logger is required');
+  });
+
+  it('throws if turnContextFactory is missing', () => {
+    expect(() => new TurnContextBuilder({ logger, assertValidEntity })).toThrow(
+      'turnContextFactory is required'
+    );
+  });
+
+  it('throws if assertValidEntity is not a function', () => {
+    expect(
+      () => new TurnContextBuilder({ logger, turnContextFactory: factory })
+    ).toThrow('assertValidEntity function is required');
+  });
+});
+
+describe('TurnContextBuilder build', () => {
+  it('validates actor and delegates to factory', () => {
+    const builder = new TurnContextBuilder({
+      logger,
+      turnContextFactory: factory,
+      assertValidEntity,
+    });
+    const actor = { id: 'a1' };
+    const strategy = {};
+    const onEnd = jest.fn();
+    const handler = {};
+
+    const ctx = builder.build({
+      actor,
+      strategy,
+      onEndTurn: onEnd,
+      handlerInstance: handler,
+    });
+
+    expect(assertValidEntity).toHaveBeenCalledWith(
+      actor,
+      logger,
+      'TurnContextBuilder'
+    );
+    expect(factory.create).toHaveBeenCalledWith({
+      actor,
+      strategy,
+      onEndTurnCallback: onEnd,
+      handlerInstance: handler,
+      isAwaitingExternalEventProvider: undefined,
+      onSetAwaitingExternalEventCallback: undefined,
+    });
+    expect(ctx).toEqual({ id: 'ctx' });
+  });
+});

--- a/tests/turns/ports/interfaces.test.js
+++ b/tests/turns/ports/interfaces.test.js
@@ -1,0 +1,60 @@
+// tests/turns/ports/interfaces.test.js
+// -----------------------------------------------------------------------------
+// Simple tests exercising the minimal interface classes in src/turns/ports.
+// Each class exposes a method that is expected to throw when called directly.
+// These tests ensure those methods behave as intended so coverage reflects their
+// existence.
+// -----------------------------------------------------------------------------
+
+import { describe, it, expect } from '@jest/globals';
+import { IPromptOutputPort } from '../../../src/turns/ports/IPromptOutputPort.js';
+import { ITurnEndPort } from '../../../src/turns/ports/ITurnEndPort.js';
+import { ICommandInputPort } from '../../../src/turns/ports/ICommandInputPort.js';
+import { IActionIndexer } from '../../../src/turns/ports/IActionIndexer.js';
+import { ILLMChooser } from '../../../src/turns/ports/ILLMChooser.js';
+import { ITurnActionFactory } from '../../../src/turns/ports/ITurnActionFactory.js';
+
+describe('Turn port interface classes', () => {
+  it('IPromptOutputPort.prompt rejects when not implemented', async () => {
+    const port = new IPromptOutputPort();
+    await expect(port.prompt('id', [], undefined)).rejects.toThrow(
+      'IPromptOutputPort.prompt method not implemented.'
+    );
+  });
+
+  it('ITurnEndPort.notifyTurnEnded rejects when not implemented', async () => {
+    const port = new ITurnEndPort();
+    await expect(port.notifyTurnEnded('id', true)).rejects.toThrow(
+      'ITurnEndPort.notifyTurnEnded() not implemented.'
+    );
+  });
+
+  it('ICommandInputPort.onCommand rejects when not implemented', () => {
+    const port = new ICommandInputPort();
+    expect(() => port.onCommand(() => {})).toThrow(
+      'ICommandInputPort.onCommand method not implemented.'
+    );
+  });
+
+  it('IActionIndexer.index rejects when not implemented', () => {
+    const indexer = new IActionIndexer();
+    expect(() => indexer.index([], 'id')).toThrow('Interface method');
+  });
+
+  it('ILLMChooser.choose rejects when not implemented', () => {
+    const chooser = new ILLMChooser();
+    expect(() =>
+      chooser.choose({
+        actor: {},
+        context: {},
+        actions: [],
+        abortSignal: new AbortController().signal,
+      })
+    ).toThrow('Interface method');
+  });
+
+  it('ITurnActionFactory.create rejects when not implemented', () => {
+    const factory = new ITurnActionFactory();
+    expect(() => factory.create({}, null)).toThrow('Interface');
+  });
+});


### PR DESCRIPTION
Summary: Added unit tests for untested interface classes and BrowserStorageProvider helper methods. Includes TurnContextBuilder constructor and build tests to cover missing branches.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test` *(fails: global coverage thresholds)*
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

```
$(tail -n 20 /tmp/test.log)
```

------
https://chatgpt.com/codex/tasks/task_e_684f87ce1fec8331ab429d850b675f6c