### PR TITLE
[Agent] fix dismiss schema test

### DIFF
--- a/tests/schemas/dismiss.schema.test.js
+++ b/tests/schemas/dismiss.schema.test.js
@@ -4,13 +4,16 @@ import actionData from '../../data/mods/core/actions/dismiss.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:dismiss'", () => {
   /** @type {import('ajv').ValidateFunction} */
   let validate;
 
   beforeAll(() => {
-    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    const ajv = new Ajv({
+      schemas: [commonSchema, jsonLogicSchema, conditionContainerSchema],
+    });
     validate = ajv.compile(actionSchema);
   });
 


### PR DESCRIPTION
Summary: Fixed dismiss schema test by including condition-container schema in Ajv initialization, ensuring validity after conditions were moved to their own JSON definitions.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 543 errors)*
- [ ] Root tests `npm run test` *(failures expected)*
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685038ed9af0833190ba3440f291c2db