### PR TITLE
[Agent] unify strategy factory token

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -404,11 +404,7 @@ export function registerAI(container) {
     `AI Systems Registration: Registered ${tokens.ILLMDecisionProvider}.`
   );
 
-  registerGenericStrategy(
-    container,
-    tokens.ILLMDecisionProvider,
-    tokens.AIStrategyFactory
-  );
+  registerGenericStrategy(container, tokens.ILLMDecisionProvider);
 
   // --- AI TURN HANDLER (MODIFIED) ---
 
@@ -419,7 +415,7 @@ export function registerAI(container) {
         logger: c.resolve(tokens.ILogger),
         turnStateFactory: c.resolve(tokens.ITurnStateFactory),
         turnEndPort: c.resolve(tokens.ITurnEndPort),
-        strategyFactory: c.resolve(tokens.AIStrategyFactory), // <-- Updated
+        strategyFactory: c.resolve(tokens.GenericStrategyFactory),
         turnContextBuilder: c.resolve(tokens.TurnContextBuilder), // <-- Added
       })
   );

--- a/src/dependencyInjection/registrations/registerGenericStrategy.js
+++ b/src/dependencyInjection/registrations/registerGenericStrategy.js
@@ -17,19 +17,12 @@ import { GenericStrategyFactory } from '../../turns/factories/genericStrategyFac
  *
  * @param {AppContainer} container - The DI container.
  * @param {DiToken} decisionProviderToken - Token for the decision provider.
- * @param {DiToken} strategyFactoryToken - Token for the resulting strategy factory.
  * @returns {void}
  */
