### PR TITLE
[Agent] add persistence operation wrapper

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -25,6 +25,7 @@ import {
   createPersistenceFailure,
   createPersistenceSuccess,
 } from '../utils/persistenceResultUtils.js';
+import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 
 /**
  * @class GamePersistenceService
@@ -305,7 +306,7 @@ class GamePersistenceService extends IGamePersistenceService {
       );
     }
 
-    try {
+    return wrapPersistenceOperation(this.#logger, async () => {
       this.#logger.debug(
         `GamePersistenceService.saveGame: Capturing current game state for save "${saveName}".`
       );
@@ -326,20 +327,7 @@ class GamePersistenceService extends IGamePersistenceService {
         );
       }
       return result;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'An unknown error occurred.';
-      this.#logger.error(
-        `GamePersistenceService.saveGame: An unexpected error occurred during saveGame for "${saveName}": ${errorMessage}`,
-        error
-      );
-      return error instanceof PersistenceError
-        ? { success: false, error }
-        : createPersistenceFailure(
-            PersistenceErrorCodes.UNEXPECTED_ERROR,
-            `Unexpected error during save: ${errorMessage}`
-          );
-    }
+    });
   }
 
   async restoreGameState(deserializedSaveData) {

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -12,6 +12,7 @@ import {
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
 import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
+import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 
 /**
@@ -87,7 +88,7 @@ export default class SaveFileRepository {
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result of the write operation.
    */
   async writeSaveFile(filePath, data) {
-    try {
+    return wrapPersistenceOperation(this.#logger, async () => {
       const writeResult = await this.#storageProvider.writeFileAtomically(
         filePath,
         data
@@ -110,15 +111,7 @@ export default class SaveFileRepository {
         PersistenceErrorCodes.WRITE_ERROR,
         userError
       );
-    } catch (error) {
-      this.#logger.error(`Error writing save file ${filePath}:`, error);
-      return error instanceof PersistenceError
-        ? { success: false, error }
-        : createPersistenceFailure(
-            PersistenceErrorCodes.UNEXPECTED_ERROR,
-            `An unexpected error occurred while saving: ${error.message}`
-          );
-    }
+    });
   }
 
   /**

--- a/src/utils/persistenceErrorUtils.js
+++ b/src/utils/persistenceErrorUtils.js
@@ -1,0 +1,26 @@
+// src/utils/persistenceErrorUtils.js
+
+import { createPersistenceFailure } from './persistenceResultUtils.js';
+import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
+
+/**
+ * Executes a persistence operation and standardizes unexpected errors.
+ *
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for error reporting.
+ * @param {() => Promise<any>} operation - Async operation to execute.
+ * @returns {Promise<any>} Result of the operation or standardized failure object.
+ */
+export async function wrapPersistenceOperation(logger, operation) {
+  try {
+    return await operation();
+  } catch (error) {
+    logger.error('Persistence operation failed:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return createPersistenceFailure(
+      PersistenceErrorCodes.UNEXPECTED_ERROR,
+      message
+    );
+  }
+}
+
+export default wrapPersistenceOperation;

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -338,7 +338,7 @@ describe('SaveLoadService edge cases', () => {
       };
       const res = await service.saveManualGame('Reject', obj);
       expect(res.success).toBe(false);
-      expect(res.error.message).toMatch(/unexpected error/i);
+      expect(res.error.message).toBe('fs fail');
       expect(logger.error).toHaveBeenCalled();
     });
   });

--- a/tests/utils/persistenceErrorUtils.test.js
+++ b/tests/utils/persistenceErrorUtils.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { wrapPersistenceOperation } from '../../src/utils/persistenceErrorUtils.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
+
+describe('wrapPersistenceOperation', () => {
+  it('returns operation result on success', async () => {
+    const logger = { error: jest.fn() };
+    const result = await wrapPersistenceOperation(logger, async () => 42);
+    expect(result).toBe(42);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs and wraps errors', async () => {
+    const logger = { error: jest.fn() };
+    const res = await wrapPersistenceOperation(logger, async () => {
+      throw new Error('boom');
+    });
+    expect(logger.error).toHaveBeenCalled();
+    expect(res.success).toBe(false);
+    expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
+    expect(res.error.message).toBe('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- add utility to standardize persistence error handling
- refactor save repository, save service and game persistence service to use the new wrapper
- update SaveLoadService edge tests for new message
- add unit tests for the wrapper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: numerous pre-existing warnings and errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6852ebbe57748331b1f1be9216efe116