### PR TITLE
[Fix] standardize bad metadata fallback

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -3,6 +3,7 @@
 import {
   FULL_MANUAL_SAVE_DIRECTORY_PATH,
   MANUAL_SAVE_PATTERN,
+  extractSaveName,
 } from '../utils/savePathUtils.js';
 import { deserializeAndDecompress, parseManualSaveFile } from './saveFileIO.js';
 import {
@@ -187,10 +188,7 @@ export default class SaveFileRepository {
       );
       return {
         identifier,
-        saveName:
-          saveName ||
-          fileName.replace(/\.sav$/, '').replace(/^manual_save_/, '') +
-            ' (Bad Metadata)',
+        saveName: saveName || `${extractSaveName(fileName)} (Bad Metadata)`,
         timestamp: timestamp || 'N/A',
         playtimeSeconds:
           typeof playtimeSeconds === 'number' ? playtimeSeconds : 0,

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -154,7 +154,7 @@ describe('SaveLoadService edge cases', () => {
       storageProvider.readFile.mockResolvedValue(compressed);
       const slots = await service.listManualSaveSlots();
       expect(slots[0].isCorrupted).toBe(true);
-      expect(slots[0].saveName).toMatch(/No Metadata/);
+      expect(slots[0].saveName).toBe('slot1 (No Metadata)');
     });
 
     it('handles malformed metadata fields', async () => {
@@ -169,7 +169,7 @@ describe('SaveLoadService edge cases', () => {
       storageProvider.readFile.mockResolvedValue(compressed);
       const slots = await service.listManualSaveSlots();
       expect(slots[0].isCorrupted).toBe(true);
-      expect(slots[0].saveName).toMatch(/Bad Metadata/);
+      expect(slots[0].saveName).toBe('slot2 (Bad Metadata)');
     });
 
     it('marks slot corrupted when deserialization fails', async () => {


### PR DESCRIPTION
Summary: Fix fallback when manual save metadata is malformed and update unit tests accordingly.

Changes Made:
- Import extractSaveName in SaveFileRepository.
- Use extractSaveName when building corrupted saveName fallback.
- Update edge case unit tests with exact expected names.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint src/persistence/saveFileRepository.js tests/services/saveLoadService.edgeCases.test.js`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation (skipped in CI)


------
https://chatgpt.com/codex/tasks/task_e_6851bf316bd08331882640754daf1f4e