### PR TITLE
[Agent] Update tests for entity loader refactor

### DIFF
--- a/tests/loaders/entityLoader.test.js
+++ b/tests/loaders/entityLoader.test.js
@@ -248,7 +248,10 @@ beforeEach(() => {
   // Ensure calls to _storeItemInRegistry invoke the real implementation so the
   // returned object includes the calculated qualifiedId.
   entityLoader._storeItemInRegistry.mockImplementation((...args) =>
-    EntityDefinitionLoader.prototype._storeItemInRegistry.apply(entityLoader, args)
+    EntityDefinitionLoader.prototype._storeItemInRegistry.apply(
+      entityLoader,
+      args
+    )
   );
 });
 
@@ -312,7 +315,8 @@ describe('EntityLoader', () => {
 
       // --- [LOADER-REFACTOR-04 Test Change START] ---
       // --- CORRECTION: Updated expected warning message ---
-      const expectedBaseWarning = `EntityLoader: Primary schema ID for content type 'entities' not found in configuration. Primary validation might be skipped.`;
+      const expectedBaseWarning =
+        "EntityDefinitionLoader: Primary schema ID for content type 'entities' not found in configuration. Primary validation might be skipped.";
 
       // Expect only ONE warning call total (from the base class)
       expect(warnLogger.warn).toHaveBeenCalledTimes(1);
@@ -398,7 +402,7 @@ describe('EntityLoader', () => {
         )
       ).rejects.toThrow(loadError);
       expect(mockLogger.info).toHaveBeenCalledWith(
-        `EntityLoader: Loading ${GENERIC_TYPE_NAME} definitions for mod '${TEST_MOD_ID}'.`
+        `EntityDefinitionLoader: Loading ${GENERIC_TYPE_NAME} definitions for mod '${TEST_MOD_ID}'.`
       );
       // Error should be logged by _loadItemsInternal or its callees, check base class logging if needed
     });
@@ -468,7 +472,10 @@ describe('EntityLoader', () => {
       // --- [LOADER-REFACTOR-04 Test Change]: Mock base class methods called within/around _processFetchedItem ---
       entityLoader._storeItemInRegistry.mockClear(); // Clear spy calls from beforeEach
       entityLoader._storeItemInRegistry.mockImplementation((...args) =>
-        EntityDefinitionLoader.prototype._storeItemInRegistry.apply(entityLoader, args)
+        EntityDefinitionLoader.prototype._storeItemInRegistry.apply(
+          entityLoader,
+          args
+        )
       );
     });
 

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -170,7 +170,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       content: {
         actions: ['core/action_move.json', 'core/action_look.json'],
         components: ['core/comp_position.json'],
-        characters: ['core/entity_player_base.json'],
+        entityDefinitions: ['characters/core/entity_player_base.json'],
         macros: ['core/logSuccess.macro.json'],
       },
     };
@@ -265,7 +265,9 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
                 id: itemId,
                 data: `mock ${typeName} data ${i}`,
               };
-              mockRegistry.store(typeName, itemId, itemData); // Use typeName for registry storage
+              const storeType =
+                typeName === 'entityDefinitions' ? 'entities' : typeName;
+              mockRegistry.store(storeType, itemId, itemData);
             }
             // Simulate the expected return structure {count, overrides, errors}
             return { count: count, overrides: 0, errors: 0 };
@@ -282,7 +284,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     setupContentLoaderMock(mockActionLoader, 'actions', 2);
     setupContentLoaderMock(mockComponentLoader, 'components', 1);
     setupContentLoaderMock(mockMacroLoader, 'macros', 2);
-    setupContentLoaderMock(mockEntityLoader, 'characters', 1); // Use 'characters' as typeName
+    setupContentLoaderMock(mockEntityLoader, 'entityDefinitions', 1);
 
     // --- 4. Instantiate SUT ---
     worldLoader = new WorldLoader({
@@ -426,9 +428,9 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenCalledWith(
       CORE_MOD_ID,
       mockCoreManifest,
-      'characters',
-      'entities/definitions/characters',
-      'characters'
+      'entityDefinitions',
+      'entities/definitions',
+      'entityDefinitions'
     );
 
     // Check loaders for types NOT in manifest were NOT called
@@ -482,8 +484,8 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       expect.any(Object)
     );
     expect(mockRegistry.store).toHaveBeenCalledWith(
-      'characters',
-      'core:characters_item_0',
+      'entities',
+      'core:entityDefinitions_item_0',
       expect.any(Object)
     );
     // Ensure store wasn't called for types not loaded
@@ -535,7 +537,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       true
     );
     expect(
-      summaryLines.some((l) => /characters\s+: C:1, O:0, E:0/.test(l))
+      summaryLines.some((l) => /entityDefinitions\s+: C:1, O:0, E:0/.test(l))
     ).toBe(true);
     expect(
       summaryLines.some((l) => /components\s+: C:1, O:0, E:0/.test(l))
@@ -554,7 +556,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
     expect(summaryLines.some((line) => /conditions\s+:/.test(line))).toBe(
       false
     );
-    expect(summaryLines.some((line) => /entities\s+:/.test(line))).toBe(false); // Check old key isn't present
+    expect(summaryLines.some((line) => /entities\s+:/.test(line))).toBe(false); // old key should not be present
 
     // 15. Verify registry.clear was not called again.
     expect(mockRegistry.clear).toHaveBeenCalledTimes(clearCalls); // Still 1

--- a/tests/loaders/worldLoader.overrides.integration.test.js
+++ b/tests/loaders/worldLoader.overrides.integration.test.js
@@ -247,21 +247,21 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       version: '1.0.0',
       name: 'Core',
       gameVersion: '^1.0.0',
-      content: { items: [itemFilename] },
+      content: { entityDefinitions: [itemFilename] },
     };
     mockFooManifest = {
       id: fooModId,
       version: '1.0.0',
       name: 'Foo Mod',
       gameVersion: '^1.0.0',
-      content: { items: [itemFilename] },
+      content: { entityDefinitions: [itemFilename] },
     };
     mockBarManifest = {
       id: barModId,
       version: '1.0.0',
       name: 'Bar Mod',
       gameVersion: '^1.0.0',
-      content: { items: [itemFilename] },
+      content: { entityDefinitions: [itemFilename] },
     };
 
     mockManifestMap = new Map();
