### PR TITLE
[Agent] Adjust schema test for conditions

### DIFF
--- a/tests/schemas/log_perceptible_events.schema.test.js
+++ b/tests/schemas/log_perceptible_events.schema.test.js
@@ -4,13 +4,13 @@ import { test, expect, describe, beforeAll } from '@jest/globals';
 
 const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
-const path = require('path');
 
 // Schemas
 const ruleSchema = require('../../data/schemas/rule.schema.json');
 const commonSchema = require('../../data/schemas/common.schema.json');
 const operationSchema = require('../../data/schemas/operation.schema.json');
 const jsonLogicSchema = require('../../data/schemas/json-logic.schema.json');
+const conditionContainerSchema = require('../../data/schemas/condition-container.schema.json');
 const loadOperationSchemas = require('../helpers/loadOperationSchemas.js');
 
 // Rule under test
@@ -31,6 +31,10 @@ describe('core/rules/log_perceptible_events.rule.json', () => {
     ajv.addSchema(
       operationSchema,
       'http://example.com/schemas/operation.schema.json'
+    );
+    ajv.addSchema(
+      conditionContainerSchema,
+      'http://example.com/schemas/condition-container.schema.json'
     );
     loadOperationSchemas(ajv);
     ajv.addSchema(


### PR DESCRIPTION
Summary: Fixes the rule schema validation test by registering the new condition-container schema so that rule references resolve correctly.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [ ] Root tests (failures expected) `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685041c818508331a8785a3c911d0439