### PR TITLE
[Feat] Centralize slot navigation behavior

### DIFF
--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -4,7 +4,6 @@
 import { SlotModalBase } from './slotModalBase.js';
 import { createSelectableItem } from './helpers/createSelectableItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
-import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -307,31 +306,7 @@ export class LlmSelectionModal extends SlotModalBase {
    * @private
    */
   _handleSlotNavigation(event) {
-    if (!this.elements.listContainerElement) return;
-
-    const arrowHandler = setupRadioListNavigation(
-      this.elements.listContainerElement,
-      'li.llm-item[role="radio"]',
-      this._datasetKey,
-      (el, value) => {
-        const slotData = this.currentSlotsDisplayData.find(
-          (s) => String(s[this._datasetKey]) === String(value)
-        );
-        if (slotData) this._onItemSelected(el, slotData);
-      }
-    );
-
-    arrowHandler(event);
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      const target = /** @type {HTMLElement} */ (event.target);
-      const value = target.dataset[this._datasetKey];
-      const slotData = this.currentSlotsDisplayData.find(
-        (s) => String(s[this._datasetKey]) === String(value)
-      );
-      if (slotData) this._onItemSelected(target, slotData);
-    }
+    super._handleSlotNavigation(event);
   }
 
   /**

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -2,7 +2,6 @@
 
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
-import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
 import { formatSaveFileMetadata } from './helpers/slotDataFormatter.js';
 import { renderSlotItem } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
@@ -380,47 +379,7 @@ class LoadGameUI extends SlotModalBase {
    * @private
    */
   _handleSlotNavigation(event) {
-    if (!this.elements.listContainerElement) return;
-
-    const arrowHandler = setupRadioListNavigation(
-      this.elements.listContainerElement,
-      '.save-slot[role="radio"]',
-      this._datasetKey,
-      (el, value) => {
-        let slotData;
-        if (this._datasetKey === 'slotId') {
-          const slotId = parseInt(value || '-1', 10);
-          slotData = this.currentSlotsDisplayData.find(
-            (s) => s.slotId === slotId
-          );
-        } else {
-          slotData = this.currentSlotsDisplayData.find(
-            (s) => String(s[this._datasetKey]) === String(value)
-          );
-        }
-        if (slotData) this._onItemSelected(el, slotData);
-      }
-    );
-
-    arrowHandler(event);
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      const target = /** @type {HTMLElement} */ (event.target);
-      const value = target.dataset[this._datasetKey];
-      let slotData;
-      if (this._datasetKey === 'slotId') {
-        const slotId = parseInt(value || '-1', 10);
-        slotData = this.currentSlotsDisplayData.find(
-          (s) => s.slotId === slotId
-        );
-      } else {
-        slotData = this.currentSlotsDisplayData.find(
-          (s) => String(s[this._datasetKey]) === String(value)
-        );
-      }
-      if (slotData) this._onItemSelected(target, slotData);
-    }
+    super._handleSlotNavigation(event);
   }
 
   /**

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -2,7 +2,6 @@
 
 import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
-import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
 import {
   formatSaveFileMetadata,
   formatEmptySlot,
@@ -375,47 +374,7 @@ export class SaveGameUI extends SlotModalBase {
    * @private
    */
   _handleSlotNavigation(event) {
-    if (!this.elements.listContainerElement) return;
-
-    const arrowHandler = setupRadioListNavigation(
-      this.elements.listContainerElement,
-      '.save-slot[role="radio"]',
-      this._datasetKey,
-      (el, value) => {
-        let slotData;
-        if (this._datasetKey === 'slotId') {
-          const slotId = parseInt(value || '-1', 10);
-          slotData = this.currentSlotsDisplayData.find(
-            (s) => s.slotId === slotId
-          );
-        } else {
-          slotData = this.currentSlotsDisplayData.find(
-            (s) => String(s[this._datasetKey]) === String(value)
-          );
-        }
-        if (slotData) this._onItemSelected(el, slotData);
-      }
-    );
-
-    arrowHandler(event);
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      const target = /** @type {HTMLElement} */ (event.target);
-      const value = target.dataset[this._datasetKey];
-      let slotData;
-      if (this._datasetKey === 'slotId') {
-        const slotId = parseInt(value || '-1', 10);
-        slotData = this.currentSlotsDisplayData.find(
-          (s) => s.slotId === slotId
-        );
-      } else {
-        slotData = this.currentSlotsDisplayData.find(
-          (s) => String(s[this._datasetKey]) === String(value)
-        );
-      }
-      if (slotData) this._onItemSelected(target, slotData);
-    }
+    super._handleSlotNavigation(event);
   }
 
   /**

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -6,6 +6,7 @@
 
 import { BaseModalRenderer } from './baseModalRenderer.js';
 import { DomUtils } from '../utils/domUtils.js';
+import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
 
 /**
@@ -138,6 +139,58 @@ export class SlotModalBase extends BaseModalRenderer {
     }
 
     this._updateButtonStates(slotData);
+  }
+
+  /**
+   * Handles keyboard navigation within the slot list.
+   * Uses arrow keys for navigation and Enter/Space for selection.
+   *
+   * @protected
+   * @param {KeyboardEvent} event - Key event to process.
+   * @returns {void}
+   */
+  _handleSlotNavigation(event) {
+    if (!this.elements.listContainerElement) return;
+
+    const arrowHandler = setupRadioListNavigation(
+      this.elements.listContainerElement,
+      '[role="radio"]',
+      this._datasetKey,
+      (el, value) => {
+        let slotData;
+        if (this._datasetKey === 'slotId') {
+          const slotId = parseInt(value || '-1', 10);
+          slotData = this.currentSlotsDisplayData.find(
+            (s) => s.slotId === slotId
+          );
+        } else {
+          slotData = this.currentSlotsDisplayData.find(
+            (s) => String(s[this._datasetKey]) === String(value)
+          );
+        }
+        if (slotData) this._onItemSelected(el, slotData);
+      }
+    );
+
+    arrowHandler(event);
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      const target = /** @type {HTMLElement} */ (event.target);
+      const value = target.dataset[this._datasetKey];
+      let slotData;
+      if (this._datasetKey === 'slotId') {
+        const slotId = parseInt(value || '-1', 10);
+        slotData = this.currentSlotsDisplayData.find(
+          (s) => s.slotId === slotId
+        );
+      } else {
+        slotData = this.currentSlotsDisplayData.find(
+          (s) => String(s[this._datasetKey]) === String(value)
+        );
+      }
+      if (slotData) this._onItemSelected(target, slotData);
+    }
   }
 
   /**

--- a/tests/domUI/loadGameUI.coverage.test.js
+++ b/tests/domUI/loadGameUI.coverage.test.js
@@ -548,14 +548,14 @@ describe('LoadGameUI', () => {
       // We cannot directly test the private method, so we check the dependency was called
       // in a scenario where it *would* be used. A better test would refactor the handler
       // creation to be more accessible if needed.
-      instance._handleSlotNavigation(
+      SlotModalBase.prototype._handleSlotNavigation.call(
+        instance,
         new mockWindow.KeyboardEvent('keydown', { key: 'ArrowDown' })
       );
       expect(listNavigationUtils.setupRadioListNavigation).toHaveBeenCalled();
       expect(mockHandler).toHaveBeenCalled();
     });
   });
-
 
   describe('dispose()', () => {
     it('should nullify gameEngine and clear data arrays', () => {


### PR DESCRIPTION
Summary: Move slot navigation logic into SlotModalBase and update consumers.

Changes Made:
- Added `_handleSlotNavigation` to SlotModalBase using setupRadioListNavigation
- Simplified save/load UI and LLM selection to call the base method
- Updated loadGameUI coverage test to invoke the base implementation

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6851b0b4b3148331a8dc178f54962906