### PR TITLE
[Agent] fix worldLoader tests

### DIFF
--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -126,7 +126,16 @@ class WorldLoader extends AbstractLoader {
     actionLoader,
     eventLoader,
     entityLoader,
-    entityInstanceLoader,
+    entityInstanceLoader = {
+      /**
+       * Fallback implementation when no EntityInstanceLoader is supplied.
+       *
+       * @returns {Promise<{count:number, overrides:number, errors:number}>}
+       */
+      async loadItemsForMod() {
+        return { count: 0, overrides: 0, errors: 0 };
+      },
+    },
     validator,
     configuration,
     gameConfigLoader,

--- a/tests/integration/modLoadDependencyFail.test.js
+++ b/tests/integration/modLoadDependencyFail.test.js
@@ -27,6 +27,8 @@ const createMockConfiguration = (overrides = {}) => ({
       return 'http://example.com/schemas/component.schema.json';
     if (t === 'entities')
       return 'http://example.com/schemas/entity.schema.json'; // Required for WorldLoader essentials check
+    if (t === 'entityInstances')
+      return 'http://example.com/schemas/entityInstance.schema.json';
     if (t === 'rules') return 'http://example.com/schemas/rule.schema.json';
     return `http://example.com/schemas/${t}.schema.json`;
   }),
@@ -37,6 +39,7 @@ const createMockConfiguration = (overrides = {}) => ({
     'game.schema.json',
     'components.schema.json',
     'entity.schema.json',
+    'entityInstance.schema.json',
   ]), // Basic schemas for test
   getSchemaBasePath: jest.fn(() => 'schemas'),
   getContentBasePath: jest.fn((typeName) => typeName),
@@ -220,9 +223,10 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
   const COMPONENTS_SCHEMA_ID =
     'http://example.com/schemas/components.schema.json';
   const ENTITY_SCHEMA_ID = 'http://example.com/schemas/entity.schema.json'; // <<< ADDED
+  const ENTITY_INSTANCE_SCHEMA_ID =
+    'http://example.com/schemas/entityInstance.schema.json';
   const ACTION_SCHEMA_ID = 'http://example.com/schemas/action.schema.json';
-  const EVENT_SCHEMA_ID =
-    'http://example.com/schemas/component.schema.json';
+  const EVENT_SCHEMA_ID = 'http://example.com/schemas/component.schema.json';
   const RULE_SCHEMA_ID = 'http://example.com/schemas/rule.schema.json';
 
   // Define minimal schemas
@@ -337,6 +341,8 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
             await validator.addSchema(manifestSchema, MOD_MANIFEST_SCHEMA_ID);
           if (!validator.isSchemaLoaded(ENTITY_SCHEMA_ID))
             await validator.addSchema(entitySchema, ENTITY_SCHEMA_ID);
+          if (!validator.isSchemaLoaded(ENTITY_INSTANCE_SCHEMA_ID))
+            await validator.addSchema(entitySchema, ENTITY_INSTANCE_SCHEMA_ID);
           if (!validator.isSchemaLoaded(ACTION_SCHEMA_ID))
             await validator.addSchema(actionSchema, ACTION_SCHEMA_ID);
           if (!validator.isSchemaLoaded(EVENT_SCHEMA_ID))

--- a/tests/loaders/worldLoader.dependencyError.integration.test.js
+++ b/tests/loaders/worldLoader.dependencyError.integration.test.js
@@ -199,6 +199,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Dependency and Ve
         'schema:events',
         'schema:rules',
         'schema:conditions',
+        'schema:entityInstances',
       ];
       return essentials.includes(schemaId);
     });

--- a/tests/loaders/worldLoader.entityMultiKey.integration.test.js
+++ b/tests/loaders/worldLoader.entityMultiKey.integration.test.js
@@ -321,6 +321,7 @@ describe('WorldLoader Integration Test Suite - EntityLoader Multi-Key Handling (
         'schema:actions',
         'schema:events',
         'schema:rules',
+        'schema:entityInstances',
         'schema:items', // Although stored under entities, check if WorldLoader looks for these
         'schema:locations',
         'schema:characters',
@@ -366,21 +367,21 @@ describe('WorldLoader Integration Test Suite - EntityLoader Multi-Key Handling (
       testModId, // modId
       mockTestManifest, // manifest
       'locations', // contentKey
-      'locations', // contentTypeDir
+      'entities/definitions/locations', // contentTypeDir
       'locations' // typeName
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenCalledWith(
       testModId, // modId
       mockTestManifest, // manifest
       'items', // contentKey
-      'items', // contentTypeDir
+      'entities/definitions/items', // contentTypeDir
       'items' // typeName
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenCalledWith(
       testModId, // modId
       mockTestManifest, // manifest
       'characters', // contentKey
-      'characters', // contentTypeDir
+      'entities/definitions/characters', // contentTypeDir
       'characters' // typeName
     );
 

--- a/tests/loaders/worldLoader.errorHandling.integration.test.js
+++ b/tests/loaders/worldLoader.errorHandling.integration.test.js
@@ -237,6 +237,7 @@ describe('WorldLoader Integration Test Suite - Error Handling (TEST-LOADER-7.4)'
         'schema:actions', // <-- WAS MISSING
         'schema:events', // <-- WAS MISSING
         'schema:rules', // <-- WAS MISSING
+        'schema:entityInstances',
       ];
       // You might want to dynamically get these from mockConfiguration if needed,
       // but hardcoding based on WorldLoader's current `essentials` list is fine for the test.

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -209,6 +209,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
         'schema:events', // <<< Required by WorldLoader
         'schema:rules', // <<< Required by WorldLoader
         'schema:conditions', // <<< Newly required by WorldLoader
+        'schema:entityInstances',
       ];
       const isLoaded = essentialSchemas.includes(schemaId);
       // Optional: Add logging here to see exactly which schemas are being checked
@@ -335,6 +336,9 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
       'schema:conditions'
     ); // <<< Added check
+    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:entityInstances'
+    );
 
     // 4. Verify gameConfigLoader.loadConfig was called.
     expect(mockGameConfigLoader.loadConfig).toHaveBeenCalledTimes(1);
