### PR TITLE
[Agent] refactor domUI selection tests

### DIFF
--- a/src/domUI/actionButtonsRenderer.js
+++ b/src/domUI/actionButtonsRenderer.js
@@ -257,7 +257,7 @@ export class ActionButtonsRenderer extends SelectableListDisplayComponent {
    * @returns {void}
    */
   _onItemSelected(selectedElement, actionData) {
-    super._handleItemSelection(selectedElement, actionData);
+    super._selectItem(selectedElement, actionData);
     this.selectedAction = actionData;
     if (this.elements.sendButtonElement) {
       this.elements.sendButtonElement.disabled = !actionData;
@@ -330,9 +330,9 @@ export class ActionButtonsRenderer extends SelectableListDisplayComponent {
       const selectedButton = container.querySelector(
         `button.action-button[data-action-index="${this.selectedAction.index}"]`
       );
-      this._handleItemSelection(selectedButton, this.selectedAction);
+      this._selectItem(selectedButton, this.selectedAction);
     } else {
-      this._onItemSelected(null, null);
+      this._selectItem(null, null);
     }
 
     if (this.elements.sendButtonElement) {

--- a/src/domUI/selectableListDisplayComponent.js
+++ b/src/domUI/selectableListDisplayComponent.js
@@ -44,6 +44,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
 
   /**
    * Stores the handler for arrow key navigation created by the utility.
+   *
    * @private
    * @type {((event: KeyboardEvent) => void) | null}
    */
@@ -51,6 +52,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
 
   /**
    * Stores the bound keydown handler to ensure it's only attached once.
+   *
    * @private
    * @type {((event: KeyboardEvent) => void) | null}
    */
@@ -122,8 +124,21 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
   }
 
   /**
+   * Programmatically selects an item.
+   *
+   * @protected
+   * @param {HTMLElement|null} selectedElement - The element representing the item to select.
+   * @param {any|null} itemData - The data associated with the item.
+   * @returns {void}
+   */
+  _selectItem(selectedElement, itemData) {
+    this._handleItemSelection(selectedElement, itemData);
+  }
+
+  /**
    * The single handler for all keydown events on the list container.
    * It delegates to the arrow key handler and also checks for selection keys.
+   *
    * @param {KeyboardEvent} event The keyboard event.
    * @private
    */
@@ -144,7 +159,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
         const data = this.currentListData.find(
           (d) => String(d[this._datasetKey]) === String(value)
         );
-        if (data) this._handleItemSelection(target, data);
+        if (data) this._selectItem(target, data);
       }
     }
   }
@@ -170,7 +185,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
         const data = this.currentListData.find(
           (d) => String(d[this._datasetKey]) === String(value)
         );
-        if (data) this._handleItemSelection(el, data);
+        if (data) this._selectItem(el, data);
       }
     );
 
@@ -181,7 +196,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
         const data = this.currentListData.find(
           (d) => String(d[this._datasetKey]) === String(value)
         );
-        if (data) this._handleItemSelection(el, data);
+        if (data) this._selectItem(el, data);
       });
     });
 

