### PR TITLE
[Docs] Harmonize turn handler comments

### DIFF
--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -74,8 +74,8 @@ import { freeze } from '../utils/objectUtils.js';
  * @property {DiToken} PayloadValueResolverService - Token for resolving payload values.
  * @property {DiToken} TurnHandlerResolver - Token for the service that resolves the correct turn handler.
  * @property {DiToken} ActorTurnHandler - Token for the unified actor turn handler implementation.
- * @property {DiToken} HumanTurnHandler - Token for the player-specific turn handler implementation.
- * @property {DiToken} AITurnHandler - Token for the AI-specific turn handler implementation.
+ * @property {DiToken} HumanTurnHandler - Token for the player-specific actor turn handler implementation.
+ * @property {DiToken} AITurnHandler - Token for the AI-specific actor turn handler implementation.
  * @property {DiToken} SystemServiceRegistry - Token for the registry mapping system IDs to services.
  * @property {DiToken} PlayerPromptService - Token for the service managing player action prompting (implementation).
  * @property {DiToken} CommandOutcomeInterpreter - Token for the service interpreting command outcomes (implementation).
@@ -252,7 +252,7 @@ export const tokens = freeze({
   ITurnContextFactory: 'ITurnContextFactory',
   HumanStrategyFactory: 'HumanStrategyFactory',
 
-  // --- Service Interfaces for AITurnHandler dependencies (if not already defined) ---
+  // --- Service Interfaces for AI actor turn handler dependencies (if not already defined) ---
   IPromptBuilder: 'IPromptBuilder',
   IAIGameStateProvider: 'IAIGameStateProvider',
   IAIPromptContentProvider: 'IAIPromptContentProvider',

--- a/src/turns/adapters/eventBusTurnEndAdapter.js
+++ b/src/turns/adapters/eventBusTurnEndAdapter.js
@@ -37,7 +37,7 @@ export default class EventBusTurnEndAdapter extends ITurnEndPort {
   }
 
   /**
-   * Canonical method used by HumanTurnHandler / TurnManager.
+   * Canonical method used by ActorTurnHandler / TurnManager.
    * The 'success' parameter is part of the ITurnEndPort interface contract
    * and IS included in the core:turn_ended event payload.
    *

--- a/src/turns/constants/turnDirectives.js
+++ b/src/turns/constants/turnDirectives.js
@@ -10,7 +10,7 @@ import { freeze } from '../../utils/objectUtils.js';
  * @enum {string}
  * @readonly
  * @description Directives indicating the result of interpreting a command outcome.
- * Used to guide the HumanTurnHandler on whether to end the turn, re-prompt,
+ * Used to guide the ActorTurnHandler on whether to end the turn, re-prompt,
  * or wait for an external event.
  */
 const TurnDirective = {

--- a/src/turns/context/turnContext.js
+++ b/src/turns/context/turnContext.js
@@ -37,7 +37,7 @@ import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js'; // ⬅ 
  * NO LONGER knows about *any* concrete state classes – it delegates
  * all transitions to its owning BaseTurnHandler instance.
  * This breaks the dependency-cruiser cycle:
- * TurnContext → ProcessingCommandState → … → HumanTurnHandler → TurnContext
+ * TurnContext → ProcessingCommandState → … → ActorTurnHandler → TurnContext
  */
 export class TurnContext extends ITurnContext {
   /** @type {Entity}              */ #actor;

--- a/src/turns/handlers/baseTurnHandler.js
+++ b/src/turns/handlers/baseTurnHandler.js
@@ -1,5 +1,5 @@
 /**
- * @file Contains the base class for the base turn handler (used by AITurnHandler, HumanTurnHandler, etc.)
+ * @file Contains the base class for actor turn handlers (specialized for AI or human players).
  * @see src/turns/handlers/baseTurnHandler.js
  */
 

--- a/src/turns/interfaces/ITurnContext.js
+++ b/src/turns/interfaces/ITurnContext.js
@@ -31,7 +31,7 @@
  * @description
  * Defines the contract for turn-specific data and services. This interface's
  * primary role is to decouple turn logic (like states and strategies) from
- * concrete handler implementations (e.g. HumanTurnHandler, AITurnHandler).
+ * concrete handler implementations (e.g. actor-specific turn handlers).
  *
  * By interacting with ITurnContext, turn states and actor strategies can
  * access essential information (current actor, game state) and functionalities

--- a/src/turns/interfaces/ITurnHandler.js
+++ b/src/turns/interfaces/ITurnHandler.js
@@ -6,8 +6,8 @@
 /**
  * @interface ITurnHandler
  * @classdesc Defines the contract for handling the specific logic required during a single
- * entity's turn. Implementations will vary based on the type of entity (e.g., HumanTurnHandler,
- * AITurnHandler). It receives the actor and is responsible for initiating their action(s)
+ * entity's turn. Implementations will vary based on the type of entity (e.g., actor-specific handlers).
+ * It receives the actor and is responsible for initiating their action(s)
  * for that turn. Turn completion is signaled externally (e.g., via an event port), not
  * by the resolution of the promise returned by `startTurn`.
  */

--- a/src/turns/ports/ICommandInputPort.js
+++ b/src/turns/ports/ICommandInputPort.js
@@ -19,7 +19,7 @@
  * @description An interface representing the input boundary for player commands.
  * Implementations (Adapters) will bridge specific input mechanisms
  * (like an EventBus subscription, WebSocket message, etc.) to this port,
- * allowing the HumanTurnHandler to remain agnostic to the command source.
+ * allowing the ActorTurnHandler to remain agnostic to the command source.
  */
 export class ICommandInputPort {
   /**

--- a/src/turns/ports/IPromptOutputPort.js
+++ b/src/turns/ports/IPromptOutputPort.js
@@ -12,7 +12,7 @@
  * @description An interface representing the output boundary for prompting the player for their turn.
  * Implementations (Adapters) will bridge this port to specific output mechanisms
  * (like dispatching an EventBus event, sending a WebSocket message, updating UI state, etc.),
- * allowing the HumanTurnHandler to request a prompt without knowing the details of *how*
+ * allowing the ActorTurnHandler to request a prompt without knowing the details of *how*
  * the prompt is presented.
  */
 export class IPromptOutputPort {

--- a/src/turns/strategies/turnDirectiveStrategyResolver.js
+++ b/src/turns/strategies/turnDirectiveStrategyResolver.js
@@ -80,7 +80,7 @@ export default class TurnDirectiveStrategyResolver {
       default: {
         // Unknown, null, or undefined directive – choose a safe default.
         // Design choice: We treat it as WAIT_FOR_EVENT because that mirrors
-        // the legacy behaviour inside HumanTurnHandler.
+        // the legacy behaviour inside the ActorTurnHandler.
 
         /* istanbul ignore next */
         if (

--- a/src/turns/strategies/waitForTurnEndEventStrategy.js
+++ b/src/turns/strategies/waitForTurnEndEventStrategy.js
@@ -63,7 +63,7 @@ export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy 
     );
 
     // Core logic: request transition to AwaitingExternalTurnEndState
-    // The responsibility for setting any underlying handler flags (like HumanTurnHandler.#isAwaitingTurnEndEvent)
+    // The responsibility for setting any underlying handler flags (like ActorTurnHandler.#isAwaitingTurnEndEvent)
     // is managed by AwaitingExternalTurnEndState itself through turnContext.setAwaitingExternalEvent(true, actorId).
     try {
       // MODIFIED: Call the new, abstract method on the turn context.


### PR DESCRIPTION
Summary: Updated comments mentioning HumanTurnHandler and AITurnHandler to use the more generic ActorTurnHandler terminology.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6851b6ee7e088331836ee8e92c2b3398