### PR TITLE
[Agent] restrict manifest content categories

### DIFF
--- a/data/schemas/mod.manifest.schema.json
+++ b/data/schemas/mod.manifest.schema.json
@@ -92,11 +92,12 @@
         },
         "macros": {
           "$ref": "#/definitions/contentFileList"
+        },
+        "ui": {
+          "$ref": "#/definitions/contentFileList"
         }
       },
-      "additionalProperties": {
-        "$ref": "#/definitions/contentFileList"
-      }
+      "additionalProperties": false
     }
   },
   "required": ["id", "version", "name"],

--- a/docs/mods/mod_manifest_format.md
+++ b/docs/mods/mod_manifest_format.md
@@ -39,7 +39,7 @@ Optional array of mod IDs that cannot be loaded alongside this mod.
 
 ## `content`
 
-Object mapping content categories to arrays of JSON definition files. Paths are relative to the mod's root directory. Predefined categories include `actions`, `characters`, `components`, `items`, `locations`, `rules`, `macros`, and `events`. Additional categories are allowed for custom systems.
+Object mapping content categories to arrays of JSON definition files. Paths are relative to the mod's root directory. Allowed categories are `actions`, `characters`, `components`, `items`, `locations`, `rules`, `macros`, `events`, and `ui`.
 
 ### Sample Manifest
 


### PR DESCRIPTION
Summary: Disallow arbitrary categories in mod manifests.

Changes Made:
- enforce `additionalProperties: false` in `mod.manifest.schema.json` and add explicit `ui` category
- update manifest format docs to list allowed categories

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (root and proxy)
- [x] Root tests pass `npm run test`
- [x] Proxy server tests pass `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68506fe887148331b02f65bdba9b3f16