### PR TITLE
[Agent] Strip mod markers

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -17,7 +17,6 @@ import { setupService } from '../utils/serviceInitializerUtils.js';
 // --- Import Tokens ---
 // tokens import removed as not used after refactor
 
-// --- MODIFICATION START: Import component IDs for cleaning logic ---
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -26,7 +25,6 @@ import {
   createPersistenceFailure,
   createPersistenceSuccess,
 } from './persistenceResultUtils.js';
-// --- MODIFICATION END ---
 
 /**
  * @class GamePersistenceService


### PR DESCRIPTION
Summary: Removed leftover `MODIFICATION START/END` comments from `gamePersistenceService.js` to tidy the imports.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint run `npm run lint` *(fails: existing repo issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851d4e9c32083319f6f91917d051799