### PR TITLE
[Agent] Add stage result factories

### DIFF
--- a/src/bootstrapper/helpers.js
+++ b/src/bootstrapper/helpers.js
@@ -5,6 +5,10 @@
  */
 
 import StageError from './StageError.js';
+import {
+  stageSuccess as baseStageSuccess,
+  stageFailure as baseStageFailure,
+} from '../types/stageResult.js';
 
 /**
  * @typedef {import('../dependencyInjection/appContainer.js').default} AppContainer
@@ -36,7 +40,7 @@ export function resolveAndInitialize(
     if (!service) {
       const err = new Error(`${token} could not be resolved.`);
       logger.warn(`${stage}: ${err.message}`);
-      return { success: false, error: err };
+      return baseStageFailure(err);
     }
     const initFn = service[initFnName];
     if (typeof initFn !== 'function') {
@@ -44,10 +48,10 @@ export function resolveAndInitialize(
     }
     initFn.apply(service, args);
     logger.debug(`${stage}: Initialized successfully.`);
-    return { success: true };
+    return baseStageSuccess();
   } catch (err) {
     logger.error(`${stage}: Failed to initialize.`, err);
-    return { success: false, error: err };
+    return baseStageFailure(err);
   }
 }
 
@@ -122,7 +126,7 @@ export function createStageError(phase, message, cause) {
  * @returns {import('../types/stageResult.js').StageResult}
  */
 export function stageSuccess(payload) {
-  return { success: true, payload };
+  return baseStageSuccess(payload);
 }
 
 /**
@@ -133,7 +137,7 @@ export function stageSuccess(payload) {
  * @returns {import('../types/stageResult.js').StageResult}
  */
 export function stageFailure(phase, message, cause) {
-  return { success: false, error: createStageError(phase, message, cause) };
+  return baseStageFailure(createStageError(phase, message, cause));
 }
 
 // --- FILE END ---

--- a/src/bootstrapper/stages/uiStages.js
+++ b/src/bootstrapper/stages/uiStages.js
@@ -84,7 +84,7 @@ export async function setupMenuButtonListenersStage(
         `${stageName}: GameEngine not available for #open-load-game-button listener.`
       );
       logger.debug(`Bootstrap Stage: ${stageName} completed successfully.`);
-      return { success: true };
+      return stageSuccess();
     }
 
     setupButtonListener(

--- a/src/types/stageResult.js
+++ b/src/types/stageResult.js
@@ -11,4 +11,22 @@
  * @property {Error} [error] - Populated when success is false with the error.
  */
 
+/**
+ * @description Factory for a successful StageResult.
+ * @param {any} [payload] - Optional value produced by the stage.
+ * @returns {StageResult}
+ */
+export function stageSuccess(payload) {
+  return { success: true, payload };
+}
+
+/**
+ * @description Factory for a failed StageResult.
+ * @param {Error} error - Error describing the failure.
+ * @returns {StageResult}
+ */
+export function stageFailure(error) {
+  return { success: false, error };
+}
+
 export {};


### PR DESCRIPTION
## Summary
- add `stageSuccess` and `stageFailure` factory functions
- use new factories inside bootstrap helpers
- replace inline stage result objects in UI stages

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6852e44dc50883318b4ccd3dafe8800f