### PR TITLE
[Agent] Add dispatcher resolver helper

### DIFF
--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -2,7 +2,7 @@
 
 import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
-import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
+import { resolveSafeDispatcher } from './dispatcherUtils.js';
 
 /**
  * Safely stores a value into `execCtx.evaluationContext.context`. If the context
@@ -19,18 +19,7 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  */
 export function storeResult(variableName, value, execCtx, dispatcher, logger) {
   const log = getModuleLogger('contextVariableUtils', logger);
-
-  let safeDispatcher = dispatcher;
-  if (!safeDispatcher && execCtx?.validatedEventDispatcher) {
-    try {
-      safeDispatcher = new SafeEventDispatcher({
-        validatedEventDispatcher: execCtx.validatedEventDispatcher,
-        logger: log,
-      });
-    } catch {
-      safeDispatcher = null;
-    }
-  }
+  const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
 
   const hasContext =
     execCtx?.evaluationContext &&
@@ -89,17 +78,7 @@ export function setContextValue(
   const log = getModuleLogger('contextVariableUtils', logger);
 
   if (!trimmedName) {
-    let safeDispatcher = dispatcher;
-    if (!safeDispatcher && execCtx?.validatedEventDispatcher) {
-      try {
-        safeDispatcher = new SafeEventDispatcher({
-          validatedEventDispatcher: execCtx.validatedEventDispatcher,
-          logger: log,
-        });
-      } catch {
-        safeDispatcher = null;
-      }
-    }
+    const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
 
     if (safeDispatcher) {
       safeDispatchError(

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -1,0 +1,39 @@
+// src/utils/dispatcherUtils.js
+
+import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
+
+/**
+ * Resolves a usable ISafeEventDispatcher instance.
+ *
+ * @description
+ * Returns the provided dispatcher when available. Otherwise, if the execution
+ * context contains a validatedEventDispatcher, a new SafeEventDispatcher is
+ * constructed using the supplied logger. Construction failures result in
+ * `null`.
+ * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] -
+ *   Optional pre-existing dispatcher.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the SafeEventDispatcher.
+ * @returns {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher | null}
+ *   The resolved dispatcher or `null` when unavailable.
+ */
+export function resolveSafeDispatcher(execCtx, dispatcher, logger) {
+  if (dispatcher) {
+    return dispatcher;
+  }
+
+  if (execCtx?.validatedEventDispatcher) {
+    try {
+      return new SafeEventDispatcher({
+        validatedEventDispatcher: execCtx.validatedEventDispatcher,
+        logger,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export default resolveSafeDispatcher;

--- a/tests/utils/dispatcherUtils.test.js
+++ b/tests/utils/dispatcherUtils.test.js
@@ -1,0 +1,39 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { resolveSafeDispatcher } from '../../src/utils/dispatcherUtils.js';
+import { SafeEventDispatcher } from '../../src/events/safeEventDispatcher.js';
+
+describe('resolveSafeDispatcher', () => {
+  test('returns provided dispatcher', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    expect(resolveSafeDispatcher({}, dispatcher)).toBe(dispatcher);
+  });
+
+  test('creates SafeEventDispatcher from execCtx', () => {
+    const validated = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    const execCtx = { validatedEventDispatcher: validated };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const result = resolveSafeDispatcher(execCtx, undefined, logger);
+    expect(result).toBeInstanceOf(SafeEventDispatcher);
+  });
+
+  test('returns null when creation fails', () => {
+    const execCtx = { validatedEventDispatcher: {} }; // missing required methods
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const result = resolveSafeDispatcher(execCtx, undefined, logger);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary: Introduces `resolveSafeDispatcher` to centralize creation of `SafeEventDispatcher` instances and updates context variable utilities to use it. Includes unit tests.

Changes Made:
- Added new `dispatcherUtils.js` with `resolveSafeDispatcher` helper.
- Updated `storeResult` and `setContextValue` to rely on the helper.
- Added tests for the new utility.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_68519853c0cc8331b24af3d00f06f6c2