### PR TITLE
[Agent] centralize turn context validation

### DIFF
--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -100,6 +100,30 @@ export class AbstractTurnState extends ITurnState {
     }
   }
 
+  /**
+   * Ensures a valid ITurnContext exists. If not, logs an error and resets
+   * the handler to an idle state.
+   *
+   * @protected
+   * @async
+   * @param {string} reason - Reason passed to the idle reset helper.
+   * @param {BaseTurnHandler} [handler] - Optional handler for
+   *   resolving a logger.
+   * @returns {Promise<ITurnContext | null>} The current ITurnContext or null if
+   *   none is available.
+   */
+  async _ensureContext(reason, handler = this._handler) {
+    const ctx = this._getTurnContext();
+    if (!ctx) {
+      this._resolveLogger(null, handler).error(
+        `${this.getStateName()}: No ITurnContext available. Resetting to idle.`
+      );
+      await this._resetToIdle(reason);
+      return null;
+    }
+    return ctx;
+  }
+
   /* Resolves a logger using the provided context or handler.
    *
    * @protected

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -52,16 +52,9 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
 
   //─────────────────────────────────────────────────────────────────────────────
   async enterState(handler, prev) {
-    const ctx = this._getTurnContext();
     await super.enterState(handler, prev);
-
-    if (!ctx) {
-      this._resolveLogger(null, handler).error(
-        `${this.getStateName()}: entered with no ITurnContext; aborting`
-      );
-      await this._resetToIdle('enter-no-context');
-      return;
-    }
+    const ctx = await this._ensureContext('enter-no-context', handler);
+    if (!ctx) return;
 
     // remember actionId purely for clearer error text
     this.#awaitingActionId =

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -52,7 +52,12 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {ITurnState_Interface} [previousState]
    */
   async enterState(handler, previousState) {
-    const turnCtx = this._getTurnContext();
+    const turnCtx = await this._ensureContext(
+      `critical-no-context-${this.getStateName()}`,
+      handler
+    );
+
+    if (!turnCtx) return;
 
     if (this._isProcessing) {
       const logger = this._resolveLogger(turnCtx);
@@ -65,15 +70,6 @@ export class ProcessingCommandState extends AbstractTurnState {
 
     await super.enterState(this._handler, previousState);
     const logger = this._resolveLogger(turnCtx);
-
-    if (!turnCtx) {
-      logger.error(
-        `${this.getStateName()}: Turn context is null on enter. Attempting to reset and idle.`
-      );
-      await this._resetToIdle(`critical-no-context-${this.getStateName()}`);
-      this._isProcessing = false;
-      return;
-    }
 
     const actor = turnCtx.getActor();
     if (!actor) {

--- a/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -169,7 +169,7 @@ describe('AwaitingExternalTurnEndState', () => {
 
       // Assert
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('entered with no ITurnContext')
+        'AwaitingExternalTurnEndState: No ITurnContext available. Resetting to idle.'
       );
       expect(mockHandler.requestIdleStateTransition).toHaveBeenCalledTimes(1);
     });

--- a/tests/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/turns/states/awaitingPlayerInputState.test.js
@@ -255,7 +255,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
         mockPreviousState
       );
       expect(specificHandlerLogger.error).toHaveBeenCalledWith(
-        'AwaitingActorDecisionState: Critical error - TurnContext is not available. Attempting to reset and idle.'
+        'AwaitingActorDecisionState: No ITurnContext available. Resetting to idle.'
       );
       expect(mockHandler._resetTurnStateAndResources).toHaveBeenCalledWith(
         'critical-no-context-AwaitingActorDecisionState'
@@ -499,9 +499,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
       );
 
       expect(specificHandlerLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `AwaitingActorDecisionState: handleSubmittedCommand (for actor ${testActor.id}, cmd: "${command}") called, but no ITurnContext. Forcing handler reset.`
-        )
+        'AwaitingActorDecisionState: No ITurnContext available. Resetting to idle.'
       );
       expect(mockHandler._resetTurnStateAndResources).toHaveBeenCalledWith(
         'no-context-submission-AwaitingActorDecisionState'
@@ -523,9 +521,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `AwaitingActorDecisionState: handleSubmittedCommand (for actor ${testActor.id}, cmd: "${command}") called, but no ITurnContext. Forcing handler reset.`
-        )
+        'AwaitingActorDecisionState: No ITurnContext available. Resetting to idle.'
       );
       expect(consoleErrorSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('CRITICAL - No ITurnContext or handler methods')

--- a/tests/turns/states/processingCommandState.enterState.test.js
+++ b/tests/turns/states/processingCommandState.enterState.test.js
@@ -323,7 +323,7 @@ describe('ProcessingCommandState', () => {
         .mockResolvedValue(undefined);
       await processingState.enterState(mockHandler, null);
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'ProcessingCommandState: Turn context is null on enter. Attempting to reset and idle.'
+        'ProcessingCommandState: No ITurnContext available. Resetting to idle.'
       );
       expect(mockHandler._resetTurnStateAndResources).toHaveBeenCalledWith(
         `critical-no-context-${processingState.getStateName()}`


### PR DESCRIPTION
## Summary
- add `_ensureContext` helper in `AbstractTurnState`
- use `_ensureContext` in AwaitingActorDecisionState, AwaitingExternalTurnEndState, and ProcessingCommandState
- update tests for new helper behavior

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 568 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68506f66c31483318cba8e734e28bec1