### PR TITLE
[Agent] Fix JSON logic array handling

### DIFF
--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -96,6 +96,10 @@ class JsonLogicEvaluationService {
       return rule;
     }
 
+    if (Array.isArray(rule)) {
+      return rule.map((item) => this.#resolveRule(item));
+    }
+
     if ('condition_ref' in rule) {
       const refId = rule.condition_ref;
 


### PR DESCRIPTION
Summary: Fixed array handling in JsonLogicEvaluationService so nested arrays remain intact during condition resolution, addressing failing logic tests.

Changes Made:
- Return mapped arrays in `#resolveRule` when a rule is an array.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified file (`npx eslint src/logic/jsonLogicEvaluationService.js`)
- [x] Root tests (expected failures remain) (`npm run test`)
- [ ] Proxy server tests (not modified)
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_685052f8d54483319ad5e172ddb160d3