### PR TITLE
[Agent] warn on invalid JSONLogic var paths

### DIFF
--- a/tests/logic/jsonLogicEvaluationService.varPathWarning.test.js
+++ b/tests/logic/jsonLogicEvaluationService.varPathWarning.test.js
@@ -1,0 +1,45 @@
+// tests/logic/jsonLogicEvaluationService.varPathWarning.test.js
+
+/**
+ * @jest-environment node
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
+
+/** @typedef {import('../../src/interfaces/coreServices.js').ILogger} ILogger */
+
+/** @type {jest.Mocked<ILogger>} */
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('JsonLogicEvaluationService bracket path warnings', () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new JsonLogicEvaluationService({ logger: mockLogger });
+    mockLogger.info.mockClear();
+  });
+
+  test('logs warning for direct var path containing brackets', () => {
+    const rule = { var: 'actor[0]' };
+    service.evaluate(rule, { actor: { id: 'a' } });
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('actor[0]')
+    );
+  });
+
+  test('logs warning for nested var path with default array form', () => {
+    const rule = { '==': [{ var: ['target.components[Bad]', null] }, null] };
+    service.evaluate(rule, { target: null });
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('target.components[Bad]')
+    );
+  });
+});


### PR DESCRIPTION
Summary: Adds detection for bracket notation in JSON Logic variable paths.

Changes Made:
- new `warnOnBracketPaths` helper in `jsonLogicEvaluationService` with recursion
- helper invoked at start of `evaluate`
- added unit test verifying warnings are logged for invalid paths

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (not performed)


------
https://chatgpt.com/codex/tasks/task_e_684f9083808483319a7fb44ae892ac36