### PR TITLE
[Agent] refactor handler utils

### DIFF
--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -14,8 +14,8 @@ import {
   initHandlerLogger,
   validateDeps,
   getExecLogger,
-} from '../../utils/handlerUtils/indexUtils.js';
-import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+} from '../../utils/handlerUtils/serviceUtils.js';
+import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
 
 class RemoveFromClosenessCircleHandler {

--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -7,35 +7,10 @@
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
-import {
-  setupService,
-  validateServiceDeps,
+export {
+  setupService as initHandlerLogger,
+  validateServiceDeps as validateDeps,
 } from '../serviceInitializerUtils.js';
-
-/**
- * @description Initialize a handler logger using the standard service
- * initializer utilities. Logs will automatically be prefixed with the
- * handler name.
- * @param {string} name - Name of the handler.
- * @param {ILogger} logger - Base logger instance.
- * @returns {ILogger} Prefixed logger instance.
- */
-export function initHandlerLogger(name, logger) {
-  return setupService(name, logger);
-}
-
-/**
- * @description Validate handler dependencies using the common service
- * dependency validator.
- * @param {string} name - Name used for validation messages.
- * @param {ILogger} logger - Logger for validation output.
- * @param {Record<string, import('../serviceInitializerUtils.js').DependencySpec>} deps
- *   - Map of dependency specs.
- * @returns {void}
- */
-export function validateDeps(name, logger, deps) {
-  validateServiceDeps(name, logger, deps);
-}
 
 /**
  * @description Retrieve the logger to use during execution. If the


### PR DESCRIPTION
Summary: Refactored `serviceUtils` to directly re-export helpers from `serviceInitializerUtils`, removing redundant function bodies. Updated `RemoveFromClosenessCircleHandler` to import these utilities from the new location. All tests continue to pass.

Testing Done:
- [x] Code formatted `npx prettier src/logic/operationHandlers/removeFromClosenessCircleHandler.js src/utils/handlerUtils/serviceUtils.js --write`
- [x] Lint run on changed files `npx eslint src/logic/operationHandlers/removeFromClosenessCircleHandler.js src/utils/handlerUtils/serviceUtils.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852f62a8f6c83319bd55736aae06dce