### PR TITLE
[Agent] remove duplicate mock variable

### DIFF
--- a/tests/loaders/worldLoader.entityMultiKey.integration.test.js
+++ b/tests/loaders/worldLoader.entityMultiKey.integration.test.js
@@ -60,8 +60,6 @@ describe('WorldLoader Integration Test Suite - EntityLoader Multi-Key Handling (
   let mockActionLoader;
   /** @type {jest.Mocked<EventLoader>} */
   let mockEventLoader;
-  /** @type {jest.Mocked<import('../../src/loaders/conditionLoader.js').default>} */
-  let mockConditionLoader;
   /** @type {jest.Mocked<EntityLoader>} */
   let mockEntityLoader; // The primary focus of this test
   /** @type {jest.Mocked<ISchemaValidator>} */
@@ -212,9 +210,6 @@ describe('WorldLoader Integration Test Suite - EntityLoader Multi-Key Handling (
       loadItemsForMod: jest.fn().mockResolvedValue(mockLoadResult),
     };
     mockEventLoader = {
-      loadItemsForMod: jest.fn().mockResolvedValue(mockLoadResult),
-    };
-    mockConditionLoader = {
       loadItemsForMod: jest.fn().mockResolvedValue(mockLoadResult),
     };
     mockRuleLoader = {


### PR DESCRIPTION
Summary: 
- fixed duplicate mock variable in worldLoader.entityMultiKey.integration.test.js

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test` *(fails)*
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

Failing tests remain after modification, see logs. 🚫 tests failing—needs human review

------
https://chatgpt.com/codex/tasks/task_e_68505f62faa0833187bf7de1609137b0