### PR TITLE
[Refactor] Introduce IActionIndexer port

### DIFF
--- a/src/data/providers/availableActionsProvider.js
+++ b/src/data/providers/availableActionsProvider.js
@@ -11,7 +11,7 @@ import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../constants/core.js';
 /** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../turns/dtos/actionComposite.js').ActionComposite} ActionComposite */
-/** @typedef {import('../../turns/services/actionIndexingService.js').ActionIndexingService} IActionIndexingService */
+/** @typedef {import('../../turns/ports/IActionIndexer.js').IActionIndexer} IActionIndexer */
 /** @typedef {import('../../interfaces/IActionDiscoveryService.js').IActionDiscoveryService} IActionDiscoveryService */
 /** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 
@@ -26,7 +26,7 @@ import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../constants/core.js';
  */
 export class AvailableActionsProvider extends IAvailableActionsProvider {
   #actionDiscoveryService;
-  #actionIndexingService;
+  #actionIndexer;
   #entityManager;
 
   // --- Turn-scoped Cache ---
@@ -36,17 +36,17 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
   /**
    * @param {object} dependencies
    * @param {IActionDiscoveryService} dependencies.actionDiscoveryService
-   * @param {IActionIndexingService} dependencies.actionIndexingService
+   * @param {IActionIndexer} dependencies.actionIndexingService
    * @param {IEntityManager} dependencies.entityManager
    */
   constructor({
     actionDiscoveryService,
-    actionIndexingService,
+    actionIndexingService: actionIndexer,
     entityManager,
   }) {
     super();
     this.#actionDiscoveryService = actionDiscoveryService;
-    this.#actionIndexingService = actionIndexingService;
+    this.#actionIndexer = actionIndexer;
     this.#entityManager = entityManager;
   }
 
@@ -102,9 +102,9 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
         await this.#actionDiscoveryService.getValidActions(actor, actionCtx);
 
       // Index the discovered actions to create the final, ordered list.
-      const indexedActions = this.#actionIndexingService.indexActions(
-        actor.id,
-        discoveredActions
+      const indexedActions = this.#actionIndexer.index(
+        discoveredActions,
+        actor.id
       );
 
       // When the indexing service caps the list, mirror its warning with richer context.

--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -309,7 +309,7 @@ export function registerAI(container) {
     (c) =>
       new AvailableActionsProvider({
         actionDiscoveryService: c.resolve(tokens.IActionDiscoveryService),
-        actionIndexingService: c.resolve(tokens.ActionIndexingService),
+        actionIndexingService: c.resolve(tokens.IActionIndexer),
         entityManager: c.resolve(tokens.IEntityManager),
       })
   );

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -82,7 +82,7 @@ export function registerTurnLifecycle(container) {
       new PromptCoordinator({
         logger: c.resolve(tokens.ILogger),
         promptOutputPort: c.resolve(tokens.IPromptOutputPort),
-        actionIndexingService: c.resolve(tokens.ActionIndexingService),
+        actionIndexingService: c.resolve(tokens.IActionIndexer),
         playerTurnEvents: c.resolve(tokens.IPlayerTurnEvents),
       })
   );

--- a/src/turns/adapters/actionIndexerAdapter.js
+++ b/src/turns/adapters/actionIndexerAdapter.js
@@ -28,10 +28,11 @@ export class ActionIndexerAdapter extends IActionIndexer {
     if (
       !actionIndexingService ||
       typeof actionIndexingService.indexActions !== 'function' ||
+      typeof actionIndexingService.resolve !== 'function' ||
       typeof actionIndexingService.beginTurn !== 'function'
     ) {
       throw new TypeError(
-        'ActionIndexerAdapter: constructor requires a valid actionIndexingService instance with indexActions and beginTurn methods.'
+        'ActionIndexerAdapter: constructor requires a valid actionIndexingService instance with indexActions, resolve, and beginTurn methods.'
       );
     }
 
@@ -76,5 +77,26 @@ export class ActionIndexerAdapter extends IActionIndexer {
     }
 
     return this._svc.indexActions(actorId, actions);
+  }
+
+  /**
+   * Resolves an indexed action choice for the actor.
+   *
+   * @param {string} actorId
+   * @param {number} chosenIndex
+   * @returns {import('../dtos/actionComposite.js').ActionComposite}
+   */
+  resolve(actorId, chosenIndex) {
+    if (typeof actorId !== 'string' || actorId.trim() === '') {
+      throw new TypeError(
+        `ActionIndexerAdapter.resolve: "actorId" parameter must be a non-empty string. Received: ${typeof actorId}`
+      );
+    }
+    if (!Number.isInteger(chosenIndex)) {
+      throw new TypeError(
+        `ActionIndexerAdapter.resolve: "chosenIndex" must be an integer. Received: ${typeof chosenIndex}`
+      );
+    }
+    return this._svc.resolve(actorId, chosenIndex);
   }
 }

