### PR TITLE
[Fix] simplify load game error handling

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -219,23 +219,9 @@ class GamePersistenceService extends IGamePersistenceService {
       };
     }
 
-    let loadResult;
-    try {
-      loadResult = await this.#saveLoadService.loadGameData(saveIdentifier);
-    } catch (serviceError) {
-      const errorMsg = `Unexpected error calling SaveLoadService.loadGameData for "${saveIdentifier}": ${serviceError.message}`;
-      this.#logger.error(
-        `GamePersistenceService.loadAndRestoreGame: ${errorMsg}`,
-        serviceError
-      );
-      return {
-        ...createPersistenceFailure(
-          PersistenceErrorCodes.UNEXPECTED_ERROR,
-          `Unexpected error during data loading: ${serviceError.message}`
-        ),
-        data: null,
-      };
-    }
+    const loadResult = await wrapPersistenceOperation(this.#logger, async () =>
+      this.#saveLoadService.loadGameData(saveIdentifier)
+    );
 
     if (!loadResult?.success || !loadResult?.data) {
       const reason = loadResult?.error || 'Load failed or no data returned.';

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -142,7 +142,7 @@ describe('GamePersistenceService error paths', () => {
       saveLoadService.loadGameData.mockRejectedValue(new Error('load fail'));
       const result = await service.loadAndRestoreGame('slot');
       expect(result.success).toBe(false);
-      expect(result.error.message).toMatch('Unexpected error');
+      expect(result.error.message).toBe('load fail');
       expect(logger.error).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Summary: Replace manual try/catch in `loadAndRestoreGame` with `wrapPersistenceOperation` to standardize error handling. Updated failing test to reflect new wrapped error message.

Testing Done:
- [x] Code formatted (`npm run format` in root and proxy)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6852ffe35a0083319fe505b5b8fb87a4