### PR TITLE
[Agent] Extend ActorAwareStrategyFactory

### DIFF
--- a/src/dependencyInjection/registrations/registerActorAwareStrategy.js
+++ b/src/dependencyInjection/registrations/registerActorAwareStrategy.js
@@ -46,8 +46,10 @@ export function registerActorAwareStrategy(container) {
   if (!container.isRegistered(tokens.TurnStrategyFactory)) {
     r.singletonFactory(tokens.TurnStrategyFactory, (c) => {
       const opts = {
-        humanProvider: c.resolve(tokens.IHumanDecisionProvider),
-        aiProvider: c.resolve(tokens.ILLMDecisionProvider),
+        providers: {
+          human: c.resolve(tokens.IHumanDecisionProvider),
+          ai: c.resolve(tokens.ILLMDecisionProvider),
+        },
         logger: c.resolve(tokens.ILogger),
         choicePipeline: c.resolve(tokens.TurnActionChoicePipeline),
         turnActionFactory: c.resolve(tokens.ITurnActionFactory),


### PR DESCRIPTION
Summary:
- add provider resolver support to ActorAwareStrategyFactory
- update DI registration for new provider map
- test new resolution logic including custom provider

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format && npm run lint && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852e6477d88833195aee63d287e1867