### PR TITLE
[Agent] centralize dispatcher resolution

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -6,7 +6,7 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../constants/eventIds.js';
 import { ICommandProcessor } from './interfaces/ICommandProcessor.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 // --- Type Imports ---
 /** @typedef {import('../entities/entity.js').default} Entity */
@@ -32,21 +32,16 @@ class CommandProcessor extends ICommandProcessor {
 
     this.#logger = logger;
 
-    try {
-      validateDependency(
-        safeEventDispatcher,
-        'safeEventDispatcher',
-        this.#logger,
-        { requiredMethods: ['dispatch'] }
+    this.#safeEventDispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      this.#logger
+    );
+    if (!this.#safeEventDispatcher) {
+      console.warn(
+        'CommandProcessor: safeEventDispatcher resolution failed; some events may not be dispatched.'
       );
-    } catch (error) {
-      this.#logger.error(
-        `CommandProcessor Constructor: Dependency validation failed. ${error.message}`
-      );
-      throw error;
     }
-
-    this.#safeEventDispatcher = safeEventDispatcher;
 
     this.#logger.debug(
       'CommandProcessor: Instance created and dependencies validated.'

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -12,6 +12,7 @@ import {
 } from '../constants/componentIds.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /**
  * Provides a stateless view of the world context, deriving information directly
@@ -73,17 +74,18 @@ class WorldContext extends IWorldContext {
         'WorldContext requires a valid ILogger instance with info, error, debug and warn methods.'
       );
     }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      throw new Error(
-        'WorldContext requires a valid ISafeEventDispatcher instance.'
+    this.#safeEventDispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      logger
+    );
+    if (!this.#safeEventDispatcher) {
+      console.warn(
+        'WorldContext: safeEventDispatcher resolution failed; some errors may not be dispatched.'
       );
     }
     this.#entityManager = entityManager;
     this.#logger = logger;
-    this.#safeEventDispatcher = safeEventDispatcher;
     this.#logger.debug(
       'WorldContext: Initialized (Stateless, backed by EntityManager).'
     );

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -4,6 +4,7 @@ import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import {
   // POSITION_COMPONENT_ID, // No longer directly used for current location logic
   // NAME_COMPONENT_ID, // Handled by EntityDisplayDataProvider
@@ -98,23 +99,26 @@ export class LocationRenderer extends BoundDomRendererBase {
       },
     };
 
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      const errMsg = `[LocationRenderer] ISafeEventDispatcher dependency is required.`;
-      throw new Error(errMsg);
+    const resolvedDispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      logger
+    );
+    if (!resolvedDispatcher) {
+      console.warn(
+        '[LocationRenderer] safeEventDispatcher resolution failed; UI errors may not be reported.'
+      );
     }
 
     super({
       logger,
       documentContext,
-      validatedEventDispatcher: safeEventDispatcher,
+      validatedEventDispatcher: resolvedDispatcher,
       elementsConfig,
       domElementFactory,
     });
 
-    this.safeEventDispatcher = safeEventDispatcher;
+    this.safeEventDispatcher = resolvedDispatcher;
 
     if (
       !entityManager ||

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -3,6 +3,7 @@
 import IPlaytimeTracker from '../interfaces/IPlaytimeTracker.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -79,17 +80,16 @@ class PlaytimeTracker extends IPlaytimeTracker {
       this.#logger = logger;
     }
 
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      console.error(
-        'PlaytimeTracker: safeEventDispatcher dependency is missing or invalid.'
+    this.#safeEventDispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      this.#logger
+    );
+    if (!this.#safeEventDispatcher) {
+      console.warn(
+        'PlaytimeTracker: safeEventDispatcher resolution failed; playtime events may not be emitted.'
       );
-      throw new Error('PlaytimeTracker requires a valid SafeEventDispatcher.');
     }
-
-    this.#safeEventDispatcher = safeEventDispatcher;
 
     this.#logger.debug('PlaytimeTracker: Instance created.');
   }

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -3,6 +3,7 @@
 
 import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -62,17 +63,17 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
       console.error(errorMsg);
       throw new Error(errorMsg);
     }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      const errorMsg =
-        'ClientApiKeyProvider: Constructor requires a valid ISafeEventDispatcher.';
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
     this.#logger = logger;
-    this.#dispatcher = safeEventDispatcher;
+    this.#dispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      this.#logger
+    );
+    if (!this.#dispatcher) {
+      console.warn(
+        'ClientApiKeyProvider: safeEventDispatcher resolution failed; errors may not be reported.'
+      );
+    }
     this.#logger.debug('ClientApiKeyProvider: Instance created.');
   }
 

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -8,6 +8,7 @@ import {
   IEnvironmentVariableReader,
 } from '../../llm-proxy-server/src/interfaces/IServerUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -44,16 +45,16 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
       throw new Error(errorMsg);
     }
     this.#logger = logger;
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      const errorMsg =
-        'ServerApiKeyProvider: Constructor requires a valid ISafeEventDispatcher.';
-      console.error(errorMsg);
-      throw new Error(errorMsg);
+    this.#dispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      this.#logger
+    );
+    if (!this.#dispatcher) {
+      console.warn(
+        'ServerApiKeyProvider: safeEventDispatcher resolution failed; key errors may not be reported.'
+      );
     }
-    this.#dispatcher = safeEventDispatcher;
     if (!fileSystemReader || typeof fileSystemReader.readFile !== 'function') {
       const errorMsg =
         'ServerApiKeyProvider: Constructor requires a valid fileSystemReader instance that implements IFileSystemReader (must have an async readFile method).';

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -1,6 +1,7 @@
 // src/services/browserStorageProvider.js
 import { IStorageProvider } from '../interfaces/IStorageProvider.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
+import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
@@ -25,16 +26,16 @@ export class BrowserStorageProvider extends IStorageProvider {
       throw new Error(errorMsg);
     }
     this.#logger = logger;
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      const errMsg =
-        'BrowserStorageProvider requires a valid ISafeEventDispatcher instance.';
-      console.error(errMsg);
-      throw new Error(errMsg);
+    this.#safeEventDispatcher = resolveSafeDispatcher(
+      null,
+      safeEventDispatcher,
+      this.#logger
+    );
+    if (!this.#safeEventDispatcher) {
+      console.warn(
+        'BrowserStorageProvider: safeEventDispatcher resolution failed; some errors may go unreported.'
+      );
     }
-    this.#safeEventDispatcher = safeEventDispatcher;
     this.#logger.debug(
       'BrowserStorageProvider: Initialized. Will use File System Access API with user prompts.'
     );

--- a/tests/context/worldContext.test.js
+++ b/tests/context/worldContext.test.js
@@ -120,7 +120,7 @@ describe('WorldContext (Stateless)', () => {
       ).toThrow('WorldContext requires a valid ILogger instance');
       expect(
         () => new WorldContext(mockEntityManager, mockLogger, null)
-      ).toThrow('WorldContext requires a valid ISafeEventDispatcher instance');
+      ).not.toThrow();
     });
 
     it('should successfully initialize with valid dependencies', () => {


### PR DESCRIPTION
Summary: Refactored multiple classes to use `resolveSafeDispatcher` for safer event dispatcher setup. Removed manual validation checks and added console fallbacks. Updated worldContext tests for new behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (warnings remain)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6851bcadf94c83318d0572ff6a6f65b9