### PR TITLE
[Agent] Add bracket warning test for JsonLogicEvaluationService

### DIFF
--- a/tests/logic/jsonLogicEvaluationService.bracketWarning.test.js
+++ b/tests/logic/jsonLogicEvaluationService.bracketWarning.test.js
@@ -1,0 +1,39 @@
+// tests/logic/jsonLogicEvaluationService.bracketWarning.test.js
+
+/**
+ * @jest-environment node
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
+
+/** @typedef {import('../../src/interfaces/coreServices.js').ILogger} ILogger */
+
+/** @type {jest.Mocked<ILogger>} */
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('JsonLogicEvaluationService bracket notation warning', () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new JsonLogicEvaluationService({
+      logger: mockLogger,
+      gameDataRepository: { getConditionDefinition: () => null },
+    });
+  });
+
+  test('returns false and logs warning for bracket notation component access', () => {
+    const rule = { var: "actor.components.['bad:component']" };
+    const result = service.evaluate(rule, { actor: { components: {} } });
+    expect(result).toBe(false);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("actor.components.['bad:component']")
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added a new Jest suite to verify that JsonLogicEvaluationService logs a warning and returns false when evaluating rules using bracket notation for component IDs.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 568 errors, 1936 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68506fb20f5c8331995b5de4d22be163