### PR TITLE
[Agent] Remove outdated saveLoadService comment

### DIFF
--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -1,5 +1,3 @@
-// src/services/saveLoadService.js
-
 import { ISaveLoadService } from '../interfaces/ISaveLoadService.js';
 import GameStateSerializer from './gameStateSerializer.js';
 import SaveValidationService from './saveValidationService.js';
@@ -19,7 +17,6 @@ import {
   validateSaveName,
   validateSaveIdentifier,
 } from './saveInputValidators.js';
-// REMOVED: import {createHash} from 'crypto';
 
 // --- Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -186,7 +183,6 @@ class SaveLoadService extends ISaveLoadService {
    * @returns {Promise<LoadGameResult>} Loaded game data or error info.
    */
   async loadGameData(saveIdentifier) {
-    //
     this.#logger.debug(
       `Attempting to load game data from: "${saveIdentifier}"`
     );


### PR DESCRIPTION
Summary: Removed an obsolete comment block from `saveLoadService.js` to reflect the current module path and cleaned up a stray placeholder comment.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851c275bfe48331834cdfc6674dd89c