### PR TITLE
[Agent] Refactor mod manifest builder

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -25,6 +25,7 @@ import ComponentCleaningService from '../../persistence/componentCleaningService
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../persistence/gameStateCaptureService.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
+import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuilder.js';
 import ReferenceResolver from '../../initializers/services/referenceResolver.js';
 import SaveLoadService from '../../persistence/saveLoadService.js';
 import { BrowserStorageProvider } from '../../storage/browserStorageProvider.js';
@@ -77,14 +78,22 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
   );
 
+  r.single(tokens.ActiveModsManifestBuilder, ActiveModsManifestBuilder, [
+    tokens.ILogger,
+    tokens.IDataRegistry,
+  ]);
+  logger.debug(
+    `Persistence Registration: Registered ${String(tokens.ActiveModsManifestBuilder)}.`
+  );
+
   r.singletonFactory(tokens.GameStateCaptureService, (c) => {
     return new GameStateCaptureService({
       logger: c.resolve(tokens.ILogger),
       entityManager: c.resolve(tokens.IEntityManager),
-      dataRegistry: c.resolve(tokens.IDataRegistry),
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
       componentCleaningService: c.resolve(tokens.ComponentCleaningService),
       metadataBuilder: c.resolve(tokens.SaveMetadataBuilder),
+      activeModsManifestBuilder: c.resolve(tokens.ActiveModsManifestBuilder),
     });
   });
   logger.debug(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -209,6 +209,7 @@ export const tokens = freeze({
   PlaytimeTracker: 'PlaytimeTracker',
   ComponentCleaningService: 'ComponentCleaningService',
   SaveMetadataBuilder: 'SaveMetadataBuilder',
+  ActiveModsManifestBuilder: 'ActiveModsManifestBuilder',
   GameStateCaptureService: 'GameStateCaptureService',
   GamePersistenceService: 'GamePersistenceService',
   EntityDisplayDataProvider: 'EntityDisplayDataProvider',

--- a/src/persistence/activeModsManifestBuilder.js
+++ b/src/persistence/activeModsManifestBuilder.js
@@ -1,0 +1,70 @@
+// src/persistence/activeModsManifestBuilder.js
+
+import { CORE_MOD_ID } from '../constants/core.js';
+import { setupService } from '../utils/serviceInitializerUtils.js';
+
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry
+ */
+
+/**
+ * @class ActiveModsManifestBuilder
+ * @description Builds the active mods manifest for save files.
+ */
+export default class ActiveModsManifestBuilder {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {IDataRegistry} */
+  #dataRegistry;
+
+  /**
+   * @param {{logger: ILogger, dataRegistry: IDataRegistry}} deps
+   */
+  constructor({ logger, dataRegistry }) {
+    this.#logger = setupService('ActiveModsManifestBuilder', logger, {
+      dataRegistry: { value: dataRegistry, requiredMethods: ['getAll'] },
+    });
+    this.#dataRegistry = dataRegistry;
+  }
+
+  /**
+   * Builds an array describing currently active mods.
+   *
+   * @returns {{modId: string, version: string}[]} List of mod identifiers and versions.
+   */
+  build() {
+    /** @type {import('../../data/schemas/mod.manifest.schema.json').ModManifest[]} */
+    const loadedManifestObjects = this.#dataRegistry.getAll('mod_manifests');
+    let activeModsManifest = [];
+    if (loadedManifestObjects && loadedManifestObjects.length > 0) {
+      activeModsManifest = loadedManifestObjects.map((manifest) => ({
+        modId: manifest.id,
+        version: manifest.version,
+      }));
+      this.#logger.debug(
+        `${this.constructor.name}: Captured ${activeModsManifest.length} active mods from 'mod_manifests' type in registry.`
+      );
+    } else {
+      this.#logger.warn(
+        `${this.constructor.name}: No mod manifests found in registry under "mod_manifests" type. Mod manifest may be incomplete. Using fallback.`
+      );
+      const coreModManifest = loadedManifestObjects?.find(
+        (m) => m.id === CORE_MOD_ID
+      );
+      if (coreModManifest) {
+        activeModsManifest = [
+          { modId: CORE_MOD_ID, version: coreModManifest.version },
+        ];
+      } else {
+        activeModsManifest = [
+          { modId: CORE_MOD_ID, version: 'unknown_fallback' },
+        ];
+      }
+      this.#logger.debug(
+        `${this.constructor.name}: Used fallback for mod manifest.`
+      );
+    }
+    return activeModsManifest;
+  }
+}

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -25,6 +25,7 @@ import GamePersistenceService from '../../../src/persistence/gamePersistenceServ
 import GameStateCaptureService from '../../../src/persistence/gameStateCaptureService.js';
 import ReferenceResolver from '../../../src/initializers/services/referenceResolver.js';
 import SaveMetadataBuilder from '../../../src/persistence/saveMetadataBuilder.js';
