### PR TITLE
[Agent] fix single test suite

### DIFF
--- a/tests/logic/jsonLogicEvaluationService.varPathWarning.test.js
+++ b/tests/logic/jsonLogicEvaluationService.varPathWarning.test.js
@@ -21,7 +21,10 @@ describe('JsonLogicEvaluationService bracket path warnings', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new JsonLogicEvaluationService({ logger: mockLogger });
+    service = new JsonLogicEvaluationService({
+      logger: mockLogger,
+      gameDataRepository: { getConditionDefinition: () => null },
+    });
     mockLogger.info.mockClear();
   });
 

--- a/tests/schemas/wait.schema.test.js
+++ b/tests/schemas/wait.schema.test.js
@@ -4,6 +4,7 @@ import actionData from '../../data/mods/core/actions/wait.action.json';
 import actionSchema from '../../data/schemas/action-definition.schema.json';
 import commonSchema from '../../data/schemas/common.schema.json';
 import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
 
 describe("Action Definition: 'core:wait'", () => {
   /** @type {import('ajv').ValidateFunction} */


### PR DESCRIPTION
Summary: fixed imports in wait action schema test and adjusted var path warning test to avoid extra logs.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 542 errors)*
- [ ] Root tests         `npm run test` *(fails: 24 failing suites)*
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6850502ad4d483319f455b617b8a90df