--- a/tests/domUI/actionButtonsRenderer.confirmActionButton.test.js
+++ b/tests/domUI/actionButtonsRenderer.confirmActionButton.test.js
@@ -245,8 +245,11 @@ describe('ActionButtonsRenderer', () => {
       jest.clearAllMocks(mockLogger, mockVed.dispatch);
       const spy = jest.spyOn(renderer, '_onItemSelected');
       await actionButtonInstance.click();
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(spy).toHaveBeenCalledWith(actionButtonInstance, actionToSubmit);
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(renderer.selectedAction).toEqual(actionToSubmit);
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(globalMockSendButton.disabled).toBe(false);
 
       jest.clearAllMocks(

--- a/tests/domUI/actionButtonsRenderer.eventHandling.test.js
+++ b/tests/domUI/actionButtonsRenderer.eventHandling.test.js
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 // --- Mock Dependencies ---
 // Standard Mocks (re-initialized in global beforeEach)
 let mockLogger;
-let mockDocumentContext;
 let capturedEventHandler;
 let mockUnsubscribeFn;
 let mockValidatedEventDispatcher;
@@ -142,12 +141,6 @@ beforeEach(() => {
     warn: jest.fn(),
     error: jest.fn(),
   };
-
-  mockDocumentContext = {
-    query: jest.fn(),
-    create: jest.fn(),
-  };
-
   capturedEventHandler = null;
   mockUnsubscribeFn = jest.fn();
 
@@ -557,7 +550,7 @@ describe('ActionButtonsRenderer', () => {
       mockContainer.children = [mockActionButton];
 
       // Scenario 1: No action selected
-      const spy = jest.spyOn(instance, '_onItemSelected');
+      const spy = jest.spyOn(instance, '_selectItem');
       instance.selectedAction = null;
       instance._onListRendered(instance.availableActions, mockContainer);
       expect(mockSendButton.disabled).toBe(true);
@@ -574,8 +567,10 @@ describe('ActionButtonsRenderer', () => {
       instance._onListRendered(instance.availableActions, mockContainer);
 
       expect(mockSendButton.disabled).toBe(false);
-      expect(mockActionButton.classList.contains('selected')).toBe(true);
-      expect(spy).not.toHaveBeenCalledWith(null, null);
+      expect(spy).toHaveBeenCalledWith(
+        mockActionButton,
+        instance.availableActions[0]
+      );
       expect(mockContainer.classList.add).toHaveBeenCalledWith(
         'actions-fade-in'
       );

--- a/tests/domUI/selectableListDisplayComponent.test.js
+++ b/tests/domUI/selectableListDisplayComponent.test.js
@@ -26,6 +26,7 @@ const mockValidatedEventDispatcher = {
 
 /**
  * A concrete implementation of the abstract BaseListDisplayComponent for testing.
+ *
  * @class TestableSelectableListComponent
  */
 class TestableSelectableListComponent extends SelectableListDisplayComponent {
@@ -69,9 +70,12 @@ describe('SelectableListDisplayComponent', () => {
 
   // Set up the DOM and component before each test
   beforeEach(async () => {
-    dom = new JSDOM('<!DOCTYPE html><html><body><ul id="list-container"></ul></body></html>', {
-      url: 'http://localhost',
-    });
+    dom = new JSDOM(
+      '<!DOCTYPE html><html><body><ul id="list-container"></ul></body></html>',
+      {
+        url: 'http://localhost',
+      }
+    );
     document = dom.window.document;
     container = document.getElementById('list-container');
 
@@ -103,13 +107,26 @@ describe('SelectableListDisplayComponent', () => {
   // These constructor tests don't need the async setup, but are fine here.
   describe('Constructor', () => {
     test('should throw an error if datasetKey is missing', () => {
-      expect(() => new SelectableListDisplayComponent({ logger: mockLogger, documentContext: mockDocumentContext })).toThrow(
+      expect(
+        () =>
+          new SelectableListDisplayComponent({
+            logger: mockLogger,
+            documentContext: mockDocumentContext,
+          })
+      ).toThrow(
         `[SelectableListDisplayComponent] 'datasetKey' is required and must be a string.`
       );
     });
 
     test('should throw an error if datasetKey is not a string', () => {
-      expect(() => new SelectableListDisplayComponent({ logger: mockLogger, documentContext: mockDocumentContext, datasetKey: 123 })).toThrow(
+      expect(
+        () =>
+          new SelectableListDisplayComponent({
+            logger: mockLogger,
+            documentContext: mockDocumentContext,
+            datasetKey: 123,
+          })
+      ).toThrow(
         `[SelectableListDisplayComponent] 'datasetKey' is required and must be a string.`
       );
     });
@@ -128,13 +145,18 @@ describe('SelectableListDisplayComponent', () => {
 
     test('constructor should throw if listContainerElement is not found in DOM', () => {
       const badContext = { ...mockDocumentContext, query: () => null };
-      expect(() => new SelectableListDisplayComponent({
-        logger: mockLogger,
-        documentContext: badContext,
-        validatedEventDispatcher: mockValidatedEventDispatcher,
-        elementsConfig: { listContainerElement: '#nonexistent' },
-        datasetKey: 'id',
-      })).toThrow(/'listContainerElement' is not defined or not found in the DOM/);
+      expect(
+        () =>
+          new SelectableListDisplayComponent({
+            logger: mockLogger,
+            documentContext: badContext,
+            validatedEventDispatcher: mockValidatedEventDispatcher,
+            elementsConfig: { listContainerElement: '#nonexistent' },
+            datasetKey: 'id',
+          })
+      ).toThrow(
+        /'listContainerElement' is not defined or not found in the DOM/
+      );
     });
   });
 
@@ -151,7 +173,9 @@ describe('SelectableListDisplayComponent', () => {
       const spy = jest.spyOn(itemToSelect, 'focus');
 
       // Simulate click
-      itemToSelect.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      itemToSelect.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
 
       expect(component.getSelectedItemData()).toBe(MOCK_DATA[1]);
       expect(itemToSelect.classList.contains('selected')).toBe(true);
@@ -164,13 +188,17 @@ describe('SelectableListDisplayComponent', () => {
       const secondItem = container.querySelector('#item-2');
 
       // First click
-      firstItem.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      firstItem.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
       expect(component.getSelectedItemData()).toBe(MOCK_DATA[0]);
       expect(firstItem.classList.contains('selected')).toBe(true);
       expect(secondItem.classList.contains('selected')).toBe(false);
 
       // Second click
-      secondItem.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      secondItem.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
       expect(component.getSelectedItemData()).toBe(MOCK_DATA[1]);
       expect(firstItem.classList.contains('selected')).toBe(false);
       expect(secondItem.classList.contains('selected')).toBe(true);
@@ -183,7 +211,9 @@ describe('SelectableListDisplayComponent', () => {
     beforeEach(() => {
       mockRadioNavHandler = jest.fn();
       // Spy on the setup utility to see if it's called correctly
-      jest.spyOn(listNavigationUtils, 'setupRadioListNavigation').mockImplementation(() => mockRadioNavHandler);
+      jest
+        .spyOn(listNavigationUtils, 'setupRadioListNavigation')
+        .mockImplementation(() => mockRadioNavHandler);
 
       // Re-render to apply the spy
       return component.refreshList();
@@ -211,9 +241,12 @@ describe('SelectableListDisplayComponent', () => {
     });
 
     test('should select an item when navigation callback is invoked', () => {
-      const navCallback = jest.spyOn(listNavigationUtils, 'setupRadioListNavigation').mock.calls[0][3];
+      const navCallback = jest.spyOn(
+        listNavigationUtils,
+        'setupRadioListNavigation'
+      ).mock.calls[0][3];
       const itemToSelect = container.querySelector('#item-3');
-      const spy = jest.spyOn(component, '_handleItemSelection');
+      const spy = jest.spyOn(component, '_selectItem');
 
       navCallback(itemToSelect, '3');
 
@@ -223,9 +256,12 @@ describe('SelectableListDisplayComponent', () => {
     test('should select focused item on "Enter" key press', () => {
       const itemToSelect = container.querySelector('#item-2');
       itemToSelect.focus(); // Set focus to simulate user navigation
-      const spy = jest.spyOn(component, '_handleItemSelection');
+      const spy = jest.spyOn(component, '_selectItem');
 
-      const event = new dom.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+      const event = new dom.window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+      });
       const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
       // Dispatch event from the item itself
@@ -238,9 +274,12 @@ describe('SelectableListDisplayComponent', () => {
     test('should select focused item on " " (Space) key press', () => {
       const itemToSelect = container.querySelector('#item-1');
       itemToSelect.focus();
-      const spy = jest.spyOn(component, '_handleItemSelection');
+      const spy = jest.spyOn(component, '_selectItem');
 
-      const event = new dom.window.KeyboardEvent('keydown', { key: ' ', bubbles: true });
+      const event = new dom.window.KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+      });
       const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
       // Dispatch event from the item itself
@@ -254,7 +293,9 @@ describe('SelectableListDisplayComponent', () => {
   describe('Dispose', () => {
     test('should clear selection and list data on dispose', () => {
       const itemToSelect = container.querySelector('#item-2');
-      itemToSelect.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      itemToSelect.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
 
       expect(component.getSelectedItemData()).not.toBeNull();
       expect(component.getCurrentListData().length).toBe(MOCK_DATA.length);
@@ -270,7 +311,11 @@ describe('SelectableListDisplayComponent', () => {
       component.dispose();
       // The base class handles the removal, so we check if it was called.
       // We expect it to be called for 'keydown'.
-      expect(spy).toHaveBeenCalledWith('keydown', expect.any(Function), undefined);
+      expect(spy).toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function),
+        undefined
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `_selectItem` helper to `SelectableListDisplayComponent`
- update list component to use `_selectItem` internally
- adapt `ActionButtonsRenderer` to call `_selectItem`
- refactor DOM UI tests to use the new API

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6851adf2c1748331bc0ad17ec7c3d83a