### PR TITLE
[Agent] Introduce stage error helpers

### DIFF
--- a/src/bootstrapper/auxiliaryStages.js
+++ b/src/bootstrapper/auxiliaryStages.js
@@ -5,7 +5,12 @@
  *
  * @module auxiliaryStages
  */
-import { resolveAndInitialize } from './helpers.js';
+import {
+  resolveAndInitialize,
+  stageSuccess,
+  stageFailure,
+  createStageError,
+} from './helpers.js';
 
 /**
  * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer
@@ -84,14 +89,13 @@ export function initLlmSelectionModal({ container, logger, tokens }) {
     const modal = container.resolve(tokens.LlmSelectionModal);
     if (modal) {
       logger.debug(`${stage}: Resolved successfully.`);
-      return { success: true };
+      return stageSuccess();
     }
-    const err = new Error('LlmSelectionModal could not be resolved.');
-    logger.warn(`${stage}: ${err.message}`);
-    return { success: false, error: err };
+    logger.warn(`${stage}: LlmSelectionModal could not be resolved.`);
+    return stageFailure(stage, 'LlmSelectionModal could not be resolved.');
   } catch (err) {
     logger.error(`${stage}: Error during resolution.`, err);
-    return { success: false, error: err };
+    return stageFailure(stage, err.message, err);
   }
 }
 
@@ -108,14 +112,16 @@ export function initCurrentTurnActorRenderer({ container, logger, tokens }) {
     const renderer = container.resolve(tokens.CurrentTurnActorRenderer);
     if (renderer) {
       logger.debug(`${stage}: Resolved successfully.`);
-      return { success: true };
+      return stageSuccess();
     }
-    const err = new Error('CurrentTurnActorRenderer could not be resolved.');
-    logger.warn(`${stage}: ${err.message}`);
-    return { success: false, error: err };
+    logger.warn(`${stage}: CurrentTurnActorRenderer could not be resolved.`);
+    return stageFailure(
+      stage,
+      'CurrentTurnActorRenderer could not be resolved.'
+    );
   } catch (err) {
     logger.error(`${stage}: Error during resolution.`, err);
-    return { success: false, error: err };
+    return stageFailure(stage, err.message, err);
   }
 }
 
@@ -132,14 +138,13 @@ export function initSpeechBubbleRenderer({ container, logger, tokens }) {
     const renderer = container.resolve(tokens.SpeechBubbleRenderer);
     if (renderer) {
       logger.debug(`${stage}: Resolved successfully.`);
-      return { success: true };
+      return stageSuccess();
     }
-    const err = new Error('SpeechBubbleRenderer could not be resolved.');
-    logger.warn(`${stage}: ${err.message}`);
-    return { success: false, error: err };
+    logger.warn(`${stage}: SpeechBubbleRenderer could not be resolved.`);
+    return stageFailure(stage, 'SpeechBubbleRenderer could not be resolved.');
   } catch (err) {
     logger.error(`${stage}: Error during resolution.`, err);
-    return { success: false, error: err };
+    return stageFailure(stage, err.message, err);
   }
 }
 
@@ -160,16 +165,18 @@ export function initProcessingIndicatorController({
     const ctrl = container.resolve(tokens.ProcessingIndicatorController);
     if (ctrl) {
       logger.debug(`${stage}: Resolved successfully.`);
-      return { success: true };
+      return stageSuccess();
     }
-    const err = new Error(
+    logger.warn(
+      `${stage}: ProcessingIndicatorController could not be resolved.`
+    );
+    return stageFailure(
+      stage,
       'ProcessingIndicatorController could not be resolved.'
     );
-    logger.warn(`${stage}: ${err.message}`);
-    return { success: false, error: err };
   } catch (err) {
     logger.error(`${stage}: Error during resolution.`, err);
-    return { success: false, error: err };
+    return stageFailure(stage, err.message, err);
   }
 }
 
@@ -263,16 +270,15 @@ export async function initializeAuxiliaryServicesStage(
 
   if (failures.length > 0) {
     const failList = failures.map((f) => f.service).join(', ');
-    const aggregatedError = new Error(`Failed to initialize: ${failList}`);
-    aggregatedError.phase = stageName;
-    aggregatedError.failures = failures;
+    const result = stageFailure(stageName, `Failed to initialize: ${failList}`);
+    result.error.failures = failures;
     logger.error(
       `Bootstrap Stage: ${stageName} encountered failures: ${failList}`,
-      aggregatedError
+      result.error
     );
-    return { success: false, error: aggregatedError };
+    return result;
   }
 
   logger.debug(`Bootstrap Stage: ${stageName} completed.`);
-  return { success: true };
+  return stageSuccess();
 }

--- a/src/bootstrapper/helpers.js
+++ b/src/bootstrapper/helpers.js
@@ -103,4 +103,37 @@ export function attachBeforeUnload(windowRef, handler) {
   windowRef.addEventListener('beforeunload', handler);
 }
 
+/**
+ * @description Creates an Error annotated with the bootstrap phase and optional cause.
+ * @param {string} phase - Name of the bootstrap phase where the error occurred.
+ * @param {string} message - Error message.
+ * @param {Error} [cause] - Optional underlying cause.
+ * @returns {Error} The constructed Error instance.
+ */
+export function createStageError(phase, message, cause) {
+  const error = new Error(message, cause ? { cause } : undefined);
+  error.phase = phase;
+  return error;
+}
+
+/**
+ * @description Helper to create a successful StageResult.
+ * @param {any} [payload] - Optional payload to include in the result.
+ * @returns {import('../types/stageResult.js').StageResult}
+ */
+export function stageSuccess(payload) {
+  return { success: true, payload };
+}
+
+/**
+ * @description Helper to create a failed StageResult with a StageError.
+ * @param {string} phase - Name of the bootstrap phase where the failure occurred.
+ * @param {string} message - Error message.
+ * @param {Error} [cause] - Optional underlying cause.
+ * @returns {import('../types/stageResult.js').StageResult}
+ */
+export function stageFailure(phase, message, cause) {
+  return { success: false, error: createStageError(phase, message, cause) };
+}
+
 // --- FILE END ---

