### PR TITLE
[Feat] add persistence success helper

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -22,7 +22,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
-import { createPersistenceFailure } from './persistenceResultUtils.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
 // --- MODIFICATION END ---
 
 /**
@@ -432,7 +435,7 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.debug(
         `GamePersistenceService.loadAndRestoreGame: Game state restored successfully for ${saveIdentifier}.`
       );
-      return { success: true, data: gameDataToRestore };
+      return createPersistenceSuccess(gameDataToRestore);
     } else {
       this.#logger.error(
         `GamePersistenceService.loadAndRestoreGame: Failed to restore game state for ${saveIdentifier}. Error: ${restoreResult.error}`

--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -7,6 +7,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
 
 /**
  * @class GameStateSerializer
@@ -153,14 +157,13 @@ class GameStateSerializer {
       this.#logger.debug(
         `Decompressed data size: ${decompressed.byteLength} bytes`
       );
-      return { success: true, data: decompressed };
+      return createPersistenceSuccess(decompressed);
     } catch (error) {
       const userMsg =
         'The save file appears to be corrupted (could not decompress). Please try another save.';
       this.#logger.error('Gzip decompression failed:', error);
       return {
-        success: false,
-        error: new PersistenceError(
+        ...createPersistenceFailure(
           PersistenceErrorCodes.DECOMPRESSION_ERROR,
           userMsg
         ),
@@ -179,14 +182,13 @@ class GameStateSerializer {
     try {
       const obj = decode(buffer);
       this.#logger.debug('Successfully deserialized MessagePack');
-      return { success: true, data: obj };
+      return createPersistenceSuccess(obj);
     } catch (error) {
       const userMsg =
         'The save file appears to be corrupted (could not understand file content). Please try another save.';
       this.#logger.error('MessagePack deserialization failed:', error);
       return {
-        success: false,
-        error: new PersistenceError(
+        ...createPersistenceFailure(
           PersistenceErrorCodes.DESERIALIZATION_ERROR,
           userMsg
         ),

--- a/src/persistence/persistenceResultUtils.js
+++ b/src/persistence/persistenceResultUtils.js
@@ -14,4 +14,16 @@ export function createPersistenceFailure(code, message) {
   return { success: false, error: new PersistenceError(code, message) };
 }
 
+/**
+ * Creates a standardized success result object for persistence operations.
+ *
+ * @description Mirrors {@link createPersistenceFailure} for success cases.
+ * @template T
+ * @param {T} data - Data to return on success.
+ * @returns {{success: true, data: T}} Success result.
+ */
+export function createPersistenceSuccess(data) {
+  return { success: true, data };
+}
+
 export default createPersistenceFailure;

--- a/src/persistence/saveFileIO.js
+++ b/src/persistence/saveFileIO.js
@@ -4,6 +4,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
 import { manualSavePath, extractSaveName } from '../utils/savePathUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -27,19 +31,17 @@ export async function readSaveFile(storage, filePath, logger) {
         'The selected save file is empty or cannot be read. It might be corrupted or inaccessible.';
       logger.warn(`File is empty or could not be read: ${filePath}.`);
       return {
-        success: false,
-        error: new PersistenceError(PersistenceErrorCodes.EMPTY_FILE, userMsg),
+        ...createPersistenceFailure(PersistenceErrorCodes.EMPTY_FILE, userMsg),
         userFriendlyError: userMsg,
       };
     }
