### PR TITLE
[Agent] standardize PersistenceResult returns

### DIFF
--- a/src/persistence/saveFileIO.js
+++ b/src/persistence/saveFileIO.js
@@ -17,7 +17,7 @@ import { manualSavePath, extractSaveName } from '../utils/savePathUtils.js';
  * @param {IStorageProvider} storage - Storage provider instance.
  * @param {string} filePath - Path to the file.
  * @param {ILogger} logger - Logger for diagnostics.
- * @returns {Promise<{success:boolean,data?:Uint8Array,error?:PersistenceError,userFriendlyError?:string}>}
+ * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Uint8Array>>}
  */
 export async function readSaveFile(storage, filePath, logger) {
   try {
@@ -55,7 +55,7 @@ export async function readSaveFile(storage, filePath, logger) {
  * @param {GameStateSerializer} serializer - Serializer instance.
  * @param {string} filePath - File path to read.
  * @param {ILogger} logger - Logger for diagnostics.
- * @returns {Promise<{success:boolean,data?:object,error?:PersistenceError,userFriendlyError?:string}>}
+ * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
  */
 export async function deserializeAndDecompress(
   storage,
@@ -83,7 +83,7 @@ export async function deserializeAndDecompress(
  * @param {IStorageProvider} storage - Storage provider.
  * @param {GameStateSerializer} serializer - Serializer instance.
  * @param {ILogger} logger - Logger for diagnostics.
- * @returns {Promise<{success:boolean,metadata:SaveFileMetadata}>}
+ * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<SaveFileMetadata>>}
  */
 export async function parseManualSaveFile(
   fileName,
@@ -107,7 +107,7 @@ export async function parseManualSaveFile(
     );
     return {
       success: false,
-      metadata: {
+      data: {
         identifier: filePath,
         saveName: extractSaveName(fileName) + ' (Corrupted)',
         timestamp: 'N/A',
@@ -132,7 +132,7 @@ export async function parseManualSaveFile(
     );
     return {
       success: false,
-      metadata: {
+      data: {
         identifier: filePath,
         saveName: extractSaveName(fileName) + ' (No Metadata)',
         timestamp: 'N/A',
@@ -144,7 +144,7 @@ export async function parseManualSaveFile(
 
   return {
     success: true,
-    metadata: {
+    data: {
       identifier: filePath,
       saveName: saveObject.metadata.saveName,
       timestamp: saveObject.metadata.timestamp,

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -385,7 +385,7 @@ class SaveLoadService extends ISaveLoadService {
    * @private
    */
   async #parseManualSaveMetadata(fileName) {
-    const { success, metadata } = await parseManualSaveFile(
+    const { success, data: metadata } = await parseManualSaveFile(
       fileName,
       this.#storageProvider,
       this.#serializer,


### PR DESCRIPTION
## Summary
- return `PersistenceResult<T>` from save file IO helpers
- adapt private metadata parser to new shapes

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f8eb981e483319a2ddd02273c0b5e