### PR TITLE
[Feat] Add shared DOM list rendering helper

### DIFF
--- a/src/domUI/helpers/renderListCommon.js
+++ b/src/domUI/helpers/renderListCommon.js
@@ -1,0 +1,121 @@
+/**
+ * @file Shared helper for rendering lists in the DOM.
+ */
+
+import { DomUtils } from '../../utils/domUtils.js';
+import createMessageElement from './createMessageElement.js';
+
+/** @typedef {import('../domElementFactory.js').default} DomElementFactory */
+/** @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger */
+
+/**
+ * Shared helper to fetch data and populate a DOM list.
+ *
+ * @description Fetches list data, clears the container, and renders the list
+ * using the supplied callbacks. Handles empty data and errors.
+ * @param {Function} fetchData - Function returning the data array (can be async).
+ * @param {Function} renderItem - Renders a DOM element for an item.
+ *   Signature `(itemData, index, listData) => HTMLElement | null`.
+ * @param {Function} getEmptyMessage - Returns a string or HTMLElement used when
+ *   the list data is empty.
+ * @param {HTMLElement} container - The DOM element to populate with list items.
+ * @param {ILogger} logger - Logger for diagnostic messages.
+ * @param {DomElementFactory} [domElementFactory] - Optional element factory used
+ *   for fallback message creation.
+ * @returns {Promise<Array<any> | null>} Resolves with the fetched list data or
+ *   `null` if an error occurred.
+ */
+export async function renderListCommon(
+  fetchData,
+  renderItem,
+  getEmptyMessage,
+  container,
+  logger,
+  domElementFactory
+) {
+  let listData = null;
+  try {
+    listData = await Promise.resolve(fetchData());
+    logger.debug(
+      `[renderListCommon] Fetched list data. Count: ${
+        listData ? listData.length : 'null/undefined'
+      }`
+    );
+  } catch (error) {
+    logger.error('[renderListCommon] Error fetching list data:', error);
+    DomUtils.clearElement(container);
+    const errorEl = createMessageElement(
+      domElementFactory,
+      'error-message',
+      'Error loading list data.'
+    );
+    container.appendChild(errorEl);
+    return null;
+  }
+
+  DomUtils.clearElement(container);
+  logger.debug('[renderListCommon] Cleared list container.');
+
+  if (!listData || !Array.isArray(listData) || listData.length === 0) {
+    const emptyMsg = getEmptyMessage();
+    if (typeof emptyMsg === 'string') {
+      if (domElementFactory) {
+        container.appendChild(
+          createMessageElement(
+            domElementFactory,
+            'empty-list-message',
+            emptyMsg
+          )
+        );
+      } else {
+        container.textContent = emptyMsg;
+      }
+    } else if (emptyMsg instanceof HTMLElement) {
+      container.appendChild(emptyMsg);
+    } else {
+      logger.warn('[renderListCommon] getEmptyMessage returned invalid type.', {
+        type: typeof emptyMsg,
+      });
+      if (domElementFactory) {
+        container.appendChild(
+          createMessageElement(
+            domElementFactory,
+            'empty-list-message',
+            'List is empty.'
+          )
+        );
+      } else {
+        container.textContent = 'List is empty.';
+      }
+    }
+    logger.debug('[renderListCommon] Empty list message displayed.');
+  } else {
+    let rendered = 0;
+    listData.forEach((item, index) => {
+      try {
+        const el = renderItem(item, index, listData);
+        if (el && el.nodeType === 1) {
+          container.appendChild(el);
+          rendered++;
+        } else if (el !== null) {
+          logger.warn(
+            '[renderListCommon] renderItem did not return an element.',
+            {
+              item,
+              returnedValue: el,
+            }
+          );
+        }
+      } catch (err) {
+        logger.error('[renderListCommon] Error in renderItem:', err, { item });
+      }
+    });
+    logger.debug(
+      `[renderListCommon] Rendered ${rendered} out of ${listData.length} items.`
+    );
+  }
+
+  return listData;
+}
+
+export default renderListCommon;

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -5,9 +5,8 @@
  */
 
 import { BaseModalRenderer } from './baseModalRenderer.js';