+import ActiveModsManifestBuilder from '../../../src/persistence/activeModsManifestBuilder.js';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import { BrowserStorageProvider } from '../../../src/storage/browserStorageProvider.js';
 
@@ -80,6 +81,9 @@ describe('registerPersistence', () => {
       `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
     );
     expect(logs).toContain(
+      `Persistence Registration: Registered ${String(tokens.ActiveModsManifestBuilder)}.`
+    );
+    expect(logs).toContain(
       `Persistence Registration: Registered ${String(tokens.GameStateCaptureService)}.`
     );
     expect(logs).toContain(
@@ -122,6 +126,12 @@ describe('registerPersistence', () => {
         Class: SaveMetadataBuilder,
         lifecycle: 'singleton',
         deps: [tokens.ILogger],
+      },
+      {
+        token: tokens.ActiveModsManifestBuilder,
+        Class: ActiveModsManifestBuilder,
+        lifecycle: 'singleton',
+        deps: [tokens.ILogger, tokens.IDataRegistry],
       },
       {
         token: tokens.GameStateCaptureService,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -61,7 +61,6 @@ describe('Persistence round-trip', () => {
   let storageProvider;
   let saveLoadService;
   let entityManager;
-  let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
   let metadataBuilder;
@@ -98,9 +97,6 @@ describe('Persistence round-trip', () => {
       }),
     };
 
-    dataRegistry = {
-      getAll: jest.fn().mockReturnValue([{ id: 'core', version: '1.0.0' }]),
-    };
     playtimeTracker = {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
@@ -121,13 +117,16 @@ describe('Persistence round-trip', () => {
       })),
     };
 
+    const activeModsManifestBuilder = {
+      build: jest.fn().mockReturnValue([{ modId: 'core', version: '1.0.0' }]),
+    };
     const captureService = new GameStateCaptureService({
       logger,
       entityManager,
-      dataRegistry,
       playtimeTracker,
       componentCleaningService,
       metadataBuilder,
+      activeModsManifestBuilder,
     });
     persistence = new GamePersistenceService({
       logger,

--- a/tests/services/activeModsManifestBuilder.test.js
+++ b/tests/services/activeModsManifestBuilder.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import ActiveModsManifestBuilder from '../../src/persistence/activeModsManifestBuilder.js';
+import { CORE_MOD_ID } from '../../src/constants/core.js';
+
+describe('ActiveModsManifestBuilder', () => {
+  let logger;
+  let dataRegistry;
+  let builder;
+
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    dataRegistry = { getAll: jest.fn() };
+    builder = new ActiveModsManifestBuilder({ logger, dataRegistry });
+  });
+
+  it('returns manifest from registry when available', () => {
+    dataRegistry.getAll.mockReturnValue([
+      { id: 'core', version: '1.0.0' },
+      { id: 'mod2', version: '2.3.4' },
+    ]);
+    const result = builder.build();
+    expect(result).toEqual([
+      { modId: 'core', version: '1.0.0' },
+      { modId: 'mod2', version: '2.3.4' },
+    ]);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('falls back to core mod version when registry empty', () => {
+    dataRegistry.getAll.mockReturnValue([]);
+    const result = builder.build();
+    expect(result).toEqual([
+      { modId: CORE_MOD_ID, version: 'unknown_fallback' },
+    ]);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('uses core mod version from registry when present', () => {
+    dataRegistry.getAll.mockReturnValue([
+      { id: CORE_MOD_ID, version: '2.0.0' },
+    ]);
+    const result = builder.build();
+    expect(result).toEqual([{ modId: CORE_MOD_ID, version: '2.0.0' }]);
+  });
+});

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -23,6 +23,7 @@ describe('GamePersistenceService error paths', () => {
   let playtimeTracker;
   let componentCleaningService;
   let metadataBuilder;
+  let activeModsManifestBuilder;
   let safeEventDispatcher;
   let service;
   let captureService;
@@ -35,7 +36,6 @@ describe('GamePersistenceService error paths', () => {
       clearAll: jest.fn(),
       reconstructEntity: jest.fn().mockReturnValue({}),
     };
-    const dataRegistry = { getAll: jest.fn().mockReturnValue([]) };
     playtimeTracker = {
       getTotalPlaytime: jest.fn().mockReturnValue(0),
       setAccumulatedPlaytime: jest.fn(),
@@ -55,13 +55,14 @@ describe('GamePersistenceService error paths', () => {
         saveName: '',
       })),
     };
+    activeModsManifestBuilder = { build: jest.fn().mockReturnValue([]) };
     captureService = new GameStateCaptureService({
       logger,
       entityManager,
-      dataRegistry,
       playtimeTracker,
       componentCleaningService,
       metadataBuilder,
+      activeModsManifestBuilder,
     });
     service = new GamePersistenceService({
       logger,

--- a/tests/services/gameStateCaptureService.additional.test.js
+++ b/tests/services/gameStateCaptureService.additional.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
+import { CURRENT_ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
+
+describe('GameStateCaptureService additional coverage', () => {
+  let logger;
+  let entityManager;
+  let playtimeTracker;
+  let componentCleaningService;
+  let metadataBuilder;
+  let activeModsManifestBuilder;
+  let service;
+
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    entityManager = { activeEntities: new Map() };
+    playtimeTracker = { getTotalPlaytime: jest.fn().mockReturnValue(5) };
+    componentCleaningService = { clean: jest.fn((id, data) => data) };
+    metadataBuilder = {
+      build: jest.fn(() => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: 'Test',
+        timestamp: 't',
+        playtimeSeconds: 5,
+        saveName: '',
+      })),
+    };
+    activeModsManifestBuilder = {
+      build: jest.fn(() => [{ modId: 'core', version: '1.0.0' }]),
+    };
+    service = new GameStateCaptureService({
+      logger,
+      entityManager,
+      playtimeTracker,
+      componentCleaningService,
+      metadataBuilder,
+      activeModsManifestBuilder,
+    });
+  });
+
+  it('delegates to ActiveModsManifestBuilder', () => {
+    service.captureCurrentGameState('World');
+    expect(activeModsManifestBuilder.build).toHaveBeenCalled();
+  });
+
+  it('passes playtime to metadata builder', () => {
+    service.captureCurrentGameState('World');
+    expect(metadataBuilder.build).toHaveBeenCalledWith('World', 5);
+  });
+});

--- a/tests/services/gameStateCaptureService.test.js
+++ b/tests/services/gameStateCaptureService.test.js
@@ -6,16 +6,15 @@ import { createMockLogger } from '../testUtils.js';
 describe('GameStateCaptureService', () => {
   let logger;
   let entityManager;
-  let dataRegistry;
   let playtimeTracker;
   let componentCleaningService;
   let metadataBuilder;
+  let activeModsManifestBuilder;
   let captureService;
 
   beforeEach(() => {
     logger = createMockLogger();
     entityManager = { activeEntities: new Map() };
-    dataRegistry = { getAll: jest.fn().mockReturnValue([]) };
     playtimeTracker = { getTotalPlaytime: jest.fn().mockReturnValue(0) };
     componentCleaningService = { clean: jest.fn() };
     metadataBuilder = {
@@ -28,13 +27,14 @@ describe('GameStateCaptureService', () => {
         saveName: '',
       })),
     };
+    activeModsManifestBuilder = { build: jest.fn().mockReturnValue([]) };
     captureService = new GameStateCaptureService({
       logger,
       entityManager,
-      dataRegistry,
       playtimeTracker,
       componentCleaningService,
       metadataBuilder,
+      activeModsManifestBuilder,
     });
   });
 


### PR DESCRIPTION
Summary:
- move active mods manifest building to dedicated ActiveModsManifestBuilder
- inject ActiveModsManifestBuilder into GameStateCaptureService
- register builder in DI container
- adjust tests for new dependency and add ActiveModsManifestBuilder tests

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 568 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68506f9c4e288331b3e7a2f71c58bf28