### PR TITLE
[Agent] Add serializer and capture service tests

### DIFF
--- a/tests/persistence/gameStateCaptureService.test.js
+++ b/tests/persistence/gameStateCaptureService.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
+import { createMockLogger } from '../testUtils.js';
+
+describe('GameStateCaptureService persistence tests', () => {
+  let logger;
+  let entityManager;
+  let playtimeTracker;
+  let componentCleaningService;
+  let metadataBuilder;
+  let activeModsManifestBuilder;
+  let service;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    entityManager = { activeEntities: new Map() };
+    playtimeTracker = { getTotalPlaytime: jest.fn().mockReturnValue(0) };
+    componentCleaningService = {
+      clean: jest.fn((id, data) => ({ cleaned: id })),
+    };
+    metadataBuilder = {
+      build: jest.fn(() => ({
+        saveFormatVersion: '1',
+        engineVersion: 'x',
+        gameTitle: 'Meta',
+        timestamp: 't',
+        playtimeSeconds: 0,
+        saveName: '',
+      })),
+    };
+    activeModsManifestBuilder = { build: jest.fn(() => []) };
+    service = new GameStateCaptureService({
+      logger,
+      entityManager,
+      playtimeTracker,
+      componentCleaningService,
+      metadataBuilder,
+      activeModsManifestBuilder,
+    });
+  });
+
+  it('returns cleaned components and metadata', () => {
+    const entity = {
+      id: 'e1',
+      definitionId: 'core:test',
+      componentEntries: new Map([['comp', { foo: 'bar' }]]),
+    };
+    entityManager.activeEntities.set('e1', entity);
+
+    const result = service.captureCurrentGameState('World');
+
+    expect(componentCleaningService.clean).toHaveBeenCalledWith('comp', {
+      foo: 'bar',
+    });
+    expect(result.gameState.entities).toEqual([
+      {
+        instanceId: 'e1',
+        definitionId: 'core:test',
+        components: { comp: { cleaned: 'comp' } },
+      },
+    ]);
+    expect(result.metadata.gameTitle).toBe('Meta');
+  });
+});

--- a/tests/persistence/gameStateSerializer.test.js
+++ b/tests/persistence/gameStateSerializer.test.js
@@ -1,0 +1,54 @@
+/* eslint-disable jsdoc/check-tag-names */
+/** @jest-environment node */
+/* eslint-enable jsdoc/check-tag-names */
+import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
+import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
+import { webcrypto } from 'crypto';
+import { createMockLogger } from '../testUtils.js';
+
+beforeAll(() => {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+  Object.defineProperty(global, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+});
+
+describe('GameStateSerializer persistence tests', () => {
+  let serializer;
+  let logger;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  });
+
+  it('round trips via serializeAndCompress/decompress/deserialize', async () => {
+    const obj = {
+      metadata: { title: 'Test' },
+      modManifest: {},
+      gameState: { foo: 'bar' },
+      integrityChecks: {},
+    };
+
+    const { compressedData, finalSaveObject } =
+      await serializer.serializeAndCompress(obj);
+    const dec = serializer.decompress(compressedData);
+    expect(dec.success).toBe(true);
+    const des = serializer.deserialize(dec.data);
+    expect(des.success).toBe(true);
+    expect(des.data).toEqual(finalSaveObject);
+  });
+
+  it('generateChecksum is consistent for identical input', async () => {
+    const data = { hello: 'world' };
+    const first = await serializer.generateChecksum(data);
+    const second = await serializer.generateChecksum(data);
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
Summary: Adds new Jest tests for game state persistence services to ensure correct serialization and capture behaviors.

Changes Made:
- Added `tests/persistence/gameStateSerializer.test.js` to verify serializer round-trip and checksum consistency.
- Added `tests/persistence/gameStateCaptureService.test.js` to confirm component cleaning and metadata inclusion.

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_6852fa2894008331a083124f182873b1