### PR TITLE
[Agent] Extract save state validation utility

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -2,7 +2,7 @@
 
 import { encode, decode } from '@msgpack/msgpack';
 import pako from 'pako';
-import { safeDeepClone } from '../utils/objectUtils.js';
+import { cloneAndValidateSaveState } from '../utils/saveStateUtils.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -118,26 +118,15 @@ class GameStateSerializer {
    * @private
    */
   #cloneForSerialization(gameStateObject) {
-    const cloneResult = safeDeepClone(gameStateObject, this.#logger);
+    const cloneResult = cloneAndValidateSaveState(
+      gameStateObject,
+      this.#logger
+    );
     if (!cloneResult.success || !cloneResult.data) {
       throw cloneResult.error;
     }
-    const finalSaveObject = cloneResult.data;
 
-    if (
-      !finalSaveObject.gameState ||
-      typeof finalSaveObject.gameState !== 'object'
-    ) {
-      this.#logger.error(
-        'Invalid or missing gameState property in save object for checksum calculation.'
-      );
-      throw new PersistenceError(
-        PersistenceErrorCodes.INVALID_GAME_STATE,
-        'Invalid gameState for checksum calculation.'
-      );
-    }
-
-    return finalSaveObject;
+    return cloneResult.data;
   }
 
   /**

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -4,7 +4,7 @@ import SaveValidationService from './saveValidationService.js';
 import { buildManualFileName, manualSavePath } from '../utils/savePathUtils.js';
 import SaveFileRepository from './saveFileRepository.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
-import { safeDeepClone } from '../utils/objectUtils.js';
+import { cloneAndValidateSaveState } from '../utils/saveStateUtils.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -126,12 +126,9 @@ class SaveLoadService extends ISaveLoadService {
    * @private
    */
   #cloneAndPrepareState(saveName, obj) {
-    const cloneResult = safeDeepClone(obj, this.#logger);
+    const cloneResult = cloneAndValidateSaveState(obj, this.#logger);
     if (!cloneResult.success || !cloneResult.data) {
-      return createPersistenceFailure(
-        cloneResult.error.code,
-        cloneResult.error.message
-      );
+      return { success: false, error: cloneResult.error };
     }
 
     /** @type {SaveGameStructure} */

--- a/src/utils/saveStateUtils.js
+++ b/src/utils/saveStateUtils.js
@@ -1,0 +1,42 @@
+// src/utils/saveStateUtils.js
+
+import { safeDeepClone } from './objectUtils.js';
+import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
+
+/**
+ * Deep clones and validates a game save object.
+ *
+ * @description Uses {@link safeDeepClone} and verifies the object contains
+ * a valid `gameState` property.
+ * @param {object} obj - Raw save state object to clone.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for
+ *   error reporting.
+ * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<object>}
+ *   Clone result with validation outcome.
+ */
+export function cloneAndValidateSaveState(obj, logger) {
+  const cloneResult = safeDeepClone(obj, logger);
+  if (!cloneResult.success || !cloneResult.data) {
+    return createPersistenceFailure(
+      cloneResult.error.code,
+      cloneResult.error.message
+    );
+  }
+
+  const cloned = cloneResult.data;
+  if (!cloned.gameState || typeof cloned.gameState !== 'object') {
+    logger.error('Invalid or missing gameState property in save object.');
+    return createPersistenceFailure(
+      PersistenceErrorCodes.INVALID_GAME_STATE,
+      'Invalid gameState for checksum calculation.'
+    );
+  }
+
+  return createPersistenceSuccess(cloned);
+}
+
+export default cloneAndValidateSaveState;

--- a/tests/persistence/saveLoadService.test.js
+++ b/tests/persistence/saveLoadService.test.js
@@ -105,6 +105,9 @@ describe('SaveLoadService', () => {
         expect.any(Uint8Array)
       );
       expect(serializer.serializeAndCompress).toHaveBeenCalledTimes(1);
+      const passedObj = serializer.serializeAndCompress.mock.calls[0][0];
+      expect(passedObj.metadata.saveName).toBe(name);
+      expect(passedObj.integrityChecks).toEqual({});
     });
 
     it('handles invalid save names', async () => {

--- a/tests/services/gameStateSerializer.test.js
+++ b/tests/services/gameStateSerializer.test.js
@@ -87,6 +87,18 @@ describe('GameStateSerializer', () => {
     expect(actual).toBe(expected);
   });
 
+  it('does not mutate the original object during serialization', async () => {
+    const obj = {
+      metadata: {},
+      modManifest: {},
+      gameState: { foo: 'bar' },
+      integrityChecks: {},
+    };
+    const before = JSON.parse(JSON.stringify(obj));
+    await serializer.serializeAndCompress(obj);
+    expect(obj).toEqual(before);
+  });
+
   it('throws PersistenceError when deep cloning fails', async () => {
     const cyc = {
       metadata: {},


### PR DESCRIPTION
## Summary
- create `cloneAndValidateSaveState` utility for deep cloning and validation
- use the new utility in `SaveLoadService` and `GameStateSerializer`
- ensure metadata injection still happens in `SaveLoadService`
- verify that serialization doesn't mutate objects
- update related unit tests

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852f10cf8b08331b3b49dcd7ec09f10