### PR TITLE
[Feat] standardize logger validation

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -4,6 +4,7 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from '../persistence/persistenceErrors.js';
+import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * @file Utility functions for working with plain JavaScript objects.
@@ -108,14 +109,13 @@ export function deepClone(value) {
  *   Clone result object.
  */
 export function safeDeepClone(value, logger) {
+  const log = ensureValidLogger(logger, 'ObjectUtils');
   try {
     /** @type {T} */
     const cloned = deepClone(value);
     return { success: true, data: cloned };
   } catch (error) {
-    if (logger && typeof logger.error === 'function') {
-      logger.error('DeepClone failed:', error);
-    }
+    log.error('DeepClone failed:', error);
     return {
       success: false,
       error: new PersistenceError(

--- a/tests/utils/schemaUtils.registerSchema.test.js
+++ b/tests/utils/schemaUtils.registerSchema.test.js
@@ -16,7 +16,12 @@ describe('registerSchema', () => {
       removeSchema: jest.fn(),
       addSchema: jest.fn().mockResolvedValue(undefined),
     };
-    logger = { warn: jest.fn() };
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
   });
 
   it('adds schema when not already loaded', async () => {


### PR DESCRIPTION
Summary: Use `ensureValidLogger` in key utility modules for consistent logging fallback behavior. Updated `llmUtils`, `schemaUtils`, and `objectUtils` to obtain safe loggers at function start and removed manual checks. Adjusted schemaUtils tests to use fully valid loggers.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6851b43070d48331b671d2a901989c01