### PR TITLE
[Agent] replace manual dispatch with safeDispatchError

### DIFF
--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -10,7 +10,7 @@ import {
   POSITION_COMPONENT_ID,
   CURRENT_ACTOR_COMPONENT_ID,
 } from '../constants/componentIds.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
+import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
 
 /**
@@ -106,10 +106,7 @@ class WorldContext extends IWorldContext {
 
     const errorMessage = `WorldContext: Expected exactly one entity with component '${CURRENT_ACTOR_COMPONENT_ID}', but found ${actorCount}.`;
 
-    this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-      message: errorMessage,
-      details: { actorCount },
-    });
+    safeDispatchError(this.#safeEventDispatcher, errorMessage, { actorCount });
 
     if (
       typeof globalThis !== 'undefined' &&
@@ -163,9 +160,7 @@ class WorldContext extends IWorldContext {
       !positionData.locationId
     ) {
       const msg = `WorldContext.getCurrentLocation: Current actor '${actor.id}' is missing a valid '${POSITION_COMPONENT_ID}' component or locationId.`;
-      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: msg,
-      });
+      safeDispatchError(this.#safeEventDispatcher, msg);
       return null;
     }
 

--- a/src/data/providers/locationSummaryProvider.js
+++ b/src/data/providers/locationSummaryProvider.js
@@ -12,7 +12,7 @@ import {
   DEFAULT_FALLBACK_EXIT_DIRECTION,
   DEFAULT_FALLBACK_LOCATION_NAME,
 } from '../../constants/textDefaults.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -73,10 +73,11 @@ export class LocationSummaryProvider extends ILocationSummaryProvider {
               targetSummary?.name || DEFAULT_FALLBACK_LOCATION_NAME,
           };
         } catch (err) {
-          this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-            message: `LocationSummaryProvider: Error fetching exit target entity '${exitData.target}': ${err.message}`,
-            details: { error: err.message, stack: err.stack, exitData },
-          });
+          safeDispatchError(
+            this.#dispatcher,
+            `LocationSummaryProvider: Error fetching exit target entity '${exitData.target}': ${err.message}`,
+            { error: err.message, stack: err.stack, exitData }
+          );
           return null;
         }
       });
@@ -152,15 +153,16 @@ export class LocationSummaryProvider extends ILocationSummaryProvider {
         characters,
       };
     } catch (err) {
-      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: `LocationSummaryProvider: Critical error generating summary for location '${position.locationId}': ${err.message}`,
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        `LocationSummaryProvider: Critical error generating summary for location '${position.locationId}': ${err.message}`,
+        {
           error: err.message,
           stack: err.stack,
           locationId: position.locationId,
           actorId: actor.id,
-        },
-      });
+        }
+      );
       return null;
     }
   }

--- a/src/data/providers/perceptionLogProvider.js
+++ b/src/data/providers/perceptionLogProvider.js
@@ -6,7 +6,7 @@
 import { IPerceptionLogProvider } from '../../interfaces/IPerceptionLogProvider.js';
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
 import { DEFAULT_FALLBACK_EVENT_DESCRIPTION_RAW } from '../../constants/textDefaults.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -43,10 +43,13 @@ export class PerceptionLogProvider extends IPerceptionLogProvider {
         }
       }
     } catch (perceptionError) {
-      dispatcher?.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: `PerceptionLogProvider: Error retrieving perception log for ${actor.id}: ${perceptionError.message}`,
-        details: { error: perceptionError },
-      });
+      if (dispatcher) {
+        safeDispatchError(
+          dispatcher,
+          `PerceptionLogProvider: Error retrieving perception log for ${actor.id}: ${perceptionError.message}`,
+          { error: perceptionError }
+        );
+      }
     }
     return perceptionLogDto;
   }

--- a/src/domUI/processingIndicatorController.js
+++ b/src/domUI/processingIndicatorController.js
@@ -6,8 +6,8 @@ import {
   TURN_PROCESSING_ENDED,
   PLAYER_TURN_SUBMITTED_ID,
   // TEXT_UI_DISPLAY_SPEECH_ID // Not directly used for hiding in this version
-  SYSTEM_ERROR_OCCURRED_ID,
 } from '../constants/eventIds.js'; // Assuming these constants are correctly named and exported
+import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -144,15 +144,11 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
           );
         } else {
           const errMsg = `${this._logPrefix} Failed to create #processing-indicator element using DomElementFactory.`;
-          this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-            message: errMsg,
-          });
+          safeDispatchError(this.safeEventDispatcher, errMsg);
         }
       } else {
         const errMsg = `${this._logPrefix} Cannot create #processing-indicator: DomElementFactory or #outputDiv element missing.`;
-        this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-          message: errMsg,
-        });
+        safeDispatchError(this.safeEventDispatcher, errMsg);
       }
     } else {
       this.logger.debug(

--- a/src/domUI/titleRenderer.js
+++ b/src/domUI/titleRenderer.js
@@ -1,5 +1,6 @@
 // src/dom-ui/titleRenderer.js
 import { RendererBase } from './rendererBase.js';
+import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
@@ -44,16 +45,13 @@ export class TitleRenderer extends RendererBase {
     // --- Validate specific titleElement dependency ---
     if (!titleElement || titleElement.nodeType !== 1) {
       const errMsg = `${this._logPrefix} 'titleElement' dependency is missing or not a valid DOM element.`;
-      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: errMsg,
-      });
+      safeDispatchError(this.validatedEventDispatcher, errMsg);
       throw new Error(errMsg);
     }
     if (titleElement.tagName !== 'H1') {
       const errMsg = `${this._logPrefix} 'titleElement' must be an H1 element, but received '${titleElement.tagName}'.`;
-      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: errMsg,
-        details: { element: titleElement },
+      safeDispatchError(this.validatedEventDispatcher, errMsg, {
+        element: titleElement,
       });
       throw new Error(errMsg);
     }
@@ -218,10 +216,11 @@ export class TitleRenderer extends RendererBase {
     const title = `Initialization Failed${payload?.worldName ? ` (World: ${payload.worldName})` : ''}`;
     this.set(title);
     // Dispatch error event for UI display
-    this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-      message: `${this._logPrefix} Overall initialization failed. Error: ${payload?.error}`,
-      details: payload,
-    });
+    safeDispatchError(
+      this.validatedEventDispatcher,
+      `${this._logPrefix} Overall initialization failed. Error: ${payload?.error}`,
+      payload
+    );
   }
 
   /**
@@ -241,10 +240,11 @@ export class TitleRenderer extends RendererBase {
     }
     const title = `${stepName} Failed`;
     this.set(title);
-    this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-      message: `${this._logPrefix} ${title}. Error: ${payload?.error}`,
-      details: payload,
-    });
+    safeDispatchError(
+      this.validatedEventDispatcher,
+      `${this._logPrefix} ${title}. Error: ${payload?.error}`,
+      payload
+    );
   }
 
   /**
@@ -287,9 +287,10 @@ export class TitleRenderer extends RendererBase {
       }
     } else {
       // Should not happen if constructor validation passed
-      this.validatedEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: `${this._logPrefix} Cannot set title, internal #titleElement reference is lost.`,
-      });
+      safeDispatchError(
+        this.validatedEventDispatcher,
+        `${this._logPrefix} Cannot set title, internal #titleElement reference is lost.`
+      );
     }
   }
 

--- a/src/modding/modVersionValidator.js
+++ b/src/modding/modVersionValidator.js
@@ -3,7 +3,7 @@
 import engineVersionSatisfies from '../engine/engineVersionSatisfies.js';
 import ModDependencyError from '../errors/modDependencyError.js';
 import { ENGINE_VERSION } from '../engine/engineVersion.js'; // Import the actual engine version
-import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
+import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -111,9 +111,9 @@ export default function validateModEngineVersions(
   // --- Acceptance: Throws only ModDependencyError on failure (for incompatibility) ---
   if (fatals.length) {
     const errorMessage = fatals.join('\n');
-    safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-      message: errorMessage,
-      details: { incompatibilities: fatals, engineVersion: ENGINE_VERSION },
+    safeDispatchError(safeEventDispatcher, errorMessage, {
+      incompatibilities: fatals,
+      engineVersion: ENGINE_VERSION,
     });
     throw new ModDependencyError(errorMessage);
   }

--- a/src/utils/handlerUtils/paramsUtils.js
+++ b/src/utils/handlerUtils/paramsUtils.js
@@ -1,6 +1,6 @@
 // src/utils/handlerUtils/paramsUtils.js
 
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../safeDispatchErrorUtils.js';
 
 /**
  * @description Ensures an operation handler received a valid parameters object.
@@ -22,7 +22,7 @@ export function assertParamsObject(params, logger, opName) {
   if (logger && typeof logger.warn === 'function') {
     logger.warn(message, { params });
   } else if (logger && typeof logger.dispatch === 'function') {
-    logger.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details: { params } });
+    safeDispatchError(logger, message, { params });
   } else {
     console.warn(message, { params });
   }


### PR DESCRIPTION
## Summary
- replace SYSTEM_ERROR_OCCURRED_ID dispatch with safeDispatchError in various modules
- ensure dispatcher is resolved safely and propagated

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 563 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851bcb5661083318f78965ec84f44d4