### PR TITLE
[Agent] inject exit discovery dependency

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -34,7 +34,12 @@ export function formatActionCommand(
   entityManager,
   options = {}
 ) {
-  const { debug = false, logger = console, safeEventDispatcher } = options;
+  const {
+    debug = false,
+    logger = console,
+    safeEventDispatcher,
+    getEntityDisplayNameFn = getEntityDisplayName,
+  } = options;
   const dispatcher = resolveSafeDispatcher(null, safeEventDispatcher, logger);
   if (!dispatcher) {
     logger.warn(
@@ -69,7 +74,7 @@ export function formatActionCommand(
       'formatActionCommand requires a valid EntityManager instance.'
     );
   }
-  if (typeof getEntityDisplayName !== 'function') {
+  if (typeof getEntityDisplayNameFn !== 'function') {
     safeDispatchError(
       dispatcher,
       'formatActionCommand: getEntityDisplayName utility function is not available.'
@@ -108,7 +113,7 @@ export function formatActionCommand(
 
         if (targetEntity) {
           // Use getEntityDisplayName utility with ID as fallback and pass logger
-          targetName = getEntityDisplayName(targetEntity, targetId, logger);
+          targetName = getEntityDisplayNameFn(targetEntity, targetId, logger);
           if (debug) {
             logger.debug(
               ` -> Found entity ${targetId}, display name: "${targetName}"`

--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -31,6 +31,7 @@ import CommandProcessor from '../../commands/commandProcessor.js';
 // --- Helper Function Imports ---
 import { formatActionCommand } from '../../actions/actionFormatter.js';
 import { getEntityIdsForScopes } from '../../entities/entityScopeService.js';
+import { getAvailableExits } from '../../utils/locationUtils.js';
 
 /**
  * Registers command and action related services.
@@ -55,6 +56,7 @@ export function registerCommandAndAction(container) {
         logger: c.resolve(tokens.ILogger),
         formatActionCommandFn: formatActionCommand,
         getEntityIdsForScopesFn: getEntityIdsForScopes,
+        getAvailableExitsFn: getAvailableExits,
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       })
   );

--- a/tests/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/actions/actionDiscoveryService.actionId.test.js
@@ -31,6 +31,7 @@ describe('ActionDiscoveryService params exposure', () => {
       warn: jest.fn(),
     };
     const safeEventDispatcher = { dispatch: jest.fn() };
+    const getAvailableExitsFn = jest.fn();
 
     service = new ActionDiscoveryService({
       gameDataRepository: gameDataRepo,
@@ -38,6 +39,7 @@ describe('ActionDiscoveryService params exposure', () => {
       actionValidationService,
       formatActionCommandFn,
       getEntityIdsForScopesFn,
+      getAvailableExitsFn,
       logger,
       safeEventDispatcher,
     });

--- a/tests/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -60,6 +60,10 @@ describe('ActionDiscoveryService – directional discovery', () => {
   const getEntityIdsForScopesFn = () => [];
 
   const safeEventDispatcher = { dispatch: jest.fn() };
+  const getAvailableExitsFn = jest.fn(() => [
+    { direction: 'north', target: 'loc-2' },
+    { direction: 'south', target: 'loc-3' },
+  ]);
 
   const service = new ActionDiscoveryService({
     gameDataRepository,
@@ -68,6 +72,7 @@ describe('ActionDiscoveryService – directional discovery', () => {
     logger,
     formatActionCommandFn,
     getEntityIdsForScopesFn,
+    getAvailableExitsFn,
     safeEventDispatcher,
   });
 

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -211,6 +211,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       logger: mockLogger,
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
+      getAvailableExitsFn: mockGetAvailableExits,
       safeEventDispatcher: mockSafeEventDispatcher,
     });
   });

--- a/tests/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/actions/actionDiscoverySystem.wait.test.js
@@ -45,6 +45,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   let mockFormatActionCommandFn;
   /** @type {jest.MockedFunction<typeof getEntityIdsForScopesFn>} */
   let mockGetEntityIdsForScopesFn;
+  let mockGetAvailableExits;
 
   const ACTOR_INSTANCE_ID = 'actor1-instance-wait';
   const LOCATION_INSTANCE_ID = 'location1-instance-wait';
@@ -72,6 +73,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
 
     mockFormatActionCommandFn = formatActionCommandFn;
     mockGetEntityIdsForScopesFn = getEntityIdsForScopesFn;
+    mockGetAvailableExits = jest.fn();
     mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockActorEntity = new Entity(ACTOR_INSTANCE_ID, DUMMY_DEFINITION_ID);
@@ -118,6 +120,7 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
       logger: mockLogger,
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
+      getAvailableExitsFn: mockGetAvailableExits,
       safeEventDispatcher: mockSafeEventDispatcher,
     });
   });


### PR DESCRIPTION
Summary:
- allow ActionDiscoveryService to inject getAvailableExits function
- pass through entity display name func in formatActionCommand
- update DI wiring for ActionDiscoveryService
- adjust action discovery tests for new dependency

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on modified files `npx eslint src/actions/actionDiscoveryService.js src/actions/actionFormatter.js`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685303275d9c8331bd2f1f91d18f0b1a