### PR TITLE
[Agent] fix lint issues in multiple modules

### DIFF
--- a/src/errors/actorError.js
+++ b/src/errors/actorError.js
@@ -1,10 +1,14 @@
 /**
+ * Base error class for actor-related issues.
+ *
  * @description Base error class for actor-related issues.
  * @class ActorError
  * @augments {Error}
  */
 export class ActorError extends Error {
   /**
+   * Creates a new ActorError instance.
+   *
    * @param {string} message The error message.
    */
   constructor(message) {

--- a/src/errors/actorMismatchError.js
+++ b/src/errors/actorMismatchError.js
@@ -1,6 +1,9 @@
 import { ActorError } from './actorError';
 
 /**
+ * Error thrown when an operation expects a specific actor but receives a different one,
+ * or when an actor context is missing entirely.
+ *
  * @description Error thrown when an operation expects a specific actor but receives a different one,
  * or when an actor context is missing entirely.
  * @class ActorMismatchError
@@ -8,6 +11,8 @@ import { ActorError } from './actorError';
  */
 export class ActorMismatchError extends ActorError {
   /**
+   * Creates a new ActorMismatchError instance.
+   *
    * @param {string} message - The error message.
    * @param {object} [context] - Additional context for debugging.
    * @param {string|null} [context.expectedActorId] - The ID of the actor that was expected.

--- a/src/errors/llmInteractionErrors.js
+++ b/src/errors/llmInteractionErrors.js
@@ -3,12 +3,16 @@
  */
 
 /**
+ * Base error for failures during interaction with a Large Language Model service.
+ *
  * @class LLMInteractionError
  * @augments Error
  * @description Base error for failures during interaction with a Large Language Model service.
  */
 export class LLMInteractionError extends Error {
   /**
+   * Creates a new LLMInteractionError instance.
+   *
    * @param {string} message - The error message.
    * @param {object} [details] - Optional contextual details.
    * @param {number} [details.status] - HTTP status code associated with the failure.

--- a/src/utils/entityRefUtils.js
+++ b/src/utils/entityRefUtils.js
@@ -1,5 +1,7 @@
 // src/utils/entityRefUtils.js
 /**
+ * Utility functions for resolving entity references to concrete entity IDs.
+ *
  * @module entityRefUtils
  * @description Utilities for resolving entity references to concrete entity IDs.
  */
@@ -7,10 +9,13 @@
 /** @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext */
 /**
  * @typedef {object} EntityRefObject
- * @property {string} entityId
+ * @property {string} entityId - The entity identifier.
  */
 
 /**
+ * Resolves an entity reference into a concrete entity ID string. Supports the special keywords
+ * 'actor' and 'target', plain ID strings, or objects of the form `{ entityId: string }`.
+ *
  * @description Resolves an entity reference into a concrete entity ID string.
  * Supports the special keywords 'actor' and 'target', plain ID strings,
  * or objects of the form `{ entityId: string }`.

--- a/src/utils/errorUtils.js
+++ b/src/utils/errorUtils.js
@@ -25,6 +25,7 @@ import { getModuleLogger } from './loggerUtils.js';
  *
  * @param {FatalErrorUIElements} uiElements - References to key UI elements.
  * @param {FatalErrorDetails} errorDetails - Details about the error.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger instance.
  */
 export function displayFatalStartupError(uiElements, errorDetails, logger) {
   const log = getModuleLogger('errorUtils', logger);

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -70,6 +70,9 @@ export function createPrefixedLogger(baseLogger, prefix) {
 }
 
 /**
+ * Convenience wrapper that validates the provided logger and returns a new logger that
+ * automatically prefixes all messages. Useful for utilities that consistently tag their log output.
+ *
  * @description Convenience wrapper that validates the provided logger and
  * returns a new logger that automatically prefixes all messages. Useful for
  * utilities that consistently tag their log output.
@@ -84,6 +87,9 @@ export function getPrefixedLogger(logger, prefix) {
 }
 
 /**
+ * Convenience wrapper for creating a logger prefixed with the module name in square brackets.
+ * Falls back to the console when the base logger is missing.
+ *
  * @description Convenience wrapper for creating a logger prefixed with the
  * module name in square brackets. Falls back to the console when the base
  * logger is missing.
@@ -96,14 +102,17 @@ export function getModuleLogger(moduleName, logger) {
 }
 
 /**
+ * Validates a logger using {@link validateDependency} and returns a safe logger instance via
+ * {@link ensureValidLogger}. When `optional` is true, missing loggers are allowed and will
+ * result in a console-based fallback.
+ *
  * @description Validates a logger using {@link validateDependency} and returns
  * a safe logger instance via {@link ensureValidLogger}. When `optional` is
  * true, missing loggers are allowed and will result in a console-based
  * fallback.
- * @param {string} serviceName - Name used for fallback prefix and error
- *   messages.
+ * @param {string} serviceName - Name used for fallback prefix and error messages.
  * @param {ILogger | undefined | null} logger - Logger instance to validate.
- * @param {object} [options]
+ * @param {object} [options] - Additional options.
  * @param {boolean} [options.optional] - Whether the logger is optional.
  * @returns {ILogger} A valid logger instance.
  */


### PR DESCRIPTION
Summary: Fixes ESLint warnings by adding missing JSDoc descriptions and param docs in several modules.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852f4aeaad0833190e353a227b94bfa