### PR TITLE
[Agent] add actor aware strategy factory

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -99,7 +99,7 @@ import * as ConditionEvaluator from '../../prompting/elementConditionEvaluator.j
 import { LLMChooser } from '../../turns/adapters/llmChooser.js';
 import { ActionIndexerAdapter } from '../../turns/adapters/actionIndexerAdapter.js';
 import { LLMDecisionProvider } from '../../turns/providers/llmDecisionProvider.js';
-import { registerGenericStrategy } from './registerGenericStrategy.js';
+import { registerActorAwareStrategy } from './registerActorAwareStrategy.js';
 
 /**
  * Registers AI, LLM, and Prompting services.
@@ -404,7 +404,7 @@ export function registerAI(container) {
     `AI Systems Registration: Registered ${tokens.ILLMDecisionProvider}.`
   );
 
-  registerGenericStrategy(container, tokens.ILLMDecisionProvider);
+  registerActorAwareStrategy(container);
 
   // --- AI TURN HANDLER (MODIFIED) ---
 

--- a/src/dependencyInjection/registrations/registerActorAwareStrategy.js
+++ b/src/dependencyInjection/registrations/registerActorAwareStrategy.js
@@ -1,0 +1,68 @@
+// src/dependencyInjection/registrations/registerActorAwareStrategy.js
+/**
+ * @file Helper for registering the ActorAwareStrategyFactory and prerequisites.
+ */
+
+/** @typedef {import('../appContainer.js').default} AppContainer */
+
+import { tokens } from '../tokens.js';
+import { Registrar } from '../registrarHelpers.js';
+import { TurnActionChoicePipeline } from '../../turns/pipeline/turnActionChoicePipeline.js';
+import { TurnActionFactory } from '../../turns/factories/turnActionFactory.js';
+import { ActorAwareStrategyFactory } from '../../turns/factories/actorAwareStrategyFactory.js';
+
+/**
+ * Registers the ActorAwareStrategyFactory and supporting services if needed.
+ *
+ * @param {AppContainer} container - The DI container.
+ */
+export function registerActorAwareStrategy(container) {
+  const r = new Registrar(container);
+  const logger = container.resolve(tokens.ILogger);
+  logger.debug('[registerActorAwareStrategy] Starting...');
+
+  if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
+    r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
+      return new TurnActionChoicePipeline({
+        availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
+        logger: c.resolve(tokens.ILogger),
+      });
+    });
+    logger.debug(
+      `[registerActorAwareStrategy] Registered ${tokens.TurnActionChoicePipeline}.`
+    );
+  }
+
+  if (!container.isRegistered(tokens.ITurnActionFactory)) {
+    r.singletonFactory(
+      tokens.ITurnActionFactory,
+      () => new TurnActionFactory()
+    );
+    logger.debug(
+      `[registerActorAwareStrategy] Registered ${tokens.ITurnActionFactory}.`
+    );
+  }
+
+  if (!container.isRegistered(tokens.TurnStrategyFactory)) {
+    r.singletonFactory(tokens.TurnStrategyFactory, (c) => {
+      const opts = {
+        humanProvider: c.resolve(tokens.IHumanDecisionProvider),
+        aiProvider: c.resolve(tokens.ILLMDecisionProvider),
+        logger: c.resolve(tokens.ILogger),
+        choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
+        turnActionFactory: c.resolve(tokens.ITurnActionFactory),
+        actorLookup: (id) =>
+          c.resolve(tokens.IEntityManager).getEntityInstance(id),
+      };
+      if (c.isRegistered(tokens.IAIFallbackActionFactory)) {
+        opts.fallbackFactory = c.resolve(tokens.IAIFallbackActionFactory);
+      }
+      return new ActorAwareStrategyFactory(opts);
+    });
+    logger.debug(
+      `[registerActorAwareStrategy] Registered ${tokens.TurnStrategyFactory}.`
+    );
+  }
+
+  logger.debug('[registerActorAwareStrategy] Completed.');
+}

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -24,7 +24,6 @@ import {
 import { HumanDecisionProvider } from '../../turns/providers/humanDecisionProvider.js';
 import { TurnContextBuilder } from '../../turns/builders/turnContextBuilder.js';
 import { assertValidEntity } from '../../utils/entityAssertionsUtils.js';
-import { registerGenericStrategy } from './registerGenericStrategy.js';
 
 /**
  * @param {import('../appContainer.js').default} container
@@ -100,9 +99,6 @@ export function registerTurnLifecycle(container) {
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );
-
-  // ────────────────── Turn Strategy Factory ──────────────────
-  registerGenericStrategy(container, tokens.IHumanDecisionProvider);
 
   // ──────────────────── Validation Utils ─────────────────────
   r.singletonFactory(

--- a/src/turns/factories/actorAwareStrategyFactory.js
+++ b/src/turns/factories/actorAwareStrategyFactory.js
@@ -1,0 +1,109 @@
+// src/turns/factories/actorAwareStrategyFactory.js
+/**
+ * @file Factory that chooses between human or AI decision providers
+ * based on an actor's properties.
+ */
+
+import { ITurnStrategyFactory } from '../interfaces/ITurnStrategyFactory.js';
+import { GenericTurnStrategy } from '../strategies/genericTurnStrategy.js';
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../pipeline/turnActionChoicePipeline.js').TurnActionChoicePipeline} TurnActionChoicePipeline */
+/** @typedef {import('../interfaces/ITurnDecisionProvider.js').ITurnDecisionProvider} ITurnDecisionProvider */
+/** @typedef {import('../ports/ITurnActionFactory.js').ITurnActionFactory} ITurnActionFactory */
+/** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+export class ActorAwareStrategyFactory extends ITurnStrategyFactory {
+  /** @type {ITurnDecisionProvider} */
+  #humanProvider;
+  /** @type {ITurnDecisionProvider} */
+  #aiProvider;
+  /** @type {ILogger} */
+  #logger;
+  /** @type {TurnActionChoicePipeline} */
+  #choicePipeline;
+  /** @type {ITurnActionFactory} */
+  #turnActionFactory;
+  /** @type {import('../interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory|null} */
+  #fallbackFactory;
+  /** @type {(id:string)=>any} */
+  #actorLookup;
+
+  /**
+   * @param {object} deps
+   * @param {ITurnDecisionProvider} deps.humanProvider
+   * @param {ITurnDecisionProvider} deps.aiProvider
+   * @param {ILogger} deps.logger
+   * @param {TurnActionChoicePipeline} deps.choicePipeline
+   * @param {ITurnActionFactory} deps.turnActionFactory
+   * @param {import('../interfaces/IAIFallbackActionFactory.js').IAIFallbackActionFactory} [deps.fallbackFactory]
+   * @param {(id:string)=>any} [deps.actorLookup]
+   * @param {IEntityManager} [deps.entityManager]
+   */
+  constructor({
+    humanProvider,
+    aiProvider,
+    logger,
+    choicePipeline,
+    turnActionFactory,
+    fallbackFactory = null,
+    actorLookup = null,
+    entityManager = null,
+  }) {
+    super();
+    if (!humanProvider)
+      throw new Error('ActorAwareStrategyFactory: humanProvider is required');
+    if (!aiProvider)
+      throw new Error('ActorAwareStrategyFactory: aiProvider is required');
+    if (!logger)
+      throw new Error('ActorAwareStrategyFactory: logger is required');
+    if (!choicePipeline)
+      throw new Error('ActorAwareStrategyFactory: choicePipeline is required');
+    if (!turnActionFactory)
+      throw new Error(
+        'ActorAwareStrategyFactory: turnActionFactory is required'
+      );
+
+    this.#humanProvider = humanProvider;
+    this.#aiProvider = aiProvider;
+    this.#logger = logger;
+    this.#choicePipeline = choicePipeline;
+    this.#turnActionFactory = turnActionFactory;
+    this.#fallbackFactory = fallbackFactory;
+
+    if (typeof actorLookup === 'function') {
+      this.#actorLookup = actorLookup;
+    } else if (
+      entityManager &&
+      typeof entityManager.getEntityInstance === 'function'
+    ) {
+      this.#actorLookup = (id) => entityManager.getEntityInstance(id);
+    } else {
+      throw new Error(
+        'ActorAwareStrategyFactory: actorLookup callback or entityManager is required'
+      );
+    }
+  }
+
+  /**
+   * Creates an appropriate GenericTurnStrategy for the given actor ID.
+   *
+   * @param {string} actorId
+   * @returns {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy}
+   */
+  create(actorId) {
+    const actor = this.#actorLookup(actorId);
+    const isAi = actor && actor.isAi === true;
+    const decisionProvider = isAi ? this.#aiProvider : this.#humanProvider;
+    this.#logger.debug(
+      `ActorAwareStrategyFactory: Creating GenericTurnStrategy for ${actorId} using ${isAi ? 'AI' : 'Human'} provider.`
+    );
+    return new GenericTurnStrategy({
+      choicePipeline: this.#choicePipeline,
+      decisionProvider,
+      turnActionFactory: this.#turnActionFactory,
+      logger: this.#logger,
+      fallbackFactory: this.#fallbackFactory,
+    });
+  }
+}

