### PR TITLE
[Fix] Update slot modals to new helper

### DIFF
--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -99,13 +99,7 @@ export class LlmSelectionModal extends SlotModalBase {
         `${this._logPrefix} Could not find #change-llm-button element. Modal cannot be opened by this button.`
       );
     }
-    if (this.elements.listContainerElement) {
-      this._addDomListener(
-        this.elements.listContainerElement,
-        'keydown',
-        this._handleSlotNavigation.bind(this)
-      );
-    }
+    // Keyboard navigation is now handled by SlotModalBase
     // Note: #bindDomElements and #attachEventListeners for modal's own elements are handled by BaseModalRenderer/BoundDomRendererBase
 
     this.logger.debug(`${this._logPrefix} Initialized successfully.`);

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -148,13 +148,7 @@ class LoadGameUI extends SlotModalBase {
         event.preventDefault()
       );
     }
-    if (this.elements.listContainerElement) {
-      this._addDomListener(
-        this.elements.listContainerElement,
-        'keydown',
-        this._handleSlotNavigation.bind(this)
-      );
-    }
+    // Keyboard navigation is now handled by SlotModalBase
   }
 
   /**
@@ -286,7 +280,7 @@ class LoadGameUI extends SlotModalBase {
       slotData.identifier,
       metadata,
       (evt) => {
-        this._handleSlotSelection(
+        this._onItemSelected(
           /** @type {HTMLElement} */ (evt.currentTarget),
           slotData
         );
@@ -343,7 +337,7 @@ class LoadGameUI extends SlotModalBase {
       'Loading saved games...'
     );
 
-    this._handleSlotSelection(null, null); // Update button states
+    this._onItemSelected(null, null); // Update button states
     this.logger.debug(`${this._logPrefix} Load slots list populated.`);
   }
 
@@ -354,7 +348,11 @@ class LoadGameUI extends SlotModalBase {
    * @param {LoadSlotDisplayData | null} slotData - Associated slot information.
    * @private
    */
-  _handleSlotSelection(selectedSlotElement, slotData) {
+  /**
+   * @protected
+   * @override
+   */
+  _onItemSelected(selectedSlotElement, slotData) {
     super._onItemSelected(selectedSlotElement, slotData);
 
     const canLoad = !!(slotData && !slotData.isCorrupted);
@@ -400,7 +398,7 @@ class LoadGameUI extends SlotModalBase {
             (s) => String(s[this._datasetKey]) === String(value)
           );
         }
-        if (slotData) this._handleSlotSelection(el, slotData);
+        if (slotData) this._onItemSelected(el, slotData);
       }
     );
 
@@ -421,7 +419,7 @@ class LoadGameUI extends SlotModalBase {
           (s) => String(s[this._datasetKey]) === String(value)
         );
       }
-      if (slotData) this._handleSlotSelection(target, slotData);
+      if (slotData) this._onItemSelected(target, slotData);
     }
   }
 
@@ -590,13 +588,13 @@ class LoadGameUI extends SlotModalBase {
           (s) => s.identifier === firstSlotIdentifier
         );
         if (firstSlotData)
-          this._handleSlotSelection(
+          this._onItemSelected(
             /** @type {HTMLElement} */ (firstSlot),
             firstSlotData
           );
-        else this._handleSlotSelection(null, null);
+        else this._onItemSelected(null, null);
       } else {
-        this._handleSlotSelection(null, null);
+        this._onItemSelected(null, null);
       }
     }
   }

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -121,13 +121,7 @@ export class SaveGameUI extends SlotModalBase {
         event.preventDefault()
       );
     }
-    if (this.elements.listContainerElement) {
-      this._addDomListener(
-        this.elements.listContainerElement,
-        'keydown',
-        this._handleSlotNavigation.bind(this)
-      );
-    }
+    // Keyboard navigation is now handled by SlotModalBase
     if (this.elements.saveNameInputEl) {
       this._addDomListener(
         this.elements.saveNameInputEl,
@@ -299,7 +293,7 @@ export class SaveGameUI extends SlotModalBase {
       slotData.slotId,
       metadata,
       (evt) => {
-        this._handleSlotSelection(
+        this._onItemSelected(
           /** @type {HTMLElement} */ (evt.currentTarget),
           slotData
         );
@@ -399,7 +393,7 @@ export class SaveGameUI extends SlotModalBase {
             (s) => String(s[this._datasetKey]) === String(value)
           );
         }
-        if (slotData) this._handleSlotSelection(el, slotData);
+        if (slotData) this._onItemSelected(el, slotData);
       }
     );
 
@@ -420,7 +414,7 @@ export class SaveGameUI extends SlotModalBase {
           (s) => String(s[this._datasetKey]) === String(value)
         );
       }
-      if (slotData) this._handleSlotSelection(target, slotData);
+      if (slotData) this._onItemSelected(target, slotData);
     }
   }
 
@@ -429,7 +423,11 @@ export class SaveGameUI extends SlotModalBase {
    * @param slotData
    * @private
    */
-  _handleSlotSelection(selectedSlotElement, slotData) {
+  /**
+   * @protected
+   * @override
+   */
+  _onItemSelected(selectedSlotElement, slotData) {
     this.logger.debug(
       `${this._logPrefix} Slot selected: ID ${slotData.slotId}`,
       slotData
@@ -570,7 +568,7 @@ export class SaveGameUI extends SlotModalBase {
             )
           );
           if (slotElement) {
-            this._handleSlotSelection(slotElement, newlySavedSlotData);
+            this._onItemSelected(slotElement, newlySavedSlotData);
           } else {
             this.logger.warn(
               `${this._logPrefix} Could not find DOM element for newly saved slot ID ${newlySavedSlotData.slotId} to re-select.`

--- a/tests/domUI/loadGameUI.test.js
+++ b/tests/domUI/loadGameUI.test.js
@@ -189,12 +189,12 @@ describe('LoadGameUI basic behaviors', () => {
     loadGameUI.elements.deleteSaveButtonEl =
       document.getElementById('delete-save-button');
 
-    loadGameUI._handleSlotSelection(slot1, slotData1);
+    loadGameUI._onItemSelected(slot1, slotData1);
     expect(slot1.classList.contains('selected')).toBe(true);
     expect(loadGameUI.elements.confirmLoadButtonEl.disabled).toBe(false);
     expect(loadGameUI.elements.deleteSaveButtonEl.disabled).toBe(false);
 
-    loadGameUI._handleSlotSelection(null, null);
+    loadGameUI._onItemSelected(null, null);
     expect(slot1.classList.contains('selected')).toBe(false);
     expect(loadGameUI.elements.confirmLoadButtonEl.disabled).toBe(true);
   });


### PR DESCRIPTION
Summary: Refactored slot modals to rely on the new selection helper and removed manual keyboard navigation bindings.

Changes Made:
- Removed custom keydown listeners in SaveGameUI, LoadGameUI and LlmSelectionModal
- Replaced calls to `_handleSlotSelection` with overridden `_onItemSelected`
- Updated tests for LoadGameUI accordingly

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685073be0dbc8331b72ac9be8bacb671