### PR TITLE
[Agent] Remove redundant file helpers

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -189,20 +189,11 @@ export default class SaveFileRepository {
    * Deletes a manual save file.
    *
    * @param {string} filePath - Full path to the save file.
-   * @param path
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result of deletion.
    */
-  async #fileExists(path) {
-    return this.#storageProvider.fileExists(path);
-  }
-
-  async #deleteFile(path) {
-    return this.#storageProvider.deleteFile(path);
-  }
-
   async deleteSaveFile(filePath) {
     return wrapPersistenceOperation(this.#logger, async () => {
-      const exists = await this.#fileExists(filePath);
+      const exists = await this.#storageProvider.fileExists(filePath);
       if (!exists) {
         const msg = `Save file "${filePath}" not found for deletion.`;
         const userMsg = 'Cannot delete: Save file not found.';
@@ -213,7 +204,7 @@ export default class SaveFileRepository {
         );
       }
 
-      const deleteResult = await this.#deleteFile(filePath);
+      const deleteResult = await this.#storageProvider.deleteFile(filePath);
       if (deleteResult.success) {
         this.#logger.debug(`Manual save "${filePath}" deleted successfully.`);
         return deleteResult;

--- a/tests/persistence/deleteSaveFile.test.js
+++ b/tests/persistence/deleteSaveFile.test.js
@@ -37,6 +37,7 @@ describe('SaveFileRepository.deleteSaveFile', () => {
     const result = await repo.deleteSaveFile('path.sav');
 
     expect(result.success).toBe(true);
+    expect(storageProvider.fileExists).toHaveBeenCalledWith('path.sav');
     expect(storageProvider.deleteFile).toHaveBeenCalledWith('path.sav');
     expect(logger.debug).toHaveBeenCalled();
   });
@@ -48,6 +49,7 @@ describe('SaveFileRepository.deleteSaveFile', () => {
 
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FILE_NOT_FOUND);
+    expect(storageProvider.fileExists).toHaveBeenCalledWith('missing.sav');
     expect(storageProvider.deleteFile).not.toHaveBeenCalled();
   });
 
@@ -62,6 +64,7 @@ describe('SaveFileRepository.deleteSaveFile', () => {
 
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FAILED);
+    expect(storageProvider.fileExists).toHaveBeenCalledWith('bad.sav');
     expect(logger.error).toHaveBeenCalled();
   });
 
@@ -73,6 +76,7 @@ describe('SaveFileRepository.deleteSaveFile', () => {
 
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
+    expect(storageProvider.fileExists).toHaveBeenCalledWith('boom.sav');
     expect(logger.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Summary: Removed private `#fileExists` and `#deleteFile` wrappers in `SaveFileRepository` and now use storage provider methods directly. Updated unit tests to assert direct calls.

Changes Made:
- refactored `deleteSaveFile` to call `this.#storageProvider.fileExists/deleteFile` directly
- cleaned up JSDoc comment
- updated tests to verify `fileExists` invocation

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6852ffc815e0833184bc5fb2693921bd