### PR TITLE
[Agent] add schema tests for core conditions

### DIFF
--- a/tests/schemas/core.allConditions.schema.test.js
+++ b/tests/schemas/core.allConditions.schema.test.js
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { describe, beforeAll, test, expect } from '@jest/globals';
+import conditionSchema from '../../data/schemas/condition.schema.json';
+import commonSchema from '../../data/schemas/common.schema.json';
+import jsonLogicSchema from '../../data/schemas/json-logic.schema.json';
+import conditionContainerSchema from '../../data/schemas/condition-container.schema.json';
+
+const conditionDir = path.resolve(__dirname, '../../data/mods/core/conditions');
+
+/** @type {import('ajv').ValidateFunction} */
+let validate;
+
+beforeAll(() => {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+  ajv.addSchema(commonSchema, 'http://example.com/schemas/common.schema.json');
+  ajv.addSchema(
+    jsonLogicSchema,
+    'http://example.com/schemas/json-logic.schema.json'
+  );
+  ajv.addSchema(
+    conditionContainerSchema,
+    'http://example.com/schemas/condition-container.schema.json'
+  );
+  validate = ajv.compile(conditionSchema);
+});
+
+describe('JSON-Schema – core condition definitions', () => {
+  fs.readdirSync(conditionDir)
+    .filter((f) => f.endsWith('.json'))
+    .forEach((file) => {
+      const data = JSON.parse(
+        fs.readFileSync(path.join(conditionDir, file), 'utf8')
+      );
+
+      test(`${data.id} should be a valid condition definition`, () => {
+        const ok = validate(data);
+        if (!ok) {
+          console.error(`Validation errors for ${data.id}:`, validate.errors);
+        }
+        expect(ok).toBe(true);
+      });
+    });
+});


### PR DESCRIPTION
## Summary
- add a schema validation test suite for `data/mods/core/conditions`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 569 errors, 1934 warnings)*
- `npm run test`
- `npx jest tests/schemas/core.allConditions.schema.test.js --runTestsByPath --no-color`

------
https://chatgpt.com/codex/tasks/task_e_685078757594833183bb5c0ae1e99a9d