### PR TITLE
[Agent] Update bootstrapper tests and add helper coverage

### DIFF
--- a/tests/bootstrapper/auxiliaryStages.test.js
+++ b/tests/bootstrapper/auxiliaryStages.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { initializeAuxiliaryServicesStage } from '../../src/bootstrapper/auxiliaryStages.js';
+import { initializeAuxiliaryServicesStage } from '../../src/bootstrapper/stages/index.js';
 import StageError from '../../src/bootstrapper/StageError.js';
 
 /**

--- a/tests/bootstrapper/helpers.test.js
+++ b/tests/bootstrapper/helpers.test.js
@@ -1,0 +1,129 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import {
+  resolveAndInitialize,
+  setupButtonListener,
+  shouldStopEngine,
+  attachBeforeUnload,
+  createStageError,
+  stageSuccess,
+  stageFailure,
+} from '../../src/bootstrapper/helpers.js';
+import StageError from '../../src/bootstrapper/StageError.js';
+
+/**
+ * Basic logger mock for helper tests.
+ *
+ * @returns {{debug: jest.Mock, warn: jest.Mock, error: jest.Mock}} Logger mock
+ */
+function createLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+describe('bootstrapper helpers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  describe('resolveAndInitialize', () => {
+    it('resolves service and calls init', () => {
+      const init = jest.fn();
+      const container = { resolve: jest.fn(() => ({ init })) };
+      const logger = createLogger();
+
+      const result = resolveAndInitialize(container, 'X', 'init', logger);
+
+      expect(container.resolve).toHaveBeenCalledWith('X');
+      expect(init).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it('fails when service missing', () => {
+      const container = { resolve: jest.fn(() => null) };
+      const logger = createLogger();
+
+      const result = resolveAndInitialize(container, 'Y', 'init', logger);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('setupButtonListener', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<button id="btn"></button>';
+    });
+
+    it('attaches click handler when element found', () => {
+      const logger = createLogger();
+      const handler = jest.fn();
+
+      setupButtonListener(document, 'btn', handler, logger, 'stage');
+      document.getElementById('btn').click();
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('logs warning when element missing', () => {
+      document.body.innerHTML = '';
+      const logger = createLogger();
+      setupButtonListener(document, 'missing', jest.fn(), logger, 'stage');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldStopEngine', () => {
+    it('returns true when engine loop running', () => {
+      const engine = {
+        getEngineStatus: () => ({ isLoopRunning: true }),
+      };
+      expect(shouldStopEngine(engine)).toBe(true);
+    });
+
+    it('returns false otherwise', () => {
+      expect(shouldStopEngine({})).toBe(false);
+    });
+  });
+
+  describe('attachBeforeUnload', () => {
+    it('attaches handler to window', () => {
+      const win = { addEventListener: jest.fn() };
+      const handler = jest.fn();
+      attachBeforeUnload(win, handler);
+      expect(win.addEventListener).toHaveBeenCalledWith(
+        'beforeunload',
+        handler
+      );
+    });
+  });
+
+  describe('stage helpers', () => {
+    it('createStageError builds StageError with cause', () => {
+      const cause = new Error('c');
+      const err = createStageError('Phase', 'msg', cause);
+      expect(err).toBeInstanceOf(StageError);
+      expect(err.phase).toBe('Phase');
+      expect(err.cause).toBe(cause);
+      expect(err.message).toBe('msg');
+    });
+
+    it('stageSuccess returns success result', () => {
+      const res = stageSuccess(123);
+      expect(res).toEqual({ success: true, payload: 123 });
+    });
+
+    it('stageFailure wraps StageError', () => {
+      const res = stageFailure('P', 'boom');
+      expect(res.success).toBe(false);
+      expect(res.error).toBeInstanceOf(StageError);
+      expect(res.error.phase).toBe('P');
+    });
+  });
+});

--- a/tests/bootstrapper/stages.menuListeners.test.js
+++ b/tests/bootstrapper/stages.menuListeners.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
-import { setupMenuButtonListenersStage } from '../../src/bootstrapper/stages/index.js';
+import { setupMenuButtonListenersStage } from '../../src/bootstrapper/stages';
 import StageError from '../../src/bootstrapper/StageError.js';
 
 /**

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -1,4 +1,4 @@
-import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages/index.js';
+import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages';
 import StageError from '../../src/bootstrapper/StageError.js';
 import { UIBootstrapper } from '../../src/bootstrapper/UIBootstrapper.js';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';


### PR DESCRIPTION
## Summary
- adjust bootstrapper test imports to use the stages index
- add a new test suite for bootstrapper helpers

## Testing Done
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f4fac87c8331b1d8f63a2074d203