### PR TITLE
[Fix] add schema to follow action test

### DIFF
--- a/tests/schemas/follow.schema.test.js
+++ b/tests/schemas/follow.schema.test.js
@@ -4,13 +4,16 @@ import actionData from '../../data/mods/core/actions/follow.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:follow'", () => {
   /** @type {import('ajv').ValidateFunction} */
   let validate;
 
   beforeAll(() => {
-    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    const ajv = new Ajv({
+      schemas: [commonSchema, jsonLogicSchema, conditionContainerSchema],
+    });
     validate = ajv.compile(actionSchema);
   });
 


### PR DESCRIPTION
Summary: Ensure the follow action definition test resolves its schema refs by adding the missing condition container schema.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass for modified suite (`npm run test:single tests/schemas/follow.schema.test.js`)
- [ ] Root tests (overall) (`npm run test`) *(failures expected in other suites)*
- [ ] Proxy server tests (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test


------
https://chatgpt.com/codex/tasks/task_e_68503ee172948331b500704a9344d690