### PR TITLE
[Feat] support DOM adapter in fatal error display

### DIFF
--- a/tests/bootstrapper/errorUtils.test.js
+++ b/tests/bootstrapper/errorUtils.test.js
@@ -30,7 +30,11 @@ describe('displayFatalStartupError', () => {
       titleElement: document.querySelector('#title'),
     };
 
-    const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
+    const alertSpy = jest.fn();
+    const domAdapter = {
+      createElement: document.createElement.bind(document),
+      alert: alertSpy,
+    };
     const logger = {
       error: jest.fn(),
       info: jest.fn(),
@@ -48,7 +52,8 @@ describe('displayFatalStartupError', () => {
         inputPlaceholder: 'halt',
         phase: 'Test',
       },
-      logger
+      logger,
+      domAdapter
     );
 
     expect(logger.error).toHaveBeenCalledWith(
@@ -69,7 +74,11 @@ describe('displayFatalStartupError', () => {
     const outputDiv = document.querySelector('#outputDiv');
     const uiElements = { outputDiv };
 
-    const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
+    const alertSpy = jest.fn();
+    const domAdapter = {
+      createElement: document.createElement.bind(document),
+      alert: alertSpy,
+    };
     const logger = {
       error: jest.fn(),
       info: jest.fn(),
@@ -83,7 +92,8 @@ describe('displayFatalStartupError', () => {
         userMessage: 'Oops',
         consoleMessage: 'Bad',
       },
-      logger
+      logger,
+      domAdapter
     );
 
     const tempEl = outputDiv.nextElementSibling;
@@ -98,7 +108,11 @@ describe('displayFatalStartupError', () => {
 
   it('falls back to alert when no DOM targets', () => {
     setDom('');
-    const alertSpy = jest.spyOn(global, 'alert').mockImplementation(() => {});
+    const alertSpy = jest.fn();
+    const domAdapter = {
+      createElement: document.createElement.bind(document),
+      alert: alertSpy,
+    };
     const logger = {
       error: jest.fn(),
       info: jest.fn(),
@@ -112,7 +126,8 @@ describe('displayFatalStartupError', () => {
         userMessage: 'Oops',
         consoleMessage: 'Bad',
       },
-      logger
+      logger,
+      domAdapter
     );
 
     expect(alertSpy).toHaveBeenCalledWith('Oops');


### PR DESCRIPTION
Summary: Add optional `domAdapter` to `displayFatalStartupError` for custom element creation and alert handling. Updated tests to use mock adapter, ensuring portability.

Changes Made:
- Extended `createTemporaryErrorElement` to accept a `createElement` function.
- Updated `displayFatalStartupError` to use optional `domAdapter`.
- Adjusted tests to inject mocked adapter.

Testing Done:
- [x] Code formatted (`npx prettier ...`)
- [x] Lint passes on modified files (`npx eslint ...`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6853027bab6483319543920f710944a3