### PR TITLE
[Fix] Include condition container schema in wait test

### DIFF
--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -4,6 +4,7 @@ import actionData from '../../data/mods/core/actions/wait.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:wait'", () => {
   /** @type {import('ajv').ValidateFunction} */


### PR DESCRIPTION
Summary: Added missing import for `condition-container.schema.json` in `wait.schema.test.js` so that the test validates action definitions correctly.

Changes Made:
- Import conditionContainerSchema in `tests/schemas/wait.schema.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified file (`npx eslint tests/schemas/wait.schema.test.js`)
- [x] Root tests run (`npm run test`) – multiple suites still failing
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68504d100ea8833190fbae149d785eee