### PR TITLE
[Agent] Normalize operation types with helper

### DIFF
--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -5,6 +5,7 @@
 
 import { resolvePlaceholders } from '../utils/contextUtils.js';
 import BaseService from '../utils/baseService.js';
+import { getNormalizedOperationType } from './utils/operationTypeUtils.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */
 /** @typedef {import('./defs.js').ExecutionContext}                               ExecutionContext */
@@ -39,21 +40,14 @@ class OperationInterpreter extends BaseService {
    * @param {ExecutionContext} executionContext
    */
   execute(operation, executionContext) {
-    if (!operation?.type || typeof operation.type !== 'string') {
-      this.#logger.error(
-        'OperationInterpreter received invalid operation object (missing type).',
-        { operation }
-      );
-      return;
-    }
-
-    const opType = operation.type.trim();
-
-    // FIX: Add a check for an empty string after trimming. This prevents
-    // the registry from being called with an empty type.
+    const opType = getNormalizedOperationType(
+      operation?.type,
+      this.#logger,
+      'OperationInterpreter.execute'
+    );
     if (!opType) {
       this.#logger.error(
-        'OperationInterpreter received an operation with a missing or empty type.',
+        'OperationInterpreter received invalid operation object (missing type).',
         { operation }
       );
       return;

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -5,6 +5,7 @@
 /** @typedef {import('./defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 import BaseService from '../utils/baseService.js';
+import { getNormalizedOperationType } from './utils/operationTypeUtils.js';
 
 class OperationRegistry extends BaseService {
   /** @type {Map<string, OperationHandler>} */ #registry = new Map();
@@ -32,14 +33,16 @@ class OperationRegistry extends BaseService {
    */
   register(operationType, handler) {
     // --- validate ------------------------------------------------------------
-    if (typeof operationType !== 'string' || !operationType.trim()) {
+    const trimmed = getNormalizedOperationType(
+      operationType,
+      this.#logger,
+      'OperationRegistry.register'
+    );
+    if (!trimmed) {
       const msg =
         'OperationRegistry.register: operationType must be a non-empty string.';
-      this.#logger.error(msg);
       throw new Error(msg);
     }
-
-    const trimmed = operationType.trim();
 
     if (typeof handler !== 'function') {
       const msg = `OperationRegistry.register: handler for type "${trimmed}" must be a function.`;
@@ -70,14 +73,14 @@ class OperationRegistry extends BaseService {
    * @returns {OperationHandler|undefined}
    */
   getHandler(operationType) {
-    if (typeof operationType !== 'string') {
-      this.#logger.warn(
-        `OperationRegistry.getHandler: Received non-string operationType: ${typeof operationType}. Returning undefined.`
-      );
+    const trimmed = getNormalizedOperationType(
+      operationType,
+      this.#logger,
+      'OperationRegistry.getHandler'
+    );
+    if (!trimmed) {
       return undefined;
     }
-
-    const trimmed = operationType.trim();
     const handler = this.#registry.get(trimmed);
 
     if (!handler) {

--- a/src/logic/utils/operationTypeUtils.js
+++ b/src/logic/utils/operationTypeUtils.js
@@ -1,0 +1,31 @@
+// src/logic/utils/operationTypeUtils.js
+
+/**
+ * Normalize and validate an operation type string.
+ *
+ * @description Trims the provided `type` and ensures it is a non-empty
+ * string. Logs an error using the provided logger and label when validation
+ * fails.
+ * @param {*} type - The operation type to normalize.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for errors.
+ * @param {string} label - Context label for error messages.
+ * @returns {string|null} The trimmed type or `null` when invalid.
+ */
+export function getNormalizedOperationType(type, logger, label) {
+  const msgPrefix = `${label}: operationType must be a non-empty string.`;
+
+  if (typeof type !== 'string') {
+    logger.error(msgPrefix);
+    return null;
+  }
+
+  const trimmed = type.trim();
+  if (!trimmed) {
+    logger.error(msgPrefix);
+    return null;
+  }
+
+  return trimmed;
+}
+
+export default getNormalizedOperationType;

--- a/tests/logic/operationInterpreter.test.js
+++ b/tests/logic/operationInterpreter.test.js
@@ -244,7 +244,9 @@ describe('OperationInterpreter', () => {
     const opMissingType = { parameters: {} };
     interpreter.execute(opMissingType, mockExecutionContext);
     expect(mockRegistry.getHandler).not.toHaveBeenCalled();
-    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'OperationInterpreter: OperationInterpreter.execute: operationType must be a non-empty string.'
+    );
   });
 
   /* ────────────────────────────────────────────────────────────────────────

--- a/tests/logic/operationRegistry.test.js
+++ b/tests/logic/operationRegistry.test.js
@@ -105,10 +105,10 @@ describe('OperationRegistry', () => {
       );
     });
 
-    test('logs warn for non-string type', () => {
+    test('logs error for non-string type via helper', () => {
       registry.getHandler(123);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'OperationRegistry: OperationRegistry.getHandler: Received non-string operationType: number. Returning undefined.'
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'OperationRegistry: OperationRegistry.getHandler: operationType must be a non-empty string.'
       );
     });
   });


### PR DESCRIPTION
Summary: Added a shared utility to normalize operation types and integrated it into operation registry and interpreter.

Changes Made:
- Created `operationTypeUtils.js` exporting `getNormalizedOperationType`.
- Updated `OperationRegistry` and `OperationInterpreter` to use the new helper.
- Adjusted related tests to verify helper-based error messages.

Testing Done:
- [x] Code formatted (`npm run format` from root and proxy)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6851bdd21e448331ba18fc8b1010366d