### PR TITLE
[Feat] add empty condition util and tests

### DIFF
--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -11,6 +11,7 @@ import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
 import BaseService from '../utils/baseService.js';
 import { executeActionSequence } from './actionSequence.js';
 import { buildRuleCache } from './ruleCacheUtils.js';
+import { isEmptyCondition } from './utils/jsonLogicUtils.js';
 
 /* ---------------------------------------------------------------------------
  * Internal types (JSDoc only)
@@ -139,7 +140,9 @@ class SystemLogicInterpreter extends BaseService {
   /* Event handling                                                        */
 
   /**
-   * @param {{type:string,payload:any}} event
+   * Handle an incoming event and execute matching rules.
+   *
+   * @param {{type:string,payload:any}} event - Event object with type and payload.
    */
   #handleEvent(event) {
     const bucket = this.#ruleCache.get(event.type);
@@ -224,12 +227,7 @@ class SystemLogicInterpreter extends BaseService {
     const ruleId = rule.rule_id || 'NO_ID';
 
     // no / empty condition → automatically passes
-    if (
-      !rule.condition ||
-      (typeof rule.condition === 'object' &&
-        !Array.isArray(rule.condition) &&
-        Object.keys(rule.condition).length === 0)
-    ) {
+    if (!rule.condition || isEmptyCondition(rule.condition)) {
       this.#logger.debug(
         `[Rule ${ruleId}] No condition defined or condition is empty. Defaulting to passed.`
       );

--- a/src/logic/utils/jsonLogicUtils.js
+++ b/src/logic/utils/jsonLogicUtils.js
@@ -1,0 +1,21 @@
+// src/logic/utils/jsonLogicUtils.js
+
+/**
+ * Determine if a condition object is "empty".
+ *
+ * A condition is considered empty when it is a plain object (not an array)
+ * with no own enumerable properties.
+ *
+ * @param {any} cond - Condition value to inspect.
+ * @returns {boolean} `true` when the condition is an object with no keys.
+ */
+export function isEmptyCondition(cond) {
+  return (
+    cond !== null &&
+    typeof cond === 'object' &&
+    !Array.isArray(cond) &&
+    Object.keys(cond).length === 0
+  );
+}
+
+export default isEmptyCondition;

--- a/tests/logic/jsonLogicUtils.test.js
+++ b/tests/logic/jsonLogicUtils.test.js
@@ -1,0 +1,25 @@
+// tests/logic/jsonLogicUtils.test.js
+
+import { describe, it, expect } from '@jest/globals';
+import { isEmptyCondition } from '../../src/logic/utils/jsonLogicUtils.js';
+
+describe('isEmptyCondition', () => {
+  it('returns true for empty object', () => {
+    expect(isEmptyCondition({})).toBe(true);
+  });
+
+  it('returns false for object with keys', () => {
+    expect(isEmptyCondition({ a: 1 })).toBe(false);
+  });
+
+  it('returns false for arrays', () => {
+    expect(isEmptyCondition([])).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isEmptyCondition(null)).toBe(false);
+    expect(isEmptyCondition(undefined)).toBe(false);
+    expect(isEmptyCondition(0)).toBe(false);
+    expect(isEmptyCondition('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary: Introduced `isEmptyCondition` helper to detect empty rule conditions and integrated it into `SystemLogicInterpreter`. Added dedicated tests for this utility and ensured interpreter behavior unchanged.

Changes Made:
- Created `jsonLogicUtils.js` with `isEmptyCondition` function.
- Updated `SystemLogicInterpreter` to use this helper and improved JSDoc.
- Added unit test `jsonLogicUtils.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint run (`npm run lint`, outputs warnings due to repo backlog)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (not performed)


------
https://chatgpt.com/codex/tasks/task_e_6851be444570833185c9ca201c401b0d