### PR TITLE
[Agent] add actor name-position condition

### DIFF
--- a/data/mods/core/conditions/actor-has-name-and-position.condition.json
+++ b/data/mods/core/conditions/actor-has-name-and-position.condition.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "core:actor-has-name-and-position",
+  "description": "Checks that the actor has both the 'core:name' and 'core:position' components.",
+  "logic": {
+    "and": [
+      { "!!": { "var": "actor.components.core:name" } },
+      { "!!": { "var": "actor.components.core:position" } }
+    ]
+  }
+}

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -108,7 +108,8 @@
       "target-is-in-same-location-as-actor.condition.json",
       "target-is-not-rooted.condition.json",
       "target-is-not-self.condition.json",
-      "way-is-not-blocked.condition.json"
+      "way-is-not-blocked.condition.json",
+      "actor-has-name-and-position.condition.json"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add new condition to check that actors have name and position components
- register the condition in `core` manifest

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2506 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68507e363f4883318d0101913184c638