### PR TITLE
[Agent] Fix follow rule integration after condition refactor

### DIFF
--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -9,8 +9,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import followRule from '../../../data/mods/core/rules/follow.rule.json';
+import eventIsActionFollow from '../../../data/mods/core/conditions/event-is-action-follow.condition.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
@@ -217,6 +220,7 @@ describe('core_handle_follow rule integration', () => {
     };
     const expandedRule = {
       ...followRule,
+      condition: eventIsActionFollow.logic,
       actions: expandMacros(
         JSON.parse(JSON.stringify(followRule.actions)),
         macroRegistry
@@ -243,6 +247,14 @@ describe('core_handle_follow rule integration', () => {
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'
+    );
+    ajv.addSchema(
+      conditionContainerSchema,
+      'http://example.com/schemas/condition-container.schema.json'
+    );
+    ajv.addSchema(
+      conditionSchema,
+      'http://example.com/schemas/condition.schema.json'
     );
     const valid = ajv.validate(ruleSchema, followRule);
     if (!valid) console.error(ajv.errors);

--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -8,6 +8,8 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
 import getCloseRule from '../../../data/mods/intimacy/rules/get_close.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
@@ -117,11 +119,6 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    QUERY_COMPONENT: new QueryComponentHandler({
-      entityManager,
-      logger,
-      safeEventDispatcher: safeDispatcher,
-    }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
     END_TURN: new EndTurnHandler({
@@ -223,6 +220,14 @@ describe('intimacy_handle_get_close rule integration', () => {
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'
+    );
+    ajv.addSchema(
+      conditionContainerSchema,
+      'http://example.com/schemas/condition-container.schema.json'
+    );
+    ajv.addSchema(
+      conditionSchema,
+      'http://example.com/schemas/condition.schema.json'
     );
     const valid = ajv.validate(ruleSchema, getCloseRule);
     if (!valid) console.error(ajv.errors);


### PR DESCRIPTION
Summary: Update rules integration tests to use the new condition loader. Added condition schema loading to `getCloseRule.integration.test.js` and expanded conditions in `followRule.integration.test.js` so schemas validate and the rule executes correctly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified files (`npm run lint`)
- [x] Root tests (known failures remain) (`npm run test`)
- [ ] Proxy tests (not run)
- [ ] Manual smoke run (skipped)


------
https://chatgpt.com/codex/tasks/task_e_6850633af96883319be4f6f25657bb34