### PR TITLE
[Agent] remove duplicate actor turn handler registration

### DIFF
--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -6,7 +6,6 @@
  */
 
 import TurnManager from '../../turns/turnManager.js';
-import ActorTurnHandler from '../../turns/handlers/actorTurnHandler.js';
 import TurnHandlerResolver from '../../turns/services/turnHandlerResolver.js';
 import { TurnOrderService } from '../../turns/order/turnOrderService.js';
 import PromptCoordinator from '../../turns/prompting/promptCoordinator.js';
@@ -17,7 +16,7 @@ import { ConcreteTurnStateFactory } from '../../turns/factories/concreteTurnStat
 
 import { tokens } from '../tokens.js';
 import { Registrar } from '../registrarHelpers.js';
-import { INITIALIZABLE, SHUTDOWNABLE } from '../tags.js';
+import { INITIALIZABLE } from '../tags.js';
 import {
   PLAYER_COMPONENT_ID,
   ACTOR_COMPONENT_ID,
@@ -130,29 +129,6 @@ export function registerTurnLifecycle(container) {
         turnContextFactory: c.resolve(tokens.ITurnContextFactory),
         assertValidEntity: c.resolve(tokens.assertValidEntity),
       })
-  );
-
-  // ─────────────────── Player handler ────────────────────
-  r.tagged(SHUTDOWNABLE).transientFactory(
-    tokens.ActorTurnHandler,
-    (c) =>
-      new ActorTurnHandler({
-        logger: c.resolve(tokens.ILogger),
-        turnStateFactory: c.resolve(tokens.ITurnStateFactory),
-        commandProcessor: c.resolve(tokens.ICommandProcessor),
-        turnEndPort: c.resolve(tokens.ITurnEndPort),
-        promptCoordinator: c.resolve(tokens.IPromptCoordinator),
-        commandOutcomeInterpreter: c.resolve(tokens.ICommandOutcomeInterpreter),
-        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
-        turnStrategyFactory: c.resolve(tokens.HumanStrategyFactory), // <-- Injected factory
-        entityManager: c.resolve(tokens.IEntityManager),
-        turnContextBuilder: c.resolve(tokens.TurnContextBuilder), // <-- Injected builder
-      })
-  );
-  logger.debug(
-    `Turn Lifecycle Registration: Registered ActorTurnHandler with new strategy deps tagged ${SHUTDOWNABLE.join(
-      ', '
-    )}.`
   );
 
   // ────────────────── Resolver & manager ──────────────────

--- a/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
@@ -14,15 +14,11 @@ import { mock } from 'jest-mock-extended';
 import AppContainer from '../../../src/dependencyInjection/appContainer.js';
 import { registerTurnLifecycle } from '../../../src/dependencyInjection/registrations/turnLifecycleRegistrations.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import {
-  INITIALIZABLE,
-  SHUTDOWNABLE,
-} from '../../../src/dependencyInjection/tags.js';
+import { INITIALIZABLE } from '../../../src/dependencyInjection/tags.js';
 
 // Concrete Classes
 import { TurnOrderService } from '../../../src/turns/order/turnOrderService.js';
 import TurnManager from '../../../src/turns/turnManager.js';
-import ActorTurnHandler from '../../../src/turns/handlers/actorTurnHandler.js';
 import TurnHandlerResolver from '../../../src/turns/services/turnHandlerResolver.js';
 import { ConcreteTurnStateFactory } from '../../../src/turns/factories/concreteTurnStateFactory.js';
 import { ConcreteTurnContextFactory } from '../../../src/turns/factories/concreteTurnContextFactory.js';
@@ -42,7 +38,6 @@ describe('registerTurnLifecycle', () => {
     mockCommandProcessor,
     mockTurnEndPort,
     mockCommandOutcome,
-    mockCommandInput,
     mockAiTurnHandler,
     mockActionIndexer,
     mockTurnActionFactory,
@@ -64,7 +59,6 @@ describe('registerTurnLifecycle', () => {
     mockCommandProcessor = mock();
     mockTurnEndPort = mock();
     mockCommandOutcome = mock();
-    mockCommandInput = mock();
     mockAiTurnHandler = mock();
 
     mockActionIndexingService = {
@@ -131,11 +125,6 @@ describe('registerTurnLifecycle', () => {
       'Turn Lifecycle Registration: Registered Turn services and factories.'
     );
     expect(calls).toContain(
-      `Turn Lifecycle Registration: Registered ActorTurnHandler with new strategy deps tagged ${SHUTDOWNABLE.join(
-        ', '
-      )}.`
-    );
-    expect(calls).toContain(
       `Turn Lifecycle Registration: Registered ${tokens.TurnHandlerResolver} with singleton resolution.`
     );
     expect(calls).toContain(
@@ -173,12 +162,6 @@ describe('registerTurnLifecycle', () => {
       lifecycle: 'singletonFactory',
     },
     {
-      token: tokens.ActorTurnHandler,
-      Class: ActorTurnHandler,
-      lifecycle: 'transient',
-      tags: SHUTDOWNABLE,
-    },
-    {
       token: tokens.TurnHandlerResolver,
       Class: TurnHandlerResolver,
       lifecycle: 'singletonFactory',
@@ -199,23 +182,23 @@ describe('registerTurnLifecycle', () => {
       const instance = container.resolve(token);
       expect(instance).toBeInstanceOf(Class);
 
+      const instance2 = container.resolve(token);
+      expect(instance2).toBeInstanceOf(Class);
       if (lifecycle === 'transient') {
-        const instance2 = container.resolve(token);
-        expect(instance2).toBeInstanceOf(Class);
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(instance2).not.toBe(instance);
       } else {
-        expect(container.resolve(token)).toBe(instance);
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(instance2).toBe(instance);
       }
 
       const call = registerSpy.mock.calls.find((c) => c[0] === token);
       expect(call).toBeDefined();
-      if (token !== tokens.ActorTurnHandler) {
-        const opts = call[2] || {};
-        expect(opts.lifecycle).toBe(lifecycle);
+      const opts = call[2] || {};
+      expect(opts.lifecycle).toBe(lifecycle);
 
-        if (tags) expect(opts.tags).toEqual(tags);
-        else expect(opts.tags).toBeUndefined();
-      }
+      const expectedTags = tags ?? undefined;
+      expect(opts.tags).toEqual(expectedTags);
     }
   );
 


### PR DESCRIPTION
## Summary
- stop registering ActorTurnHandler in the turn lifecycle bundle
- adjust tests for new registration locations

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851a033ebf883319cedea1bedf32636