### PR TITLE
[Agent] initialize prompt static content

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -89,7 +89,7 @@ import { AIPromptContentProvider } from '../../prompting/AIPromptContentProvider
 import { LLMResponseProcessor } from '../../turns/services/LLMResponseProcessor.js';
 import { AIFallbackActionFactory } from '../../turns/services/AIFallbackActionFactory.js';
 import { AIPromptPipeline } from '../../prompting/AIPromptPipeline.js';
-import { SHUTDOWNABLE } from '../tags.js';
+import { SHUTDOWNABLE, INITIALIZABLE } from '../tags.js';
 import {
   INDEXED_CHOICES_KEY,
   IndexedChoicesAssembler,
@@ -160,7 +160,7 @@ export function registerAI(container) {
 
   // --- PROMPTING ENGINE SERVICES ---
 
-  r.singletonFactory(
+  r.tagged(INITIALIZABLE).singletonFactory(
     tokens.IPromptStaticContentService,
     (c) =>
       new PromptStaticContentService({

--- a/tests/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/aiRegistrations.test.js
@@ -10,6 +10,7 @@ import { registerAI } from '../../../src/dependencyInjection/registrations/aiReg
 // --- Dependencies for Mocking & Testing ---
 import AppContainer from '../../../src/dependencyInjection/appContainer.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
+import { INITIALIZABLE } from '../../../src/dependencyInjection/tags.js';
 import { LLM_TURN_ACTION_RESPONSE_SCHEMA_ID } from '../../../src/turns/schemas/llmOutputSchemas.js';
 
 // --- Concrete Classes for `instanceof` checks ---
@@ -206,6 +207,19 @@ describe('registerAI', () => {
       expect(loggerSpies.debug).toHaveBeenCalledWith(
         expect.stringContaining('Registered Prompting Engine services')
       );
+    });
+
+    it('registers IPromptStaticContentService as INITIALIZABLE singletonFactory', () => {
+      const registerSpy = jest.spyOn(container, 'register');
+      registerAI(container);
+      const registrationCall = registerSpy.mock.calls.find(
+        (call) => call[0] === tokens.IPromptStaticContentService
+      );
+      expect(registrationCall).toBeDefined();
+      const options = registrationCall[2] || {};
+      expect(options.lifecycle).toBe('singletonFactory');
+      expect(options.tags).toEqual(INITIALIZABLE);
+      registerSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- initialize PromptStaticContentService via DI container
- tag PromptStaticContentService as INITIALIZABLE
- test that container registers the service with INITIALIZABLE tag

## Testing Done
- `npm run format`
- `npx eslint src/dependencyInjection/registrations/aiRegistrations.js tests/dependencyInjection/registrations/aiRegistrations.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`
- `PORT=8081 npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684f9462bb7883319151187ee74afef6