### PR TITLE
[Agent] Move all utility modules to src/utils

### DIFF
--- a/llm-proxy-server/src/nodeFileSystemReader.js
+++ b/llm-proxy-server/src/nodeFileSystemReader.js
@@ -2,7 +2,7 @@
 
 import * as fs from 'node:fs/promises';
 
-/** @typedef {import('./interfaces/IServerUtils.js').IFileSystemReader} IFileSystemReader */
+/** @typedef {import('./utils/IServerUtils.js').IFileSystemReader} IFileSystemReader */
 
 /**
  * @class NodeFileSystemReader

--- a/llm-proxy-server/src/utils/IServerUtils.js
+++ b/llm-proxy-server/src/utils/IServerUtils.js
@@ -1,4 +1,4 @@
-// llm-proxy-server/src/interfaces/IServerUtils.js
+// llm-proxy-server/src/utils/IServerUtils.js
 // --- FILE START ---
 
 /**

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -6,7 +6,7 @@ import * as path from 'node:path'; // Corrected import style
 import {
   IFileSystemReader,
   IEnvironmentVariableReader,
-} from '../../llm-proxy-server/src/interfaces/IServerUtils.js';
+} from '../../llm-proxy-server/src/utils/IServerUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -2,7 +2,7 @@
 import jsonLogic from 'json-logic-js';
 import { validateServiceDeps } from '../utils/serviceInitializerUtils.js';
 import BaseService from '../utils/baseService.js';
-import { warnOnBracketPaths } from './utils/jsonLogicUtils.js';
+import { warnOnBracketPaths } from '../utils/jsonLogicUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -5,7 +5,7 @@
 
 import { resolvePlaceholders } from '../utils/contextUtils.js';
 import BaseService from '../utils/baseService.js';
-import { getNormalizedOperationType } from './utils/operationTypeUtils.js';
+import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */
 /** @typedef {import('./defs.js').ExecutionContext}                               ExecutionContext */

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -5,7 +5,7 @@
 /** @typedef {import('./defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 import BaseService from '../utils/baseService.js';
-import { getNormalizedOperationType } from './utils/operationTypeUtils.js';
+import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 class OperationRegistry extends BaseService {
   /** @type {Map<string, OperationHandler>} */ #registry = new Map();

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -10,8 +10,8 @@ import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
 import BaseService from '../utils/baseService.js';
 import { executeActionSequence } from './actionSequence.js';
-import { buildRuleCache } from './ruleCacheUtils.js';
-import { isEmptyCondition } from './utils/jsonLogicUtils.js';
+import { buildRuleCache } from '../utils/ruleCacheUtils.js';
+import { isEmptyCondition } from '../utils/jsonLogicUtils.js';
 
 /* ---------------------------------------------------------------------------
  * Internal types (JSDoc only)

--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -24,7 +24,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
-} from './persistenceResultUtils.js';
+} from '../utils/persistenceResultUtils.js';
 
 /**
  * @class GamePersistenceService

--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -10,7 +10,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
-} from './persistenceResultUtils.js';
+} from '../utils/persistenceResultUtils.js';
 
 /**
  * @class GameStateSerializer

--- a/src/persistence/saveFileIO.js
+++ b/src/persistence/saveFileIO.js
@@ -7,9 +7,9 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
-} from './persistenceResultUtils.js';
+} from '../utils/persistenceResultUtils.js';
 import { manualSavePath, extractSaveName } from '../utils/savePathUtils.js';
-import { validateSaveMetadataFields } from './saveMetadataUtils.js';
+import { validateSaveMetadataFields } from '../utils/saveMetadataUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/IStorageProvider.js').IStorageProvider} IStorageProvider */

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -6,12 +6,12 @@ import {
   extractSaveName,
 } from '../utils/savePathUtils.js';
 import { deserializeAndDecompress, parseManualSaveFile } from './saveFileIO.js';
