### PR TITLE
[Agent] allow custom component cleaners

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -21,7 +21,9 @@ import { Registrar } from '../registrarHelpers.js';
 
 // --- Service Imports ---
 import PlaytimeTracker from '../../engine/playtimeTracker.js';
-import ComponentCleaningService from '../../persistence/componentCleaningService.js';
+import ComponentCleaningService, {
+  buildDefaultComponentCleaners,
+} from '../../persistence/componentCleaningService.js';
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../persistence/gameStateCaptureService.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
@@ -80,10 +82,14 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.PlaytimeTracker)}.`
   );
 
-  r.single(tokens.ComponentCleaningService, ComponentCleaningService, [
-    tokens.ILogger,
-    tokens.ISafeEventDispatcher,
-  ]);
+  r.singletonFactory(tokens.ComponentCleaningService, (c) => {
+    const logger = c.resolve(tokens.ILogger);
+    return new ComponentCleaningService({
+      logger,
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+      defaultCleaners: buildDefaultComponentCleaners(logger),
+    });
+  });
   logger.debug(
     `Persistence Registration: Registered ${String(tokens.ComponentCleaningService)}.`
   );

--- a/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -127,8 +127,7 @@ describe('registerPersistence', () => {
       {
         token: tokens.ComponentCleaningService,
         Class: ComponentCleaningService,
-        lifecycle: 'singleton',
-        deps: [tokens.ILogger, tokens.ISafeEventDispatcher],
+        lifecycle: 'singletonFactory',
       },
       {
         token: tokens.SaveMetadataBuilder,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -2,7 +2,9 @@ import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
-import ComponentCleaningService from '../../src/persistence/componentCleaningService.js';
+import ComponentCleaningService, {
+  buildDefaultComponentCleaners,
+} from '../../src/persistence/componentCleaningService.js';
 import receptionistDef from '../../data/mods/isekai/characters/receptionist.character.json';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -105,6 +107,7 @@ describe('Persistence round-trip', () => {
     componentCleaningService = new ComponentCleaningService({
       logger,
       safeEventDispatcher,
+      defaultCleaners: buildDefaultComponentCleaners(logger),
     });
     metadataBuilder = {
       build: jest.fn((n, p) => ({

--- a/tests/services/componentCleaningService.test.js
+++ b/tests/services/componentCleaningService.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import ComponentCleaningService from '../../src/persistence/componentCleaningService.js';
+import ComponentCleaningService, {
+  buildDefaultComponentCleaners,
+} from '../../src/persistence/componentCleaningService.js';
 import {
   NOTES_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
@@ -28,6 +30,7 @@ describe('ComponentCleaningService', () => {
     service = new ComponentCleaningService({
       logger,
       safeEventDispatcher: dispatcher,
+      defaultCleaners: buildDefaultComponentCleaners(logger),
     });
   });
 

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
-import ComponentCleaningService from '../../src/persistence/componentCleaningService.js';
+import ComponentCleaningService, {
+  buildDefaultComponentCleaners,
+} from '../../src/persistence/componentCleaningService.js';
 import {
   NOTES_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
@@ -51,6 +53,7 @@ describe('GamePersistenceService edge cases', () => {
     componentCleaningService = new ComponentCleaningService({
       logger,
       safeEventDispatcher,
+      defaultCleaners: buildDefaultComponentCleaners(logger),
     });
     metadataBuilder = {
       build: jest.fn((n, p) => {

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
-import ComponentCleaningService from '../../src/persistence/componentCleaningService.js';
+import ComponentCleaningService, {
+  buildDefaultComponentCleaners,
+} from '../../src/persistence/componentCleaningService.js';
 
 const makeLogger = () => ({
   info: jest.fn(),
@@ -44,6 +46,7 @@ describe('GamePersistenceService error paths', () => {
     componentCleaningService = new ComponentCleaningService({
       logger,
       safeEventDispatcher,
+      defaultCleaners: buildDefaultComponentCleaners(logger),
     });
     metadataBuilder = {
       build: jest.fn((n, p) => ({


### PR DESCRIPTION
## Summary
- inject default cleaners into `ComponentCleaningService`
- register default cleaners during DI setup
- update tests to supply default cleaners

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format`
- [x] `cd llm-proxy-server && npm run lint`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851a82496b883318913665c6e108687