### PR TITLE
[Agent] integrate setupService in SaveValidationService

### DIFF
--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -2,6 +2,7 @@
 
 import { PersistenceErrorCodes } from './persistenceErrors.js';
 import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
+import { setupService } from '../utils/serviceInitializerUtils.js';
 import {
   MSG_INTEGRITY_CALCULATION_ERROR,
   MSG_CHECKSUM_MISMATCH,
@@ -30,8 +31,13 @@ class SaveValidationService {
    * @param {GameStateSerializer} dependencies.gameStateSerializer - Serializer used for checksum generation.
    */
   constructor({ logger, gameStateSerializer }) {
-    this.#logger = logger;
     this.#serializer = gameStateSerializer;
+    this.#logger = setupService('SaveValidationService', logger, {
+      gameStateSerializer: {
+        value: gameStateSerializer,
+        requiredMethods: ['calculateGameStateChecksum'],
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
Summary: Updated SaveValidationService to initialize a prefixed logger via setupService and validate its serializer dependency. This ensures consistent logger prefixing and dependency checks across services.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 540 errors, 1986 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852ffc13e548331980c1df677a9ac5a