-import { validateSaveMetadataFields } from './saveMetadataUtils.js';
+import { validateSaveMetadataFields } from '../utils/saveMetadataUtils.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
-import { createPersistenceFailure } from './persistenceResultUtils.js';
+import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 
 /**

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -12,7 +12,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
-} from './persistenceResultUtils.js';
+} from '../utils/persistenceResultUtils.js';
 import {
   validateSaveName,
   validateSaveIdentifier,

--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -1,7 +1,7 @@
 // src/persistence/saveValidationService.js
 
 import { PersistenceErrorCodes } from './persistenceErrors.js';
-import { createPersistenceFailure } from './persistenceResultUtils.js';
+import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -7,7 +7,7 @@
 
 import { AbstractTurnState } from './abstractTurnState.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
-import { getActorType } from '../utils/actorTypeUtils.js';
+import { getActorType } from '../../utils/actorTypeUtils.js';
 
 /**
  * State in which the engine waits for the current actor’s turn-strategy to

--- a/src/utils/actorTypeUtils.js
+++ b/src/utils/actorTypeUtils.js
@@ -1,4 +1,4 @@
-// src/turns/utils/actorTypeUtils.js
+// src/utils/actorTypeUtils.js
 
 /**
  * @file Utility to determine the actor type string.

--- a/src/utils/jsonLogicUtils.js
+++ b/src/utils/jsonLogicUtils.js
@@ -1,4 +1,4 @@
-// src/logic/utils/jsonLogicUtils.js
+// src/utils/jsonLogicUtils.js
 
 /**
  * Determine if a condition object is "empty".

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -7,7 +7,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
-} from '../persistence/persistenceResultUtils.js';
+} from './persistenceResultUtils.js';
 import { ensureValidLogger } from './loggerUtils.js';
 
 /**

--- a/src/utils/operationTypeUtils.js
+++ b/src/utils/operationTypeUtils.js
@@ -1,4 +1,4 @@
-// src/logic/utils/operationTypeUtils.js
+// src/utils/operationTypeUtils.js
 
 /**
  * Normalize and validate an operation type string.

--- a/src/utils/persistenceResultUtils.js
+++ b/src/utils/persistenceResultUtils.js
@@ -1,6 +1,6 @@
-// src/persistence/persistenceResultUtils.js
+// src/utils/persistenceResultUtils.js
 
-import { PersistenceError } from './persistenceErrors.js';
+import { PersistenceError } from '../persistence/persistenceErrors.js';
 
 /**
  * Creates a standardized failure result object for persistence operations.

--- a/src/utils/ruleCacheUtils.js
+++ b/src/utils/ruleCacheUtils.js
@@ -1,4 +1,4 @@
-// src/logic/ruleCacheUtils.js
+// src/utils/ruleCacheUtils.js
 
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 

--- a/src/utils/saveMetadataUtils.js
+++ b/src/utils/saveMetadataUtils.js
@@ -1,4 +1,4 @@
-// src/persistence/saveMetadataUtils.js
+// src/utils/saveMetadataUtils.js
 
 import { extractSaveName } from '../utils/savePathUtils.js';
 

--- a/tests/logic/jsonLogicUtils.test.js
+++ b/tests/logic/jsonLogicUtils.test.js
@@ -1,7 +1,7 @@
 // tests/logic/jsonLogicUtils.test.js
 
 import { describe, it, expect } from '@jest/globals';
-import { isEmptyCondition } from '../../src/logic/utils/jsonLogicUtils.js';
+import { isEmptyCondition } from '../../src/utils/jsonLogicUtils.js';
 
 describe('isEmptyCondition', () => {
   it('returns true for empty object', () => {

--- a/tests/logic/ruleCacheUtils.test.js
+++ b/tests/logic/ruleCacheUtils.test.js
@@ -4,7 +4,7 @@
  * @jest-environment node
  */
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
-import { buildRuleCache } from '../../src/logic/ruleCacheUtils.js';
+import { buildRuleCache } from '../../src/utils/ruleCacheUtils.js';
 import { ATTEMPT_ACTION_ID } from '../../src/constants/eventIds.js';
 
 /** @typedef {import('../../data/schemas/rule.schema.json').SystemRule} SystemRule */

--- a/tests/turns/utils/actorTypeUtils.test.js
+++ b/tests/turns/utils/actorTypeUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { getActorType } from '../../../src/turns/utils/actorTypeUtils.js';
+import { getActorType } from '../../../src/utils/actorTypeUtils.js';
 
 describe('getActorType', () => {
   it('returns "ai" when actor.isAi is true', () => {


### PR DESCRIPTION
Summary: Centralized scattered utility modules under `src/utils` and updated imports accordingly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6852e516177c833184ab6b04c34fe169