### PR TITLE
[Feat] add loader result aggregation helpers

### DIFF
--- a/tests/loaders/worldLoader.privateHelpers.test.js
+++ b/tests/loaders/worldLoader.privateHelpers.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import WorldLoader from '../../src/loaders/worldLoader.js';
+
+/**
+ * Helper to create a bare WorldLoader instance without running the constructor.
+ * This allows direct testing of private helper methods.
+ *
+ * @returns {WorldLoader}
+ */
+function makeBareWorldLoader() {
+  return Object.create(WorldLoader.prototype);
+}
+
+describe('WorldLoader private helpers', () => {
+  let loader;
+
+  beforeEach(() => {
+    loader = makeBareWorldLoader();
+  });
+
+  it('_aggregateLoaderResult updates mod and total counts', () => {
+    const modResults = {};
+    const totals = {};
+
+    loader._aggregateLoaderResult(modResults, totals, 'actions', {
+      count: 2,
+      overrides: 1,
+      errors: 0,
+    });
+
+    expect(modResults).toEqual({
+      actions: { count: 2, overrides: 1, errors: 0 },
+    });
+    expect(totals).toEqual({ actions: { count: 2, overrides: 1, errors: 0 } });
+  });
+
+  it('_aggregateLoaderResult handles invalid results', () => {
+    const modResults = {};
+    const totals = {};
+
+    loader._aggregateLoaderResult(modResults, totals, 'rules', null);
+
+    expect(modResults).toEqual({
+      rules: { count: 0, overrides: 0, errors: 0 },
+    });
+    expect(totals).toEqual({ rules: { count: 0, overrides: 0, errors: 0 } });
+  });
+
+  it('_recordLoaderError increments error counts', () => {
+    const modResults = { events: { count: 5, overrides: 0, errors: 0 } };
+    const totals = { events: { count: 5, overrides: 0, errors: 0 } };
+
+    loader._recordLoaderError(modResults, totals, 'events', 'boom');
+    loader._recordLoaderError(modResults, totals, 'events', 'boom again');
+
+    expect(modResults.events.errors).toBe(2);
+    expect(totals.events.errors).toBe(2);
+  });
+});


### PR DESCRIPTION
Summary: Implement helper methods for aggregating loader results and errors within WorldLoader.

Changes Made:
- Added `_aggregateLoaderResult` and `_recordLoaderError` private methods with JSDoc.
- Replaced inline aggregation logic in `#loadContentForMods` with calls to these helpers.
- Added unit tests verifying helper behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6852f0f473a08331a8895233d155a5e8