--- a/tests/turns/factories/actorAwareStrategyFactory.test.js
+++ b/tests/turns/factories/actorAwareStrategyFactory.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { ActorAwareStrategyFactory } from '../../../src/turns/factories/actorAwareStrategyFactory.js';
+import { GenericTurnStrategy } from '../../../src/turns/strategies/genericTurnStrategy.js';
+
+describe('ActorAwareStrategyFactory', () => {
+  let humanProvider;
+  let aiProvider;
+  let logger;
+  let choicePipeline;
+  let actionFactory;
+  let lookup;
+  let actors;
+
+  beforeEach(() => {
+    humanProvider = { name: 'human' };
+    aiProvider = { name: 'ai' };
+    logger = { debug: jest.fn() };
+    choicePipeline = {};
+    actionFactory = {};
+    actors = {
+      human1: { id: 'human1' },
+      ai1: { id: 'ai1', isAi: true },
+    };
+    lookup = jest.fn((id) => actors[id]);
+  });
+
+  it('returns strategy using human provider for non-AI actor', () => {
+    const factory = new ActorAwareStrategyFactory({
+      humanProvider,
+      aiProvider,
+      logger,
+      choicePipeline,
+      turnActionFactory: actionFactory,
+      actorLookup: lookup,
+    });
+
+    const strategy = factory.create('human1');
+    expect(strategy).toBeInstanceOf(GenericTurnStrategy);
+    expect(strategy.decisionProvider).toBe(humanProvider);
+    expect(lookup).toHaveBeenCalledWith('human1');
+  });
+
+  it('returns strategy using AI provider for AI actor', () => {
+    const factory = new ActorAwareStrategyFactory({
+      humanProvider,
+      aiProvider,
+      logger,
+      choicePipeline,
+      turnActionFactory: actionFactory,
+      actorLookup: lookup,
+    });
+
+    const strategy = factory.create('ai1');
+    expect(strategy).toBeInstanceOf(GenericTurnStrategy);
+    expect(strategy.decisionProvider).toBe(aiProvider);
+    expect(lookup).toHaveBeenCalledWith('ai1');
+  });
+});


### PR DESCRIPTION
Summary: 
- choose human or AI decision provider at runtime
- register ActorAwareStrategyFactory in DI
- use it for actor turns
- cover actor aware factory with tests

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6851bc523a608331ae2f48b95073aa81