-    return { success: true, data: fileContent };
+    return createPersistenceSuccess(fileContent);
   } catch (error) {
     const userMsg =
       'Could not access or read the selected save file. Please check file permissions or try another save.';
     logger.error(`Error reading file ${filePath}:`, error);
     return {
-      success: false,
-      error: new PersistenceError(
+      ...createPersistenceFailure(
         PersistenceErrorCodes.FILE_READ_ERROR,
         userMsg
       ),
@@ -73,7 +75,7 @@ export async function deserializeAndDecompress(
   const deserializeRes = serializer.deserialize(decompressRes.data);
   if (!deserializeRes.success) return deserializeRes;
 
-  return { success: true, data: deserializeRes.data };
+  return createPersistenceSuccess(deserializeRes.data);
 }
 
 /**

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -11,7 +11,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
-import { createPersistenceFailure } from './persistenceResultUtils.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
 import {
   validateSaveName,
   validateSaveIdentifier,
@@ -136,14 +139,17 @@ class SaveLoadService extends ISaveLoadService {
   #cloneAndPrepareState(saveName, obj) {
     const cloneResult = safeDeepClone(obj, this.#logger);
     if (!cloneResult.success || !cloneResult.data) {
-      return { success: false, error: cloneResult.error };
+      return createPersistenceFailure(
+        cloneResult.error.code,
+        cloneResult.error.message
+      );
     }
 
     /** @type {SaveGameStructure} */
     const cloned = cloneResult.data;
     cloned.metadata = { ...(cloned.metadata || {}), saveName };
     cloned.integrityChecks = { ...(cloned.integrityChecks || {}) };
-    return { success: true, data: cloned };
+    return createPersistenceSuccess(cloned);
   }
 
   /**
@@ -229,7 +235,7 @@ class SaveLoadService extends ISaveLoadService {
     this.#logger.debug(
       `Game data loaded and validated successfully from: "${saveIdentifier}"`
     );
-    return { success: true, data: loadedObject, error: null };
+    return createPersistenceSuccess(loadedObject);
   }
 
   /**

--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -5,6 +5,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */
@@ -57,13 +61,10 @@ class SaveValidationService {
         const userMsg =
           'The save file is incomplete or has an unknown format. It might be corrupted or from an incompatible game version.';
         this.#logger.error(devMsg + ` User message: "${userMsg}"`);
-        return {
-          success: false,
-          error: new PersistenceError(
-            PersistenceErrorCodes.INVALID_GAME_STATE,
-            userMsg
-          ),
-        };
+        return createPersistenceFailure(
+          PersistenceErrorCodes.INVALID_GAME_STATE,
+          userMsg
+        );
       }
     }
     this.#logger.debug(
@@ -86,13 +87,10 @@ class SaveValidationService {
       const userMsg =
         'The save file is missing integrity information and cannot be safely loaded. It might be corrupted or from an incompatible older version.';
       this.#logger.error(devMsg + ` User message: "${userMsg}"`);
-      return {
-        success: false,
-        error: new PersistenceError(
-          PersistenceErrorCodes.INVALID_GAME_STATE,
-          userMsg
-        ),
-      };
+      return createPersistenceFailure(
+        PersistenceErrorCodes.INVALID_GAME_STATE,
+        userMsg
+      );
     }
 
     let recalculatedChecksum;
@@ -105,13 +103,10 @@ class SaveValidationService {
       const userMsg =
         'Could not verify the integrity of the save file due to an internal error. The file might be corrupted.';
       this.#logger.error(devMsg + ` User message: "${userMsg}"`, checksumError);
-      return {
-        success: false,
-        error: new PersistenceError(
-          PersistenceErrorCodes.CHECKSUM_CALCULATION_ERROR,
-          userMsg
-        ),
-      };
+      return createPersistenceFailure(
+        PersistenceErrorCodes.CHECKSUM_CALCULATION_ERROR,
+        userMsg
+      );
     }
 
     if (storedChecksum !== recalculatedChecksum) {
@@ -119,13 +114,10 @@ class SaveValidationService {
       const userMsg =
         'The save file appears to be corrupted (integrity check failed). Please try another save or a backup.';
       this.#logger.error(devMsg + ` User message: "${userMsg}"`);
-      return {
-        success: false,
-        error: new PersistenceError(
-          PersistenceErrorCodes.CHECKSUM_MISMATCH,
-          userMsg
-        ),
-      };
+      return createPersistenceFailure(
+        PersistenceErrorCodes.CHECKSUM_MISMATCH,
+        userMsg
+      );
     }
     this.#logger.debug(`Checksum VERIFIED for ${identifier}.`);
     return { success: true };

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -4,6 +4,10 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from '../persistence/persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from '../persistence/persistenceResultUtils.js';
 
 /**
  * @file Utility functions for working with plain JavaScript objects.
@@ -111,18 +115,15 @@ export function safeDeepClone(value, logger) {
   try {
     /** @type {T} */
     const cloned = deepClone(value);
-    return { success: true, data: cloned };
+    return createPersistenceSuccess(cloned);
   } catch (error) {
     if (logger && typeof logger.error === 'function') {
       logger.error('DeepClone failed:', error);
     }
-    return {
-      success: false,
-      error: new PersistenceError(
-        PersistenceErrorCodes.DEEP_CLONE_FAILED,
-        'Failed to deep clone object.'
-      ),
-    };
+    return createPersistenceFailure(
+      PersistenceErrorCodes.DEEP_CLONE_FAILED,
+      'Failed to deep clone object.'
+    );
   }
 }
 

--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -119,7 +119,7 @@ describe('SaveLoadService additional coverage', () => {
     const res = await service.loadGameData(
       'saves/manual_saves/manual_save_Slot1.sav'
     );
-    expect(res).toEqual({ success: true, data: obj, error: null });
+    expect(res).toEqual({ success: true, data: obj });
   });
 
   it('saveManualGame validates name', async () => {


### PR DESCRIPTION
Summary: Implemented a unified `createPersistenceSuccess` helper and refactored persistence modules to eliminate manual construction of failure objects. Updated `objectUtils` and related services to use the new helpers, and adjusted tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: existing repo issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6851b4a8365c83318d1586ed9e060261