### PR TITLE
[Agent] add missing tests for utils and validator

### DIFF
--- a/tests/utils/handlerUtils.indexUtils.test.js
+++ b/tests/utils/handlerUtils.indexUtils.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from '@jest/globals';
+import indexUtils, {
+  assertParamsObject,
+  initHandlerLogger,
+  validateDeps,
+  getExecLogger,
+} from '../../src/utils/handlerUtils/indexUtils.js';
+import { assertParamsObject as paramsAssert } from '../../src/utils/handlerUtils/paramsUtils.js';
+import {
+  initHandlerLogger as serviceInit,
+  validateDeps as serviceValidate,
+  getExecLogger as serviceGetExec,
+} from '../../src/utils/handlerUtils/serviceUtils.js';
+
+describe('handlerUtils/indexUtils exports', () => {
+  it('re-exports functions from paramsUtils and serviceUtils', () => {
+    expect(assertParamsObject).toBe(paramsAssert);
+    expect(initHandlerLogger).toBe(serviceInit);
+    expect(validateDeps).toBe(serviceValidate);
+    expect(getExecLogger).toBe(serviceGetExec);
+  });
+
+  it('default export contains same references', () => {
+    expect(indexUtils).toEqual({
+      assertParamsObject: paramsAssert,
+      initHandlerLogger: serviceInit,
+      validateDeps: serviceValidate,
+      getExecLogger: serviceGetExec,
+    });
+  });
+});

--- a/tests/validation/ajvSchemaValidator.init.test.js
+++ b/tests/validation/ajvSchemaValidator.init.test.js
@@ -1,0 +1,83 @@
+/**
+ * @file Test suite for AjvSchemaValidator initialization edge cases.
+ * @returns {void}
+ */
+/**
+ * Creates a mock logger.
+ *
+ * @returns {object} mock logger
+ */
+function createMockLogger() {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+describe('AjvSchemaValidator initialization edge cases', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('ajv');
+    jest.dontMock('ajv-formats');
+  });
+
+  it('throws when Ajv constructor fails', () => {
+    jest.doMock('ajv', () => {
+      return jest.fn(() => {
+        throw new Error('boom');
+      });
+    });
+    jest.doMock('ajv-formats', () => jest.fn());
+    const logger = createMockLogger();
+    const AjvSchemaValidator =
+      require('../../src/validation/ajvSchemaValidator.js').default;
+    expect(() => new AjvSchemaValidator(logger)).toThrow(
+      'AjvSchemaValidator: Failed to initialize Ajv.'
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'AjvSchemaValidator: CRITICAL - Failed to instantiate Ajv or add formats:',
+      expect.any(Error)
+    );
+  });
+
+  it('does not add schema if it already exists', () => {
+    const addSchema = jest.fn();
+    const getSchema = jest.fn(() => ({}));
+    jest.doMock('ajv', () =>
+      jest.fn(() => ({ addSchema, getSchema, removeSchema: jest.fn() }))
+    );
+    jest.doMock('ajv-formats', () => jest.fn());
+    const logger = createMockLogger();
+    const AjvSchemaValidator =
+      require('../../src/validation/ajvSchemaValidator.js').default;
+    new AjvSchemaValidator(logger);
+    expect(addSchema).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('already loaded. Skipping.')
+    );
+  });
+
+  it('logs an error when preloading schema fails', () => {
+    const getSchema = jest.fn(() => null);
+    const addSchema = jest.fn(() => {
+      throw new Error('add fail');
+    });
+    jest.doMock('ajv', () =>
+      jest.fn(() => ({ addSchema, getSchema, removeSchema: jest.fn() }))
+    );
+    jest.doMock('ajv-formats', () => jest.fn());
+    const logger = createMockLogger();
+    const AjvSchemaValidator =
+      require('../../src/validation/ajvSchemaValidator.js').default;
+    new AjvSchemaValidator(logger);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to preload schema'),
+      expect.objectContaining({
+        schemaId: expect.any(String),
+        error: expect.any(Error),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added new Jest suites covering utility export integrity and AjvSchemaValidator initialization edge cases.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6850797ab2f883319f3a3c54690f97b1