### PR TITLE
[Agent] share placeholder regex constants

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -1,19 +1,17 @@
 // src/utils/contextUtils.js
 import { resolvePath } from './objectUtils.js';
 import { NAME_COMPONENT_ID } from '../constants/componentIds.js';
-import { PlaceholderResolver } from './placeholderResolverUtils.js';
+import {
+  PlaceholderResolver,
+  PLACEHOLDER_FIND_REGEX,
+  FULL_STRING_PLACEHOLDER_REGEX,
+} from './placeholderResolverUtils.js';
 import { getEntityDisplayName } from './entityUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 
-// Regex to find placeholders like {path.to.value} within a string.
-// Group 1: Captures the brace style path (excluding braces).
-// The 'g' flag ensures it finds *all* occurrences.
-const PLACEHOLDER_FIND_REGEX = /{\s*([^}\s]+)\s*}/g; // Only matches {...}
-
-// Regex to check if the entire string is *only* a placeholder ({...})
-// Group 1: Captures the path within braces.
-const FULL_STRING_PLACEHOLDER_REGEX = /^{\s*([^}\s]+)\s*}$/; // Only matches {...}
+// PLACEHOLDER_FIND_REGEX and FULL_STRING_PLACEHOLDER_REGEX are imported from
+// placeholderResolverUtils.js to keep placeholder matching logic consistent.
 
 /**
  * Provides a fallback to resolve common placeholders such as `actor.name` or

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -5,6 +5,23 @@
 import { resolvePath as objectResolvePath } from './objectUtils.js';
 
 /**
+ * Regex to find placeholders like {path.to.value} within a string.
+ * Group 1 captures the path without braces.
+ * The global flag ensures all occurrences are matched.
+ *
+ * @type {RegExp}
+ */
+export const PLACEHOLDER_FIND_REGEX = /{\s*([^}\s]+)\s*}/g;
+
+/**
+ * Regex to check if an entire string is only a placeholder.
+ * Group 1 captures the path within the braces.
+ *
+ * @type {RegExp}
+ */
+export const FULL_STRING_PLACEHOLDER_REGEX = /^{\s*([^}\s]+)\s*}$/;
+
+/**
  * @class PlaceholderResolver
  * @description A utility class dedicated to resolving placeholders in strings.
  * It replaces placeholders (e.g., `{key}`) with values from provided data objects.
@@ -71,7 +88,7 @@ export class PlaceholderResolver {
       return '';
     }
 
-    return str.replace(/{([^{}]+)}/g, (match, placeholderKey) => {
+    return str.replace(PLACEHOLDER_FIND_REGEX, (match, placeholderKey) => {
       let trimmedKey = placeholderKey.trim();
       const isOptional = trimmedKey.endsWith('?');
       if (isOptional) {


### PR DESCRIPTION
## Summary
- expose shared regex constants for placeholders in `placeholderResolverUtils`
- import shared regexes in `contextUtils`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852e53a5a0c83318698cac67b0ff406