### PR TITLE
[Agent] Fix failing rule integration tests

### DIFF
--- a/tests/integration/rules/closenessActionAvailability.integration.test.js
+++ b/tests/integration/rules/closenessActionAvailability.integration.test.js
@@ -6,6 +6,7 @@ import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import getCloseRule from '../../../data/mods/intimacy/rules/get_close.rule.json';
 import adjustClothingAction from '../../../data/mods/intimacy/actions/adjust_clothing.action.json';
 import thumbWipeCheekAction from '../../../data/mods/intimacy/actions/thumb_wipe_cheek.action.json';
+import eventIsActionGetClose from '../../../data/mods/intimacy/conditions/event-is-action-get-close.condition.json';
 import logSuccessMacro from '../../../data/mods/core/macros/logSuccessAndEndTurn.macro.json';
 
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
@@ -126,7 +127,10 @@ function init(entities) {
     operationRegistry,
   });
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -180,6 +184,11 @@ beforeEach(() => {
   };
   dataRegistry = {
     getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+    getConditionDefinition: jest.fn((id) =>
+      id === 'intimacy:event-is-action-get-close'
+        ? eventIsActionGetClose
+        : undefined
+    ),
   };
 
   init([]);

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -9,7 +9,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionDismiss from '../../../data/mods/core/conditions/event-is-action-dismiss.condition.json';
 import dismissRule from '../../../data/mods/core/rules/dismiss.rule.json';
 import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
@@ -190,7 +194,10 @@ function init(entities) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -260,6 +267,9 @@ describe('core_handle_dismiss rule integration', () => {
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'core:event-is-action-dismiss' ? eventIsActionDismiss : undefined
+      ),
     };
 
     init([]);
@@ -276,6 +286,7 @@ describe('core_handle_dismiss rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/entitySpeechRule.integration.test.js
+++ b/tests/integration/rules/entitySpeechRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import entitySpeechRule from '../../../data/mods/core/rules/entity_speech.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -178,6 +181,7 @@ describe('core_entity_speech rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -8,7 +8,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import actorIsNotNull from '../../../data/mods/core/conditions/actor-is-not-null.condition.json';
 import followAutoMoveRule from '../../../data/mods/core/rules/follow_auto_move.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -257,9 +261,15 @@ describe('core_follow_auto_move rule integration', () => {
     };
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'core:actor-is-not-null' ? actorIsNotNull : undefined
+      ),
     };
 
-    jsonLogic = new JsonLogicEvaluationService({ logger });
+    jsonLogic = new JsonLogicEvaluationService({
+      logger,
+      gameDataRepository: dataRegistry,
+    });
 
     init([]);
   });
@@ -275,6 +285,7 @@ describe('core_follow_auto_move rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -11,6 +11,8 @@ import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
 import conditionSchema from '../../../data/schemas/condition.schema.json';
 import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionGo from '../../../data/mods/core/conditions/event-is-action-go.condition.json';
 import goRule from '../../../data/mods/core/rules/go.rule.json';
 import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
@@ -209,7 +211,10 @@ function init(entities) {
     operationRegistry,
   });
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -272,6 +277,9 @@ describe('core_handle_go rule integration', () => {
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'core:event-is-action-go' ? eventIsActionGo : undefined
+      ),
     };
 
     init([]);
@@ -288,17 +296,10 @@ describe('core_handle_go rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'
-    );
-    ajv.addSchema(
-      conditionContainerSchema,
-      'http://example.com/schemas/condition-container.schema.json'
-    );
-    ajv.addSchema(
-      conditionSchema,
-      'http://example.com/schemas/condition.schema.json'
     );
     const valid = ajv.validate(ruleSchema, goRule);
     if (!valid) console.error(ajv.errors);

--- a/tests/integration/rules/intimacyShowOnlookersRule.integration.test.js
+++ b/tests/integration/rules/intimacyShowOnlookersRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import showOnlookersRule from '../../../data/mods/intimacy/rules/intimacy_show_onlookers.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -169,6 +172,7 @@ describe('intimacy_show_onlookers rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
+++ b/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import logPerceptibleEventsRule from '../../../data/mods/core/rules/log_perceptible_events.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -212,6 +215,7 @@ describe('log_perceptible_events rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/playerTurnPromptRule.integration.test.js
+++ b/tests/integration/rules/playerTurnPromptRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import playerTurnPromptRule from '../../../data/mods/core/rules/player_turn_prompt.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -166,6 +169,7 @@ describe('player_turn_prompt rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -11,6 +11,8 @@ import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
 import conditionSchema from '../../../data/schemas/condition.schema.json';
 import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionStepBack from '../../../data/mods/intimacy/conditions/event-is-action-step-back.condition.json';
 import stepBackRule from '../../../data/mods/intimacy/rules/step_back.rule.json';
 import logSuccessMacro from '../../../data/mods/core/macros/logSuccessAndEndTurn.macro.json';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
