### PR TITLE
[Fix] Resolve dependency-cruiser errors

### DIFF
--- a/src/data/gameDataRepository.js
+++ b/src/data/gameDataRepository.js
@@ -5,11 +5,11 @@ import { IGameDataRepository } from '../interfaces/IGameDataRepository.js';
 /**
  * @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
- * @typedef {import('../../../data/schemas/action.schema.json').ActionDefinition} ActionDefinition
- * @typedef {import('../../../data/schemas/entity-definition.schema.json').EntityDefinition} EntityDefinition
- * @typedef {import('../../../data/schemas/component.schema.json').EventDefinition} EventDefinition
- * @typedef {import('../../../data/schemas/component.schema.json').ComponentDefinition} ComponentDefinition
- * @typedef {import('../../../data/schemas/condition.schema.json').ConditionDefinition} ConditionDefinition
+ * @typedef {import('../../data/schemas/action.schema.json').ActionDefinition} ActionDefinition
+ * @typedef {import('../../data/schemas/entity.schema.json').EntityDefinition} EntityDefinition
+ * @typedef {import('../../data/schemas/component.schema.json').EventDefinition} EventDefinition
+ * @typedef {import('../../data/schemas/component.schema.json').ComponentDefinition} ComponentDefinition
+ * @typedef {import('../../data/schemas/condition.schema.json').ConditionDefinition} ConditionDefinition
  */
 
 /**

--- a/src/interfaces/IGameDataRepository.js
+++ b/src/interfaces/IGameDataRepository.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import('../../../data/schemas/action.schema.json').ActionDefinition} ActionDefinition
- * @typedef {import('../../../data/schemas/condition.schema.json').ConditionDefinition} ConditionDefinition
+ * @typedef {import('../../data/schemas/action.schema.json').ActionDefinition} ActionDefinition
+ * @typedef {import('../../data/schemas/condition.schema.json').ConditionDefinition} ConditionDefinition
  */
 
 /**


### PR DESCRIPTION
Summary: Fixed invalid relative paths for JSON schema typedef imports so dependency-cruiser can resolve them.

Changes Made:
- Updated schema import paths in `IGameDataRepository.js`.
- Updated schema import paths in `gameDataRepository.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root **fails due to pre-existing issues**)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (skipped)


------
https://chatgpt.com/codex/tasks/task_e_6851b12480f08331a708fe896a6c2633