### PR TITLE
[Fix] Resolve lint warnings in helper modules

### DIFF
--- a/src/domUI/helpers/createMessageElement.js
+++ b/src/domUI/helpers/createMessageElement.js
@@ -5,9 +5,10 @@
 /** @typedef {import('../domElementFactory.js').default} DomElementFactory */
 
 /**
- * @description Creates a paragraph element containing a message using the
- * provided {@link DomElementFactory}. Falls back to a Text node if the
- * factory is unavailable or fails to create the element.
+ * Creates a paragraph element containing a message using the provided
+ * {@link DomElementFactory}. Falls back to a Text node if the factory is
+ * unavailable or fails to create the element.
+ *
  * @param {DomElementFactory} [domFactory] - Optional DOM element factory.
  * @param {string} [cssClass] - CSS class to apply to the element.
  * @param {string} text - The message text content.

--- a/src/domUI/helpers/createSelectableItem.js
+++ b/src/domUI/helpers/createSelectableItem.js
@@ -5,9 +5,10 @@
 /** @typedef {import('../domElementFactory.js').default} DomElementFactory */
 
 /**
- * @description Creates an element representing a selectable slot or list item.
- * The returned element has the standard classes and ARIA attributes used
- * throughout the save/load and LLM selection modals.
+ * Creates an element representing a selectable slot or list item. The returned
+ * element has the standard classes and ARIA attributes used throughout the
+ * save/load and LLM selection modals.
+ *
  * @param {DomElementFactory} domFactory - The DOM element factory.
  * @param {string} tagName - Tag name for the element (e.g., 'div', 'li').
  * @param {string} datasetKey - Name of the dataset property to set.

--- a/src/domUI/helpers/renderSlotItem.js
+++ b/src/domUI/helpers/renderSlotItem.js
@@ -16,7 +16,8 @@ import { createSelectableItem } from './createSelectableItem.js';
  */
 
 /**
- * @description Creates a DOM element representing a save/load slot.
+ * Creates a DOM element representing a save/load slot.
+ *
  * @param {DomElementFactory} domFactory - Factory used to create elements.
  * @param {string} datasetKey - Name of the dataset property for identification.
  * @param {string|number} datasetValue - Value for the dataset property.

--- a/src/domUI/helpers/slotDataFormatter.js
+++ b/src/domUI/helpers/slotDataFormatter.js
@@ -16,8 +16,9 @@ import { formatPlaytime, formatTimestamp } from '../../utils/textUtils.js';
  */
 
 /**
- * @description Converts a {@link SaveFileMetadata} record into the metadata object
- * expected by {@link renderSlotItem}.
+ * Converts a {@link SaveFileMetadata} record into the metadata object expected
+ * by the `renderSlotItem` helper.
+ *
  * @param {SaveFileMetadata} metadata - Save file metadata to convert.
  * @returns {SlotItemMetadata} Formatted slot item metadata.
  */
@@ -49,7 +50,8 @@ export function formatSaveFileMetadata(metadata) {
 }
 
 /**
- * @description Creates metadata representing an empty slot.
+ * Creates metadata representing an empty slot.
+ *
  * @param {string} name - Name label for the empty slot.
  * @returns {SlotItemMetadata} Metadata for an empty slot.
  */

--- a/src/domUI/icons.js
+++ b/src/domUI/icons.js
@@ -41,7 +41,8 @@ const DEFAULT_ICONS = {
 let iconRegistry = null;
 
 /**
- * @description Retrieves an icon by name, falling back to defaults.
+ * Retrieves an icon by name, falling back to defaults.
+ *
  * @param {string} name - Icon identifier.
  * @returns {string} SVG markup for the icon.
  */


### PR DESCRIPTION
Summary: Fixes ESLint warnings across several DOM UI helper modules so lint passes for these files.

Changes Made:
- Updated JSDoc in `createMessageElement.js` to use plain description text
- Adjusted `createSelectableItem.js` description block
- Clarified docs in `renderSlotItem.js`
- Reworded comments in `slotDataFormatter.js` and removed undefined type link
- Simplified description in `icons.js`

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [x] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6852efac3f988331b3e8607e21c06d8c