### PR TITLE
[Agent] Prevent fade-out clearing when next actions are ready

### DIFF
--- a/src/domUI/actionButtonsRenderer.js
+++ b/src/domUI/actionButtonsRenderer.js
@@ -492,10 +492,12 @@ export class ActionButtonsRenderer extends BaseListDisplayComponent {
             'animationend',
             () => {
               container.classList.remove(ActionButtonsRenderer.FADE_OUT_CLASS);
-              while (container.firstChild) {
-                container.removeChild(container.firstChild);
+              if (this.availableActions.length === 0) {
+                while (container.firstChild) {
+                  container.removeChild(container.firstChild);
+                }
+                container.classList.add(ActionButtonsRenderer.DISABLED_CLASS);
               }
-              container.classList.add(ActionButtonsRenderer.DISABLED_CLASS);
             },
             { once: true }
           );


### PR DESCRIPTION
## Summary
- guard ActionButtonsRenderer fade-out cleanup when new actions already loaded
- test that fade-out does not disable panel if actions refresh early

## Testing
- `npm run lint`
- `npm run test` *(fails: coverage threshold for branches (80%) not met)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f8afaa87c8331be806f01f05d2ffb