### PR TITLE
[Agent] Fix wait schema test

### DIFF
--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -4,13 +4,16 @@ import actionData from '../../data/mods/core/actions/wait.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:wait'", () => {
   /** @type {import('ajv').ValidateFunction} */
   let validate;
 
   beforeAll(() => {
-    const ajv = new Ajv({ schemas: [commonSchema, jsonLogicSchema] });
+    const ajv = new Ajv({
+      schemas: [commonSchema, jsonLogicSchema, conditionContainerSchema],
+    });
     validate = ajv.compile(actionSchema);
   });
 


### PR DESCRIPTION
Summary: Fixed the wait action schema test to include the new `condition-container` schema required by the updated action-definition schema.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test` *(fails)*
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

Root tests continue to fail with many errors involving missing `ConditionLoader` and `gameDataRepository` dependencies (e.g., see sample failure below). A single suite `tests/schemas/wait.schema.test.js` now passes.

```
Missing required dependency: ConditionLoader.
      at validateDependency (src/utils/validationUtils.js:35:11)
      at validateDependency (src/utils/validationUtils.js:74:5)
      at new AbstractLoader (src/loaders/abstractLoader.js:22:23)
      at new WorldLoader (src/loaders/worldLoader.js:133:5)
      at Object.<anonymous> (tests/loaders/worldLoader.preLoopErrors.integration.test.js:228:19)
```


------
https://chatgpt.com/codex/tasks/task_e_685041ca640c83319925b0c36b983c70