### PR TITLE
[Agent] add shared dependency validation helper

### DIFF
--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -11,7 +11,7 @@ import {
   createPrefixedLogger,
   initLogger as baseInitLogger,
 } from './loggerUtils.js';
-import { validateDependency } from './validationUtils.js';
+import { validateDependencies } from './validationUtils.js';
 
 /**
  * Validate the provided logger and return a prefixed logger instance.
@@ -37,13 +37,20 @@ export function initPrefixedLogger(serviceName, logger) {
  */
 export function validateServiceDeps(serviceName, logger, deps) {
   if (!deps) return;
+
+  const checks = [];
+
   for (const [depName, spec] of Object.entries(deps)) {
     if (!spec) continue;
-    validateDependency(spec.value, `${serviceName}: ${depName}`, logger, {
-      requiredMethods: spec.requiredMethods,
+    checks.push({
+      dependency: spec.value,
+      name: `${serviceName}: ${depName}`,
+      methods: spec.requiredMethods,
       isFunction: spec.isFunction,
     });
   }
+
+  validateDependencies(checks, logger);
 }
 
 /**

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -58,6 +58,26 @@ export function validateDependency(
 }
 
 /**
+ * Validate a list of dependencies using {@link validateDependency}.
+ *
+ * @description Iterates over each spec and validates the dependency.
+ * @param {Iterable<{dependency: *, name: string, methods?: string[], isFunction?: boolean}>} deps
+ *   Iterable of dependency specs.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger used for validation errors.
+ * @returns {void}
+ */
+export function validateDependencies(deps, logger) {
+  if (!deps) return;
+
+  for (const { dependency, name, methods = [], isFunction = false } of deps) {
+    validateDependency(dependency, name, logger, {
+      requiredMethods: methods,
+      isFunction,
+    });
+  }
+}
+
+/**
  * @description Validates a set of loader dependencies using {@link validateDependency}.
  * The provided logger is validated first and then used for all subsequent checks.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to record validation errors.
@@ -66,13 +86,16 @@ export function validateDependency(
  * @throws {Error} If any dependency fails validation.
  */
 export function validateLoaderDeps(logger, checks) {
-  validateDependency(logger, 'ILogger', console, {
-    requiredMethods: ['info', 'warn', 'error', 'debug'],
-  });
+  const deps = [
+    {
+      dependency: logger,
+      name: 'ILogger',
+      methods: ['info', 'warn', 'error', 'debug'],
+    },
+    ...(checks || []),
+  ];
 
-  for (const { dependency, name, methods = [] } of checks) {
-    validateDependency(dependency, name, logger, { requiredMethods: methods });
-  }
+  validateDependencies(deps, logger);
 }
 
 /**


### PR DESCRIPTION
Summary: Introduces `validateDependencies` for batch dependency checking and refactors loaders and services to use it.

Changes Made:
- Implemented `validateDependencies` in `validationUtils.js` and refactored `validateLoaderDeps` to rely on it.
- Updated `serviceInitializerUtils` to build dependency specs and validate via new helper.
- Adjusted related unit tests and added new ones for `validateDependencies`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & checked specific files)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6852eb9292188331aeaa9bd994102453