### PR TITLE
[Agent] add StageError class

### DIFF
--- a/src/bootstrapper/StageError.js
+++ b/src/bootstrapper/StageError.js
@@ -1,0 +1,14 @@
+export default class StageError extends Error {
+  /**
+   * Represents an error thrown during a bootstrap stage.
+   *
+   * @description Error thrown during a bootstrap stage.
+   * @param {string} phase - Name of the bootstrap phase.
+   * @param {string} message - Error message.
+   * @param {Error} [cause] - Underlying error cause.
+   */
+  constructor(phase, message, cause) {
+    super(message, cause ? { cause } : undefined);
+    this.phase = phase;
+  }
+}

--- a/src/bootstrapper/auxiliaryStages.js
+++ b/src/bootstrapper/auxiliaryStages.js
@@ -5,12 +5,7 @@
  *
  * @module auxiliaryStages
  */
-import {
-  resolveAndInitialize,
-  stageSuccess,
-  stageFailure,
-  createStageError,
-} from './helpers.js';
+import { resolveAndInitialize, stageSuccess, stageFailure } from './helpers.js';
 
 /**
  * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer

--- a/src/bootstrapper/helpers.js
+++ b/src/bootstrapper/helpers.js
@@ -4,6 +4,8 @@
  * @file Utility helpers used during application bootstrap stages.
  */
 
+import StageError from './StageError.js';
+
 /**
  * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -111,9 +113,7 @@ export function attachBeforeUnload(windowRef, handler) {
  * @returns {Error} The constructed Error instance.
  */
 export function createStageError(phase, message, cause) {
-  const error = new Error(message, cause ? { cause } : undefined);
-  error.phase = phase;
-  return error;
+  return new StageError(phase, message, cause);
 }
 
 /**

--- a/tests/bootstrapper/auxiliaryStages.test.js
+++ b/tests/bootstrapper/auxiliaryStages.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { initializeAuxiliaryServicesStage } from '../../src/bootstrapper/auxiliaryStages.js';
+import StageError from '../../src/bootstrapper/StageError.js';
 
 /**
  *
@@ -50,6 +51,7 @@ describe('initializeAuxiliaryServicesStage', () => {
       tokens
     );
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('Auxiliary Services Initialization');
     expect(Array.isArray(result.error.failures)).toBe(true);
   });

--- a/tests/bootstrapper/stages.additional.test.js
+++ b/tests/bootstrapper/stages.additional.test.js
@@ -16,6 +16,7 @@ import {
   startGameStage,
 } from '../../src/bootstrapper/stages/index.js';
 import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import StageError from '../../src/bootstrapper/StageError.js';
 
 const createLogger = () => ({
   debug: jest.fn(),
@@ -46,6 +47,7 @@ describe('setupDIContainerStage', () => {
       createAppContainer: () => new AppContainer(),
     });
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('DI Container Setup');
   });
 
@@ -85,6 +87,7 @@ describe('resolveLoggerStage', () => {
     const tokens = { ILogger: 'LOGGER' };
     const result = await resolveLoggerStage(container, tokens);
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('Core Services Resolution');
   });
 
@@ -94,6 +97,7 @@ describe('resolveLoggerStage', () => {
 
     const result = await resolveLoggerStage(container, tokens);
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('Core Services Resolution');
   });
 });
@@ -119,6 +123,7 @@ describe('initializeGameEngineStage', () => {
       createGameEngine: (opts) => new GameEngine(opts),
     });
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('GameEngine Initialization');
   });
 
@@ -146,6 +151,7 @@ describe('initializeGameEngineStage', () => {
       createGameEngine: factory,
     });
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('GameEngine Initialization');
   });
 });
@@ -182,6 +188,7 @@ describe('setupGlobalEventListenersStage', () => {
     const logger = createLogger();
     const result = await setupGlobalEventListenersStage({}, logger, null);
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('Global Event Listeners Setup');
   });
 
@@ -220,6 +227,7 @@ describe('startGameStage', () => {
     const logger = createLogger();
     const resultMissing = await startGameStage(null, 'w', logger);
     expect(resultMissing.success).toBe(false);
+    expect(resultMissing.error).toBeInstanceOf(StageError);
     expect(resultMissing.error.phase).toBe('Start Game');
   });
 
@@ -227,6 +235,7 @@ describe('startGameStage', () => {
     const logger = createLogger();
     const resultInvalid = await startGameStage({}, '', logger);
     expect(resultInvalid.success).toBe(false);
+    expect(resultInvalid.error).toBeInstanceOf(StageError);
     expect(resultInvalid.error.phase).toBe('Start Game');
   });
 
@@ -237,6 +246,7 @@ describe('startGameStage', () => {
     };
     const resultError = await startGameStage(gameEngine, 'w', logger);
     expect(resultError.success).toBe(false);
+    expect(resultError.error).toBeInstanceOf(StageError);
     expect(resultError.error.phase).toBe('Start Game');
   });
 });

--- a/tests/bootstrapper/stages.menuListeners.test.js
+++ b/tests/bootstrapper/stages.menuListeners.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import { setupMenuButtonListenersStage } from '../../src/bootstrapper/stages/index.js';
+import StageError from '../../src/bootstrapper/StageError.js';
 
 /**
  *
@@ -71,6 +72,7 @@ describe('setupMenuButtonListenersStage', () => {
 
     const result = await setupMenuButtonListenersStage({}, logger, fakeDoc);
     expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('Menu Button Listeners Setup');
     expect(logger.error).toHaveBeenCalled();
   });

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -1,4 +1,5 @@
 import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages/index.js';
+import StageError from '../../src/bootstrapper/StageError.js';
 import { UIBootstrapper } from '../../src/bootstrapper/UIBootstrapper.js';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 
@@ -61,7 +62,7 @@ describe('ensureCriticalDOMElementsStage', () => {
       createUIBootstrapper: () => uiBoot,
     });
     expect(result.success).toBe(false);
-    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.message).toContain('fail');
     expect(result.error.phase).toBe('UI Element Validation');
   });


### PR DESCRIPTION
Summary:
- introduce StageError class for bootstrap phase errors
- hook StageError into bootstrap helpers
- update stage tests to assert StageError instances

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 'module' is not defined)*
- [x] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851c1718a108331a3954b2ce2e0c954