### PR TITLE
[Agent] Fix schema test with condition container

### DIFF
--- a/tests/schemas/go.schema.test.js
+++ b/tests/schemas/go.schema.test.js
@@ -4,13 +4,16 @@ import actionData from '../../data/mods/core/actions/go.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:go'", () => {
   /** @type {import('ajv').ValidateFunction} */
   let validate;
 
   beforeAll(() => {
-    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    const ajv = new Ajv({
+      schemas: [commonSchema, jsonLogicSchema, conditionContainerSchema],
+    });
     validate = ajv.compile(actionSchema);
   });
 


### PR DESCRIPTION
Summary: Fixed the go.action schema test by adding the missing condition-container schema to the Ajv instance, addressing failures after conditions became their own category.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test` *(fails)*
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

Root tests still fail due to numerous missing dependencies following recent refactors.

------
https://chatgpt.com/codex/tasks/task_e_6850346253b08331aac261d516cbe8c8