### PR TITLE
[Agent] add save metadata validation helper

### DIFF
--- a/src/persistence/saveFileIO.js
+++ b/src/persistence/saveFileIO.js
@@ -9,6 +9,7 @@ import {
   createPersistenceSuccess,
 } from './persistenceResultUtils.js';
 import { manualSavePath, extractSaveName } from '../utils/savePathUtils.js';
+import { validateSaveMetadataFields } from './saveMetadataUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/IStorageProvider.js').IStorageProvider} IStorageProvider */
@@ -144,13 +145,19 @@ export async function parseManualSaveFile(
     };
   }
 
-  return {
-    success: true,
-    data: {
+  const validated = validateSaveMetadataFields(
+    {
       identifier: filePath,
       saveName: saveObject.metadata.saveName,
       timestamp: saveObject.metadata.timestamp,
       playtimeSeconds: saveObject.metadata.playtimeSeconds,
     },
+    fileName,
+    logger
+  );
+
+  return {
+    success: !validated.isCorrupted,
+    data: validated,
   };
 }

--- a/src/persistence/saveMetadataUtils.js
+++ b/src/persistence/saveMetadataUtils.js
@@ -1,0 +1,45 @@
+// src/persistence/saveMetadataUtils.js
+
+import { extractSaveName } from '../utils/savePathUtils.js';
+
+/**
+ * Validates essential save metadata fields.
+ *
+ * @description Ensures metadata contains required values. Logs and marks
+ * corrupted metadata when fields are missing or malformed.
+ * @param {import('../interfaces/ISaveLoadService.js').SaveFileMetadata} metadata - Parsed metadata object.
+ * @param {string} fileName - Manual save file name for context.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for warnings.
+ * @returns {import('../interfaces/ISaveLoadService.js').SaveFileMetadata & {isCorrupted?: boolean}}
+ * The validated metadata, possibly marked as corrupted.
+ */
+export function validateSaveMetadataFields(metadata, fileName, logger) {
+  const { identifier, saveName, timestamp, playtimeSeconds } = metadata;
+
+  if (
+    typeof saveName !== 'string' ||
+    !saveName ||
+    typeof timestamp !== 'string' ||
+    !timestamp ||
+    typeof playtimeSeconds !== 'number' ||
+    Number.isNaN(playtimeSeconds)
+  ) {
+    logger.warn(
+      `Essential metadata missing or malformed in ${identifier}. Contents: ${JSON.stringify(
+        metadata
+      )}. Flagging as corrupted for listing.`
+    );
+    return {
+      identifier,
+      saveName: saveName || `${extractSaveName(fileName)} (Bad Metadata)`,
+      timestamp: timestamp || 'N/A',
+      playtimeSeconds:
+        typeof playtimeSeconds === 'number' ? playtimeSeconds : 0,
+      isCorrupted: true,
+    };
+  }
+
+  return metadata;
+}
+
+export default validateSaveMetadataFields;


### PR DESCRIPTION
## Summary
- create `validateSaveMetadataFields` for metadata validation
- use helper in `parseManualSaveFile` and `parseManualSaveMetadata`

## Testing
- `npm run lint` *(fails: numerous existing errors)*
- `npx eslint src/persistence/saveMetadataUtils.js src/persistence/saveFileIO.js src/persistence/saveFileRepository.js`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d4f52f308331a9d48904f562bdc7