### PR TITLE
[Agent] Fix wait schema test import

### DIFF
--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -5,7 +5,6 @@ import actionData from '../../data/mods/core/actions/wait.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
-import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:wait'", () => {
   /** @type {import('ajv').ValidateFunction} */


### PR DESCRIPTION
## Summary
- fix duplicate import in `wait.schema.test.js`

## Testing Done
- `npm run test:single tests/schemas/wait.schema.test.js`
- `npm run test` *(fails: 52 failed, 480 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685048d900d88331b65f29c6ee70b3ed