@@ -322,7 +322,10 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
         contentTypeDirArg,
         typeNameArg
       ) => {
-        if (typeNameArg === 'items' && contentKeyArg === 'items') {
+        if (
+          typeNameArg === 'entityDefinitions' &&
+          contentKeyArg === 'entityDefinitions'
+        ) {
           // Determine which data to "load" and store based on the modId
           let itemData;
           if (modIdArg === CORE_MOD_ID) {
@@ -407,25 +410,25 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       1,
       CORE_MOD_ID,
       mockCoreManifest,
-      'items',
-      'entities/definitions/items',
-      'items'
+      'entityDefinitions',
+      'entities/definitions',
+      'entityDefinitions'
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenNthCalledWith(
       2,
       fooModId,
       mockFooManifest,
-      'items',
-      'entities/definitions/items',
-      'items'
+      'entityDefinitions',
+      'entities/definitions',
+      'entityDefinitions'
     );
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenNthCalledWith(
       3,
       barModId,
       mockBarManifest,
-      'items',
-      'entities/definitions/items',
-      'items'
+      'entityDefinitions',
+      'entities/definitions',
+      'entityDefinitions'
     );
 
     // 3. Verify Registry Storage - check that store was called with the correct prefixed keys and data
@@ -504,7 +507,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
     expect(barPotionFinal).toBeDefined();
     expect(barPotionFinal.description).toContain('Bar potion effect');
 
-    // 6. Verify Summary Log reflects loading items (EntityDefinitionLoader covers 'items')
+    // 6. Verify Summary Log reflects loading entity definitions
     const infoCalls = mockLogger.info.mock.calls;
     const summaryStart = infoCalls.findIndex((call) =>
       call[0].includes(`WorldLoader Load Summary (World: '${worldName}')`)
@@ -514,7 +517,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
     const summaryLines = infoCalls.slice(summaryStart).map((call) => call[0]);
     expect(summaryLines).toEqual(
       expect.arrayContaining([
-        expect.stringMatching(/items\s+: C:3, O:0, E:0/), // 3 items loaded (1 per mod)
+        expect.stringMatching(/entityDefinitions\s+: C:3, O:0, E:0/), // 3 items loaded (1 per mod)
         expect.stringMatching(/TOTAL\s+: C:3, O:0, E:0/), // Grand Total
       ])
     );

--- a/tests/loaders/worldLoader.timingLogs.integration.test.js
+++ b/tests/loaders/worldLoader.timingLogs.integration.test.js
@@ -206,7 +206,7 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
       gameVersion: '^1.0.0',
       // Define some content for foo mod
       content: {
-        items: ['foo_item.json'],
+        entityDefinitions: ['items/foo_item.json'],
         conditions: ['foo_condition.json'],
       },
     };
@@ -317,13 +317,13 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
       'conditions',
       'conditions'
     );
-    // Foo mod has items (handled by EntityDefinitionLoader)
+    // Foo mod has entity definitions (handled by EntityDefinitionLoader)
     expect(mockEntityLoader.loadItemsForMod).toHaveBeenCalledWith(
       fooModId,
       mockFooManifest,
-      'items',
-      'entities/definitions/items',
-      'items'
+      'entityDefinitions',
+      'entities/definitions',
+      'entityDefinitions'
     );
     expect(mockConditionLoader.loadItemsForMod).toHaveBeenCalledWith(
       fooModId,


### PR DESCRIPTION
## Summary
- update tests expecting EntityDefinitionLoader messages
- adjust world loader integration tests for new entity loaders and manifest keys

## Testing Done
- `npm run format`
- `npm run lint` (fails: `process` not defined)
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851b218759c83318d020a90ee40d6d9