### PR TITLE
[Agent] rename initLogger helper

### DIFF
--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -14,13 +14,15 @@ import {
 import { validateDependency } from './validationUtils.js';
 
 /**
- * Validates the provided logger and returns a prefixed logger instance.
+ * Validate the provided logger and return a prefixed logger instance.
  *
+ * @description Validates the provided logger and returns a prefixed logger
+ *   instance.
  * @param {string} serviceName - Name used for log prefix and error messages.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to validate.
  * @returns {import('../interfaces/coreServices.js').ILogger} Prefixed logger.
  */
-export function initLogger(serviceName, logger) {
+export function initPrefixedLogger(serviceName, logger) {
   const validated = baseInitLogger(serviceName, logger);
   return createPrefixedLogger(validated, `${serviceName}: `);
 }
@@ -45,8 +47,10 @@ export function validateServiceDeps(serviceName, logger, deps) {
 }
 
 /**
- * @description Convenience helper that initializes a service logger and
- * validates its dependencies in one step.
+ * Initialize a service logger and validate dependencies.
+ *
+ * @description Convenience helper that initializes a service logger via
+ *   {@link initPrefixedLogger} and validates its dependencies in one step.
  * @param {string} serviceName - The service name used for logger prefixing and
  *   validation messages.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to
@@ -57,7 +61,7 @@ export function validateServiceDeps(serviceName, logger, deps) {
  *   prefixed logger instance.
  */
 export function setupService(serviceName, logger, deps) {
-  const prefixedLogger = initLogger(serviceName, logger);
+  const prefixedLogger = initPrefixedLogger(serviceName, logger);
   validateServiceDeps(serviceName, prefixedLogger, deps);
   return prefixedLogger;
 }

--- a/tests/utils/serviceInitializerUtils.test.js
+++ b/tests/utils/serviceInitializerUtils.test.js
@@ -8,7 +8,7 @@ import {
 } from '@jest/globals';
 
 import {
-  initLogger,
+  initPrefixedLogger,
   validateServiceDeps,
   setupService,
 } from '../../src/utils/serviceInitializerUtils.js';
@@ -51,9 +51,9 @@ describe('serviceInitializer utilities', () => {
     jest.resetAllMocks();
   });
 
-  describe('initLogger', () => {
+  describe('initPrefixedLogger', () => {
     it('validates and returns a prefixed logger', () => {
-      const logger = initLogger('MyService', baseLogger);
+      const logger = initPrefixedLogger('MyService', baseLogger);
       expect(baseInitLogger).toHaveBeenCalledWith('MyService', baseLogger);
       expect(createPrefixedLogger).toHaveBeenCalledWith(
         baseLogger,
@@ -66,7 +66,7 @@ describe('serviceInitializer utilities', () => {
       baseInitLogger.mockImplementation(() => {
         throw new Error('bad');
       });
-      expect(() => initLogger('FailService', null)).toThrow('bad');
+      expect(() => initPrefixedLogger('FailService', null)).toThrow('bad');
     });
   });
 


### PR DESCRIPTION
Summary: Rename `initLogger` in serviceInitializerUtils to `initPrefixedLogger` with updated JSDoc and tests.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 566 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851a7b81b3c833199a0d7f655b20321