### PR TITLE
[Feat] Support custom fetch in fetchWithRetry

### DIFF
--- a/src/utils/httpUtils.js
+++ b/src/utils/httpUtils.js
@@ -72,6 +72,7 @@ function _shouldRetry(status, attempt, maxRetries) {
  * @param {number} maxDelayMs Maximum delay in milliseconds between retries, capping the exponential backoff.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} safeEventDispatcher Dispatcher for SYSTEM_ERROR_OCCURRED_ID events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] Optional logger instance.
+ * @param {typeof fetch} [fetchFn] The fetch implementation to use.
  * @returns {Promise<any>} A promise that resolves with the parsed JSON response on success.
  * @throws {Error} Throws an error if all retries fail, a non-retryable HTTP error occurs,
  * or another unhandled error arises during fetching.
@@ -83,7 +84,8 @@ export async function fetchWithRetry(
   baseDelayMs,
   maxDelayMs,
   safeEventDispatcher,
-  logger
+  logger,
+  fetchFn = fetch
 ) {
   const log = getModuleLogger('fetchWithRetry', logger);
 
@@ -96,7 +98,7 @@ export async function fetchWithRetry(
       log.debug(
         `Attempt ${currentAttempt}/${maxRetries} - Fetching ${options.method || 'GET'} ${url}`
       );
-      const response = await fetch(url, options);
+      const response = await fetchFn(url, options);
 
       if (!response.ok) {
         const { parsedBody, bodyText } = await _parseErrorResponse(response);

--- a/tests/utils/httpUtils.fetchWithRetry.network.test.js
+++ b/tests/utils/httpUtils.fetchWithRetry.network.test.js
@@ -33,7 +33,16 @@ describe('fetchWithRetry network errors', () => {
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
 
-    const promise = fetchWithRetry(url, opts, 2, 100, 1000, dispatcher);
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
     await jest.runOnlyPendingTimersAsync();
     const result = await promise;
 
@@ -49,9 +58,16 @@ describe('fetchWithRetry network errors', () => {
     fetch.mockRejectedValue(new TypeError('network request failed'));
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
 
-    const promise = fetchWithRetry(url, opts, 2, 100, 1000, dispatcher).catch(
-      (e) => e
-    );
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    ).catch((e) => e);
     await jest.runOnlyPendingTimersAsync();
     await jest.runOnlyPendingTimersAsync();
     const err = await promise;

--- a/tests/utils/httpUtils.fetchWithRetry.test.js
+++ b/tests/utils/httpUtils.fetchWithRetry.test.js
@@ -48,7 +48,7 @@ describe('fetchWithRetry', () => {
 
     let caught;
     try {
-      await fetchWithRetry(url, opts, 1, 1, 1, dispatcher);
+      await fetchWithRetry(url, opts, 1, 1, 1, dispatcher, undefined, fetch);
     } catch (e) {
       caught = e;
     }
@@ -63,9 +63,16 @@ describe('fetchWithRetry', () => {
     resp.text.mockResolvedValue('bad text');
     fetch.mockResolvedValueOnce(resp);
 
-    const err = await fetchWithRetry(url, opts, 1, 1, 1, dispatcher).catch(
-      (e) => e
-    );
+    const err = await fetchWithRetry(
+      url,
+      opts,
+      1,
+      1,
+      1,
+      dispatcher,
+      undefined,
+      fetch
+    ).catch((e) => e);
     expect(err.body).toBe('bad text');
   });
 
@@ -83,7 +90,16 @@ describe('fetchWithRetry', () => {
     fetch.mockResolvedValueOnce(first).mockResolvedValueOnce(okResp);
 
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
-    const promise = fetchWithRetry(url, opts, 2, 100, 1000, dispatcher);
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
     await jest.runOnlyPendingTimersAsync();
     await promise;
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
@@ -103,9 +119,16 @@ describe('fetchWithRetry', () => {
     };
     fetch.mockResolvedValueOnce(resp);
 
-    const err = await fetchWithRetry(url, opts, 1, 1, 1, dispatcher).catch(
-      (e) => e
-    );
+    const err = await fetchWithRetry(
+      url,
+      opts,
+      1,
+      1,
+      1,
+      dispatcher,
+      undefined,
+      fetch
+    ).catch((e) => e);
 
     expect(resp.clone).toHaveBeenCalled();
     expect(cloneText).toHaveBeenCalled();
@@ -121,7 +144,16 @@ describe('fetchWithRetry', () => {
 
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
-    const promise = fetchWithRetry(url, opts, 2, 100, 1000, dispatcher);
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
     await jest.runOnlyPendingTimersAsync();
     const result = await promise;
 
@@ -138,9 +170,16 @@ describe('fetchWithRetry', () => {
     resp.json.mockResolvedValue({ error: 'auth' });
     fetch.mockResolvedValueOnce(resp);
 
-    const err = await fetchWithRetry(url, opts, 3, 100, 1000, dispatcher).catch(
-      (e) => e
-    );
+    const err = await fetchWithRetry(
+      url,
+      opts,
+      3,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    ).catch((e) => e);
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(err.status).toBe(401);


### PR DESCRIPTION
Summary: Add optional `fetchFn` parameter to `fetchWithRetry` allowing callers to inject their own fetch implementation. Updated internal usage to call `fetchFn` and extended JSDoc. Tests now pass mock fetch functions explicitly.

Changes Made:
- updated `fetchWithRetry` signature and implementation
- documented new parameter in JSDoc
- adjusted unit tests to supply mock fetch

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68530276ecb483319f2d0bb139b0b597