### PR TITLE
[Refactor] Consolidate save validation helpers

### DIFF
--- a/src/persistence/saveInputValidators.js
+++ b/src/persistence/saveInputValidators.js
@@ -7,21 +7,14 @@
 import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
- * Validates a manual save name.
+ * @description Determines if the provided value is a valid save-related string.
  *
- * @param {*} saveName - The candidate save name.
- * @returns {boolean} `true` if the save name is a non-empty string.
+ * Both manual save slot names and save file identifiers are considered valid
+ * when they are non-blank strings. This function acts as the single entry point
+ * for validating either scenario.
+ * @param {*} value - Candidate save string to validate.
+ * @returns {boolean} `true` if the value is a non-empty string.
  */
-export function validateSaveName(saveName) {
-  return isNonBlankString(saveName);
-}
-
-/**
- * Validates a save identifier.
- *
- * @param {*} saveIdentifier - The identifier to validate.
- * @returns {boolean} `true` if the identifier is a non-empty string.
- */
-export function validateSaveIdentifier(saveIdentifier) {
-  return isNonBlankString(saveIdentifier);
+export function isValidSaveString(value) {
+  return isNonBlankString(value);
 }

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -14,10 +14,7 @@ import {
   createPersistenceSuccess,
 } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
-import {
-  validateSaveName,
-  validateSaveIdentifier,
-} from './saveInputValidators.js';
+import { isValidSaveString } from './saveInputValidators.js';
 
 // --- Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -106,7 +103,7 @@ class SaveLoadService extends ISaveLoadService {
    * @private
    */
   #assertValidIdentifier(id) {
-    if (!validateSaveIdentifier(id)) {
+    if (!isValidSaveString(id)) {
       this.#logger.error('Invalid saveIdentifier provided.');
       return createPersistenceFailure(
         PersistenceErrorCodes.INVALID_SAVE_IDENTIFIER,
@@ -263,7 +260,7 @@ class SaveLoadService extends ISaveLoadService {
   async saveManualGame(saveName, gameStateObject) {
     this.#logger.debug(`Attempting to save manual game: "${saveName}"`);
 
-    if (!validateSaveName(saveName)) {
+    if (!isValidSaveString(saveName)) {
       const userMsg = 'Invalid save name provided. Please enter a valid name.';
       this.#logger.error('Invalid saveName provided for manual save.');
       return createPersistenceFailure(

--- a/tests/utils/saveInputValidators.test.js
+++ b/tests/utils/saveInputValidators.test.js
@@ -1,33 +1,30 @@
 import { describe, it, expect } from '@jest/globals';
-import {
-  validateSaveName,
-  validateSaveIdentifier,
-} from '../../src/persistence/saveInputValidators.js';
+import { isValidSaveString } from '../../src/persistence/saveInputValidators.js';
 
 describe('save input validators', () => {
-  describe('validateSaveName', () => {
+  describe('validate save names via isValidSaveString', () => {
     it('returns true for non-empty strings', () => {
-      expect(validateSaveName('slot1')).toBe(true);
+      expect(isValidSaveString('slot1')).toBe(true);
     });
 
     it('returns false for empty or non-string values', () => {
-      expect(validateSaveName('')).toBe(false);
-      expect(validateSaveName('   ')).toBe(false);
-      expect(validateSaveName(null)).toBe(false);
-      expect(validateSaveName(undefined)).toBe(false);
+      expect(isValidSaveString('')).toBe(false);
+      expect(isValidSaveString('   ')).toBe(false);
+      expect(isValidSaveString(null)).toBe(false);
+      expect(isValidSaveString(undefined)).toBe(false);
     });
   });
 
-  describe('validateSaveIdentifier', () => {
+  describe('validate save identifiers via isValidSaveString', () => {
     it('returns true for non-empty strings', () => {
-      expect(validateSaveIdentifier('path/file.sav')).toBe(true);
+      expect(isValidSaveString('path/file.sav')).toBe(true);
     });
 
     it('returns false for empty or non-string values', () => {
-      expect(validateSaveIdentifier('')).toBe(false);
-      expect(validateSaveIdentifier('   ')).toBe(false);
-      expect(validateSaveIdentifier(0)).toBe(false);
-      expect(validateSaveIdentifier(null)).toBe(false);
+      expect(isValidSaveString('')).toBe(false);
+      expect(isValidSaveString('   ')).toBe(false);
+      expect(isValidSaveString(0)).toBe(false);
+      expect(isValidSaveString(null)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Summary: Simplified save string validation by merging name and identifier checks.

Changes Made:
- Replaced `validateSaveName` and `validateSaveIdentifier` with unified `isValidSaveString`.
- Updated `SaveLoadService` to use the new validator.
- Adjusted unit tests for the consolidated API.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6852ffe961348331bbfde854e819e5ff