### PR TITLE
[Agent] Fix perception log renderer test

### DIFF
--- a/tests/domUI/perceptionLogRenderer.test.js
+++ b/tests/domUI/perceptionLogRenderer.test.js
@@ -10,7 +10,6 @@ import {
 } from '@jest/globals';
 import { JSDOM } from 'jsdom';
 import { PerceptionLogRenderer } from '../../src/domUI/perceptionLogRenderer.js';
-import { PERCEPTION_LOG_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import { TURN_STARTED_ID } from '../../src/constants/eventIds.js';
 
 jest.mock('../../src/logging/consoleLogger.js');
@@ -108,7 +107,9 @@ describe('PerceptionLogRenderer', () => {
         );
         Object.defineProperty(li, 'title', {
           get: () => li.getAttribute('title') || '',
-          set: (value) => li.setAttribute('title', value),
+          set: (value) => {
+            li.setAttribute('title', value);
+          },
           configurable: true,
         });
         return li;
@@ -278,8 +279,7 @@ describe('PerceptionLogRenderer', () => {
       };
       const li = renderer._renderListItem(logEntry, 0, [logEntry]);
       expect(mockDomElementFactoryInstance.li).toHaveBeenCalledWith(
-        undefined,
-        'Test Log'
+        'log-generic'
       );
       expect(li.textContent).toBe('Test Log');
       expect(li.setAttribute).toHaveBeenCalledWith(
@@ -294,7 +294,7 @@ describe('PerceptionLogRenderer', () => {
         renderer._renderListItem(malformedEntry, 0, [malformedEntry])
       ).toBeNull();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Malformed log entry'),
+        expect.stringContaining('malformed log entry'),
         expect.any(Object)
       );
     });


### PR DESCRIPTION
## Summary
- address outdated call expectations in perception log renderer tests
- adjust mock DOM element setter for lint

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run test -- tests/domUI/perceptionLogRenderer.test.js`
- `npm run test` *(fails: 17 failed suites)*

------
https://chatgpt.com/codex/tasks/task_e_68505f610844833185b547f6f1bc6599