--- a/src/bootstrapper/stages/containerStages.js
+++ b/src/bootstrapper/stages/containerStages.js
@@ -3,6 +3,7 @@
 
 // eslint-disable-next-line no-unused-vars
 import { tokens } from '../../dependencyInjection/tokens.js';
+import { stageSuccess, stageFailure } from '../helpers.js';
 
 /**
  * @typedef {import('../UIBootstrapper.js').EssentialUIElements} EssentialUIElements
@@ -37,15 +38,13 @@ export async function setupDIContainerStage(
     containerConfigFunc(container, uiReferences);
   } catch (registrationError) {
     const errorMsg = `Fatal Error during service registration: ${registrationError.message}.`;
-    const stageError = new Error(errorMsg, { cause: registrationError });
-    stageError.phase = 'DI Container Setup';
     console.error(
       `Bootstrap Stage: setupDIContainerStage failed. ${errorMsg}`,
       registrationError
     );
-    return { success: false, error: stageError };
+    return stageFailure('DI Container Setup', errorMsg, registrationError);
   }
-  return { success: true, payload: container };
+  return stageSuccess(container);
 }
 
 /**
@@ -73,16 +72,14 @@ export async function resolveLoggerStage(container, diTokens) {
     }
   } catch (resolveError) {
     const errorMsg = `Fatal Error: Could not resolve essential ILogger service: ${resolveError.message}.`;
-    const stageError = new Error(errorMsg, { cause: resolveError });
-    stageError.phase = 'Core Services Resolution';
     console.error(
       `Bootstrap Stage: resolveLoggerStage failed. ${errorMsg}`,
       resolveError
     );
-    return { success: false, error: stageError };
+    return stageFailure('Core Services Resolution', errorMsg, resolveError);
   }
   logger.debug(
     'Bootstrap Stage: Resolving logger service... DONE. Logger resolved successfully.'
   );
-  return { success: true, payload: { logger } };
+  return stageSuccess({ logger });
 }

--- a/src/bootstrapper/stages/engineStages.js
+++ b/src/bootstrapper/stages/engineStages.js
@@ -5,6 +5,7 @@
 /** @typedef {import('../../engine/gameEngine.js').default} GameEngineInstance */
 /** @typedef {import('../../engine/gameEngine.js').default} GameEngine */
 /** @typedef {import('../../dependencyInjection/appContainer.js').default} AppContainer */