--- a/src/turns/ports/IActionIndexer.js
+++ b/src/turns/ports/IActionIndexer.js
@@ -30,4 +30,15 @@ export class IActionIndexer {
   index(actions, actorId) {
     throw new Error('Interface method');
   }
+
+  /**
+   * Resolves a previously indexed list by numeric choice.
+   *
+   * @param {string} actorId
+   * @param {number} chosenIndex
+   * @returns {import('../dtos/actionComposite.js').ActionComposite}
+   */
+  resolve(actorId, chosenIndex) {
+    throw new Error('Interface method');
+  }
 }

--- a/src/turns/prompting/promptCoordinator.js
+++ b/src/turns/prompting/promptCoordinator.js
@@ -11,7 +11,7 @@ import IPromptCoordinator from '../../interfaces/IPromptCoordinator';
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../ports/IPromptOutputPort.js').IPromptOutputPort} IPromptOutputPort
  * @typedef {import('../interfaces/IPlayerTurnEvents.js').IPlayerTurnEvents} IPlayerTurnEvents
- * @typedef {import('../services/actionIndexingService.js').ActionIndexingService} ActionIndexingService
+ * @typedef {import('../ports/IActionIndexer.js').IActionIndexer} IActionIndexer
  * @typedef {import('../../entities/entity.js').default} Entity
  */
 
@@ -19,7 +19,7 @@ import IPromptCoordinator from '../../interfaces/IPromptCoordinator';
  * @typedef {object} PromptCoordinatorDependencies
  * @property {ILogger} logger
  * @property {IPromptOutputPort} promptOutputPort
- * @property {ActionIndexingService} actionIndexingService
+ * @property {IActionIndexer} actionIndexingService
  * @property {IPlayerTurnEvents} playerTurnEvents
  */
 