@@ -186,7 +188,10 @@ function init(entities) {
     operationRegistry,
   });
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -249,6 +254,11 @@ describe('intimacy_handle_step_back rule integration', () => {
       getAllSystemRules: jest
         .fn()
         .mockReturnValue([{ ...stepBackRule, actions: expanded }]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'intimacy:event-is-action-step-back'
+          ? eventIsActionStepBack
+          : undefined
+      ),
     };
 
     init([]);
@@ -265,17 +275,10 @@ describe('intimacy_handle_step_back rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'
-    );
-    ajv.addSchema(
-      conditionSchema,
-      'http://example.com/schemas/condition.schema.json'
-    );
-    ajv.addSchema(
-      conditionContainerSchema,
-      'http://example.com/schemas/condition-container.schema.json'
     );
     const macros = { 'core:logSuccessAndEndTurn': logSuccessMacro };
     const expanded = expandMacros(stepBackRule.actions, {

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -9,7 +9,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionStopFollowing from '../../../data/mods/core/conditions/event-is-action-stop-following.condition.json';
 import stopFollowingRule from '../../../data/mods/core/rules/stop_following.rule.json';
 import logFailureAndEndTurn from '../../../data/mods/core/macros/logFailureAndEndTurn.macro.json';
 import displaySuccessAndEndTurn from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
@@ -191,7 +195,10 @@ function init(entities) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -277,6 +284,11 @@ describe('core_handle_stop_following rule integration', () => {
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'core:event-is-action-stop-following'
+          ? eventIsActionStopFollowing
+          : undefined
+      ),
     };
 
     init([]);
@@ -293,6 +305,7 @@ describe('core_handle_stop_following rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/thumbWipeCheekRule.integration.test.js
+++ b/tests/integration/rules/thumbWipeCheekRule.integration.test.js
@@ -9,7 +9,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionThumbWipeCheek from '../../../data/mods/intimacy/conditions/event-is-action-thumb-wipe-cheek.condition.json';
 import thumbWipeCheekRule from '../../../data/mods/intimacy/rules/thumb_wipe_cheek.rule.json';
 import logSuccessMacro from '../../../data/mods/core/macros/logSuccessAndEndTurn.macro.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
@@ -123,7 +127,10 @@ function init(entities) {
     operationRegistry.register(type, handler.execute.bind(handler));
   }
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -185,6 +192,11 @@ describe('intimacy:handle_thumb_wipe_cheek rule integration', () => {
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([expandedRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'intimacy:event-is-action-thumb-wipe-cheek'
+          ? eventIsActionThumbWipeCheek
+          : undefined
+      ),
     };
 
     init([]);
@@ -201,6 +213,7 @@ describe('intimacy:handle_thumb_wipe_cheek rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/turnEndedRule.integration.test.js
+++ b/tests/integration/rules/turnEndedRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import turnEndedRule from '../../../data/mods/core/rules/turn_ended.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -180,6 +183,7 @@ describe('turn_ended rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/turnStartedRule.integration.test.js
+++ b/tests/integration/rules/turnStartedRule.integration.test.js
@@ -8,7 +8,10 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
 import turnStartedRule from '../../../data/mods/core/rules/turn_started.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -181,6 +184,7 @@ describe('turn_started rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'

--- a/tests/integration/rules/waitRule.integration.test.js
+++ b/tests/integration/rules/waitRule.integration.test.js
@@ -8,7 +8,11 @@ import ruleSchema from '../../../data/schemas/rule.schema.json';
 import commonSchema from '../../../data/schemas/common.schema.json';
 import operationSchema from '../../../data/schemas/operation.schema.json';
 import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import conditionSchema from '../../../data/schemas/condition.schema.json';
+import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
 import loadOperationSchemas from '../../helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../helpers/loadConditionSchemas.js';
+import eventIsActionWait from '../../../data/mods/core/conditions/event-is-action-wait.condition.json';
 import waitRule from '../../../data/mods/core/rules/wait.rule.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
@@ -102,7 +106,10 @@ function init(entities) {
     operationRegistry,
   });
 
-  jsonLogic = new JsonLogicEvaluationService({ logger });
+  jsonLogic = new JsonLogicEvaluationService({
+    logger,
+    gameDataRepository: dataRegistry,
+  });
 
   interpreter = new SystemLogicInterpreter({
     logger,
@@ -152,6 +159,9 @@ describe('core_handle_wait rule integration', () => {
 
     dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([waitRule]),
+      getConditionDefinition: jest.fn((id) =>
+        id === 'core:event-is-action-wait' ? eventIsActionWait : undefined
+      ),
     };
 
     init([]);
@@ -168,6 +178,7 @@ describe('core_handle_wait rule integration', () => {
       'http://example.com/schemas/operation.schema.json'
     );
     loadOperationSchemas(ajv);
+    loadConditionSchemas(ajv);
     ajv.addSchema(
       jsonLogicSchema,
       'http://example.com/schemas/json-logic.schema.json'


### PR DESCRIPTION
Summary: Updated rule integration tests to load condition schemas and supply condition definitions via the game data registry, ensuring compatibility with the new `ConditionLoader`. All Jest suites now pass.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: existing repo issues)*
- [x] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68506ad25f588331a9bcc41ce5bbab9f