### PR TITLE
[Agent] remove name getter from AwaitingActorDecisionState

### DIFF
--- a/tests/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/turns/states/awaitingPlayerInputState.test.js
@@ -350,7 +350,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
         mockHandler,
         mockPreviousState
       );
-      const expectedLogMessage = `${awaitingPlayerInputState.name}: Error during action decision, storage, or transition for actor ${testActor.id}: ${strategyError.message}`;
+      const expectedLogMessage = `${awaitingPlayerInputState.getStateName()}: Error during action decision, storage, or transition for actor ${testActor.id}: ${strategyError.message}`;
       expect(mockLogger.error).toHaveBeenCalledWith(expectedLogMessage, {
         originalError: strategyError,
       });
@@ -421,7 +421,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
       expect(mockTestTurnContext.setChosenAction).toHaveBeenCalledWith(
         mockAction
       );
-      const expectedLogMessage = `${awaitingPlayerInputState.name}: Error during action decision, storage, or transition for actor ${testActor.id}: ${transitionError.message}`;
+      const expectedLogMessage = `${awaitingPlayerInputState.getStateName()}: Error during action decision, storage, or transition for actor ${testActor.id}: ${transitionError.message}`;
       expect(mockLogger.error).toHaveBeenCalledWith(expectedLogMessage, {
         originalError: transitionError,
       });


### PR DESCRIPTION
Summary: Removed the unused `name` getter from `AwaitingActorDecisionState` and updated all references to use `getStateName()`. Adjusted tests accordingly.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6852fd6924d48331b91389e3e7a07f3a