@@ -31,7 +31,7 @@ import IPromptCoordinator from '../../interfaces/IPromptCoordinator';
 class PromptCoordinator extends IPromptCoordinator {
   /** @type {ILogger} */ #logger;
   /** @type {IPromptOutputPort} */ #promptOutputPort;
-  /** @type {ActionIndexingService} */ #actionIndexingService;
+  /** @type {IActionIndexer} */ #actionIndexer;
   /** @type {IPlayerTurnEvents} */ #playerTurnEvents;
 
   /** @type {PromptSession | null} */
@@ -43,7 +43,7 @@ class PromptCoordinator extends IPromptCoordinator {
   constructor({
     logger,
     promptOutputPort,
-    actionIndexingService,
+    actionIndexingService: actionIndexer,
     playerTurnEvents,
   }) {
     super();
@@ -54,14 +54,14 @@ class PromptCoordinator extends IPromptCoordinator {
     validateDependency(promptOutputPort, 'promptOutputPort', logger, {
       requiredMethods: ['prompt'],
     });
-    validateDependency(actionIndexingService, 'actionIndexingService', logger, {
-      requiredMethods: ['indexActions', 'resolve'],
+    validateDependency(actionIndexer, 'actionIndexingService', logger, {
+      requiredMethods: ['index', 'resolve'],
     });
     validateDependency(playerTurnEvents, 'playerTurnEvents', logger);
 
     this.#logger = logger;
     this.#promptOutputPort = promptOutputPort;
-    this.#actionIndexingService = actionIndexingService;
+    this.#actionIndexer = actionIndexer;
     this.#playerTurnEvents = playerTurnEvents;
 
     this.#logger.debug('PromptCoordinator initialised.');
@@ -110,7 +110,7 @@ class PromptCoordinator extends IPromptCoordinator {
       eventBus: this.#playerTurnEvents,
       logger: this.#logger,
       abortSignal: cancellationSignal,
-      actionIndexingService: this.#actionIndexingService, // <— same singleton
+      actionIndexingService: this.#actionIndexer, // <— same singleton
     });
     this.#activeSession = session;
 

--- a/tests/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/aiRegistrations.test.js
@@ -89,9 +89,11 @@ describe('registerAI', () => {
     });
     container.register(tokens.IActionDiscoveryService, {});
     container.register(tokens.IEntityManager, {});
-    // FIX: The ActionIndexerAdapter constructor requires a service with an `indexActions` method.
+    // The ActionIndexerAdapter constructor requires the real service shape.
     container.register(tokens.ActionIndexingService, {
       indexActions: jest.fn(),
+      resolve: jest.fn(),
+      beginTurn: jest.fn(),
     });
 
     // Final Fix: The initial state object must have a `startTurn` method to be considered valid.
@@ -134,10 +136,11 @@ describe('registerAI', () => {
       fallbackContainer.register(tokens.IValidatedEventDispatcher, {
         dispatch: jest.fn(),
       });
-      // FIX: The fallback container also needs the ActionIndexingService mock
-      // with the `indexActions` method.
+      // Provide a minimal ActionIndexingService for the adapter.
       fallbackContainer.register(tokens.ActionIndexingService, {
         indexActions: jest.fn(),
+        resolve: jest.fn(),
+        beginTurn: jest.fn(),
       });
 
       registerAI(fallbackContainer);

--- a/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
+++ b/tests/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
@@ -40,8 +40,7 @@ describe('registerTurnLifecycle', () => {
     mockCommandOutcome,
     mockAiTurnHandler,
     mockActionIndexer,
-    mockTurnActionFactory,
-    mockActionIndexingService;
+    mockTurnActionFactory;
 
   beforeEach(() => {
     container = new AppContainer();
@@ -60,12 +59,6 @@ describe('registerTurnLifecycle', () => {
     mockTurnEndPort = mock();
     mockCommandOutcome = mock();
     mockAiTurnHandler = mock();
-
-    mockActionIndexingService = {
-      indexActions: jest.fn(),
-      getIndexedList: jest.fn(),
-      resolve: jest.fn(),
-    };
 
     // register the bare‐minimum dependencies
     container.register(tokens.ILogger, () => mockLogger);
@@ -92,12 +85,7 @@ describe('registerTurnLifecycle', () => {
     mockAiTurnHandler = mock();
     container.register(tokens.ActorTurnHandler, () => mockAiTurnHandler);
 
-    // Register the new mock for the service.
-    // This is needed by IActionIndexer and IPromptCoordinator.
-    container.register(
-      tokens.ActionIndexingService,
-      () => mockActionIndexingService
-    );
+    // Register a mock IActionIndexer for PromptCoordinator usage.
 
     // register action indexing interface for TurnActionChoicePipeline
     mockActionIndexer = mock();

--- a/tests/integration/availableActionsProvider.integration.test.js
+++ b/tests/integration/availableActionsProvider.integration.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { AvailableActionsProvider } from '../../src/data/providers/availableActionsProvider.js';
 import { ActionIndexingService } from '../../src/turns/services/actionIndexingService.js';
+import { ActionIndexerAdapter } from '../../src/turns/adapters/actionIndexerAdapter.js';
 import { TurnActionChoicePipeline } from '../../src/turns/pipeline/turnActionChoicePipeline.js';
 
 /**
@@ -43,7 +44,9 @@ describe('Integration – AvailableActionsProvider caching', () => {
       error: jest.fn(),
     };
     discoverySvc = { getValidActions: jest.fn() };
-    indexingService = new ActionIndexingService({ logger });
+    indexingService = new ActionIndexerAdapter(
+      new ActionIndexingService({ logger })
+    );
     entityManager = { getEntityInstance: jest.fn().mockResolvedValue(null) };
 
     provider = new AvailableActionsProvider({

--- a/tests/integration/guardrailIndexOverflow.integration.test.js
+++ b/tests/integration/guardrailIndexOverflow.integration.test.js
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect, jest } from '@jest/globals';
 import { AvailableActionsProvider } from '../../src/data/providers/availableActionsProvider.js';
 import { ActionIndexingService } from '../../src/turns/services/actionIndexingService.js';
+import { ActionIndexerAdapter } from '../../src/turns/adapters/actionIndexerAdapter.js';
 import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../src/constants/core.js';
 
 /**
@@ -23,7 +24,9 @@ describe('Guardrail – index overflow', () => {
     };
     discoverySvc = { getValidActions: jest.fn() };
     entityManager = { getEntityInstance: jest.fn().mockResolvedValue(null) };
-    const indexingService = new ActionIndexingService({ logger });
+    const indexingService = new ActionIndexerAdapter(
+      new ActionIndexingService({ logger })
+    );
     provider = new AvailableActionsProvider({
       actionDiscoveryService: discoverySvc,
       actionIndexingService: indexingService,

--- a/tests/turns/adapters/actionIndexerAdapter.test.js
+++ b/tests/turns/adapters/actionIndexerAdapter.test.js
@@ -12,6 +12,7 @@ describe('ActionIndexerAdapter', () => {
         indexActions: jest
           .fn()
           .mockReturnValue([{ actionId: 'a', params: {} }]),
+        resolve: jest.fn(),
         beginTurn: jest.fn(),
       };
       const adapter = new ActionIndexerAdapter(mockService);
@@ -83,6 +84,7 @@ describe('ActionIndexerAdapter', () => {
         indexActions: jest.fn().mockImplementation(() => {
           throw error;
         }),
+        resolve: jest.fn(),
         beginTurn: jest.fn(),
       };
       const adapter = new ActionIndexerAdapter(mockService);


### PR DESCRIPTION
Summary: Abstracted action indexing behind IActionIndexer interface. AvailableActionsProvider and PromptCoordinator now depend on IActionIndexer. Updated registrations to supply ActionIndexerAdapter and adjusted tests.

Changes Made:
- New resolve method added to IActionIndexer and ActionIndexerAdapter.
- Updated provider and coordinator to use the interface.
- DI registrations updated to inject IActionIndexer.
- Tests switched to mock IActionIndexer or adapter accordingly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint pass attempted (`npm run lint`) – fails due to pre-existing issues
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6852f08b1bcc833180b5e40e9ad9f217