### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -24,12 +24,19 @@ function setPath(obj, path, value) {
   let current = obj;
   for (let i = 0; i < pathParts.length - 1; i++) {
     const part = pathParts[i];
+    if (part === "__proto__" || part === "constructor") {
+      throw new Error(`Unsafe property name detected: ${part}`);
+    }
     if (current[part] === undefined || typeof current[part] !== 'object') {
       current[part] = {};
     }
     current = current[part];
   }
-  current[pathParts[pathParts.length - 1]] = value;
+  const lastPart = pathParts[pathParts.length - 1];
+  if (lastPart === "__proto__" || lastPart === "constructor") {
+    throw new Error(`Unsafe property name detected: ${lastPart}`);
+  }
+  current[lastPart] = value;
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/1](https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/1)

To fix the issue, the `setPath` function should be updated to block assignment to dangerous property names like `__proto__` and `constructor`. This can be achieved by adding a check to skip these property names during the recursive assignment process. This approach ensures that the function remains safe against prototype pollution while preserving its existing functionality.

The changes will be made in the `setPath` function within the file `src/logic/operationHandlers/modifyContextArrayHandler.js`. Specifically:
1. Add a check to skip dangerous property names (`__proto__` and `constructor`) during the loop that processes `pathParts`.
2. Ensure that the function does not modify `Object.prototype` or other global objects.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
