### PR TITLE
[Fix] update get_close rule test for conditions

### DIFF
--- a/tests/helpers/loadConditionSchemas.js
+++ b/tests/helpers/loadConditionSchemas.js
@@ -1,0 +1,19 @@
+/* eslint-env node */
+/**
+ * @description Registers condition-related schemas with AJV for testing.
+ * @param {import('ajv').default} ajv - AJV instance
+ * @returns {void}
+ */
+function loadConditionSchemas(ajv) {
+  const containerSchema = require('../..//data/schemas/condition-container.schema.json');
+  const conditionSchema = require('../..//data/schemas/condition.schema.json');
+  ajv.addSchema(
+    containerSchema,
+    'http://example.com/schemas/condition-container.schema.json'
+  );
+  ajv.addSchema(
+    conditionSchema,
+    'http://example.com/schemas/condition.schema.json'
+  );
+}
+module.exports = loadConditionSchemas;


### PR DESCRIPTION
Summary: Updated getCloseRule integration test to load condition schemas and provide condition definitions to JsonLogicEvaluationService. Added helper for registering condition schemas.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests (`npm run test`) - failing suites remain
- [x] Proxy server tests (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685061f36e8883318041431b682deea5