### PR TITLE
[Agent] Refactor deleteSaveFile with helpers

### DIFF
--- a/tests/persistence/deleteSaveFile.test.js
+++ b/tests/persistence/deleteSaveFile.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
+import { createMockLogger } from '../testUtils.js';
+
+/**
+ *
+ */
+function makeDeps() {
+  const logger = createMockLogger();
+  const storageProvider = {
+    writeFileAtomically: jest.fn(),
+    listFiles: jest.fn(),
+    readFile: jest.fn(),
+    deleteFile: jest.fn(),
+    fileExists: jest.fn(),
+    ensureDirectoryExists: jest.fn(),
+  };
+  const serializer = {};
+  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  return { repo, logger, storageProvider };
+}
+
+describe('SaveFileRepository.deleteSaveFile', () => {
+  let repo;
+  let logger;
+  let storageProvider;
+
+  beforeEach(() => {
+    ({ repo, logger, storageProvider } = makeDeps());
+  });
+
+  it('returns success when deletion succeeds', async () => {
+    storageProvider.fileExists.mockResolvedValue(true);
+    storageProvider.deleteFile.mockResolvedValue({ success: true });
+
+    const result = await repo.deleteSaveFile('path.sav');
+
+    expect(result.success).toBe(true);
+    expect(storageProvider.deleteFile).toHaveBeenCalledWith('path.sav');
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('returns DELETE_FILE_NOT_FOUND when file is missing', async () => {
+    storageProvider.fileExists.mockResolvedValue(false);
+
+    const result = await repo.deleteSaveFile('missing.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FILE_NOT_FOUND);
+    expect(storageProvider.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('returns DELETE_FAILED when deleteFile fails', async () => {
+    storageProvider.fileExists.mockResolvedValue(true);
+    storageProvider.deleteFile.mockResolvedValue({
+      success: false,
+      error: 'bad',
+    });
+
+    const result = await repo.deleteSaveFile('bad.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FAILED);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns UNEXPECTED_ERROR when an exception occurs', async () => {
+    storageProvider.fileExists.mockResolvedValue(true);
+    storageProvider.deleteFile.mockRejectedValue(new Error('boom'));
+
+    const result = await repo.deleteSaveFile('boom.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -9,6 +9,7 @@ import {
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { TextEncoder, TextDecoder } from 'util';
@@ -112,7 +113,8 @@ describe('SaveLoadService error paths', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.deleteManualSave('saves/manual_saves/bad.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toMatch(/unexpected error/i);
+    expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
+    expect(res.error.message).toBe('fs failure');
     expect(logger.error).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Summary: Refactored `deleteSaveFile` in `SaveFileRepository` to use `wrapPersistenceOperation` and small helpers. Added new unit tests covering successful deletion, file-not-found, delete failure and unexpected error paths. Updated existing SaveLoadService error path test.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852fa2219c4833192b588ab6b1df8f4