### PR TITLE
[Agent] clarify runtime IDs in memory docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Purpose: Chronological log of events the character perceives (e.g., “Player X 
 Lifecycle: Capped by maxEntries (default 50).  
 Included in Prompt: Under “Perception Log”.  
 Schema ID: core:perception_log → `./data/mods/core/perception_log.component.json`
+Entries reference runtime entity IDs and aren’t resolved to instances.
 
 core:notes
 

--- a/docs/mods/namespaced_ids_and_resolveFields.md
+++ b/docs/mods/namespaced_ids_and_resolveFields.md
@@ -65,3 +65,7 @@ When both mods load, the engine creates instances for `modA:castle` and `modB:kn
 - Only fields declared in a component's `resolveFields` array are processed. Other strings that look like IDs remain unchanged.
 
 Using namespaced IDs consistently and declaring `resolveFields` correctly allows the engine to keep mods isolated yet interoperable.
+
+### Runtime IDs in memory components
+
+Some components are designed to store the **runtime instance IDs** produced when the world loads. Examples include `core:perception_log`, `core:following`, and `core:leading`. These components intentionally omit `resolveFields` because their fields don’t reference other definitions during initialization. If you pre-populate them with namespaced IDs, those values will remain raw strings unless your game introduces custom logic to resolve them later.


### PR DESCRIPTION
Summary: Added docs on runtime IDs stored in memory components. Updated README memory section to specify perception_log stores runtime entity IDs. No other files changed.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 2438 problems but existing)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_684f9257d4e88331992e787864280d06