### PR TITLE
[Agent] Normalize persistence failure handling

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -24,6 +24,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
+  normalizePersistenceFailure,
 } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 import GameStateRestorer from './gameStateRestorer.js';
@@ -228,15 +229,11 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.error(
         `GamePersistenceService.loadAndRestoreGame: Failed to load raw game data from ${saveIdentifier}. Reason: ${reason}`
       );
-      return {
-        ...(loadResult?.error instanceof PersistenceError
-          ? { success: false, error: loadResult.error }
-          : createPersistenceFailure(
-              PersistenceErrorCodes.UNEXPECTED_ERROR,
-              loadResult?.error || 'Failed to load raw game data.'
-            )),
-        data: null,
-      };
+      return normalizePersistenceFailure(
+        loadResult,
+        PersistenceErrorCodes.UNEXPECTED_ERROR,
+        loadResult?.error || 'Failed to load raw game data.'
+      );
     }
 
     this.#logger.debug(
@@ -256,15 +253,11 @@ class GamePersistenceService extends IGamePersistenceService {
       this.#logger.error(
         `GamePersistenceService.loadAndRestoreGame: Failed to restore game state for ${saveIdentifier}. Error: ${restoreResult.error}`
       );
-      return {
-        ...(restoreResult.error instanceof PersistenceError
-          ? { success: false, error: restoreResult.error }
-          : createPersistenceFailure(
-              PersistenceErrorCodes.UNEXPECTED_ERROR,
-              restoreResult.error || 'Failed to restore game state.'
-            )),
-        data: null,
-      };
+      return normalizePersistenceFailure(
+        restoreResult,
+        PersistenceErrorCodes.UNEXPECTED_ERROR,
+        restoreResult.error || 'Failed to restore game state.'
+      );
     }
   }
 }

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -12,6 +12,7 @@ import {
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
+  normalizePersistenceFailure,
 } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 import { isValidSaveString } from './saveInputValidators.js';
@@ -223,16 +224,12 @@ class SaveLoadService extends ISaveLoadService {
       this.#logger.warn(
         `Failed to deserialize ${saveIdentifier}: ${deserializationResult.error}`
       );
-      return {
-        ...(deserializationResult.error instanceof PersistenceError
-          ? { success: false, error: deserializationResult.error }
-          : createPersistenceFailure(
-              PersistenceErrorCodes.DESERIALIZATION_ERROR,
-              deserializationResult.userFriendlyError ||
-                'Unknown deserialization error'
-            )),
-        data: null,
-      };
+      return normalizePersistenceFailure(
+        deserializationResult,
+        PersistenceErrorCodes.DESERIALIZATION_ERROR,
+        deserializationResult.userFriendlyError ||
+          'Unknown deserialization error'
+      );
     }
 
     const loadedObject = /** @type {SaveGameStructure} */ (

--- a/src/utils/persistenceResultUtils.js
+++ b/src/utils/persistenceResultUtils.js
@@ -26,4 +26,34 @@ export function createPersistenceSuccess(data) {
   return { success: true, data };
 }
 
+/**
+ * Normalizes the output of a persistence operation, ensuring failures always
+ * return a {@link PersistenceError} instance.
+ *
+ * @template T
+ * @param {{success: boolean, data?: T, error?: any}} result - Raw persistence
+ *   result object.
+ * @param {string} fallbackCode - Error code used when `result.error` is not a
+ *   {@link PersistenceError}.
+ * @param {string} defaultMsg - Message for the generated error when no
+ *   {@link PersistenceError} is present.
+ * @returns {{success: true, data: T} | {success: false, error: PersistenceError, data: null}}
+ *   Normalized result object.
+ */
+export function normalizePersistenceFailure(result, fallbackCode, defaultMsg) {
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+
+  if (result.error instanceof PersistenceError) {
+    return { success: false, error: result.error, data: null };
+  }
+
+  return {
+    success: false,
+    error: new PersistenceError(fallbackCode, defaultMsg),
+    data: null,
+  };
+}
+
 export default createPersistenceFailure;

--- a/tests/persistence/saveLoadService.test.js
+++ b/tests/persistence/saveLoadService.test.js
@@ -146,6 +146,28 @@ describe('SaveLoadService', () => {
       );
       expect(validationService.validateLoadedSaveObject).not.toHaveBeenCalled();
     });
+
+    it('normalizes non-PersistenceError failures', async () => {
+      // Arrange
+      const path = 'saves/manual_saves/manual_save_bad.sav';
+      storageProvider.readFile.mockResolvedValue(new Uint8Array([1]));
+      serializer.deserialize.mockReturnValue({
+        success: false,
+        error: 'boom',
+        userFriendlyError: 'Boom!',
+      });
+
+      // Act
+      const result = await service.loadGameData(path);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(PersistenceError);
+      expect(result.error.code).toBe(
+        PersistenceErrorCodes.DESERIALIZATION_ERROR
+      );
+      expect(result.error.message).toBe('Boom!');
+    });
   });
 
   describe('deleteManualSave', () => {

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import { CURRENT_ACTOR_COMPONENT_ID } from '../../src/constants/componentIds.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 
 // Helpers to create minimal mocks
 const makeLogger = () => ({
@@ -197,6 +198,7 @@ describe('GamePersistenceService additional coverage', () => {
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
       expect(res.error.message).toBe('no');
+      expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
     });
 
     it('loads and restores on success', async () => {

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -11,6 +11,7 @@ import {
   CURRENT_ACTOR_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
 import { CORE_MOD_ID } from '../../src/constants/core.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 
 const makeLogger = () => ({
   info: jest.fn(),
@@ -186,6 +187,7 @@ describe('GamePersistenceService edge cases', () => {
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
       expect(res.error.message).toBe('no');
+      expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
     });
 
     it('returns failure when restoreGameState fails', async () => {
@@ -197,6 +199,7 @@ describe('GamePersistenceService edge cases', () => {
       const res = await service.loadAndRestoreGame('slot1');
       expect(res.success).toBe(false);
       expect(res.error.message).toBe('bad');
+      expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
     });
   });
 });

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -4,6 +4,7 @@ import GameStateCaptureService from '../../src/persistence/gameStateCaptureServi
 import ComponentCleaningService, {
   buildDefaultComponentCleaners,
 } from '../../src/persistence/componentCleaningService.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
 
 const makeLogger = () => ({
   info: jest.fn(),
@@ -143,6 +144,7 @@ describe('GamePersistenceService error paths', () => {
       const result = await service.loadAndRestoreGame('slot');
       expect(result.success).toBe(false);
       expect(result.error.message).toBe('load fail');
+      expect(result.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
       expect(logger.error).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Summary: Added normalizePersistenceFailure helper and refactored load logic to use it. Updated related unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6853039cd27083319706dec811ecc2e3