### PR TITLE
[Agent] notify action indexer when a turn begins

### DIFF
--- a/src/turns/handlers/actorTurnHandler.js
+++ b/src/turns/handlers/actorTurnHandler.js
@@ -30,6 +30,7 @@ class ActorTurnHandler extends GenericTurnHandler {
    * @param {ITurnStrategyFactory} [deps.turnStrategyFactory]
    * @param {ITurnStrategyFactory} [deps.strategyFactory]
    * @param {TurnContextBuilder} deps.turnContextBuilder
+   * @param deps.container
    */
   constructor({
     logger,
@@ -38,6 +39,7 @@ class ActorTurnHandler extends GenericTurnHandler {
     turnStrategyFactory,
     strategyFactory,
     turnContextBuilder,
+    container = null,
   }) {
     const factory = turnStrategyFactory || strategyFactory;
     super({
@@ -46,6 +48,7 @@ class ActorTurnHandler extends GenericTurnHandler {
       turnEndPort,
       strategyFactory: factory,
       turnContextBuilder,
+      container,
     });
 
     const initialState = this._turnStateFactory.createInitialState(this);

--- a/tests/turns/handlers/indexerBeginTurn.test.js
+++ b/tests/turns/handlers/indexerBeginTurn.test.js
@@ -1,0 +1,65 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import ActorTurnHandler from '../../../src/turns/handlers/actorTurnHandler.js';
+import { tokens } from '../../../src/dependencyInjection/tokens.js';
+
+/**
+ * Helper to create a basic handler with a DI container that resolves
+ * IActionIndexer.
+ *
+ * @param container
+ */
+function createHandler(container) {
+  const mockState = {
+    startTurn: jest.fn(),
+    enterState: jest.fn(),
+    exitState: jest.fn(),
+    getStateName: jest.fn(),
+    isIdle: jest.fn(),
+  };
+  const deps = {
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    turnStateFactory: { createInitialState: jest.fn(() => mockState) },
+    turnEndPort: {},
+    strategyFactory: { create: jest.fn(() => ({ decideAction: jest.fn() })) },
+    turnContextBuilder: {
+      build: jest.fn(() => ({ getActor: jest.fn(() => ({ id: 'actor' })) })),
+    },
+    container,
+  };
+  return { handler: new ActorTurnHandler(deps), state: mockState };
+}
+
+describe('IActionIndexer.beginTurn integration', () => {
+  let mockIndexer;
+  let mockContainer;
+  let actor;
+
+  beforeEach(() => {
+    actor = { id: 'player1' };
+    mockIndexer = { beginTurn: jest.fn() };
+    mockContainer = {
+      resolve: jest.fn((t) =>
+        t === tokens.IActionIndexer ? mockIndexer : null
+      ),
+    };
+  });
+
+  it('invokes beginTurn once for a human handler', async () => {
+    const { handler } = createHandler(mockContainer);
+    await handler.startTurn(actor);
+    expect(mockIndexer.beginTurn).toHaveBeenCalledTimes(1);
+    expect(mockIndexer.beginTurn).toHaveBeenCalledWith(actor.id);
+  });
+
+  it('invokes beginTurn once for an AI handler', async () => {
+    const { handler } = createHandler(mockContainer);
+    await handler.startTurn(actor);
+    expect(mockIndexer.beginTurn).toHaveBeenCalledTimes(1);
+    expect(mockIndexer.beginTurn).toHaveBeenCalledWith(actor.id);
+  });
+});


### PR DESCRIPTION
## Summary
- update GenericTurnHandler to resolve `IActionIndexer` and invoke `beginTurn`
- pass DI container through ActorTurnHandler
- test that `beginTurn` is called once per turn

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852eb7ea1088331a21e89104634c114