### PR TITLE
[Agent] centralize unknown ID constants

### DIFF
--- a/src/constants/unknownIds.js
+++ b/src/constants/unknownIds.js
@@ -1,0 +1,9 @@
+// src/constants/unknownIds.js
+// -----------------------------------------------------------------------------
+// Constants for unknown actor and entity IDs used throughout the state modules.
+// -----------------------------------------------------------------------------
+
+/** @type {string} */
+export const UNKNOWN_ACTOR_ID = 'UNKNOWN_ACTOR';
+/** @type {string} */
+export const UNKNOWN_ENTITY_ID = 'UNKNOWN_ENTITY';

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -13,6 +13,7 @@
  */
 
 import { ITurnState } from '../interfaces/ITurnState.js';
+import { UNKNOWN_ACTOR_ID } from '../../constants/unknownIds.js';
 
 /**
  * @class AbstractTurnState
@@ -247,7 +248,7 @@ export class AbstractTurnState extends ITurnState {
   async startTurn(handler, actorEntity) {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
-    const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ACTOR';
+    const actorIdForLog = actorEntity?.id ?? UNKNOWN_ACTOR_ID;
     const warningMessage = `Method 'startTurn(actorId: ${actorIdForLog})' called on state ${this.getStateName()} where it is not expected or handled.`;
     logger.warn(warningMessage);
     throw new Error(

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -13,6 +13,7 @@
 import { AbstractTurnState } from './abstractTurnState.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { UNKNOWN_ACTOR_ID } from '../../constants/unknownIds.js';
 
 export class TurnEndingState extends AbstractTurnState {
   /** @type {string}     */ #actorToEndId;
@@ -37,8 +38,7 @@ export class TurnEndingState extends AbstractTurnState {
           providedActorId: actorToEndId ?? null,
         });
       }
-      this.#actorToEndId =
-        handler.getCurrentActor()?.id ?? 'UNKNOWN_ACTOR_CONSTRUCTOR_FALLBACK';
+      this.#actorToEndId = handler.getCurrentActor()?.id ?? UNKNOWN_ACTOR_ID;
       log.warn(
         `TurnEndingState Constructor: actorToEndId was missing, fell back to '${this.#actorToEndId}'.`
       );

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -10,6 +10,7 @@
  */
 
 import { AbstractTurnState } from './abstractTurnState.js';
+import { UNKNOWN_ENTITY_ID } from '../../constants/unknownIds.js';
 
 /**
  * @class TurnIdleState
@@ -40,7 +41,7 @@ export class TurnIdleState extends AbstractTurnState {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
 
-    const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ENTITY';
+    const actorIdForLog = actorEntity?.id ?? UNKNOWN_ENTITY_ID;
     logger.debug(
       `${this.getStateName()}: Received startTurn for actor ${actorIdForLog}.`
     );
@@ -159,7 +160,7 @@ export class TurnIdleState extends AbstractTurnState {
   async handleSubmittedCommand(handler, commandString, actorEntity) {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
-    const actorIdForLog = actorEntity?.id ?? 'UNKNOWN_ENTITY';
+    const actorIdForLog = actorEntity?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: Command ('${commandString}') submitted by ${actorIdForLog} but no turn is active (handler is Idle).`;
     logger.warn(message);
     return super.handleSubmittedCommand(handler, commandString, actorEntity);
@@ -169,7 +170,7 @@ export class TurnIdleState extends AbstractTurnState {
   async handleTurnEndedEvent(handler, payload) {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
-    const payloadActorId = payload?.entityId ?? 'UNKNOWN_ENTITY';
+    const payloadActorId = payload?.entityId ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: handleTurnEndedEvent called (for ${payloadActorId}) but no turn is active (handler is Idle).`;
     logger.warn(message);
     return super.handleTurnEndedEvent(handler, payload);
@@ -179,7 +180,7 @@ export class TurnIdleState extends AbstractTurnState {
   async processCommandResult(handler, actor, cmdProcResult, commandString) {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
-    const actorIdForLog = actor?.id ?? 'UNKNOWN_ENTITY';
+    const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: processCommandResult called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
     return super.processCommandResult(
@@ -194,7 +195,7 @@ export class TurnIdleState extends AbstractTurnState {
   async handleDirective(handler, actor, directive, cmdProcResult) {
     const turnCtx = this._getTurnContext();
     const logger = this._resolveLogger(turnCtx, handler);
-    const actorIdForLog = actor?.id ?? 'UNKNOWN_ENTITY';
+    const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: handleDirective called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
     return super.handleDirective(handler, actor, directive, cmdProcResult);


### PR DESCRIPTION
Summary: introduce `UNKNOWN_ACTOR_ID` and `UNKNOWN_ENTITY_ID` constants for use in turn state modules to avoid hardcoded strings.

Testing Done:
- [x] Code formatted `npx prettier -w src/constants/unknownIds.js src/turns/states/abstractTurnState.js src/turns/states/turnEndingState.js src/turns/states/turnIdleState.js`
- [x] Lint run `npm run lint` (fails: known repository issues)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6852fd6f0ce48331be32b93ec2602bc0