### PR TITLE
[Agent] fix duplicate import in wait schema test

### DIFF
--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -1,6 +1,5 @@
 import { describe, test, expect, beforeAll } from '@jest/globals';
 import Ajv from 'ajv';
-import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 import actionData from '../../data/mods/core/actions/wait.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';


### PR DESCRIPTION
## Summary
- fix duplicate import in wait schema test

## Testing Done
- `npm run test:single tests/schemas/wait.schema.test.js`
- `npm run test` *(fails: missing dependencies in many test suites)*
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685047339c5083319beb455cbbeedafa