### PR TITLE
[Agent] simplify metadata parsing

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -161,31 +161,20 @@ export default class SaveFileRepository {
    * @returns {Promise<import('../interfaces/ISaveLoadService.js').SaveFileMetadata>} Parsed metadata.
    */
   async parseManualSaveMetadata(fileName) {
-    const { success, data: metadata } = await parseManualSaveFile(
+    const { data: metadata } = await parseManualSaveFile(
       fileName,
       this.#storageProvider,
       this.#serializer,
       this.#logger
     );
 
-    if (!success) {
-      return metadata;
+    if (!metadata.isCorrupted) {
+      this.#logger.debug(
+        `Successfully parsed metadata for ${metadata.identifier}: Name="${metadata.saveName}", Timestamp="${metadata.timestamp}"`
+      );
     }
 
-    const validated = validateSaveMetadataFields(
-      metadata,
-      fileName,
-      this.#logger
-    );
-
-    if (validated.isCorrupted) {
-      return validated;
-    }
-
-    this.#logger.debug(
-      `Successfully parsed metadata for ${validated.identifier}: Name="${validated.saveName}", Timestamp="${validated.timestamp}"`
-    );
-    return validated;
+    return metadata;
   }
 
   /**

--- a/tests/persistence/parseManualSaveMetadata.test.js
+++ b/tests/persistence/parseManualSaveMetadata.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
+import { parseManualSaveFile } from '../../src/persistence/saveFileIO.js';
+import { createMockLogger } from '../testUtils.js';
+
+jest.mock('../../src/persistence/saveFileIO.js', () => ({
+  parseManualSaveFile: jest.fn(),
+}));
+
+/**
+ *
+ */
+function makeDeps() {
+  const logger = createMockLogger();
+  const storageProvider = {
+    writeFileAtomically: jest.fn(),
+    listFiles: jest.fn(),
+    readFile: jest.fn(),
+    deleteFile: jest.fn(),
+    fileExists: jest.fn(),
+    ensureDirectoryExists: jest.fn(),
+  };
+  const serializer = {};
+  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  return { repo, logger, storageProvider, serializer };
+}
+
+describe('SaveFileRepository.parseManualSaveMetadata', () => {
+  let repo;
+  let logger;
+  let storageProvider;
+  let serializer;
+
+  beforeEach(() => {
+    ({ repo, logger, storageProvider, serializer } = makeDeps());
+    parseManualSaveFile.mockReset();
+    logger.debug.mockReset();
+  });
+
+  it('returns metadata from parseManualSaveFile unchanged and logs once', async () => {
+    const metadata = {
+      identifier: 'path',
+      saveName: 'Name',
+      timestamp: 'now',
+      playtimeSeconds: 42,
+    };
+    parseManualSaveFile.mockResolvedValue({ success: true, data: metadata });
+
+    const result = await repo.parseManualSaveMetadata('manual_save_Name.sav');
+
+    expect(result).toBe(metadata);
+    expect(parseManualSaveFile).toHaveBeenCalledWith(
+      'manual_save_Name.sav',
+      storageProvider,
+      serializer,
+      expect.any(Object)
+    );
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Summary: Simplified parseManualSaveMetadata to rely on parseManualSaveFile results and added targeted test.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 563 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6852df01f4b48331b9a09a839441e5bc