### PR TITLE
[Agent] add configurable content loader registration

### DIFF
--- a/tests/integration/modLoadDependencyFail.test.js
+++ b/tests/integration/modLoadDependencyFail.test.js
@@ -17,14 +17,15 @@ const createMockConfiguration = (overrides = {}) => ({
     // This map now reflects the current essential schema requirements of WorldLoader
     const schemaMap = {
       'mod-manifest': 'http://example.com/schemas/mod.manifest.schema.json',
-      'game': 'http://example.com/schemas/game.schema.json',
-      'conditions': 'http://example.com/schemas/condition.schema.json',
-      'components': 'http://example.com/schemas/component.schema.json',
-      'actions': 'http://example.com/schemas/action.schema.json',
-      'events': 'http://example.com/schemas/event.schema.json',
-      'entityDefinitions': 'http://example.com/schemas/entity-definition.schema.json', // <<< CORRECTED
-      'entityInstances': 'http://example.com/schemas/entity-instance.schema.json', // <<< CORRECTED
-      'rules': 'http://example.com/schemas/rule.schema.json',
+      game: 'http://example.com/schemas/game.schema.json',
+      conditions: 'http://example.com/schemas/condition.schema.json',
+      components: 'http://example.com/schemas/component.schema.json',
+      actions: 'http://example.com/schemas/action.schema.json',
+      events: 'http://example.com/schemas/event.schema.json',
+      entityDefinitions:
+        'http://example.com/schemas/entity-definition.schema.json', // <<< CORRECTED
+      entityInstances: 'http://example.com/schemas/entity-instance.schema.json', // <<< CORRECTED
+      rules: 'http://example.com/schemas/rule.schema.json',
     };
     return schemaMap[t] || `http://example.com/schemas/${t}.schema.json`;
   }),