-import { DomUtils } from '../utils/domUtils.js';
 import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
-import createMessageElement from './helpers/createMessageElement.js';
+import renderListCommon from './helpers/renderListCommon.js';
 
 /**
  * @class SlotModalBase
@@ -213,31 +212,15 @@ export class SlotModalBase extends BaseModalRenderer {
     this._setOperationInProgress(true);
     this._displayStatusMessage(loadingMessage, 'info');
 
-    DomUtils.clearElement(this.elements.listContainerElement);
-
-    const slotsData = await fetchDataFn();
-    this.currentSlotsDisplayData = Array.isArray(slotsData) ? slotsData : [];
-
-    if (this.currentSlotsDisplayData.length === 0) {
-      const emptyMessage = getEmptyMessageFn();
-      if (typeof emptyMessage === 'string') {
-        this.elements.listContainerElement?.appendChild(
-          createMessageElement(this.domElementFactory, undefined, emptyMessage)
-        );
-      } else if (
-        emptyMessage instanceof
-        this.documentContext.document.defaultView.HTMLElement
-      ) {
-        this.elements.listContainerElement?.appendChild(emptyMessage);
-      }
-    } else {
-      this.currentSlotsDisplayData.forEach((slotData, index) => {
-        const el = renderItemFn(slotData, index);
-        if (el && this.elements.listContainerElement) {
-          this.elements.listContainerElement.appendChild(el);
-        }
-      });
-    }
+    const data = await renderListCommon(
+      fetchDataFn,
+      (item, index, list) => renderItemFn(item, index, list),
+      getEmptyMessageFn,
+      this.elements.listContainerElement,
+      this.logger,
+      this.domElementFactory
+    );
+    this.currentSlotsDisplayData = Array.isArray(data) ? data : [];
 
     this._clearStatusMessage();
     this._setOperationInProgress(false);

--- a/tests/domUI/baseListDisplayComponent.test.js
+++ b/tests/domUI/baseListDisplayComponent.test.js
@@ -243,9 +243,7 @@ describe('BaseListDisplayComponent', () => {
         await instance.renderList();
 
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(
-            '_getEmptyListMessage() returned an invalid type'
-          ),
+          expect.stringContaining('getEmptyMessage returned invalid type'),
           expect.any(Object)
         );
         expect(listContainerElement.textContent).toBe('List is empty.');
@@ -338,9 +336,7 @@ describe('BaseListDisplayComponent', () => {
         await instance.renderList();
 
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(
-            '_renderListItem for item at index 0 did not return an HTMLElement or null'
-          ),
+          expect.stringContaining('renderItem did not return an element'),
           expect.anything()
         );
         expect(listContainerElement.children.length).toBe(1); // Only the valid element
@@ -359,9 +355,7 @@ describe('BaseListDisplayComponent', () => {
         await instance.renderList();
 
         expect(mockLogger.error).toHaveBeenCalledWith(
-          expect.stringContaining(
-            'Error in _renderListItem for item at index 0:'
-          ),
+          expect.stringContaining('Error in renderItem'),
           error,
           expect.anything()
         );
@@ -402,7 +396,7 @@ describe('BaseListDisplayComponent', () => {
       await instance.renderList();
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error fetching list items data'),
+        expect.stringContaining('Error fetching list data'),
         error
       );
       expect(DomUtils.clearElement).toHaveBeenCalledWith(listContainerElement);


### PR DESCRIPTION
Summary: Introduces `renderListCommon` utility to centralize DOM list rendering logic used in UI components. BaseListDisplayComponent and SlotModalBase now delegate to this helper and tests updated accordingly.

Changes Made:
- Added `renderListCommon` helper with JSDoc.
- Refactored BaseListDisplayComponent.renderList and SlotModalBase.populateSlotsList to use the helper.
- Updated BaseListDisplayComponent tests for new log messages.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6851ba9331908331a5de3faacab2efb5