### PR TITLE
[Agent] Centralize persistence messages

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -8,6 +8,10 @@ import {
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
 import {
+  MSG_DECOMPRESSION_FAILED,
+  MSG_DESERIALIZATION_FAILED,
+} from './persistenceMessages.js';
+import {
   createPersistenceFailure,
   createPersistenceSuccess,
 } from '../utils/persistenceResultUtils.js';
@@ -192,8 +196,7 @@ class GameStateSerializer {
       );
       return createPersistenceSuccess(decompressed);
     } catch (error) {
-      const userMsg =
-        'The save file appears to be corrupted (could not decompress). Please try another save.';
+      const userMsg = MSG_DECOMPRESSION_FAILED;
       this.#logger.error('Gzip decompression failed:', error);
       return {
         ...createPersistenceFailure(
@@ -217,8 +220,7 @@ class GameStateSerializer {
       this.#logger.debug('Successfully deserialized MessagePack');
       return createPersistenceSuccess(obj);
     } catch (error) {
-      const userMsg =
-        'The save file appears to be corrupted (could not understand file content). Please try another save.';
+      const userMsg = MSG_DESERIALIZATION_FAILED;
       this.#logger.error('MessagePack deserialization failed:', error);
       return {
         ...createPersistenceFailure(

--- a/src/persistence/persistenceMessages.js
+++ b/src/persistence/persistenceMessages.js
@@ -1,0 +1,18 @@
+// src/persistence/persistenceMessages.js
+
+/**
+ * @file User-facing messages used by persistence services.
+ */
+
+export const MSG_FILE_READ_ERROR =
+  'Could not access or read the selected save file. Please check file permissions or try another save.';
+export const MSG_EMPTY_FILE =
+  'The selected save file is empty or cannot be read. It might be corrupted or inaccessible.';
+export const MSG_DECOMPRESSION_FAILED =
+  'The save file appears to be corrupted (could not decompress). Please try another save.';
+export const MSG_DESERIALIZATION_FAILED =
+  'The save file appears to be corrupted (could not understand file content). Please try another save.';
+export const MSG_INTEGRITY_CALCULATION_ERROR =
+  'Could not verify the integrity of the save file due to an internal error. The file might be corrupted.';
+export const MSG_CHECKSUM_MISMATCH =
+  'The save file appears to be corrupted (integrity check failed). Please try another save or a backup.';

--- a/src/persistence/saveFileIO.js
+++ b/src/persistence/saveFileIO.js
@@ -4,6 +4,7 @@ import {
   PersistenceError,
   PersistenceErrorCodes,
 } from './persistenceErrors.js';
+import { MSG_FILE_READ_ERROR, MSG_EMPTY_FILE } from './persistenceMessages.js';
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
@@ -31,8 +32,7 @@ export async function readSaveFile(storage, filePath, logger) {
     try {
       fileContent = await storage.readFile(filePath);
     } catch (error) {
-      const userMsg =
-        'Could not access or read the selected save file. Please check file permissions or try another save.';
+      const userMsg = MSG_FILE_READ_ERROR;
       logger.error(`Error reading file ${filePath}:`, error);
       return {
         ...createPersistenceFailure(
@@ -44,8 +44,7 @@ export async function readSaveFile(storage, filePath, logger) {
     }
 
     if (!fileContent || fileContent.byteLength === 0) {
-      const userMsg =
-        'The selected save file is empty or cannot be read. It might be corrupted or inaccessible.';
+      const userMsg = MSG_EMPTY_FILE;
       logger.warn(`File is empty or could not be read: ${filePath}.`);
       return {
         ...createPersistenceFailure(PersistenceErrorCodes.EMPTY_FILE, userMsg),

--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -2,6 +2,10 @@
 
 import { PersistenceErrorCodes } from './persistenceErrors.js';
 import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
+import {
+  MSG_INTEGRITY_CALCULATION_ERROR,
+  MSG_CHECKSUM_MISMATCH,
+} from './persistenceMessages.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */
@@ -93,8 +97,7 @@ class SaveValidationService {
       );
     } catch (checksumError) {
       const devMsg = `Error calculating checksum for gameState in ${identifier}: ${checksumError.message}.`;
-      const userMsg =
-        'Could not verify the integrity of the save file due to an internal error. The file might be corrupted.';
+      const userMsg = MSG_INTEGRITY_CALCULATION_ERROR;
       this.#logger.error(devMsg + ` User message: "${userMsg}"`, checksumError);
       return createPersistenceFailure(
         PersistenceErrorCodes.CHECKSUM_CALCULATION_ERROR,
@@ -104,8 +107,7 @@ class SaveValidationService {
 
     if (storedChecksum !== recalculatedChecksum) {
       const devMsg = `Checksum mismatch for ${identifier}. Stored: ${storedChecksum}, Calculated: ${recalculatedChecksum}.`;
-      const userMsg =
-        'The save file appears to be corrupted (integrity check failed). Please try another save or a backup.';
+      const userMsg = MSG_CHECKSUM_MISMATCH;
       this.#logger.error(devMsg + ` User message: "${userMsg}"`);
       return createPersistenceFailure(
         PersistenceErrorCodes.CHECKSUM_MISMATCH,

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -9,6 +9,12 @@ import {
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
+import {
+  MSG_FILE_READ_ERROR,
+  MSG_EMPTY_FILE,
+  MSG_DECOMPRESSION_FAILED,
+  MSG_DESERIALIZATION_FAILED,
+} from '../../src/persistence/persistenceMessages.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -94,7 +100,7 @@ describe('SaveLoadService private helper error propagation', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toMatch(/Could not access/);
+    expect(res.error.message).toBe(MSG_FILE_READ_ERROR);
   });
 
   it('propagates empty file error', async () => {
@@ -102,7 +108,7 @@ describe('SaveLoadService private helper error propagation', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toMatch(/empty or cannot be read/);
+    expect(res.error.message).toBe(MSG_EMPTY_FILE);
   });
 
   it('propagates decompression errors', async () => {
@@ -110,7 +116,7 @@ describe('SaveLoadService private helper error propagation', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toMatch(/could not decompress/);
+    expect(res.error.message).toBe(MSG_DECOMPRESSION_FAILED);
   });
 
   it('propagates deserialization errors', async () => {
@@ -119,7 +125,7 @@ describe('SaveLoadService private helper error propagation', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toMatch(/could not understand/);
+    expect(res.error.message).toBe(MSG_DESERIALIZATION_FAILED);
   });
 });
 


### PR DESCRIPTION
Summary: Introduced a module `persistenceMessages.js` defining reusable constants for user-facing persistence messages and replaced hardcoded strings in persistence utilities and tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails with known repo warnings)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852fa2daec88331a1b7eafdec6a6bf7