### PR TITLE
[Agent] add actor type utility

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -7,6 +7,7 @@
 
 import { AbstractTurnState } from './abstractTurnState.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
+import { getActorType } from '../utils/actorTypeUtils.js';
 
 /**
  * State in which the engine waits for the current actor’s turn-strategy to
@@ -87,7 +88,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
       }
 
       // Determine actor type: 'ai' or 'human'
-      const actorType = actor.isAi === true ? 'ai' : 'human';
+      const actorType = getActorType(actor);
 
       // Dispatch the standardized action_decided event
       const payload = {

--- a/src/turns/utils/actorTypeUtils.js
+++ b/src/turns/utils/actorTypeUtils.js
@@ -1,0 +1,19 @@
+// src/turns/utils/actorTypeUtils.js
+
+/**
+ * @file Utility to determine the actor type string.
+ */
+
+/**
+ * Determines the actor type for event payloads.
+ *
+ * @description
+ * Returns `'ai'` when the provided actor has an `isAi` property set to
+ * `true`. For all other cases, `'human'` is returned. The function may be
+ * extended later to handle additional actor classifications.
+ * @param {object} actor - Actor entity or model to inspect.
+ * @returns {string} `'ai'` if the actor is flagged as AI, otherwise `'human'`.
+ */
+export function getActorType(actor) {
+  return actor && actor.isAi === true ? 'ai' : 'human';
+}

--- a/tests/turns/utils/actorTypeUtils.test.js
+++ b/tests/turns/utils/actorTypeUtils.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { getActorType } from '../../../src/turns/utils/actorTypeUtils.js';
+
+describe('getActorType', () => {
+  it('returns "ai" when actor.isAi is true', () => {
+    const actor = { isAi: true };
+    expect(getActorType(actor)).toBe('ai');
+  });
+
+  it('returns "human" when actor.isAi is false', () => {
+    const actor = { isAi: false };
+    expect(getActorType(actor)).toBe('human');
+  });
+
+  it('defaults to "human" when actor.isAi is undefined', () => {
+    const actor = {};
+    expect(getActorType(actor)).toBe('human');
+  });
+});


### PR DESCRIPTION
Summary: Extracted AI/human actor type logic into `getActorType` utility and updated `AwaitingActorDecisionState` to use it. Added unit tests.

Testing Done:
- [x] Code formatted `npx prettier -w src/turns/utils/actorTypeUtils.js src/turns/states/awaitingActorDecisionState.js tests/turns/utils/actorTypeUtils.test.js`
- [x] Lint passes on changed files `npx eslint src/turns/utils/actorTypeUtils.js src/turns/states/awaitingActorDecisionState.js tests/turns/utils/actorTypeUtils.test.js --fix`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851bc78b40c83318faab5b312b2bf13