### PR TITLE
[Agent] add BaseService init helper

### DIFF
--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -1,9 +1,7 @@
 // src/logic/jsonLogicEvaluationService.js
 import jsonLogic from 'json-logic-js';
-import {
-  setupService,
-  validateServiceDeps,
-} from '../utils/serviceInitializerUtils.js';
+import { validateServiceDeps } from '../utils/serviceInitializerUtils.js';
+import BaseService from '../utils/baseService.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -45,7 +43,7 @@ function warnOnBracketPaths(rule, logger) {
  * @class JsonLogicEvaluationService
  * Encapsulates the evaluation of JSON Logic rules, including resolving condition_ref references.
  */
-class JsonLogicEvaluationService {
+class JsonLogicEvaluationService extends BaseService {
   /** @private @type {ILogger} */
   #logger;
   /** @private @type {IGameDataRepository} */
@@ -60,7 +58,8 @@ class JsonLogicEvaluationService {
    * @throws {Error} If required dependencies are missing or invalid.
    */
   constructor({ logger, gameDataRepository } = {}) {
-    this.#logger = setupService('JsonLogicEvaluationService', logger);
+    super();
+    this.#logger = this._init('JsonLogicEvaluationService', logger);
 
     if (!gameDataRepository) {
       this.#logger.warn(

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -4,7 +4,7 @@
 // -----------------------------------------------------------------------------
 
 import { resolvePlaceholders } from '../utils/contextUtils.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import BaseService from '../utils/baseService.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */
 /** @typedef {import('./defs.js').ExecutionContext}                               ExecutionContext */
@@ -13,12 +13,13 @@ import { setupService } from '../utils/serviceInitializerUtils.js';
 
 const ACTION_ARRAY_KEYS = new Set(['then_actions', 'else_actions', 'actions']);
 
-class OperationInterpreter {
+class OperationInterpreter extends BaseService {
   /** @type {ILogger} */ #logger;
   /** @type {OperationRegistry} */ #registry;
 
   constructor({ logger, operationRegistry }) {
-    this.#logger = setupService('OperationInterpreter', logger, {
+    super();
+    this.#logger = this._init('OperationInterpreter', logger, {
       operationRegistry: {
         value: operationRegistry,
         requiredMethods: ['getHandler'],

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -4,9 +4,9 @@
 
 /** @typedef {import('./defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import BaseService from '../utils/baseService.js';
 
-class OperationRegistry {
+class OperationRegistry extends BaseService {
   /** @type {Map<string, OperationHandler>} */ #registry = new Map();
   /** @type {ILogger|null}                  */ #logger = null;
 
@@ -17,7 +17,8 @@ class OperationRegistry {
    * @param {ILogger} [options.logger] - Logging service.
    */
   constructor({ logger } = {}) {
-    this.#logger = setupService('OperationRegistry', logger);
+    super();
+    this.#logger = this._init('OperationRegistry', logger);
     this.#logger.info('OperationRegistry initialized.');
   }
 

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -8,7 +8,7 @@ import { createJsonLogicContext } from './contextAssembler.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import BaseService from '../utils/baseService.js';
 import { executeActionSequence } from './actionSequence.js';
 
 /* ---------------------------------------------------------------------------
@@ -27,7 +27,7 @@ import { executeActionSequence } from './actionSequence.js';
 /* ---------------------------------------------------------------------------
  * Class
  * ------------------------------------------------------------------------- */
-class SystemLogicInterpreter {
+class SystemLogicInterpreter extends BaseService {
   /** @type {ILogger} */ #logger;
   /** @type {EventBus} */ #eventBus;
   /** @type {IDataRegistry} */ #dataRegistry;
@@ -47,7 +47,8 @@ class SystemLogicInterpreter {
     entityManager,
     operationInterpreter,
   }) {
-    this.#logger = setupService('SystemLogicInterpreter', logger, {
+    super();
+    this.#logger = this._init('SystemLogicInterpreter', logger, {
       eventBus: {
         value: eventBus,
         requiredMethods: ['subscribe', 'unsubscribe'],

--- a/src/utils/baseService.js
+++ b/src/utils/baseService.js
@@ -1,0 +1,26 @@
+// src/utils/baseService.js
+
+import { setupService } from './serviceInitializerUtils.js';
+
+/**
+ * @class BaseService
+ * @description Provides a protected helper for initializing service loggers
+ * and validating dependencies using {@link setupService}.
+ */
+export class BaseService {
+  /**
+   * Initialize the service's logger and validate dependencies.
+   *
+   * @protected
+   * @param {string} serviceName - Name used for log prefixing and validation messages.
+   * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger instance.
+   * @param {Record<string, import('./serviceInitializerUtils.js').DependencySpec>} [deps]
+   *   - Map of dependency specifications to validate.
+   * @returns {import('../interfaces/coreServices.js').ILogger} The initialized logger.
+   */
+  _init(serviceName, logger, deps) {
+    return setupService(serviceName, logger, deps);
+  }
+}
+
+export default BaseService;


### PR DESCRIPTION
Summary: Implemented BaseService with protected `_init` for standardized service setup. Updated SystemLogicInterpreter, OperationRegistry, OperationInterpreter and JsonLogicEvaluationService to extend this base class and invoke `_init`. Removed direct `setupService` usage in these constructors.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685078da832083318f99b6b3ddce7a33