### PR TITLE
[Agent] Guard clause for menu button listeners

### DIFF
--- a/src/bootstrapper/stages/uiStages.js
+++ b/src/bootstrapper/stages/uiStages.js
@@ -62,29 +62,7 @@ export async function setupMenuButtonListenersStage(
   logger.debug(`Bootstrap Stage: Starting ${stageName}...`);
 
   try {
-    if (gameEngine) {
-      setupButtonListener(
-        documentRef,
-        'open-save-game-button',
-        () => {
-          logger.debug(`${stageName}: "Open Save Game UI" button clicked.`);
-          gameEngine.showSaveGameUI();
-        },
-        logger,
-        stageName
-      );
-
-      setupButtonListener(
-        documentRef,
-        'open-load-game-button',
-        () => {
-          logger.debug(`${stageName}: "Open Load Game UI" button clicked.`);
-          gameEngine.showLoadGameUI();
-        },
-        logger,
-        stageName
-      );
-    } else {
+    if (!gameEngine) {
       setupButtonListener(
         documentRef,
         'open-save-game-button',
@@ -105,7 +83,32 @@ export async function setupMenuButtonListenersStage(
       logger.warn(
         `${stageName}: GameEngine not available for #open-load-game-button listener.`
       );
+      logger.debug(`Bootstrap Stage: ${stageName} completed successfully.`);
+      return { success: true };
     }
+
+    setupButtonListener(
+      documentRef,
+      'open-save-game-button',
+      () => {
+        logger.debug(`${stageName}: "Open Save Game UI" button clicked.`);
+        gameEngine.showSaveGameUI();
+      },
+      logger,
+      stageName
+    );
+
+    setupButtonListener(
+      documentRef,
+      'open-load-game-button',
+      () => {
+        logger.debug(`${stageName}: "Open Load Game UI" button clicked.`);
+        gameEngine.showLoadGameUI();
+      },
+      logger,
+      stageName
+    );
+
     logger.debug(`Bootstrap Stage: ${stageName} completed successfully.`);
     return stageSuccess();
   } catch (error) {


### PR DESCRIPTION
Summary: Simplified `setupMenuButtonListenersStage` to return early when the `gameEngine` isn't provided. Empty handlers are still attached with warnings, mirroring previous behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on target file `npx eslint src/bootstrapper/stages/uiStages.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851bb121fcc83319b60bcaf4b6fb07f