### PR TITLE
[Agent] fix lint in root modules

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -6,6 +6,9 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/**
+ * @typedef {import('../interfaces/IGameDataRepository.js').ActionDefinition} ActionDefinition
+ */
 
 // --- Dependency Imports ---
 import { getEntityDisplayName } from '../utils/entityUtils.js';
@@ -34,7 +37,7 @@ export function formatActionCommand(
   const { debug = false, logger = console, safeEventDispatcher } = options;
   const dispatcher = resolveSafeDispatcher(null, safeEventDispatcher, logger);
   if (!dispatcher) {
-    console.warn(
+    logger.warn(
       'formatActionCommand: safeEventDispatcher resolution failed; error events may not be dispatched.'
     );
   }

--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -9,6 +9,7 @@
 // --- ADDED Import for ActionTargetContext ---
 /** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 // --- ADDED Import for ActionDefinition (used in ActionAttemptPseudoEvent) ---
+/** @typedef {import('../interfaces/IGameDataRepository.js').ActionDefinition} ActionDefinition */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */ // Added for ActionContext
 /** @typedef {import('../interfaces/IWorldContext.js').IWorldContext} IWorldContext */ // Added for ActionContext
 /** @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher */ // Added for ActionContext

--- a/src/ai/notesPersistenceListener.js
+++ b/src/ai/notesPersistenceListener.js
@@ -5,16 +5,20 @@ import { persistNotes } from './notesPersistenceHook.js';
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
- * Consumes ACTION_DECIDED_ID and merges generated notes into the
- * actor’s notes component.
+ * @class
+ * @description Consumes ACTION_DECIDED_ID events and merges generated notes into the
+ * actor's notes component.
  */
 export class NotesPersistenceListener {
   /**
+   * Creates an instance of the listener.
+   *
    * @param {{
    *   logger: import('../interfaces/coreServices.js').ILogger,
    *   entityManager: import('../interfaces/IEntityManager.js').IEntityManager,
    *   dispatcher: ISafeEventDispatcher
    * }} deps
+   *   Dependencies for the listener.
    */
   constructor({ logger, entityManager, dispatcher }) {
     this.logger = logger;
@@ -24,7 +28,10 @@ export class NotesPersistenceListener {
   }
 
   /**
-   * @param {{ type: string, payload: { actorId: string, extractedData?: { notes?: string[] } } }} event
+   * Handles events emitted after an action decision.
+   *
+   * @param {{ type: string, payload: { actorId: string, extractedData?: { notes?: string[] } } }} event -
+   * The event containing any notes produced by the actor's decision process.
    */
   handleEvent(event) {
     if (!event || !event.payload) return;

--- a/src/ai/thoughtPersistenceListener.js
+++ b/src/ai/thoughtPersistenceListener.js
@@ -3,15 +3,19 @@
 import { persistThoughts } from './thoughtPersistenceHook.js';
 
 /**
- * Listens for ACTION_DECIDED_ID and persists any thoughts in the
- * actor’s short-term memory component.
+ * @class
+ * @description Listens for ACTION_DECIDED_ID events and persists any thoughts in the
+ * actor's short-term memory component.
  */
 export class ThoughtPersistenceListener {
   /**
+   * Creates an instance of the listener.
+   *
    * @param {{
    *   logger: import('../interfaces/coreServices.js').ILogger,
    *   entityManager: import('../interfaces/IEntityManager.js').IEntityManager
    * }} deps
+   *   Dependencies for the listener.
    */
   constructor({ logger, entityManager }) {
     this.logger = logger;
@@ -19,7 +23,10 @@ export class ThoughtPersistenceListener {
   }
 
   /**
-   * @param {{ type: string, payload: { actorId: string, extractedData?: { thoughts?: string } } }} event
+   * Handles events emitted after an action decision.
+   *
+   * @param {{ type: string, payload: { actorId: string, extractedData?: { thoughts?: string } } }} event -
+   * The event containing any thoughts produced during the decision process.
    */
   handleEvent(event) {
     if (!event || !event.payload) return;

--- a/src/alerting/statusCodeMapper.js
+++ b/src/alerting/statusCodeMapper.js
@@ -24,8 +24,9 @@ export const statusCodeMap = new Map([
 ]);
 
 /**
- * @description Converts an event's details object, which may contain an HTTP status code,
- * into a user-friendly message and a set of developer details.
+ * Converts an event's details object, which may contain an HTTP status code,
+ * into a user-friendly message and developer-oriented details.
+ *
  * @param {object | null | undefined} details - The details object from the event payload. May contain `statusCode`, `url`, and `raw` properties.
  * @param {string} originalMessage - The original message from the event, used as a fallback if no status code logic applies.
  * @returns {FriendlyResult} An object containing the message to display and the developer details.

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -80,7 +80,7 @@ class WorldContext extends IWorldContext {
       logger
     );
     if (!this.#safeEventDispatcher) {
-      console.warn(
+      logger.warn(
         'WorldContext: safeEventDispatcher resolution failed; some errors may not be dispatched.'
       );
     }


### PR DESCRIPTION
Summary: Fixed lint warnings in several core modules by adding missing JSDoc and replacing console calls with logger methods.

Changes Made:
- added ActionDefinition typedef and logger.warn call in actionFormatter
- imported ActionDefinition typedef in actionTypes
- documented notes/thought persistence listeners
- updated statusCodeMapper JSDoc
- replaced console.warn in worldContext

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (none)


------
https://chatgpt.com/codex/tasks/task_e_6852f201471c8331845b037be7a4395e