### PR TITLE
[Agent] consolidate turn strategy factory

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -404,11 +404,7 @@ export function registerAI(container) {
     `AI Systems Registration: Registered ${tokens.ILLMDecisionProvider}.`
   );
 
-  registerGenericStrategy(
-    container,
-    tokens.ILLMDecisionProvider,
-    tokens.AIStrategyFactory
-  );
+  registerGenericStrategy(container, tokens.ILLMDecisionProvider);
 
   // --- AI TURN HANDLER (MODIFIED) ---
 
@@ -419,7 +415,7 @@ export function registerAI(container) {
         logger: c.resolve(tokens.ILogger),
         turnStateFactory: c.resolve(tokens.ITurnStateFactory),
         turnEndPort: c.resolve(tokens.ITurnEndPort),
-        strategyFactory: c.resolve(tokens.AIStrategyFactory), // <-- Updated
+        strategyFactory: c.resolve(tokens.TurnStrategyFactory),
         turnContextBuilder: c.resolve(tokens.TurnContextBuilder), // <-- Added
       })
   );

--- a/src/dependencyInjection/registrations/registerGenericStrategy.js
+++ b/src/dependencyInjection/registrations/registerGenericStrategy.js
@@ -17,19 +17,12 @@ import { GenericStrategyFactory } from '../../turns/factories/genericStrategyFac
  *
  * @param {AppContainer} container - The DI container.
  * @param {DiToken} decisionProviderToken - Token for the decision provider.
- * @param {DiToken} strategyFactoryToken - Token for the resulting strategy factory.
  * @returns {void}
  */
-export function registerGenericStrategy(
-  container,
-  decisionProviderToken,
-  strategyFactoryToken
-) {
+export function registerGenericStrategy(container, decisionProviderToken) {
   const r = new Registrar(container);
   const logger = container.resolve(tokens.ILogger);
-  logger.debug(
-    `[registerGenericStrategy] Starting for ${String(strategyFactoryToken)}...`
-  );
+  logger.debug('[registerGenericStrategy] Starting...');
 
   if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
     r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
@@ -53,8 +46,8 @@ export function registerGenericStrategy(
     );
   }
 
-  if (!container.isRegistered(strategyFactoryToken)) {
-    r.singletonFactory(strategyFactoryToken, (c) => {
+  if (!container.isRegistered(tokens.TurnStrategyFactory)) {
+    r.singletonFactory(tokens.TurnStrategyFactory, (c) => {
       const opts = {
         choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
         decisionProvider: c.resolve(decisionProviderToken),
@@ -67,11 +60,9 @@ export function registerGenericStrategy(
       return new GenericStrategyFactory(opts);
     });
     logger.debug(
-      `[registerGenericStrategy] Registered ${String(strategyFactoryToken)}.`
+      `[registerGenericStrategy] Registered ${tokens.TurnStrategyFactory}.`
     );
   }
 
-  logger.debug(
-    `[registerGenericStrategy] Completed for ${String(strategyFactoryToken)}.`
-  );
+  logger.debug('[registerGenericStrategy] Completed.');
 }

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -102,11 +102,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ────────────────── Turn Strategy Factory ──────────────────
-  registerGenericStrategy(
-    container,
-    tokens.IHumanDecisionProvider,
-    tokens.HumanStrategyFactory
-  );
+  registerGenericStrategy(container, tokens.IHumanDecisionProvider);
 
   // ──────────────────── Validation Utils ─────────────────────
   r.singletonFactory(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -248,6 +248,7 @@ export const tokens = freeze({
 
   // --- Turn System Factories ---
   ITurnStateFactory: 'ITurnStateFactory',
+  TurnStrategyFactory: 'TurnStrategyFactory',
   AIStrategyFactory: 'AIStrategyFactory',
   ITurnContextFactory: 'ITurnContextFactory',
   HumanStrategyFactory: 'HumanStrategyFactory',

--- a/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
+++ b/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
@@ -59,7 +59,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
 
     // Stub out IAIPlayerStrategyFactory so resolver can build the handler
     container.register(
-      tokens.AIStrategyFactory,
+      tokens.TurnStrategyFactory,
       () => ({
         create: () => ({
           // dummy strategy; TurnHandlerResolver doesn’t execute it here
@@ -131,7 +131,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
 
     // ── Stub IAIPlayerStrategyFactory properly ──
     brokenContainer.register(
-      tokens.AIStrategyFactory,
+      tokens.TurnStrategyFactory,
       () => ({
         create: () => ({
           // dummy strategy; not invoked here
@@ -148,7 +148,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
           logger: c.resolve(tokens.ILogger),
           turnStateFactory: c.resolve(tokens.ITurnStateFactory),
           turnEndPort: c.resolve(tokens.ITurnEndPort),
-          strategyFactory: c.resolve(tokens.AIStrategyFactory),
+          strategyFactory: c.resolve(tokens.TurnStrategyFactory),
           // turnContextBuilder intentionally omitted
         }),
       { lifecycle: 'transient' }

--- a/tests/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/aiRegistrations.test.js
@@ -105,7 +105,7 @@ describe('registerAI', () => {
     container.register(tokens.ITurnEndPort, {});
     container.register(tokens.ICommandProcessor, {});
     container.register(tokens.ICommandOutcomeInterpreter, {});
-    container.register(tokens.AIStrategyFactory, {});
+    container.register(tokens.TurnStrategyFactory, {});
     container.register(tokens.ITurnContextFactory, {});
     container.register(tokens.PromptTextLoader, { loadPromptText: jest.fn() });
   });


### PR DESCRIPTION
## Summary
- add `TurnStrategyFactory` token for unified registration
- update `registerGenericStrategy` to always register under `TurnStrategyFactory`
- register generic strategies using new token in AI and turn lifecycle registrations
- resolve `TurnStrategyFactory` when constructing `ActorTurnHandler`
- adjust unit tests for new token

## Testing
- `npm run lint` *(fails: many existing warnings/errors)*
- `npx eslint src/dependencyInjection/registrations/registerGenericStrategy.js src/dependencyInjection/registrations/aiRegistrations.js src/dependencyInjection/registrations/turnLifecycleRegistrations.js src/dependencyInjection/tokens.js tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js tests/dependencyInjection/registrations/aiRegistrations.test.js` *(passes with warnings)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851b6f61fd88331b34dcb8fdb19e08e