+import { stageSuccess, stageFailure } from '../helpers.js';
 
 /**
  * Bootstrap Stage: Initializes the GameEngine.
@@ -39,14 +40,12 @@ export async function initializeGameEngineStage(
       engineCreationError
     );
     const errorMsg = `Fatal Error during GameEngine instantiation: ${engineCreationError.message}.`;
-    const stageError = new Error(errorMsg, { cause: engineCreationError });
-    stageError.phase = currentPhase;
-    return { success: false, error: stageError };
+    return stageFailure(currentPhase, errorMsg, engineCreationError);
   }
   logger.debug(
     `Bootstrap Stage: Initializing GameEngine... DONE. GameEngine instance available.`
   );
-  return { success: true, payload: gameEngine };
+  return stageSuccess(gameEngine);
 }
 
 /**
@@ -69,21 +68,19 @@ export async function startGameStage(gameEngine, activeWorldName, logger) {
     logger.error(
       `Bootstrap Stage: ${stageName} failed. GameEngine instance is not available.`
     );
-    const criticalError = new Error(
+    return stageFailure(
+      stageName,
       'GameEngine not initialized before attempting to start game.'
     );
-    criticalError.phase = stageName;
-    return { success: false, error: criticalError };
   }
   if (typeof activeWorldName !== 'string' || activeWorldName.trim() === '') {
     logger.error(
       `Bootstrap Stage: ${stageName} failed. activeWorldName is invalid or empty.`
     );
-    const criticalError = new Error(
+    return stageFailure(
+      stageName,
       'activeWorldName is invalid or empty, cannot start game.'
     );
-    criticalError.phase = stageName;
-    return { success: false, error: criticalError };
   }
 
   try {
@@ -96,13 +93,12 @@ export async function startGameStage(gameEngine, activeWorldName, logger) {
       `Bootstrap Stage: ${stageName}: Error during gameEngine.startNewGame for world "${activeWorldName}".`,
       startGameError
     );
-    const stageError = new Error(
+    return stageFailure(
+      stageName,
       `Failed to start new game with world "${activeWorldName}": ${startGameError.message}`,
-      { cause: startGameError }
+      startGameError
     );
-    stageError.phase = stageName;
-    return { success: false, error: stageError };
   }
   logger.debug(`Bootstrap Stage: ${stageName} completed.`);
-  return { success: true };
+  return stageSuccess();
 }

--- a/src/bootstrapper/stages/eventStages.js
+++ b/src/bootstrapper/stages/eventStages.js
@@ -1,6 +1,11 @@
 // src/bootstrapper/stages/eventStages.js
 
-import { shouldStopEngine, attachBeforeUnload } from '../helpers.js';
+import {
+  shouldStopEngine,
+  attachBeforeUnload,
+  stageSuccess,
+  stageFailure,
+} from '../helpers.js';
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../engine/gameEngine.js').default} GameEngineInstance */
@@ -66,17 +71,16 @@ export async function setupGlobalEventListenersStage(
       `${stageName}: '${eventName}' event listener attached successfully.`
     );
     logger.debug(`Bootstrap Stage: ${stageName} completed.`);
-    return { success: true };
+    return stageSuccess();
   } catch (error) {
     logger.error(
       `Bootstrap Stage: ${stageName} encountered an unexpected error during '${eventName}' listener setup.`,
       error
     );
-    const stageError = new Error(
+    return stageFailure(
+      stageName,
       `Unexpected error during ${stageName} for '${eventName}': ${error.message}`,
-      { cause: error }
+      error
     );
-    stageError.phase = stageName;
-    return { success: false, error: stageError };
   }
 }

--- a/src/bootstrapper/stages/uiStages.js
+++ b/src/bootstrapper/stages/uiStages.js
@@ -1,7 +1,7 @@
 // src/bootstrapper/stages/uiStages.js
 /* eslint-disable no-console */
 
-import { setupButtonListener } from '../helpers.js';
+import { setupButtonListener, stageSuccess, stageFailure } from '../helpers.js';
 
 // eslint-disable-next-line no-unused-vars
 import { tokens } from '../../dependencyInjection/tokens.js';
@@ -33,18 +33,14 @@ export async function ensureCriticalDOMElementsStage(
   const uiBootstrapper = createUIBootstrapper();
   try {
     const essentialUIElements = uiBootstrapper.gatherEssentialElements(doc);
-    return { success: true, payload: essentialUIElements };
+    return stageSuccess(essentialUIElements);
   } catch (error) {
-    const stageError = new Error(
-      `UI Element Validation Failed: ${error.message}`,
-      { cause: error }
-    );
-    stageError.phase = 'UI Element Validation';
+    const message = `UI Element Validation Failed: ${error.message}`;
     console.error(
-      `Bootstrap Stage: ensureCriticalDOMElementsStage failed. ${stageError.message}`,
+      `Bootstrap Stage: ensureCriticalDOMElementsStage failed. ${message}`,
       error
     );
-    return { success: false, error: stageError };
+    return stageFailure('UI Element Validation', message, error);
   }
 }
 
@@ -111,17 +107,16 @@ export async function setupMenuButtonListenersStage(
       );
     }
     logger.debug(`Bootstrap Stage: ${stageName} completed successfully.`);
-    return { success: true };
+    return stageSuccess();
   } catch (error) {
     logger.error(
       `Bootstrap Stage: ${stageName} encountered an unexpected error during listener setup.`,
       error
     );
-    const stageError = new Error(
+    return stageFailure(
+      stageName,
       `Unexpected error during ${stageName}: ${error.message}`,
-      { cause: error }
+      error
     );
-    stageError.phase = stageName;
-    return { success: false, error: stageError };
   }
 }


### PR DESCRIPTION
Summary: Added helper functions for bootstrap stages to centralize result and error creation. Updated stage modules to use these helpers for clearer success and failure handling.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851ada4afa083318c5f2b0028e13b90