### PR TITLE
[Agent] refactor bootstrap stage dependencies

### DIFF
--- a/src/bootstrapper/stages/containerStages.js
+++ b/src/bootstrapper/stages/containerStages.js
@@ -1,8 +1,6 @@
 // src/bootstrapper/stages/containerStages.js
 /* eslint-disable no-console */
 
-import AppContainer from '../../dependencyInjection/appContainer.js';
-
 // eslint-disable-next-line no-unused-vars
 import { tokens } from '../../dependencyInjection/tokens.js';
 
@@ -15,6 +13,7 @@ import { tokens } from '../../dependencyInjection/tokens.js';
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {typeof tokens} TokensObject */
 /** @typedef {import('../../types/stageResult.js').StageResult} StageResult */
+/** @typedef {import('../../dependencyInjection/appContainer.js').default} AppContainer */
 
 /**
  * Bootstrap Stage: Sets up the Dependency Injection (DI) container.
@@ -23,19 +22,16 @@ import { tokens } from '../../dependencyInjection/tokens.js';
  * @async
  * @param {EssentialUIElements} uiReferences - The object containing DOM element references.
  * @param {ConfigureContainerFunction} containerConfigFunc - A reference to the configureContainer function.
- * @param {(AppContainer|function(): AppContainer)} [containerOrFactory]
- *  - Instance or factory for an AppContainer.
+ * @param {{ createAppContainer: function(): AppContainer }} options
+ *  - Factory provider for an AppContainer instance.
  * @returns {Promise<StageResult>} Result object with the configured AppContainer on success.
  */
 export async function setupDIContainerStage(
   uiReferences,
   containerConfigFunc,
-  containerOrFactory = () => new AppContainer()
+  { createAppContainer }
 ) {
-  const container =
-    typeof containerOrFactory === 'function'
-      ? containerOrFactory()
-      : containerOrFactory;
+  const container = createAppContainer();
 
   try {
     containerConfigFunc(container, uiReferences);

--- a/src/bootstrapper/stages/engineStages.js
+++ b/src/bootstrapper/stages/engineStages.js
@@ -1,11 +1,10 @@
 // src/bootstrapper/stages/engineStages.js
 
-import GameEngine from '../../engine/gameEngine.js';
-import AppContainer from '../../dependencyInjection/appContainer.js';
-
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../types/stageResult.js').StageResult} StageResult */
 /** @typedef {import('../../engine/gameEngine.js').default} GameEngineInstance */
+/** @typedef {import('../../engine/gameEngine.js').default} GameEngine */
+/** @typedef {import('../../dependencyInjection/appContainer.js').default} AppContainer */
 
 /**
  * Bootstrap Stage: Initializes the GameEngine.
@@ -14,14 +13,14 @@ import AppContainer from '../../dependencyInjection/appContainer.js';
  * @async
  * @param {AppContainer} container - The configured AppContainer instance.
  * @param {ILogger} logger - The resolved ILogger instance.
- * @param {(function(new:GameEngine,object):GameEngine)|function(object):GameEngine|typeof GameEngine} [GameEngineCtorOrFactory]
- *  - GameEngine class or factory to instantiate.
+ * @param {{ createGameEngine: function(object): GameEngine }} options
+ *  - Factory provider for a GameEngine instance.
  * @returns {Promise<StageResult>} Result object with the GameEngine instance on success.
  */
 export async function initializeGameEngineStage(
   container,
   logger,
-  GameEngineCtorOrFactory = GameEngine
+  { createGameEngine }
 ) {
   logger.debug('Bootstrap Stage: Initializing GameEngine...');
   const currentPhase = 'GameEngine Initialization';
@@ -29,15 +28,7 @@ export async function initializeGameEngineStage(
   let gameEngine;
   try {
     logger.debug('GameEngine Stage: Creating GameEngine instance...');
-    if (
-      GameEngineCtorOrFactory &&
-      GameEngineCtorOrFactory.prototype &&
-      GameEngineCtorOrFactory.prototype.constructor
-    ) {
-      gameEngine = new GameEngineCtorOrFactory({ container });
-    } else {
-      gameEngine = GameEngineCtorOrFactory({ container });
-    }
+    gameEngine = createGameEngine({ container });
     if (!gameEngine) {
       throw new Error('GameEngine constructor returned null or undefined.');
     }

--- a/src/bootstrapper/stages/uiStages.js
+++ b/src/bootstrapper/stages/uiStages.js
@@ -1,7 +1,6 @@
 // src/bootstrapper/stages/uiStages.js
 /* eslint-disable no-console */
 
-import { UIBootstrapper } from '../UIBootstrapper.js';
 import { setupButtonListener } from '../helpers.js';
 
 // eslint-disable-next-line no-unused-vars
@@ -10,6 +9,7 @@ import { tokens } from '../../dependencyInjection/tokens.js';
 /**
  * @typedef {import('../UIBootstrapper.js').EssentialUIElements} EssentialUIElements
  */
+/** @typedef {import('../UIBootstrapper.js').UIBootstrapper} UIBootstrapper */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../engine/gameEngine.js').default} GameEngineInstance */
 /** @typedef {import('../../types/stageResult.js').StageResult} StageResult */
@@ -22,18 +22,15 @@ import { tokens } from '../../dependencyInjection/tokens.js';
  *
  * @async
  * @param {Document} doc - The global document object.
- * @param {(UIBootstrapper|function(): UIBootstrapper)} [uiBootstrapperOrFactory]
- *  - Instance or factory for a UIBootstrapper.
+ * @param {{ createUIBootstrapper: function(): UIBootstrapper }} options
+ *  - Factory provider for a UIBootstrapper instance.
  * @returns {Promise<StageResult>} Result object with gathered DOM elements on success.
  */
 export async function ensureCriticalDOMElementsStage(
   doc,
-  uiBootstrapperOrFactory = () => new UIBootstrapper()
+  { createUIBootstrapper }
 ) {
-  const uiBootstrapper =
-    typeof uiBootstrapperOrFactory === 'function'
-      ? uiBootstrapperOrFactory()
-      : uiBootstrapperOrFactory;
+  const uiBootstrapper = createUIBootstrapper();
   try {
     const essentialUIElements = uiBootstrapper.gatherEssentialElements(doc);
     return { success: true, payload: essentialUIElements };

--- a/src/main.js
+++ b/src/main.js
@@ -41,10 +41,9 @@ export async function bootstrapApp() {
   try {
     // STAGE 1: Ensure Critical DOM Elements
     currentPhaseForError = 'UI Element Validation';
-    const uiResult = await ensureCriticalDOMElementsStage(
-      document,
-      () => new UIBootstrapper()
-    );
+    const uiResult = await ensureCriticalDOMElementsStage(document, {
+      createUIBootstrapper: () => new UIBootstrapper(),
+    });
     if (!uiResult.success) throw uiResult.error;
     uiElements = uiResult.payload;
 
@@ -53,7 +52,9 @@ export async function bootstrapApp() {
     const diResult = await setupDIContainerStage(
       uiElements,
       configureContainer,
-      () => new AppContainer()
+      {
+        createAppContainer: () => new AppContainer(),
+      }
     );
     if (!diResult.success) throw diResult.error;
     container = diResult.payload;
@@ -70,11 +71,9 @@ export async function bootstrapApp() {
     // STAGE 4: Initialize Game Engine
     currentPhaseForError = 'Game Engine Initialization';
     logger.debug(`main.js: Executing ${currentPhaseForError} stage...`);
-    const engineResult = await initializeGameEngineStage(
-      container,
-      logger,
-      GameEngine
-    );
+    const engineResult = await initializeGameEngineStage(container, logger, {
+      createGameEngine: (opts) => new GameEngine(opts),
+    });
     if (!engineResult.success) throw engineResult.error;
     gameEngine = engineResult.payload;
     logger.debug(`main.js: ${currentPhaseForError} stage completed.`);

--- a/tests/bootstrapper/stages.additional.test.js
+++ b/tests/bootstrapper/stages.additional.test.js
@@ -30,7 +30,9 @@ afterEach(() => {
 describe('setupDIContainerStage', () => {
   it('configures the container using provided function', async () => {
     const configFn = jest.fn();
-    const result = await setupDIContainerStage({}, configFn);
+    const result = await setupDIContainerStage({}, configFn, {
+      createAppContainer: () => new AppContainer(),
+    });
     expect(result.success).toBe(true);
     expect(configFn).toHaveBeenCalledWith(result.payload, {});
     expect(result.payload).toBeInstanceOf(AppContainer);
@@ -40,7 +42,9 @@ describe('setupDIContainerStage', () => {
     const configFn = jest.fn(() => {
       throw new Error('fail');
     });
-    const result = await setupDIContainerStage({}, configFn);
+    const result = await setupDIContainerStage({}, configFn, {
+      createAppContainer: () => new AppContainer(),
+    });
     expect(result.success).toBe(false);
     expect(result.error.phase).toBe('DI Container Setup');
   });
@@ -50,7 +54,9 @@ describe('setupDIContainerStage', () => {
     const cont = new AppContainer();
     const factory = jest.fn(() => cont);
 
-    const result = await setupDIContainerStage({}, configFn, factory);
+    const result = await setupDIContainerStage({}, configFn, {
+      createAppContainer: factory,
+    });
 
     expect(factory).toHaveBeenCalled();
     expect(configFn).toHaveBeenCalledWith(cont, {});
@@ -96,7 +102,9 @@ describe('initializeGameEngineStage', () => {
   it('instantiates GameEngine with container', async () => {
     const logger = createLogger();
     const container = {};
-    const result = await initializeGameEngineStage(container, logger);
+    const result = await initializeGameEngineStage(container, logger, {
+      createGameEngine: (opts) => GameEngine(opts),
+    });
     expect(GameEngine).toHaveBeenCalledWith({ container });
     expect(result.success).toBe(true);
     expect(result.payload).toEqual({ mocked: true });
@@ -107,7 +115,9 @@ describe('initializeGameEngineStage', () => {
       throw new Error('bad');
     });
     const logger = createLogger();
-    const result = await initializeGameEngineStage({}, logger);
+    const result = await initializeGameEngineStage({}, logger, {
+      createGameEngine: (opts) => new GameEngine(opts),
+    });
     expect(result.success).toBe(false);
     expect(result.error.phase).toBe('GameEngine Initialization');
   });
@@ -118,7 +128,9 @@ describe('initializeGameEngineStage', () => {
     const engine = { custom: true };
     const factory = jest.fn(() => engine);
 
-    const result = await initializeGameEngineStage(container, logger, factory);
+    const result = await initializeGameEngineStage(container, logger, {
+      createGameEngine: factory,
+    });
 
     expect(factory).toHaveBeenCalledWith({ container });
     expect(result.success).toBe(true);
@@ -130,7 +142,9 @@ describe('initializeGameEngineStage', () => {
     const factory = jest.fn(() => null);
     factory.prototype = undefined;
 
-    const result = await initializeGameEngineStage({}, logger, factory);
+    const result = await initializeGameEngineStage({}, logger, {
+      createGameEngine: factory,
+    });
     expect(result.success).toBe(false);
     expect(result.error.phase).toBe('GameEngine Initialization');
   });

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -11,7 +11,9 @@ describe('ensureCriticalDOMElementsStage', () => {
     const mockElements = { root: document.body };
     const uiBoot = new UIBootstrapper();
     jest.spyOn(uiBoot, 'gatherEssentialElements').mockReturnValue(mockElements);
-    const result = await ensureCriticalDOMElementsStage(document, uiBoot);
+    const result = await ensureCriticalDOMElementsStage(document, {
+      createUIBootstrapper: () => uiBoot,
+    });
     expect(result.success).toBe(true);
     expect(result.payload).toBe(mockElements);
   });
@@ -24,7 +26,9 @@ describe('ensureCriticalDOMElementsStage', () => {
       .mockReturnValue(mockElements);
     const factory = jest.fn(() => inst);
 
-    const result = await ensureCriticalDOMElementsStage(document, factory);
+    const result = await ensureCriticalDOMElementsStage(document, {
+      createUIBootstrapper: factory,
+    });
 
     expect(factory).toHaveBeenCalled();
     expect(gatherSpy).toHaveBeenCalledWith(document);
@@ -32,13 +36,15 @@ describe('ensureCriticalDOMElementsStage', () => {
     expect(result.payload).toBe(mockElements);
   });
 
-  it('instantiates default UIBootstrapper when not provided', async () => {
+  it('uses provided createUIBootstrapper to instantiate', async () => {
     const mockElements = { root: document.body };
     const gatherSpy = jest
       .spyOn(UIBootstrapper.prototype, 'gatherEssentialElements')
       .mockReturnValue(mockElements);
 
-    const result = await ensureCriticalDOMElementsStage(document);
+    const result = await ensureCriticalDOMElementsStage(document, {
+      createUIBootstrapper: () => new UIBootstrapper(),
+    });
 
     expect(gatherSpy).toHaveBeenCalledWith(document);
     expect(result.success).toBe(true);
@@ -51,7 +57,9 @@ describe('ensureCriticalDOMElementsStage', () => {
     jest.spyOn(uiBoot, 'gatherEssentialElements').mockImplementation(() => {
       throw error;
     });
-    const result = await ensureCriticalDOMElementsStage(document, uiBoot);
+    const result = await ensureCriticalDOMElementsStage(document, {
+      createUIBootstrapper: () => uiBoot,
+    });
     expect(result.success).toBe(false);
     expect(result.error).toBeInstanceOf(Error);
     expect(result.error.message).toContain('fail');


### PR DESCRIPTION
## Summary
- inject dependency factories into bootstrapper stages
- provide default factories in main.js
- update tests for new stage signatures

## Testing
- `npm run lint` *(fails: 573 errors, 1936 warnings)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68519cfb84e08331bed0a70a6fb0c420