### PR TITLE
[Agent] introduce getModuleLogger helper

### DIFF
--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -1,6 +1,6 @@
 // src/utils/apiUtils.js
 // --- FILE START ---
-import { getPrefixedLogger } from './loggerUtils.js';
+import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
@@ -61,7 +61,7 @@ export async function Workspace_retry(
   safeEventDispatcher,
   logger
 ) {
-  const log = getPrefixedLogger(logger, '[Workspace_retry] ');
+  const log = getModuleLogger('Workspace_retry', logger);
   // This internal recursive function handles the actual fetch attempts and retry logic.
   // It's called by Workspace_retry with the initial attempt number.
   /**

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -1,6 +1,6 @@
 // src/utils/contextVariableUtils.js
 
-import { getPrefixedLogger } from './loggerUtils.js';
+import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
 
@@ -18,7 +18,7 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  * @returns {boolean} `true` if the value was stored successfully, otherwise `false`.
  */
 export function storeResult(variableName, value, execCtx, dispatcher, logger) {
-  const log = getPrefixedLogger(logger, '[contextVariableUtils] ');
+  const log = getModuleLogger('contextVariableUtils', logger);
 
   let safeDispatcher = dispatcher;
   if (!safeDispatcher && execCtx?.validatedEventDispatcher) {
@@ -86,7 +86,7 @@ export function setContextValue(
 ) {
   const trimmedName =
     typeof variableName === 'string' ? variableName.trim() : '';
-  const log = getPrefixedLogger(logger, '[contextVariableUtils] ');
+  const log = getModuleLogger('contextVariableUtils', logger);
 
   if (!trimmedName) {
     let safeDispatcher = dispatcher;

--- a/src/utils/entityAssertionsUtils.js
+++ b/src/utils/entityAssertionsUtils.js
@@ -10,7 +10,7 @@
  */
 
 import { isNonBlankString } from './textUtils.js';
-import { getPrefixedLogger } from './loggerUtils.js';
+import { getModuleLogger } from './loggerUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
@@ -29,7 +29,7 @@ export function assertValidEntity(
   contextName = 'UnknownContext',
   safeEventDispatcher
 ) {
-  const log = getPrefixedLogger(logger, '[EntityValidation] ');
+  const log = getModuleLogger('EntityValidation', logger);
   if (!entity || !isNonBlankString(entity.id)) {
     const errMsg = `${contextName}: entity is required and must have a valid id.`;
     const payload = {

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -3,7 +3,7 @@
 import { EXITS_COMPONENT_ID } from '../constants/componentIds.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { isNonBlankString } from './textUtils.js';
-import { getPrefixedLogger } from './loggerUtils.js';
+import { getModuleLogger } from './loggerUtils.js';
 import {
   isValidEntityManager,
   isValidEntity,
@@ -42,7 +42,7 @@ function _getExitsComponentData(
   logger,
   dispatcher
 ) {
-  const log = getPrefixedLogger(logger, '[locationUtils] ');
+  const log = getModuleLogger('locationUtils', logger);
   if (
     typeof locationEntityOrId === 'string' &&
     !isValidEntityManager(entityManager)
@@ -105,7 +105,7 @@ export function getExitByDirection(
   logger,
   dispatcher
 ) {
-  const log = getPrefixedLogger(logger, '[locationUtils] ');
+  const log = getModuleLogger('locationUtils', logger);
   if (!isNonBlankString(directionName)) {
     log.debug('getExitByDirection: Invalid or empty directionName provided.');
     return null;
@@ -170,7 +170,7 @@ export function getAvailableExits(
   dispatcher,
   logger
 ) {
-  const log = getPrefixedLogger(logger, '[locationUtils] ');
+  const log = getModuleLogger('locationUtils', logger);
   const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -84,6 +84,18 @@ export function getPrefixedLogger(logger, prefix) {
 }
 
 /**
+ * @description Convenience wrapper for creating a logger prefixed with the
+ * module name in square brackets. Falls back to the console when the base
+ * logger is missing.
+ * @param {string} moduleName - Name of the module using the logger.
+ * @param {ILogger | undefined | null} logger - Optional logger instance.
+ * @returns {ILogger} Logger instance that prefixes messages with `[moduleName]`.
+ */
+export function getModuleLogger(moduleName, logger) {
+  return getPrefixedLogger(logger, `[${moduleName}] `);
+}
+
+/**
  * @description Validates a logger using {@link validateDependency} and returns
  * a safe logger instance via {@link ensureValidLogger}. When `optional` is
  * true, missing loggers are allowed and will result in a console-based

--- a/tests/utils/loggerUtils.test.js
+++ b/tests/utils/loggerUtils.test.js
@@ -10,6 +10,7 @@ import {
   ensureValidLogger,
   createPrefixedLogger,
   getPrefixedLogger,
+  getModuleLogger,
   initLogger,
 } from '../../src/utils/loggerUtils.js';
 import { validateDependency } from '../../src/utils/validationUtils.js';
@@ -60,6 +61,18 @@ describe('loggerUtils', () => {
     const prefixed = createPrefixedLogger(valid, 'X: ');
     prefixed.info('hello');
     expect(valid.info).toHaveBeenCalledWith('X: hello');
+  });
+
+  it('getModuleLogger prefixes messages with module name', () => {
+    const mod = getModuleLogger('modX', valid);
+    mod.info('ping');
+    expect(valid.info).toHaveBeenCalledWith('[modX] ping');
+  });
+
+  it('getModuleLogger falls back to console when logger missing', () => {
+    const log = getModuleLogger('modY', null);
+    log.warn('oops');
+    expect(consoleSpies.warn).toHaveBeenCalledWith('[modY] : ', '[modY] oops');
   });
 
   it('getPrefixedLogger returns prefixed fallback when logger missing', () => {


### PR DESCRIPTION
Summary: Added `getModuleLogger` in loggerUtils for module-specific prefixing and refactored utilities to use it. Updated unit tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68507934978c8331a59409e32005b49c