### PR TITLE
[Agent] Add persistence constant

### DIFF
--- a/src/constants/persistence.js
+++ b/src/constants/persistence.js
@@ -1,0 +1,7 @@
+// src/constants/persistence.js
+
+/**
+ * @file Persistence-related constants shared across the application.
+ */
+
+export const CHECKSUM_PENDING = 'PENDING_CALCULATION';

--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -1,6 +1,7 @@
 // src/persistence/gameStateCaptureService.js
 
 import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
+import { CHECKSUM_PENDING } from '../constants/persistence.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 
 /**
@@ -193,7 +194,7 @@ class GameStateCaptureService {
         engineInternals: {},
       },
       integrityChecks: {
-        gameStateChecksum: 'PENDING_CALCULATION',
+        gameStateChecksum: CHECKSUM_PENDING,
       },
     };
 

--- a/tests/services/gameStateCaptureService.test.js
+++ b/tests/services/gameStateCaptureService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import { CURRENT_ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
+import { CHECKSUM_PENDING } from '../../src/constants/persistence.js';
 import { createMockLogger } from '../testUtils.js';
 
 describe('GameStateCaptureService', () => {
@@ -70,5 +71,10 @@ describe('GameStateCaptureService', () => {
     expect(comps).toHaveProperty('primitive', 7);
     expect(comps).not.toHaveProperty('nullComp');
     expect(comps).not.toHaveProperty(CURRENT_ACTOR_COMPONENT_ID);
+  });
+
+  it('uses CHECKSUM_PENDING in integrityChecks', () => {
+    const result = captureService.captureCurrentGameState('World');
+    expect(result.integrityChecks.gameStateChecksum).toBe(CHECKSUM_PENDING);
   });
 });


### PR DESCRIPTION
## Summary
- add `CHECKSUM_PENDING` constant for persistence
- replace hardcoded string in `GameStateCaptureService`
- test checksum pending constant usage

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 563 errors, 1956 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851bce392708331af6dff8842e60f85