### PR TITLE
[Agent] Adapt worldAndEntityRegistrations test

### DIFF
--- a/tests/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
@@ -43,7 +43,9 @@ describe('registerWorldAndEntity', () => {
     container.register(tokens.ISafeEventDispatcher, () => ({
       dispatch: jest.fn().mockResolvedValue(true),
     }));
-    container.register(tokens.IGameDataRepository, () => ({}));
+    container.register(tokens.IGameDataRepository, () => ({
+      getConditionDefinition: jest.fn(),
+    }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- update test stub to include `getConditionDefinition`

## Testing
- `npm run test:single tests/dependencyInjection/registrations/worldAndEntityRegistrations.test.js`
- `npm run test` *(fails: 68 failed, 464 passed)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6850326633a883319a43c7e761218aad