-export function registerGenericStrategy(
-  container,
-  decisionProviderToken,
-  strategyFactoryToken
-) {
+export function registerGenericStrategy(container, decisionProviderToken) {
   const r = new Registrar(container);
   const logger = container.resolve(tokens.ILogger);
-  logger.debug(
-    `[registerGenericStrategy] Starting for ${String(strategyFactoryToken)}...`
-  );
+  logger.debug('[registerGenericStrategy] Starting...');
 
   if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
     r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
@@ -53,8 +46,8 @@ export function registerGenericStrategy(
     );
   }
 
-  if (!container.isRegistered(strategyFactoryToken)) {
-    r.singletonFactory(strategyFactoryToken, (c) => {
+  if (!container.isRegistered(tokens.GenericStrategyFactory)) {
+    r.singletonFactory(tokens.GenericStrategyFactory, (c) => {
       const opts = {
         choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
         decisionProvider: c.resolve(decisionProviderToken),
@@ -67,11 +60,9 @@ export function registerGenericStrategy(
       return new GenericStrategyFactory(opts);
     });
     logger.debug(
-      `[registerGenericStrategy] Registered ${String(strategyFactoryToken)}.`
+      `[registerGenericStrategy] Registered ${tokens.GenericStrategyFactory}.`
     );
   }
 
-  logger.debug(
-    `[registerGenericStrategy] Completed for ${String(strategyFactoryToken)}.`
-  );
+  logger.debug('[registerGenericStrategy] Completed.');
 }

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -103,11 +103,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ────────────────── Turn Strategy Factory ──────────────────
-  registerGenericStrategy(
-    container,
-    tokens.IHumanDecisionProvider,
-    tokens.HumanStrategyFactory
-  );
+  registerGenericStrategy(container, tokens.IHumanDecisionProvider);
 
   // ──────────────────── Validation Utils ─────────────────────
   r.singletonFactory(
@@ -144,7 +140,7 @@ export function registerTurnLifecycle(container) {
         promptCoordinator: c.resolve(tokens.IPromptCoordinator),
         commandOutcomeInterpreter: c.resolve(tokens.ICommandOutcomeInterpreter),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
-        turnStrategyFactory: c.resolve(tokens.HumanStrategyFactory), // <-- Injected factory
+        strategyFactory: c.resolve(tokens.GenericStrategyFactory),
         entityManager: c.resolve(tokens.IEntityManager),
         turnContextBuilder: c.resolve(tokens.TurnContextBuilder), // <-- Injected builder
       })

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -247,6 +247,7 @@ export const tokens = freeze({
   // --- Turn System Factories ---
   ITurnStateFactory: 'ITurnStateFactory',
   AIStrategyFactory: 'AIStrategyFactory',
+  GenericStrategyFactory: 'GenericStrategyFactory',
   ITurnContextFactory: 'ITurnContextFactory',
   HumanStrategyFactory: 'HumanStrategyFactory',
 

--- a/src/turns/handlers/actorTurnHandler.js
+++ b/src/turns/handlers/actorTurnHandler.js
@@ -27,24 +27,21 @@ class ActorTurnHandler extends GenericTurnHandler {
    * @param {ILogger} deps.logger
    * @param {ITurnStateFactory} deps.turnStateFactory
    * @param {ITurnEndPort} deps.turnEndPort
-   * @param {ITurnStrategyFactory} [deps.turnStrategyFactory]
-   * @param {ITurnStrategyFactory} [deps.strategyFactory]
+   * @param {ITurnStrategyFactory} deps.strategyFactory
    * @param {TurnContextBuilder} deps.turnContextBuilder
    */
   constructor({
     logger,
     turnStateFactory,
     turnEndPort,
-    turnStrategyFactory,
     strategyFactory,
     turnContextBuilder,
   }) {
-    const factory = turnStrategyFactory || strategyFactory;
     super({
       logger,
       turnStateFactory,
       turnEndPort,
-      strategyFactory: factory,
+      strategyFactory,
       turnContextBuilder,
     });
 

--- a/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
+++ b/tests/config/registrations/coreSystemsRegistration.AIFallbackActionFactory.test.js
@@ -59,7 +59,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
 
     // Stub out IAIPlayerStrategyFactory so resolver can build the handler
     container.register(
-      tokens.AIStrategyFactory,
+      tokens.GenericStrategyFactory,
       () => ({
         create: () => ({
           // dummy strategy; TurnHandlerResolver doesn’t execute it here
@@ -131,7 +131,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
 
     // ── Stub IAIPlayerStrategyFactory properly ──
     brokenContainer.register(
-      tokens.AIStrategyFactory,
+      tokens.GenericStrategyFactory,
       () => ({
         create: () => ({
           // dummy strategy; not invoked here
@@ -148,7 +148,7 @@ describe('Core Systems Registrations: Turn Handler Creation', () => {
           logger: c.resolve(tokens.ILogger),
           turnStateFactory: c.resolve(tokens.ITurnStateFactory),
           turnEndPort: c.resolve(tokens.ITurnEndPort),
-          strategyFactory: c.resolve(tokens.AIStrategyFactory),
+          strategyFactory: c.resolve(tokens.GenericStrategyFactory),
           // turnContextBuilder intentionally omitted
         }),
       { lifecycle: 'transient' }

--- a/tests/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/aiRegistrations.test.js
@@ -105,7 +105,7 @@ describe('registerAI', () => {
     container.register(tokens.ITurnEndPort, {});
     container.register(tokens.ICommandProcessor, {});
     container.register(tokens.ICommandOutcomeInterpreter, {});
-    container.register(tokens.AIStrategyFactory, {});
+    container.register(tokens.GenericStrategyFactory, {});
     container.register(tokens.ITurnContextFactory, {});
     container.register(tokens.PromptTextLoader, { loadPromptText: jest.fn() });
   });

--- a/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
+++ b/tests/turns/handlers/humanTurnHandler.actorMismatchAwait.test.js
@@ -69,7 +69,7 @@ describe('ActorTurnHandler handleSubmittedCommand actor mismatch', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
-      turnStrategyFactory: mockTurnStrategyFactory,
+      strategyFactory: mockTurnStrategyFactory,
       turnContextBuilder: mockTurnContextBuilder,
     };
 

--- a/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitTurnEndPromise.test.js
@@ -69,7 +69,7 @@ describe('ActorTurnHandler handleSubmittedCommand awaiting _handleTurnEnd', () =
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
-      turnStrategyFactory: mockTurnStrategyFactory,
+      strategyFactory: mockTurnStrategyFactory,
       turnContextBuilder: mockTurnContextBuilder,
     };
 

--- a/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.awaitingExternalEventFlag.test.js
@@ -73,7 +73,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
-    turnStrategyFactory: mockTurnStrategyFactory,
+    strategyFactory: mockTurnStrategyFactory,
     turnContextBuilder: mockTurnContextBuilder,
   };
 

--- a/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
+++ b/tests/turns/handlers/humanTurnHandler.clearAwaitFlag.test.js
@@ -65,7 +65,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
-    turnStrategyFactory: mockTurnStrategyFactory,
+    strategyFactory: mockTurnStrategyFactory,
     turnContextBuilder: mockTurnContextBuilder,
   };
 

--- a/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
+++ b/tests/turns/handlers/humanTurnHandler.getTurnEndPort.test.js
@@ -51,7 +51,7 @@ beforeEach(() => {
     humanDecisionProvider: {},
     turnActionFactory: {},
 
-    turnStrategyFactory: {
+    strategyFactory: {
       createForHuman: jest.fn(() => ({ decideAction: jest.fn() })),
     },
 

--- a/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
+++ b/tests/turns/handlers/humanTurnHandler.invalidActor.test.js
@@ -67,7 +67,7 @@ describe('ActorTurnHandler.handleSubmittedCommand with invalid actor', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
-      turnStrategyFactory: mockTurnStrategyFactory,
+      strategyFactory: mockTurnStrategyFactory,
       turnContextBuilder: mockTurnContextBuilder,
     };
 

--- a/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.methodDelegation.test.js
@@ -68,7 +68,7 @@ describe('ActorTurnHandler method delegation', () => {
       choicePipeline: mockChoicePipeline,
       humanDecisionProvider: mockHumanDecisionProvider,
       turnActionFactory: mockTurnActionFactory,
-      turnStrategyFactory: mockTurnStrategyFactory,
+      strategyFactory: mockTurnStrategyFactory,
       turnContextBuilder: mockTurnContextBuilder,
     };
     jest

--- a/tests/turns/handlers/humanTurnHandler.startTurn.test.js
+++ b/tests/turns/handlers/humanTurnHandler.startTurn.test.js
@@ -84,7 +84,7 @@ describe('ActorTurnHandler', () => {
       promptCoordinator: mockPromptCoordinator,
       commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
       safeEventDispatcher: mockSafeEventDispatcher,
-      turnStrategyFactory: mockTurnStrategyFactory,
+      strategyFactory: mockTurnStrategyFactory,
       turnContextBuilder: mockTurnContextBuilder,
     });
   };

--- a/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
+++ b/tests/turns/handlers/humanTurnHandler.startTurn.validation.test.js
@@ -65,7 +65,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
-    turnStrategyFactory: mockTurnStrategyFactory,
+    strategyFactory: mockTurnStrategyFactory,
     turnContextBuilder: mockTurnContextBuilder,
   };
 

--- a/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
+++ b/tests/turns/handlers/humanTurnHandler.turnEndedPayload.test.js
@@ -66,7 +66,7 @@ beforeEach(() => {
     choicePipeline: mockChoicePipeline,
     humanDecisionProvider: mockHumanDecisionProvider,
     turnActionFactory: mockTurnActionFactory,
-    turnStrategyFactory: mockTurnStrategyFactory,
+    strategyFactory: mockTurnStrategyFactory,
     turnContextBuilder: mockTurnContextBuilder,
   };
 

--- a/tests/turns/handlers/playerTurnHandler.fixes.test.js
+++ b/tests/turns/handlers/playerTurnHandler.fixes.test.js
@@ -65,7 +65,7 @@ describe('ActorTurnHandler Constructor', () => {
     logger: mockLogger,
     turnStateFactory: mockTurnStateFactory,
     turnEndPort: mockTurnEndPort,
-    turnStrategyFactory: mockTurnStrategyFactory,
+    strategyFactory: mockTurnStrategyFactory,
     turnContextBuilder: mockTurnContextBuilder,
     gameWorldAccess: mockGameWorldAccess,
   });
@@ -116,9 +116,9 @@ describe('ActorTurnHandler Constructor', () => {
   });
 
   // New test case for the new required dependency
-  it('should throw an error if turnStrategyFactory is not provided', () => {
+  it('should throw an error if strategyFactory is not provided', () => {
     const deps = getValidDependencies();
-    delete deps.turnStrategyFactory;
+    delete deps.strategyFactory;
     expect(() => new ActorTurnHandler(deps)).toThrow(
       'GenericTurnHandler: strategyFactory is required'
     );


### PR DESCRIPTION
Summary: Implemented GenericStrategyFactory token to standardize turn strategy creation.

Changes Made:
- Added new token in `tokens.js` and updated `registerGenericStrategy` to always register under it.
- Modified AI and human turn lifecycle registrations to use the unified factory.
- Updated `ActorTurnHandler` to accept a single `strategyFactory` dependency.
- Adjusted tests and DI registrations to reference the new token and parameter.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_68519d9f73748331bb4328806eda361a