### PR TITLE
[Agent] add safe dispatcher helper

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -105,14 +105,20 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
         };
       }
 
-      try {
-        const dispatcher = turnContext.getSafeEventDispatcher();
-        await dispatcher.dispatch(ACTION_DECIDED_ID, payload);
-        logger.debug(`Dispatched ${ACTION_DECIDED_ID} for actor ${actor.id}`);
-      } catch (e) {
+      const dispatcher = this._getSafeEventDispatcher(turnContext);
+      if (dispatcher) {
+        try {
+          await dispatcher.dispatch(ACTION_DECIDED_ID, payload);
+          logger.debug(`Dispatched ${ACTION_DECIDED_ID} for actor ${actor.id}`);
+        } catch (e) {
+          logger.error(
+            `Failed to dispatch ${ACTION_DECIDED_ID} event for actor ${actor.id}`,
+            e
+          );
+        }
+      } else {
         logger.error(
-          `Failed to dispatch ${ACTION_DECIDED_ID} event for actor ${actor.id}`,
-          e
+          `${this.name}: No SafeEventDispatcher available to dispatch ${ACTION_DECIDED_ID} for actor ${actor.id}.`
         );
       }
 

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -65,11 +65,10 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     // --- REFACTORED: Use SafeEventDispatcher directly ---
     // The context now provides the dispatcher directly, bypassing the problematic manager.
     // The returned unsubscribe function is stored and used identically to before.
-    this.#unsubscribeFn = ctx
-      .getSafeEventDispatcher()
-      .subscribe(TURN_ENDED_ID, (event) =>
-        this.handleTurnEndedEvent(handler, event)
-      );
+    const dispatcher = this._getSafeEventDispatcher(ctx);
+    this.#unsubscribeFn = dispatcher?.subscribe(TURN_ENDED_ID, (event) =>
+      this.handleTurnEndedEvent(handler, event)
+    );
 
     // mark context
     ctx.setAwaitingExternalEvent(true, ctx.getActor().id);
@@ -143,7 +142,8 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     );
 
     // 1) tell the UI / console
-    ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
+    const dispatcher = this._getSafeEventDispatcher(ctx, handler);
+    dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
       message: msg,
       details: {
         code: err.code,

--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -37,15 +37,7 @@ export async function getServiceFromContext(
     return null;
   }
   const logger = turnCtx.getLogger();
-  let dispatcher = null;
-  if (typeof turnCtx.getSafeEventDispatcher === 'function') {
-    dispatcher = turnCtx.getSafeEventDispatcher();
-  } else if (
-    state._handler?.safeEventDispatcher &&
-    typeof state._handler.safeEventDispatcher.dispatch === 'function'
-  ) {
-    dispatcher = state._handler.safeEventDispatcher;
-  }
+  const dispatcher = state._getSafeEventDispatcher(turnCtx);
   try {
     if (typeof turnCtx[methodName] !== 'function') {
       throw new Error(

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -48,21 +48,11 @@ export async function handleProcessingException(
     error
   );
 
-  /** @type {ISafeEventDispatcher | undefined} */
-  let systemErrorDispatcher;
-  if (turnCtx && typeof turnCtx.getSafeEventDispatcher === 'function') {
-    systemErrorDispatcher = turnCtx.getSafeEventDispatcher();
-  } else if (
-    state._handler &&
-    typeof state._handler.safeEventDispatcher === 'object' &&
-    state._handler.safeEventDispatcher !== null &&
-    typeof state._handler.safeEventDispatcher.dispatch === 'function'
-  ) {
-    logger.warn(
-      `${state.getStateName()}: SafeEventDispatcher not found on TurnContext for actor ${currentActorIdForLog}. Attempting to use this._handler.safeEventDispatcher.`
-    );
-    systemErrorDispatcher = state._handler.safeEventDispatcher;
-  }
+  /** @type {ISafeEventDispatcher | null} */
+  const systemErrorDispatcher = state._getSafeEventDispatcher(
+    turnCtx,
+    state._handler
+  );
 
   if (systemErrorDispatcher) {
     try {

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -23,7 +23,10 @@ export class TurnEndingState extends AbstractTurnState {
 
     const log = this._resolveLogger(null, handler);
 
-    const dispatcher = handler.getTurnContext?.()?.getSafeEventDispatcher?.();
+    const dispatcher = this._getSafeEventDispatcher(
+      handler.getTurnContext?.(),
+      handler
+    );
 
     if (!actorToEndId) {
       const message =
@@ -63,14 +66,17 @@ export class TurnEndingState extends AbstractTurnState {
       try {
         await ctx.getTurnEndPort().notifyTurnEnded(this.#actorToEndId, success);
       } catch (err) {
-        ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-          message: `TurnEndingState: Failed notifying TurnEndPort for actor ${this.#actorToEndId}: ${err.message}`,
-          details: {
-            actorId: this.#actorToEndId,
-            stack: err.stack,
-            error: err.message,
-          },
-        });
+        this._getSafeEventDispatcher(ctx, handler)?.dispatch(
+          SYSTEM_ERROR_OCCURRED_ID,
+          {
+            message: `TurnEndingState: Failed notifying TurnEndPort for actor ${this.#actorToEndId}: ${err.message}`,
+            details: {
+              actorId: this.#actorToEndId,
+              stack: err.stack,
+              error: err.message,
+            },
+          }
+        );
       }
     } else {
       const reason = !ctx
@@ -146,14 +152,17 @@ export class TurnEndingState extends AbstractTurnState {
       try {
         await ctx.requestIdleStateTransition();
       } catch (err) {
-        ctx.getSafeEventDispatcher?.().dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-          message: `TurnEndingState: Failed forced transition to TurnIdleState during destroy for actor ${this.#actorToEndId}: ${err.message}`,
-          details: {
-            actorId: this.#actorToEndId,
-            stack: err.stack,
-            error: err.message,
-          },
-        });
+        this._getSafeEventDispatcher(ctx, handler)?.dispatch(
+          SYSTEM_ERROR_OCCURRED_ID,
+          {
+            message: `TurnEndingState: Failed forced transition to TurnIdleState during destroy for actor ${this.#actorToEndId}: ${err.message}`,
+            details: {
+              actorId: this.#actorToEndId,
+              stack: err.stack,
+              error: err.message,
+            },
+          }
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- centralize fallback logic for safe event dispatchers
- use new helper in awaitingActorDecisionState
- use new helper in awaitingExternalTurnEndState
- use new helper in turnEndingState
- update helper modules to use new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many known issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851a32d79088331b5ef818e04906bd5