### PR TITLE
[Agent] verify message rendering via helper spy

### DIFF
--- a/tests/domUI/baseListDisplayComponent.test.js
+++ b/tests/domUI/baseListDisplayComponent.test.js
@@ -14,6 +14,7 @@ import { DomUtils } from '../../src/utils/domUtils.js';
 import DocumentContext from '../../src/domUI/documentContext.js';
 import DomElementFactory from '../../src/domUI/domElementFactory.js';
 import { BoundDomRendererBase } from '../../src/domUI/boundDomRendererBase.js'; // For spyOn prototype
+import * as createMessageElementModule from '../../src/domUI/helpers/createMessageElement.js';
 
 // Mock DomUtils
 jest.mock('../../src/utils/domUtils.js', () => ({
@@ -40,6 +41,8 @@ describe('BaseListDisplayComponent', () => {
   let mockDocumentContext;
   let mockValidatedEventDispatcher;
   let mockDomElementFactory;
+  /** @type {jest.SpiedFunction<typeof createMessageElementModule.createMessageElement>} */
+  let createMessageElementSpy;
   let listContainerElement;
   let dom;
   let mockWindow; // Added
@@ -76,6 +79,7 @@ describe('BaseListDisplayComponent', () => {
     mockDomElementFactory = new DomElementFactory(mockDocumentContext);
     jest.spyOn(mockDomElementFactory, 'p');
     jest.spyOn(mockDomElementFactory, 'create');
+    createMessageElementSpy = jest.spyOn(createMessageElementModule, 'default');
 
     // Reset DomUtils mocks
     DomUtils.clearElement.mockClear();
@@ -83,6 +87,9 @@ describe('BaseListDisplayComponent', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    if (createMessageElementSpy) {
+      createMessageElementSpy.mockRestore();
+    }
     // ---- START Global Cleanup ----
     if (mockWindow) mockWindow.close();
     global.window = undefined;
@@ -190,12 +197,13 @@ describe('BaseListDisplayComponent', () => {
 
         const mockParagraph = dom.window.document.createElement('p');
         mockParagraph.textContent = emptyMsg;
-        mockDomElementFactory.p.mockReturnValue(mockParagraph);
+        createMessageElementSpy.mockReturnValue(mockParagraph);
 
         await instance.renderList();
 
         expect(instance._getEmptyListMessage).toHaveBeenCalledTimes(1);
-        expect(mockDomElementFactory.p).toHaveBeenCalledWith(
+        expect(createMessageElementSpy).toHaveBeenCalledWith(
+          mockDomElementFactory,
           'empty-list-message',
           emptyMsg
         );

--- a/tests/domUI/perceptionLogRenderer.test.js
+++ b/tests/domUI/perceptionLogRenderer.test.js
@@ -11,6 +11,7 @@ import {
 import { JSDOM } from 'jsdom';
 import { PerceptionLogRenderer } from '../../src/domUI/perceptionLogRenderer.js';
 import { TURN_STARTED_ID } from '../../src/constants/eventIds.js';
+import * as createMessageElementModule from '../../src/domUI/helpers/createMessageElement.js';
 
 jest.mock('../../src/logging/consoleLogger.js');
 jest.mock('../../src/events/validatedEventDispatcher.js');
@@ -26,6 +27,8 @@ describe('PerceptionLogRenderer', () => {
   let mockLogger;
   let mockVed;
   let mockDomElementFactoryInstance;
+  /** @type {jest.SpiedFunction<typeof createMessageElementModule.createMessageElement>} */
+  let createMessageElementSpy;
   let mockEntityManager;
   let mockDocumentContext;
   let listContainerElementInDom;
@@ -121,6 +124,8 @@ describe('PerceptionLogRenderer', () => {
         return p;
       }),
     };
+
+    createMessageElementSpy = jest.spyOn(createMessageElementModule, 'default');
 
     mockEntityManager = {
       getEntityInstance: jest.fn(),
@@ -401,7 +406,7 @@ describe('PerceptionLogRenderer', () => {
         .mockRejectedValue(new Error('Simulated refreshList failure'));
 
       mockLogger.error.mockClear(); // Clear previous logs
-      mockDomElementFactoryInstance.p.mockClear();
+      createMessageElementSpy.mockClear();
       if (listContainerElementInDom)
         listContainerElementInDom.appendChild.mockClear();
 
@@ -420,16 +425,17 @@ describe('PerceptionLogRenderer', () => {
         ),
         expect.objectContaining({ message: 'Simulated refreshList failure' })
       );
-      expect(mockDomElementFactoryInstance.p).toHaveBeenCalledWith(
+      expect(createMessageElementSpy).toHaveBeenCalledWith(
+        mockDomElementFactoryInstance,
         'error-message',
         'Error updating perception log.'
       );
       if (
         listContainerElementInDom &&
-        mockDomElementFactoryInstance.p.mock.results[0]
+        createMessageElementSpy.mock.results[0]
       ) {
         expect(listContainerElementInDom.appendChild).toHaveBeenCalledWith(
-          mockDomElementFactoryInstance.p.mock.results[0].value
+          createMessageElementSpy.mock.results[0].value
         );
       }
     });
@@ -479,16 +485,17 @@ describe('PerceptionLogRenderer', () => {
       createRenderer();
       await flushPromises();
 
-      expect(mockDomElementFactoryInstance.p).toHaveBeenCalledWith(
+      expect(createMessageElementSpy).toHaveBeenCalledWith(
+        mockDomElementFactoryInstance,
         'empty-list-message',
         'No actor selected.'
       );
       if (
         listContainerElementInDom &&
-        mockDomElementFactoryInstance.p.mock.results[0]
+        createMessageElementSpy.mock.results[0]
       ) {
         expect(listContainerElementInDom.appendChild).toHaveBeenCalledWith(
-          mockDomElementFactoryInstance.p.mock.results[0].value
+          createMessageElementSpy.mock.results[0].value
         );
       }
     });


### PR DESCRIPTION
Summary: Updated tests to spy on the `createMessageElement` helper instead of direct DOM factory calls. Adjusted expectations in `baseListDisplayComponent` and `perceptionLogRenderer` to assert the helper is invoked with the DOM factory and message details. Ensured spies are restored between tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685078ba3834833195acf7c4628607e2