### PR TITLE
[Agent] Adjust perception log renderer test

### DIFF
--- a/tests/domUI/perceptionLogRenderer.test.js
+++ b/tests/domUI/perceptionLogRenderer.test.js
@@ -278,8 +278,7 @@ describe('PerceptionLogRenderer', () => {
       };
       const li = renderer._renderListItem(logEntry, 0, [logEntry]);
       expect(mockDomElementFactoryInstance.li).toHaveBeenCalledWith(
-        undefined,
-        'Test Log'
+        'log-generic'
       );
       expect(li.textContent).toBe('Test Log');
       expect(li.setAttribute).toHaveBeenCalledWith(
@@ -294,7 +293,7 @@ describe('PerceptionLogRenderer', () => {
         renderer._renderListItem(malformedEntry, 0, [malformedEntry])
       ).toBeNull();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Malformed log entry'),
+        expect.stringContaining('malformed log entry'),
         expect.any(Object)
       );
     });


### PR DESCRIPTION
## Summary
- update perception log renderer tests for new list item generation

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 542 errors, 1925 warnings)*
- `npm run test:single tests/domUI/perceptionLogRenderer.test.js`
- `npm run test` *(fails: 18 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68505d1a0f508331bd43d24734723cc0