### PR TITLE
[Agent] add logger support to displayFatalStartupError

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,8 @@ export async function bootstrapApp() {
         inputElement: document.getElementById('speech-input'),
         document: document,
       },
-      errorDetails
+      errorDetails,
+      logger
     );
   }
 }
@@ -176,12 +177,16 @@ export async function beginGame(showLoadUI = false) {
       'Critical: GameEngine not initialized before attempting Start Game stage.';
     const errorObj = new Error(errMsg);
     (logger || console).error(`main.js: ${errMsg}`);
-    displayFatalStartupError(uiElements, {
-      userMessage: errMsg,
-      consoleMessage: errMsg,
-      errorObject: errorObj,
-      phase: currentPhaseForError,
-    });
+    displayFatalStartupError(
+      uiElements,
+      {
+        userMessage: errMsg,
+        consoleMessage: errMsg,
+        errorObject: errorObj,
+        phase: currentPhaseForError,
+      },
+      logger
+    );
     throw errorObj;
   }
 
@@ -192,12 +197,16 @@ export async function beginGame(showLoadUI = false) {
       gameEngine.showLoadGameUI();
     }
   } catch (error) {
-    displayFatalStartupError(uiElements, {
-      userMessage: `Application failed to start due to a critical error: ${error.message}`,
-      consoleMessage: `Critical error during application bootstrap in phase: ${currentPhaseForError}.`,
-      errorObject: error,
-      phase: currentPhaseForError,
-    });
+    displayFatalStartupError(
+      uiElements,
+      {
+        userMessage: `Application failed to start due to a critical error: ${error.message}`,
+        consoleMessage: `Critical error during application bootstrap in phase: ${currentPhaseForError}.`,
+        errorObject: error,
+        phase: currentPhaseForError,
+      },
+      logger
+    );
     throw error;
   }
 }

--- a/src/utils/errorUtils.js
+++ b/src/utils/errorUtils.js
@@ -1,5 +1,6 @@
 // src/utils/errorUtils.js
-/* eslint-disable no-console */
+
+import { getModuleLogger } from './loggerUtils.js';
 
 /**
  * @typedef {object} FatalErrorUIElements
@@ -25,7 +26,8 @@
  * @param {FatalErrorUIElements} uiElements - References to key UI elements.
  * @param {FatalErrorDetails} errorDetails - Details about the error.
  */
