### PR TITLE
[Agent] Remove unused apiUtils

### DIFF
--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -1,1 +1,0 @@
-export { fetchWithRetry } from './httpUtils.js';


### PR DESCRIPTION
Summary: Deleted deprecated `src/utils/apiUtils.js` after confirming no references. `src/utils/index.js` continues exporting `fetchWithRetry` unchanged.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing project issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852eb8c4db08331b6f071a18bd0068d