### PR TITLE
[Agent] Refactor manifest processing in WorldLoader

### DIFF
--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -390,13 +390,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       CORE_MOD_ID,
     ]);
 
-    // 11. Verify registry.get was called for manifest lookup during content loading.
-    expect(mockRegistry.get).toHaveBeenCalledWith(
-      'mod_manifests',
-      CORE_MOD_ID.toLowerCase()
-    );
-
-    // 12. Verify Content Loader calls.
+    // 11. Verify Content Loader calls.
     expect(mockActionLoader.loadItemsForMod).toHaveBeenCalledTimes(1);
     expect(mockActionLoader.loadItemsForMod).toHaveBeenCalledWith(
       CORE_MOD_ID,


### PR DESCRIPTION
## Summary
- refine processing of manifest maps in WorldLoader
- ensure helper JSDoc descriptions are complete
- update worldLoader integration tests for new behavior

## Testing Done
- [x] `npm run format`
- [ ] `npm run lint` *(fails: 2524 problems (563 errors, 1961 warnings))*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852df2cd7008331920de587b38ce14b