-export function displayFatalStartupError(uiElements, errorDetails) {
+export function displayFatalStartupError(uiElements, errorDetails, logger) {
+  const log = getModuleLogger('errorUtils', logger);
   const { outputDiv, errorDiv, titleElement, inputElement } = uiElements;
   const {
     userMessage,
@@ -36,8 +38,8 @@ export function displayFatalStartupError(uiElements, errorDetails) {
     phase = 'Unknown Phase',
   } = errorDetails;
 
-  // 1. Log to console.error
-  console.error(
+  // 1. Log to logger.error
+  log.error(
     `[Bootstrapper Error - Phase: ${phase}] ${consoleMessage}`,
     errorObject || ''
   );
@@ -50,7 +52,7 @@ export function displayFatalStartupError(uiElements, errorDetails) {
       errorDiv.style.display = 'block'; // Ensure it's visible
       displayedInErrorDiv = true;
     } catch (e) {
-      console.error(
+      log.error(
         'displayFatalStartupError: Failed to set textContent on errorDiv.',
         e
       );
@@ -68,12 +70,12 @@ export function displayFatalStartupError(uiElements, errorDetails) {
       temporaryErrorElement.style.border = '1px solid red';
       temporaryErrorElement.style.marginTop = '10px';
       outputDiv.insertAdjacentElement('afterend', temporaryErrorElement); // Append near outputDiv
-      console.log(
+      log.info(
         'displayFatalStartupError: Displayed error in a dynamically created element near outputDiv.'
       );
       displayedInErrorDiv = true; // Consider this as having displayed the error in a DOM element
     } catch (e) {
-      console.error(
+      log.error(
         'displayFatalStartupError: Failed to create or append temporary error element.',
         e
       );
@@ -83,7 +85,7 @@ export function displayFatalStartupError(uiElements, errorDetails) {
   // 4. Ultimate fallback to alert if no DOM display was feasible
   if (!displayedInErrorDiv) {
     alert(userMessage);
-    console.log(
+    log.info(
       'displayFatalStartupError: Displayed error using alert() as a fallback.'
     );
   }
@@ -93,7 +95,7 @@ export function displayFatalStartupError(uiElements, errorDetails) {
     try {
       titleElement.textContent = pageTitle;
     } catch (e) {
-      console.error(
+      log.error(
         'displayFatalStartupError: Failed to set textContent on titleElement.',
         e
       );
@@ -106,7 +108,7 @@ export function displayFatalStartupError(uiElements, errorDetails) {
       inputElement.disabled = true;
       inputElement.placeholder = inputPlaceholder;
     } catch (e) {
-      console.error(
+      log.error(
         'displayFatalStartupError: Failed to disable or set placeholder on inputElement.',
         e
       );

--- a/tests/bootstrapper/errorUtils.test.js
+++ b/tests/bootstrapper/errorUtils.test.js
@@ -31,21 +31,28 @@ describe('displayFatalStartupError', () => {
     };
 
     const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
+    const logger = {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
 
-    displayFatalStartupError(uiElements, {
-      userMessage: 'Oops',
-      consoleMessage: 'Bad things',
-      errorObject: new Error('fail'),
-      pageTitle: 'Error',
-      inputPlaceholder: 'halt',
-      phase: 'Test',
-    });
+    displayFatalStartupError(
+      uiElements,
+      {
+        userMessage: 'Oops',
+        consoleMessage: 'Bad things',
+        errorObject: new Error('fail'),
+        pageTitle: 'Error',
+        inputPlaceholder: 'halt',
+        phase: 'Test',
+      },
+      logger
+    );
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[Bootstrapper Error - Phase: Test] Bad things',
+    expect(logger.error).toHaveBeenCalledWith(
+      '[errorUtils] [Bootstrapper Error - Phase: Test] Bad things',
       expect.any(Error)
     );
     const errorDiv = uiElements.errorDiv;
@@ -63,19 +70,28 @@ describe('displayFatalStartupError', () => {
     const uiElements = { outputDiv };
 
     const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const logger = {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
 
-    displayFatalStartupError(uiElements, {
-      userMessage: 'Oops',
-      consoleMessage: 'Bad',
-    });
+    displayFatalStartupError(
+      uiElements,
+      {
+        userMessage: 'Oops',
+        consoleMessage: 'Bad',
+      },
+      logger
+    );
 
     const tempEl = outputDiv.nextElementSibling;
     expect(tempEl).not.toBeNull();
     expect(tempEl.id).toBe('temp-startup-error');
     expect(tempEl.textContent).toBe('Oops');
-    expect(logSpy).toHaveBeenCalledWith(
-      'displayFatalStartupError: Displayed error in a dynamically created element near outputDiv.'
+    expect(logger.info).toHaveBeenCalledWith(
+      '[errorUtils] displayFatalStartupError: Displayed error in a dynamically created element near outputDiv.'
     );
     expect(alertSpy).not.toHaveBeenCalled();
   });
@@ -83,19 +99,25 @@ describe('displayFatalStartupError', () => {
   it('falls back to alert when no DOM targets', () => {
     setDom('');
     const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const logger = {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
 
     displayFatalStartupError(
       {},
       {
         userMessage: 'Oops',
         consoleMessage: 'Bad',
-      }
+      },
+      logger
     );
 
     expect(alertSpy).toHaveBeenCalledWith('Oops');
-    expect(logSpy).toHaveBeenCalledWith(
-      'displayFatalStartupError: Displayed error using alert() as a fallback.'
+    expect(logger.info).toHaveBeenCalledWith(
+      '[errorUtils] displayFatalStartupError: Displayed error using alert() as a fallback.'
     );
   });
 });

--- a/tests/main/main.bootstrapFlow.test.js
+++ b/tests/main/main.bootstrapFlow.test.js
@@ -123,8 +123,9 @@ describe('main.js bootstrap extended coverage', () => {
 
     expect(mockStartGame).not.toHaveBeenCalled();
     expect(mockDisplayFatal).toHaveBeenCalledTimes(1);
-    const [elements, details] = mockDisplayFatal.mock.calls[0];
+    const [elements, details, passedLogger] = mockDisplayFatal.mock.calls[0];
     expect(elements.outputDiv).toBe(uiElements.outputDiv);
     expect(details.phase).toContain('Start Game');
+    expect(passedLogger).toBe(logger);
   });
 });

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -111,10 +111,11 @@ describe('main.js bootstrap process', () => {
 
     expect(mockSetupDI).toHaveBeenCalled();
     expect(mockDisplayFatal).toHaveBeenCalledTimes(1);
-    const [elements, details] = mockDisplayFatal.mock.calls[0];
+    const [elements, details, passedLogger] = mockDisplayFatal.mock.calls[0];
     expect(elements.outputDiv).toBe(uiElements.outputDiv);
     expect(details.errorObject).toBe(stageError);
     expect(details.phase).toBe(stageError.phase);
+    expect(passedLogger).toBeNull();
     expect(mockResolveCore).not.toHaveBeenCalled();
     expect(mockStartGame).not.toHaveBeenCalled();
   });
@@ -151,8 +152,9 @@ describe('main.js bootstrap process', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(mockDisplayFatal).toHaveBeenCalledTimes(1);
-    const [, details] = mockDisplayFatal.mock.calls[0];
+    const [, details, passedLogger] = mockDisplayFatal.mock.calls[0];
     expect(details.errorObject).toBe(aggError);
     expect(details.phase).toBe(aggError.phase);
+    expect(passedLogger).toBe(logger);
   });
 });


### PR DESCRIPTION
## Summary
- allow `displayFatalStartupError` to accept an optional logger
- use module logger inside `displayFatalStartupError`
- pass logger in `main.js`
- check logger calls in `errorUtils` tests
- verify logger argument in main tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852ec6bf2d08331a53dd8f550272dcc