@@ -68,7 +69,7 @@ const createMockFetcher = (idToResponse = {}, errorIds = []) => ({
       if (errorIds.includes(modId)) {
         throw new Error(`Fetch failed for ${modId} manifest`);
       }
-      if (idToResponse.hasOwnProperty(modId)) {
+      if (Object.prototype.hasOwnProperty.call(idToResponse, modId)) {
         return JSON.parse(JSON.stringify(idToResponse[modId]));
       }
     }
@@ -76,20 +77,26 @@ const createMockFetcher = (idToResponse = {}, errorIds = []) => ({
     // Match schema fetch requests
     const schemaMatch = path.match(/\/schemas\/([^/]+)/);
     if (schemaMatch) {
-      const schemaName = schemaMatch[1];
       const schemaIdMap = {
-        'mod.manifest.schema.json': 'http://example.com/schemas/mod.manifest.schema.json',
+        'mod.manifest.schema.json':
+          'http://example.com/schemas/mod.manifest.schema.json',
         'game.schema.json': 'http://example.com/schemas/game.schema.json',
-        'component.schema.json': 'http://example.com/schemas/component.schema.json',
-        'entity-definition.schema.json': 'http://example.com/schemas/entity-definition.schema.json',
-        'entity-instance.schema.json': 'http://example.com/schemas/entity-instance.schema.json',
+        'component.schema.json':
+          'http://example.com/schemas/component.schema.json',
+        'entity-definition.schema.json':
+          'http://example.com/schemas/entity-definition.schema.json',
+        'entity-instance.schema.json':
+          'http://example.com/schemas/entity-instance.schema.json',
         'action.schema.json': 'http://example.com/schemas/action.schema.json',
         'event.schema.json': 'http://example.com/schemas/event.schema.json',
         'rule.schema.json': 'http://example.com/schemas/rule.schema.json',
-        'condition.schema.json': 'http://example.com/schemas/condition.schema.json'
+        'condition.schema.json':
+          'http://example.com/schemas/condition.schema.json',
       };
-      const schemaId = Object.values(schemaIdMap).find(id => path.includes(id.split('/').pop()));
-      if(schemaId) {
+      const schemaId = Object.values(schemaIdMap).find((id) =>
+        path.includes(id.split('/').pop())
+      );
+      if (schemaId) {
         return { $id: schemaId, type: 'object', properties: {}, required: [] };
       }
     }
@@ -119,8 +126,8 @@ const createMockRegistry = () => {
     const typeMap = data.get(type);
     return typeMap
       ? Array.from(typeMap.values()).map((obj) =>
-        JSON.parse(JSON.stringify(obj))
-      )
+          JSON.parse(JSON.stringify(obj))
+        )
       : [];
   });
 
@@ -166,25 +173,36 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
   let worldLoader;
 
   const schemaDefs = {
-    MOD_MANIFEST: { id: 'http://example.com/schemas/mod.manifest.schema.json', required: ['id', 'name', 'version'], props: { id: { type: 'string' } } },
-    GAME: { id: 'http://example.com/schemas/game.schema.json', required: ['mods'], props: { mods: { type: 'array' } } },
+    MOD_MANIFEST: {
+      id: 'http://example.com/schemas/mod.manifest.schema.json',
+      required: ['id', 'name', 'version'],
+      props: { id: { type: 'string' } },
+    },
+    GAME: {
+      id: 'http://example.com/schemas/game.schema.json',
+      required: ['mods'],
+      props: { mods: { type: 'array' } },
+    },
     CONDITION: { id: 'http://example.com/schemas/condition.schema.json' },
     COMPONENT: { id: 'http://example.com/schemas/component.schema.json' },
-    ENTITY_DEFINITION: { id: 'http://example.com/schemas/entity-definition.schema.json' },
-    ENTITY_INSTANCE: { id: 'http://example.com/schemas/entity-instance.schema.json' },
+    ENTITY_DEFINITION: {
+      id: 'http://example.com/schemas/entity-definition.schema.json',
+    },
+    ENTITY_INSTANCE: {
+      id: 'http://example.com/schemas/entity-instance.schema.json',
+    },
     ACTION: { id: 'http://example.com/schemas/action.schema.json' },
     EVENT: { id: 'http://example.com/schemas/event.schema.json' },
     RULE: { id: 'http://example.com/schemas/rule.schema.json' },
   };
 
-  const buildSchema = ({id, required = [], props = {}}) => ({
+  const buildSchema = ({ id, required = [], props = {} }) => ({
     $id: id,
     type: 'object',
     required: required,
     properties: props,
-    additionalProperties: true
+    additionalProperties: true,
   });
-
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -228,18 +246,25 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
     registry = createMockRegistry();
 
     /* -------------------- Auxiliary loaders ------------------------------ */
-    ruleLoader = { loadItemsForMod: jest.fn().mockResolvedValue({count: 0}) };
+    ruleLoader = { loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }) };
     conditionLoader = {
-      loadItemsForMod: jest.fn().mockResolvedValue({count: 0}),
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
     };
     componentDefinitionLoader = {
-      loadItemsForMod: jest.fn().mockResolvedValue({count: 0}),
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
     };
-    actionLoader = { loadItemsForMod: jest.fn().mockResolvedValue({count: 0}) };
-    eventLoader = { loadItemsForMod: jest.fn().mockResolvedValue({count: 0}) };
-    entityLoader = { loadItemsForMod: jest.fn().mockResolvedValue({count: 0}) };
-    entityInstanceLoader = { loadItemsForMod: jest.fn().mockResolvedValue({count: 0}) };
-
+    actionLoader = {
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
+    };
+    eventLoader = {
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
+    };
+    entityLoader = {
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
+    };
+    entityInstanceLoader = {
+      loadItemsForMod: jest.fn().mockResolvedValue({ count: 0 }),
+    };
 
     gameConfigLoader = {
       loadConfig: jest.fn().mockResolvedValue(['basegame', 'badmod']),
@@ -277,6 +302,7 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader,
       validatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 
@@ -311,9 +337,10 @@ describe('WorldLoader → ModDependencyValidator integration (missing dependency
     );
 
     // Check that NO content files were fetched
-    const contentFetches = fetcher.fetch.mock.calls.filter(
-      ([p]) =>
-        /\/mods\/[^/]+\/(actions|components|events|rules|entityDefinitions|entityInstances)\//.test(p)
+    const contentFetches = fetcher.fetch.mock.calls.filter(([p]) =>
+      /\/mods\/[^/]+\/(actions|components|events|rules|entityDefinitions|entityInstances)\//.test(
+        p
+      )
     );
     expect(contentFetches).toHaveLength(0);
 

--- a/tests/loaders/worldLoader.dependencyError.integration.test.js
+++ b/tests/loaders/worldLoader.dependencyError.integration.test.js
@@ -239,6 +239,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Dependency and Ve
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.entityMultiKey.integration.test.js
+++ b/tests/loaders/worldLoader.entityMultiKey.integration.test.js
@@ -339,6 +339,7 @@ describe('WorldLoader Integration Test Suite - EntityDefinitionLoader Multi-Key 
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.errorHandling.integration.test.js
+++ b/tests/loaders/worldLoader.errorHandling.integration.test.js
@@ -359,6 +359,7 @@ describe('WorldLoader Integration Test Suite - Error Handling (TEST-LOADER-7.4)'
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   }); // End beforeEach
 

--- a/tests/loaders/worldLoader.essentialSchemas.test.js
+++ b/tests/loaders/worldLoader.essentialSchemas.test.js
@@ -9,8 +9,15 @@ import WorldLoaderError from '../../src/errors/worldLoaderError.js';
 
 // Minimal mocks for all WorldLoader dependencies
 const mockRegistry = { store: jest.fn(), get: jest.fn(), clear: jest.fn() };
-const mockLogger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
-const mockSchemaLoader = { loadAndCompileAllSchemas: jest.fn().mockResolvedValue() };
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const mockSchemaLoader = {
+  loadAndCompileAllSchemas: jest.fn().mockResolvedValue(),
+};
 const mockComponentLoader = { loadItemsForMod: jest.fn() };
 const mockConditionLoader = { loadItemsForMod: jest.fn() };
 const mockRuleLoader = { loadItemsForMod: jest.fn() };
@@ -19,10 +26,16 @@ const mockActionLoader = { loadItemsForMod: jest.fn() };
 const mockEventLoader = { loadItemsForMod: jest.fn() };
 const mockEntityDefinitionLoader = { loadItemsForMod: jest.fn() };
 const mockEntityInstanceLoader = { loadItemsForMod: jest.fn() };
-const mockGameConfigLoader = { loadConfig: jest.fn().mockResolvedValue(['core']) };
+const mockGameConfigLoader = {
+  loadConfig: jest.fn().mockResolvedValue(['core']),
+};
 const mockPromptTextLoader = { loadPromptText: jest.fn().mockResolvedValue() };
-const mockModManifestLoader = { loadRequestedManifests: jest.fn().mockResolvedValue(new Map()) };
-const mockValidatedEventDispatcher = { dispatch: jest.fn().mockResolvedValue() };
+const mockModManifestLoader = {
+  loadRequestedManifests: jest.fn().mockResolvedValue(new Map()),
+};
+const mockValidatedEventDispatcher = {
+  dispatch: jest.fn().mockResolvedValue(),
+};
 
 // Mocks for the specific services under test
 let mockConfiguration;
@@ -35,15 +48,16 @@ describe('WorldLoader Essential Schema Validation', () => {
 
     // Define schema IDs for a successful run, reflecting the fix
     const schemaIds = {
-      'game': 'http://example.com/schemas/game.schema.json',
-      'components': 'http://example.com/schemas/component.schema.json',
+      game: 'http://example.com/schemas/game.schema.json',
+      components: 'http://example.com/schemas/component.schema.json',
       'mod-manifest': 'http://example.com/schemas/mod.manifest.schema.json',
-      'entityDefinitions': 'http://example.com/schemas/entity-definition.schema.json',
-      'entityInstances': 'http://example.com/schemas/entity-instance.schema.json',
-      'actions': 'http://example.com/schemas/action.schema.json',
-      'events': 'http://example.com/schemas/event.schema.json',
-      'rules': 'http://example.com/schemas/rule.schema.json',
-      'conditions': 'http://example.com/schemas/condition.schema.json',
+      entityDefinitions:
+        'http://example.com/schemas/entity-definition.schema.json',
+      entityInstances: 'http://example.com/schemas/entity-instance.schema.json',
+      actions: 'http://example.com/schemas/action.schema.json',
+      events: 'http://example.com/schemas/event.schema.json',
+      rules: 'http://example.com/schemas/rule.schema.json',
+      conditions: 'http://example.com/schemas/condition.schema.json',
     };
 
     mockConfiguration = {
@@ -57,6 +71,7 @@ describe('WorldLoader Essential Schema Validation', () => {
 
   /**
    * Helper function to create a new WorldLoader instance with the current mocks.
+   *
    * @returns {WorldLoader}
    */
   const createWorldLoaderInstance = () => {
@@ -78,6 +93,7 @@ describe('WorldLoader Essential Schema Validation', () => {
       promptTextLoader: mockPromptTextLoader,
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   };
 
@@ -102,14 +118,16 @@ describe('WorldLoader Essential Schema Validation', () => {
       }
       // Provide a valid ID for all other types.
       const schemaIds = {
-        'game': 'http://example.com/schemas/game.schema.json',
-        'components': 'http://example.com/schemas/component.schema.json',
+        game: 'http://example.com/schemas/game.schema.json',
+        components: 'http://example.com/schemas/component.schema.json',
         'mod-manifest': 'http://example.com/schemas/mod.manifest.schema.json',
-        'entityDefinitions': 'http://example.com/schemas/entity-definition.schema.json',
-        'entityInstances': 'http://example.com/schemas/entity-instance.schema.json',
-        'events': 'http://example.com/schemas/event.schema.json',
-        'rules': 'http://example.com/schemas/rule.schema.json',
-        'conditions': 'http://example.com/schemas/condition.schema.json',
+        entityDefinitions:
+          'http://example.com/schemas/entity-definition.schema.json',
+        entityInstances:
+          'http://example.com/schemas/entity-instance.schema.json',
+        events: 'http://example.com/schemas/event.schema.json',
+        rules: 'http://example.com/schemas/rule.schema.json',
+        conditions: 'http://example.com/schemas/condition.schema.json',
       };
       return schemaIds[typeName];
     });
@@ -117,7 +135,9 @@ describe('WorldLoader Essential Schema Validation', () => {
     const worldLoader = createWorldLoaderInstance();
 
     // The promise should be rejected with a specific error type and message.
-    await expect(worldLoader.loadWorld('test-world')).rejects.toThrow(WorldLoaderError);
+    await expect(worldLoader.loadWorld('test-world')).rejects.toThrow(
+      WorldLoaderError
+    );
     await expect(worldLoader.loadWorld('test-world')).rejects.toThrow(
       "WorldLoader failed: Essential schema 'Unknown Essential Schema ID' missing or check failed – aborting world load. Original error: Essential schema check failed for: Unknown Essential Schema ID"
     );
@@ -145,7 +165,9 @@ describe('WorldLoader Essential Schema Validation', () => {
     try {
       await worldLoader.loadWorld('test-world');
       // This line should not be reached; if it is, the test fails.
-      throw new Error('Test failed: worldLoader.loadWorld did not throw an error as expected.');
+      throw new Error(
+        'Test failed: worldLoader.loadWorld did not throw an error as expected.'
+      );
     } catch (error) {
       caughtError = error;
     }

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -304,6 +304,7 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.logVerification.integration.test.js
+++ b/tests/loaders/worldLoader.logVerification.integration.test.js
@@ -276,6 +276,7 @@ describe('WorldLoader Integration Test Suite - Log Verification (TEST-LOADER-7.7
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.override.integration.test.js
+++ b/tests/loaders/worldLoader.override.integration.test.js
@@ -449,6 +449,7 @@ describe('WorldLoader Integration Test Suite - Overrides (TEST-LOADER-7.2)', () 
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.overrides.integration.test.js
+++ b/tests/loaders/worldLoader.overrides.integration.test.js
@@ -385,6 +385,7 @@ describe('WorldLoader Integration Test Suite - Mod Overrides and Load Order (Sub
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.partialContent.integration.test.js
+++ b/tests/loaders/worldLoader.partialContent.integration.test.js
@@ -399,6 +399,7 @@ describe('WorldLoader Integration Test Suite - Partial/Empty Content (TEST-LOADE
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher, // Pass the added mock
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.preLoopErrors.integration.test.js
+++ b/tests/loaders/worldLoader.preLoopErrors.integration.test.js
@@ -246,6 +246,7 @@ describe('WorldLoader Integration Test Suite - Error Handling: Manifest Schema, 
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 

--- a/tests/loaders/worldLoader.timingLogs.integration.test.js
+++ b/tests/loaders/worldLoader.timingLogs.integration.test.js
@@ -250,6 +250,7 @@ describe('WorldLoader Integration Test Suite - Performance Timing Logs (Sub-Tick
       promptTextLoader: { loadPromptText: jest.fn() },
       modManifestLoader: mockModManifestLoader,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      contentLoadersConfig: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- allow specifying custom content loaders in `WorldLoader`
- build default content loader config in helper
- expose `registerContentLoader` to extend config
- update tests to pass `contentLoadersConfig: null`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2526 problems)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852e9a0b3908331a8399f17e3abcee7