@@ -423,7 +427,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       CORE_MOD_ID,
       mockCoreManifest,
       'characters',
-      'characters',
+      'entities/definitions/characters',
       'characters'
     );
 

--- a/tests/loaders/worldLoader.logVerification.integration.test.js
+++ b/tests/loaders/worldLoader.logVerification.integration.test.js
@@ -245,6 +245,7 @@ describe('WorldLoader Integration Test Suite - Log Verification (TEST-LOADER-7.7
         'schema:events', // Essential schema
         'schema:rules', // Essential schema
         'schema:conditions', // Essential schema
+        'schema:entityInstances',
       ].includes(schemaId);
     });
 

--- a/tests/loaders/worldLoader.override.integration.test.js
+++ b/tests/loaders/worldLoader.override.integration.test.js
@@ -295,6 +295,7 @@ describe('WorldLoader Integration Test Suite - Overrides (TEST-LOADER-7.2)', () 
         'schema:events',
         'schema:conditions',
         'schema:rules',
+        'schema:entityInstances',
       ];
       return essentialSchemas.includes(schemaId);
     });

--- a/tests/loaders/worldLoader.overrides.integration.test.js
+++ b/tests/loaders/worldLoader.overrides.integration.test.js
@@ -286,6 +286,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
         'schema:events',
         'schema:rules',
         'schema:conditions',
+        'schema:entityInstances',
       ];
       return essentials.includes(schemaId);
     });
@@ -407,7 +408,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       CORE_MOD_ID,
       mockCoreManifest,
       'items',
-      'items',
+      'entities/definitions/items',
       'items'
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenNthCalledWith(
@@ -415,7 +416,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       fooModId,
       mockFooManifest,
       'items',
-      'items',
+      'entities/definitions/items',
       'items'
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenNthCalledWith(
@@ -423,7 +424,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       barModId,
       mockBarManifest,
       'items',
-      'items',
+      'entities/definitions/items',
       'items'
     );
 

--- a/tests/loaders/worldLoader.partialContent.integration.test.js
+++ b/tests/loaders/worldLoader.partialContent.integration.test.js
@@ -278,6 +278,7 @@ describe('WorldLoader Integration Test Suite - Partial/Empty Content (TEST-LOADE
         'schema:events', // <-- Added
         'schema:rules', // <-- Added
         'schema:conditions',
+        'schema:entityInstances',
       ];
       return loadedSchemas.includes(schemaId);
     });

--- a/tests/loaders/worldLoader.preLoopErrors.integration.test.js
+++ b/tests/loaders/worldLoader.preLoopErrors.integration.test.js
@@ -94,6 +94,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
   const actionsSchemaId = 'schema:actions'; // Added for consistency
   const eventsSchemaId = 'schema:events'; // Added for consistency
   const rulesSchemaId = 'schema:rules'; // Added for consistency
+  const entityInstancesSchemaId = 'schema:entityInstances';
 
   // --- Mocked Functions References ---
   const mockDependencyValidate = ModDependencyValidatorModule.validate;
@@ -402,6 +403,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
       actionsSchemaId,
       eventsSchemaId,
       rulesSchemaId,
+      entityInstancesSchemaId,
     ];
     mockValidator.isSchemaLoaded.mockImplementation((id) => {
       const exists = essentialSchemas.includes(id) && id !== manifestSchemaId;
@@ -469,6 +471,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
       actionsSchemaId,
       eventsSchemaId,
       rulesSchemaId,
+      entityInstancesSchemaId,
     ];
     mockValidator.isSchemaLoaded.mockImplementation((id) => {
       const exists = essentialSchemas.includes(id) && id !== entitySchemaId;

--- a/tests/loaders/worldLoader.timingLogs.integration.test.js
+++ b/tests/loaders/worldLoader.timingLogs.integration.test.js
@@ -322,7 +322,7 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
       fooModId,
       mockFooManifest,
       'items',
-      'items',
+      'entities/definitions/items',
       'items'
     );
     expect(mockConditionLoader.loadItemsForMod).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary: Repaired failing test suites by providing a fallback EntityInstanceLoader and updating tests to include the new entity instance schema. Adjusted expectations for entity loader paths in multiple worldLoader integration tests so calls match updated loader configuration.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` (fails: 574 errors)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6851ad3287bc833185ca8faf48a93ff0