### PR TITLE
[Agent] use shared display name util

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -1,6 +1,6 @@
 // src/utils/contextUtils.js
 import { resolvePath } from './objectUtils.js';
-import { NAME_COMPONENT_ID } from '../constants/componentIds.js';
+import { getEntityDisplayName } from './entityUtils.js';
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 
 // Regex to find placeholders like {path.to.value} within a string.
@@ -41,8 +41,19 @@ export function resolveEntityNameFallback(
     return undefined; // Not a recognized shorthand, so no fallback applies.
   }
 
-  // Safely access the name component's text property using optional chaining.
-  const name = entity?.components?.[NAME_COMPONENT_ID]?.text;
+  if (!entity) return undefined;
+
+  // If entity lacks getComponentData, provide a simple adapter so
+  // getEntityDisplayName can still read from the components object.
+  const adaptedEntity =
+    typeof entity.getComponentData === 'function'
+      ? entity
+      : {
+          ...entity,
+          getComponentData: (type) => entity?.components?.[type],
+        };
+
+  const name = getEntityDisplayName(adaptedEntity, undefined, logger);
 
   if (typeof name === 'string') {
     logger?.debug(

--- a/tests/logic/contextUtils.test.js
+++ b/tests/logic/contextUtils.test.js
@@ -495,12 +495,24 @@ describe('resolvePlaceholders (contextUtils.js)', () => {
       );
     });
 
-    test('should return undefined when component missing', () => {
+    test('should fall back to entity.name when component missing', () => {
       const context = createMockExecutionContext();
 
+      expect(resolveEntityNameFallback('actor.name', context, mockLogger)).toBe(
+        'ActorName'
+      );
+    });
+
+    test('should resolve target name via getEntityDisplayName', () => {
+      const targetData = {
+        id: 't1',
+        components: { [NAME_COMPONENT_ID]: { text: 'Villain' } },
+      };
+      const context = createMockExecutionContext({}, {}, null, targetData);
+
       expect(
-        resolveEntityNameFallback('actor.name', context, mockLogger)
-      ).toBeUndefined();
+        resolveEntityNameFallback('target.name', context, mockLogger)
+      ).toBe('Villain');
     });
   });
 });


### PR DESCRIPTION
Summary: Reuse existing display-name logic when resolving actor and target placeholders.

Changes Made:
- call `getEntityDisplayName` inside `resolveEntityNameFallback`
- adapt plain objects so the util works on mock data
- extend tests to cover new fallback behavior

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing repo lint errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851a7ad705483318781e48cf1ef3e32