### PR TITLE
[Feat] add modular condition definitions

### DIFF
--- a/data/mods/core/conditions/follow-cycle-detected.condition.json
+++ b/data/mods/core/conditions/follow-cycle-detected.condition.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "core:follow-cycle-detected",
+  "description": "True when a follow cycle has been detected in context.cycleCheck.",
+  "logic": { "var": "context.cycleCheck.cycleDetected" }
+}

--- a/data/mods/core/conditions/followers-to-move-exist.condition.json
+++ b/data/mods/core/conditions/followers-to-move-exist.condition.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "core:followers-to-move-exist",
+  "description": "True when context.followersToMove contains at least one ID.",
+  "logic": { ">": [{ "var": "context.followersToMove.length" }, 0] }
+}

--- a/data/mods/core/conditions/following-leader-is-event-entity.condition.json
+++ b/data/mods/core/conditions/following-leader-is-event-entity.condition.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "core:following-leader-is-event-entity",
+  "description": "Matches when a core:following component's leaderId equals the event entity.",
+  "logic": { "==": [{ "var": "leaderId" }, "{event.payload.entityId}"] }
+}

--- a/data/mods/core/conditions/resolved-target-location-null.condition.json
+++ b/data/mods/core/conditions/resolved-target-location-null.condition.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "core:resolved-target-location-null",
+  "description": "True when context.resolvedTargetLocationId is null.",
+  "logic": { "==": [{ "var": "context.resolvedTargetLocationId" }, null] }
+}

--- a/data/mods/core/mod.manifest.json
+++ b/data/mods/core/mod.manifest.json
@@ -107,7 +107,11 @@
       "target-is-not-rooted.condition.json",
       "target-is-not-self.condition.json",
       "way-is-not-blocked.condition.json",
-      "actor-has-name-and-position.condition.json"
+      "actor-has-name-and-position.condition.json",
+      "follow-cycle-detected.condition.json",
+      "following-leader-is-event-entity.condition.json",
+      "followers-to-move-exist.condition.json",
+      "resolved-target-location-null.condition.json"
     ]
   }
 }

--- a/data/mods/intimacy/conditions/room-has-kissing-pair.condition.json
+++ b/data/mods/intimacy/conditions/room-has-kissing-pair.condition.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://example.com/schemas/condition.schema.json",
+  "id": "intimacy:room-has-kissing-pair",
+  "description": "True when context.kissingEntities has two or more IDs and the moved entity is not among them.",
+  "logic": {
+    "and": [
+      { ">=": [{ "var": "context.kissingEntities.length" }, 2] },
+      {
+        "!": {
+          "in": [
+            { "var": "event.payload.entityId" },
+            { "var": "context.kissingEntities" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/data/mods/intimacy/mod.manifest.json
+++ b/data/mods/intimacy/mod.manifest.json
@@ -37,7 +37,8 @@
       "event-is-action-step-back.condition.json",
       "event-is-action-thumb-wipe-cheek.condition.json",
       "target-is-actors-closeness-partner.condition.json",
-      "target-is-in-actors-closeness-partners-list.condition.json"
+      "target-is-in-actors-closeness-partners-list.condition.json",
+      "room-has-kissing-pair.condition.json"
     ],
     "macros": []
   }


### PR DESCRIPTION
Summary: Added reusable condition files to support modular JSON logic. Updated core and intimacy manifests to include the new conditions.

Changes Made:
- Added follow-cycle, follower list, leader match, and target-location conditions under core mod.
- Added room-has-kissing-pair condition for intimacy mod.
- Registered new conditions in corresponding manifests.

Testing Done:
- [ ] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` *fails: 'process' is not defined*)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`) *(not run)*


------
https://chatgpt.com/codex/tasks/task_e_6850715fb2008331a074ed9a20f59327