### PR TITLE
[Agent] centralize checksum calculation

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -99,6 +99,17 @@ class GameStateSerializer {
   }
 
   /**
+   * Calculates the checksum for the provided game state object.
+   *
+   * @param {object} gameState - The game state to encode and hash.
+   * @returns {Promise<string>} Hexadecimal checksum.
+   */
+  async calculateGameStateChecksum(gameState) {
+    const encoded = encode(gameState);
+    return this.#generateChecksum(encoded);
+  }
+
+  /**
    * Serializes the game state to MessagePack and compresses it with Gzip.
    * Embeds a checksum of the gameState section.
    *
@@ -125,9 +136,8 @@ class GameStateSerializer {
       );
     }
 
-    const gameStateMessagePack = encode(finalSaveObject.gameState);
     finalSaveObject.integrityChecks.gameStateChecksum =
-      await this.#generateChecksum(gameStateMessagePack);
+      await this.calculateGameStateChecksum(finalSaveObject.gameState);
     this.#logger.debug(
       `Calculated gameStateChecksum: ${finalSaveObject.integrityChecks.gameStateChecksum}`
     );

--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -1,14 +1,7 @@
 // src/persistence/saveValidationService.js
 
-import { encode } from '@msgpack/msgpack';
-import {
-  PersistenceError,
-  PersistenceErrorCodes,
-} from './persistenceErrors.js';
-import {
-  createPersistenceFailure,
-  createPersistenceSuccess,
-} from './persistenceResultUtils.js';
+import { PersistenceErrorCodes } from './persistenceErrors.js';
+import { createPersistenceFailure } from './persistenceResultUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */
@@ -95,9 +88,9 @@ class SaveValidationService {
 
     let recalculatedChecksum;
     try {
-      const gameStateMessagePack = encode(obj.gameState);
-      recalculatedChecksum =
-        await this.#serializer.generateChecksum(gameStateMessagePack);
+      recalculatedChecksum = await this.#serializer.calculateGameStateChecksum(
+        obj.gameState
+      );
     } catch (checksumError) {
       const devMsg = `Error calculating checksum for gameState in ${identifier}: ${checksumError.message}.`;
       const userMsg =

--- a/tests/services/gameStateSerializer.test.js
+++ b/tests/services/gameStateSerializer.test.js
@@ -78,6 +78,13 @@ describe('GameStateSerializer', () => {
     expect(checksum1.length).toBeGreaterThan(0);
   });
 
+  it('calculateGameStateChecksum encodes and hashes the game state', async () => {
+    const gameState = { level: 1, score: 10 };
+    const expected = await serializer.generateChecksum(encode(gameState));
+    const actual = await serializer.calculateGameStateChecksum(gameState);
+    expect(actual).toBe(expected);
+  });
+
   it('throws PersistenceError when deep cloning fails', async () => {
     const cyc = {
       metadata: {},

--- a/tests/services/saveValidationService.test.js
+++ b/tests/services/saveValidationService.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
 import SaveValidationService from '../../src/persistence/saveValidationService.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
-import { encode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 import { webcrypto } from 'crypto';
 import { createMockLogger } from '../testUtils.js';
@@ -58,9 +57,8 @@ describe('SaveValidationService', () => {
       gameState: { a: 1 },
       integrityChecks: {},
     };
-    const buffer = encode(obj.gameState);
     obj.integrityChecks.gameStateChecksum =
-      await serializer.generateChecksum(buffer);
+      await serializer.calculateGameStateChecksum(obj.gameState);
     const result = await service.verifyChecksum(obj, 'id');
     expect(result).toEqual({ success: true });
   });


### PR DESCRIPTION
Summary: Refactored checksum generation by adding `calculateGameStateChecksum` to `GameStateSerializer`. The new method encodes the game state and hashes it using the existing private checksum generator. `serializeAndCompress` and `SaveValidationService.verifyChecksum` now use this helper. Updated tests ensure the method works and verify checksum validation uses it.

Testing Done:
- [x] Code formatted `npx prettier`
- [x] Lint passes `npx eslint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6851cd4bfbdc8331891fbf0c9a56844d