### PR TITLE
[Agent] Add safeResolvePath utility

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -1,5 +1,5 @@
 // src/utils/contextUtils.js
-import { resolvePath } from './objectUtils.js';
+import { safeResolvePath } from './objectUtils.js';
 import { NAME_COMPONENT_ID } from '../constants/componentIds.js';
 import {
   PlaceholderResolver,
@@ -69,7 +69,7 @@ export function resolveEntityNameFallback(
 /**
  * Resolves a placeholder path against the provided execution context.
  *
- * @description Handles the `context.` prefix, uses {@link resolvePath}, and
+ * @description Handles the `context.` prefix, uses {@link safeResolvePath}, and
  * falls back to {@link resolveEntityNameFallback} when direct resolution fails.
  * @param {string} placeholderPath - Path from the placeholder (e.g.,
  *   `context.varA`).
@@ -116,16 +116,12 @@ function resolvePlaceholderPath(
     }
   }
 
-  let resolvedValue;
-  try {
-    resolvedValue = resolvePath(effectiveRoot, pathForResolvePath);
-  } catch (e) {
-    logger?.error(
-      `Error resolving path "${placeholderPath}" (interpreted as "${pathForResolvePath}") at ${logPath}`,
-      e
-    );
-    resolvedValue = undefined;
-  }
+  let resolvedValue = safeResolvePath(
+    effectiveRoot,
+    pathForResolvePath,
+    logger,
+    `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
+  );
 
   if (resolvedValue === undefined) {
     resolvedValue = resolveEntityNameFallback(

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -64,6 +64,32 @@ export function resolvePath(obj, propertyPath) {
 }
 
 /**
+ * Safely resolves a path within an object and logs errors on failure.
+ *
+ * @description Wraps {@link resolvePath} in a try/catch block. When
+ * resolution throws an error, the error is logged using
+ * {@link ensureValidLogger} and `undefined` is returned.
+ * @param {Record<string, any> | any[] | null | undefined} obj - Root object to
+ *   resolve against.
+ * @param {string} propertyPath - Dot separated path.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger for
+ *   error reporting.
+ * @param {string} [contextInfo] - Additional context included in log messages.
+ * @returns {any | undefined} The resolved value or `undefined` when resolution
+ *   fails.
+ */
+export function safeResolvePath(obj, propertyPath, logger, contextInfo = '') {
+  const log = ensureValidLogger(logger, 'ObjectUtils');
+  try {
+    return resolvePath(obj, propertyPath);
+  } catch (error) {
+    const info = contextInfo ? ` (${contextInfo})` : '';
+    log.error(`Error resolving path "${propertyPath}"${info}`, error);
+    return undefined;
+  }
+}
+
+/**
  * Freezes an object to make it immutable.
  *
  * @description

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-import { resolvePath as objectResolvePath } from './objectUtils.js';
+import { safeResolvePath } from './objectUtils.js';
 
 /**
  * Regex to find placeholders like {path.to.value} within a string.
@@ -52,15 +52,12 @@ export class PlaceholderResolver {
    * @returns {any|undefined} Resolved value or undefined if not found.
    */
   resolvePath(obj, path) {
-    try {
-      return objectResolvePath(obj, path);
-    } catch (err) {
-      this.#logger.error(
-        `PlaceholderResolver: Error resolving path "${path}"`,
-        err
-      );
-      return undefined;
-    }
+    return safeResolvePath(
+      obj,
+      path,
+      this.#logger,
+      'PlaceholderResolver.resolvePath'
+    );
   }
 
   /**
@@ -136,11 +133,10 @@ export class PlaceholderResolver {
    * If a string consists solely of a single placeholder, the resolved value is
    * returned with its original type. Arrays and objects are traversed
    * recursively.
-   *
    * @param {*} input - The value that may contain placeholders.
    * @param {object|object[]} context - Primary data source or array of sources
    *   used for resolution.
-   * @param {object} [fallback={}] - Optional fallback data source.
+   * @param {object} [fallback] - Optional fallback data source.
    * @returns {*} The input with all placeholders resolved.
    */
   resolveStructure(input, context, fallback = {}) {

--- a/tests/utils/safeResolvePath.test.js
+++ b/tests/utils/safeResolvePath.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { safeResolvePath } from '../../src/utils/objectUtils.js';
+import { createMockLogger } from '../testUtils.js';
+
+describe('safeResolvePath', () => {
+  it('returns undefined and logs when resolvePath throws', () => {
+    const logger = createMockLogger();
+    const result = safeResolvePath({}, null, logger, 'unit-test');
+    expect(result).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('unit-test'),
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added `safeResolvePath` utility with logging, updated placeholder and context utilities to use it, and created unit tests for error handling.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852f5e840a88331b159cf856863326c