### PR TITLE
[Agent] Refactor turn states with helper methods

### DIFF
--- a/tests/turns/states/awaitingActorDecisionState.helpers.test.js
+++ b/tests/turns/states/awaitingActorDecisionState.helpers.test.js
@@ -1,0 +1,60 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { AwaitingActorDecisionState } from '../../../src/turns/states/awaitingActorDecisionState.js';
+
+const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+const makeCtx = (opts = {}) => ({
+  getLogger: () => logger,
+  getActor: jest.fn(() => opts.actor),
+  getStrategy: jest.fn(() => opts.strategy),
+  setDecisionMeta: jest.fn(),
+  setChosenAction: jest.fn(),
+  getSafeEventDispatcher: jest.fn(() => ({ dispatch: jest.fn() })),
+  requestProcessingCommandStateTransition: jest.fn(),
+});
+
+describe('AwaitingActorDecisionState helpers', () => {
+  let state;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    state = new AwaitingActorDecisionState({ getLogger: () => logger });
+  });
+
+  test('_validateActorAndStrategy returns actor and strategy', async () => {
+    const actor = { id: 'a1' };
+    const strategy = { decideAction: jest.fn() };
+    const ctx = makeCtx({ actor, strategy });
+    await expect(state._validateActorAndStrategy(ctx)).resolves.toEqual({
+      actor,
+      strategy,
+    });
+  });
+
+  test('_decideAction returns action info', async () => {
+    const strategy = {
+      decideAction: jest
+        .fn()
+        .mockResolvedValue({ action: { id: 1 }, extractedData: { t: 1 } }),
+    };
+    const ctx = makeCtx({ actor: { id: 'a1' }, strategy });
+    const result = await state._decideAction(strategy, ctx, ctx.getActor());
+    expect(result.action).toEqual({ id: 1 });
+    expect(result.extractedData).toEqual({ t: 1 });
+  });
+
+  test('_recordDecision stores meta and action', () => {
+    const actor = { id: 'a1' };
+    const ctx = makeCtx({ actor });
+    state._recordDecision(ctx, { actionDefinitionId: 'act' }, { notes: [] });
+    expect(ctx.setDecisionMeta).toHaveBeenCalled();
+    expect(ctx.setChosenAction).toHaveBeenCalled();
+  });
+
+  test('_emitActionDecided dispatches event', async () => {
+    const actor = { id: 'a1', type: 'ai' };
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const ctx = makeCtx({ actor });
+    ctx.getSafeEventDispatcher = () => dispatcher;
+    await state._emitActionDecided(ctx, actor, null);
+    expect(dispatcher.dispatch).toHaveBeenCalled();
+  });
+});

--- a/tests/turns/states/processingCommandState.helpers.test.js
+++ b/tests/turns/states/processingCommandState.helpers.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { ProcessingCommandState } from '../../../src/turns/states/processingCommandState.js';
+
+const mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+const mockHandler = {
+  getTurnContext: jest.fn(),
+  _resetTurnStateAndResources: jest.fn(),
+  _transitionToState: jest.fn(),
+  getLogger: jest.fn(() => mockLogger),
+  _turnStateFactory: { createIdleState: jest.fn(() => ({})) },
+};
+
+const makeCtx = (actor, extra = {}) => ({
+  getLogger: () => mockLogger,
+  getActor: () => actor,
+  getChosenAction: jest.fn(),
+  getSafeEventDispatcher: jest.fn(() => ({ dispatch: jest.fn() })),
+  ...extra,
+});
+
+describe('ProcessingCommandState helpers', () => {
+  let state;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    state = new ProcessingCommandState(mockHandler, null, null);
+  });
+
+  test('_validateContextAndActor returns actor when valid', async () => {
+    const actor = { id: 'a1' };
+    const ctx = makeCtx(actor);
+    await expect(state._validateContextAndActor(ctx)).resolves.toBe(actor);
+  });
+
+  test('_validateContextAndActor returns null when actor missing', async () => {
+    const ctx = makeCtx(null);
+    await expect(state._validateContextAndActor(ctx)).resolves.toBeNull();
+  });
+
+  test('_resolveTurnAction uses constructor action', async () => {
+    const actor = { id: 'a1' };
+    const action = { actionDefinitionId: 'act' };
+    state = new ProcessingCommandState(mockHandler, null, action);
+    const ctx = makeCtx(actor);
+    await expect(state._resolveTurnAction(ctx, actor)).resolves.toBe(action);
+  });
+
+  test('_dispatchSpeech dispatches when speech present', async () => {
+    const actor = { id: 'a1' };
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const ctx = makeCtx(actor, { getSafeEventDispatcher: () => dispatcher });
+    await state._dispatchSpeech(ctx, actor, { speech: 'hi' });
+    expect(dispatcher.dispatch).toHaveBeenCalled();
+  });
+
+  test('_processAction calls _processCommandInternal', async () => {
+    const actor = { id: 'a1' };
+    const ctx = makeCtx(actor);
+    const action = { actionDefinitionId: 'act' };
+    const spy = jest
+      .spyOn(state, '_processCommandInternal')
+      .mockResolvedValue(undefined);
+    await state._processAction(ctx, actor, action);
+    expect(spy).toHaveBeenCalledWith(ctx, actor, action);
+  });
+});

--- a/tests/turns/states/turnIdleState.helpers.test.js
+++ b/tests/turns/states/turnIdleState.helpers.test.js
@@ -1,0 +1,51 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js';
+
+const makeActor = (id = 'a1') => ({ id });
+
+const buildHandler = () => ({
+  _resetTurnStateAndResources: jest.fn(),
+  _transitionToState: jest.fn(),
+  _turnStateFactory: { createIdleState: jest.fn(() => ({})) },
+});
+
+const buildCtx = (actor) => ({
+  getActor: () => actor,
+  requestAwaitingInputStateTransition: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('TurnIdleState helper methods', () => {
+  let idle;
+  let handler;
+  beforeEach(() => {
+    handler = buildHandler();
+    idle = new TurnIdleState(handler);
+  });
+
+  test('_validateActorEntity throws on invalid actor', () => {
+    expect(() => idle._validateActorEntity(handler, null, console)).toThrow();
+    expect(handler._resetTurnStateAndResources).toHaveBeenCalled();
+  });
+
+  test('_validateTurnContext throws when context missing', () => {
+    expect(() =>
+      idle._validateTurnContext(handler, null, 'a1', console)
+    ).toThrow();
+    expect(handler._resetTurnStateAndResources).toHaveBeenCalled();
+  });
+
+  test('_validateActorMatch throws when mismatch', () => {
+    const actor = makeActor('a1');
+    const ctx = buildCtx(makeActor('a2'));
+    expect(() =>
+      idle._validateActorMatch(handler, ctx, actor, console)
+    ).toThrow();
+  });
+
+  test('_requestAwaitingInput delegates to context', async () => {
+    const actor = makeActor('a1');
+    const ctx = buildCtx(actor);
+    await idle._requestAwaitingInput(ctx, actor, handler, console);
+    expect(ctx.requestAwaitingInputStateTransition).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Refactored core turn state classes by extracting validation and workflow logic into new helper methods. Added comprehensive unit tests for each helper.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails globally but executed)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852f0d13e3c83319bff7c2dc20c0b7e