### PR TITLE
[Agent] return persistence result when listing saves

### DIFF
--- a/src/interfaces/ISaveLoadService.js
+++ b/src/interfaces/ISaveLoadService.js
@@ -57,7 +57,8 @@ export class ISaveLoadService {
   /**
    * Lists available manual save files and their parsed metadata.
    *
-   * @returns {Promise<Array<SaveFileMetadata>>} A list of metadata objects for discovered manual save files.
+   * @returns {Promise<import('../persistence/persistenceTypes.js').PersistenceResult<Array<SaveFileMetadata>>>}
+   *   A result containing a list of metadata objects for discovered manual save files.
    * @async
    */
   async listManualSaveSlots() {

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -118,7 +118,8 @@ export default class SaveFileRepository {
   /**
    * Lists manual save filenames in the save directory.
    *
-   * @returns {Promise<Array<string>>} Array of file names.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<string[]>>}
+   *   Array of file names wrapped in a PersistenceResult.
    */
   async listManualSaveFiles() {
     try {
@@ -129,7 +130,7 @@ export default class SaveFileRepository {
       this.#logger.debug(
         `Found ${files.length} potential manual save files in ${FULL_MANUAL_SAVE_DIRECTORY_PATH}.`
       );
-      return files;
+      return { success: true, data: files };
     } catch (listError) {
       if (
         listError.message &&
@@ -138,13 +139,17 @@ export default class SaveFileRepository {
         this.#logger.debug(
           `${FULL_MANUAL_SAVE_DIRECTORY_PATH} not found. Assuming no manual saves yet.`
         );
-        return [];
+        return { success: true, data: [] };
       }
+
       this.#logger.error(
         `Error listing files in ${FULL_MANUAL_SAVE_DIRECTORY_PATH}:`,
         listError
       );
-      return [];
+      return createPersistenceFailure(
+        PersistenceErrorCodes.FILE_READ_ERROR,
+        `Failed to list save files: ${listError.message}`
+      );
     }
   }
 

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -184,12 +184,18 @@ class SaveLoadService extends ISaveLoadService {
 
   /**
    * @inheritdoc
-   * @returns {Promise<Array<SaveFileMetadata>>} Parsed metadata entries.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Array<SaveFileMetadata>>>}
+   *   Parsed metadata entries wrapped in a PersistenceResult.
    */
   async listManualSaveSlots() {
     this.#logger.debug('Listing manual save slots...');
-    const files = await this.#fileRepository.listManualSaveFiles();
+    const fileListResult = await this.#fileRepository.listManualSaveFiles();
 
+    if (!fileListResult.success) {
+      return fileListResult;
+    }
+
+    const files = fileListResult.data || [];
     const metadataList = await Promise.all(
       files.map((name) => this.#fileRepository.parseManualSaveMetadata(name))
     );
@@ -197,7 +203,7 @@ class SaveLoadService extends ISaveLoadService {
     this.#logger.debug(
       `Finished listing manual save slots. Returning ${metadataList.length} items.`
     );
-    return metadataList;
+    return { success: true, data: metadataList };
   }
 
   /**

--- a/tests/services/saveLoadService.additional.test.js
+++ b/tests/services/saveLoadService.additional.test.js
@@ -83,8 +83,8 @@ describe('SaveLoadService additional coverage', () => {
 
   it('returns empty list when directory missing', async () => {
     storageProvider.listFiles.mockRejectedValue(new Error('not found'));
-    const slots = await service.listManualSaveSlots();
-    expect(slots).toEqual([]);
+    const result = await service.listManualSaveSlots();
+    expect(result).toEqual({ success: true, data: [] });
     expect(logger.debug).toHaveBeenCalled();
   });
 
@@ -99,8 +99,8 @@ describe('SaveLoadService additional coverage', () => {
     storageProvider.listFiles.mockResolvedValue(['manual_save_Slot1.sav']);
     storageProvider.readFile.mockResolvedValue(compressed);
 
-    const slots = await service.listManualSaveSlots();
-    expect(slots).toEqual([
+    const result = await service.listManualSaveSlots();
+    expect(result.data).toEqual([
       {
         identifier: 'saves/manual_saves/manual_save_Slot1.sav',
         saveName: 'Slot1',

--- a/tests/services/saveLoadService.edgeCases.test.js
+++ b/tests/services/saveLoadService.edgeCases.test.js
@@ -172,9 +172,9 @@ describe('SaveLoadService edge cases', () => {
       const compressed = pako.gzip(encode(obj));
       storageProvider.listFiles.mockResolvedValue(['manual_save_slot1.sav']);
       storageProvider.readFile.mockResolvedValue(compressed);
-      const slots = await service.listManualSaveSlots();
-      expect(slots[0].isCorrupted).toBe(true);
-      expect(slots[0].saveName).toBe('slot1 (No Metadata)');
+      const result = await service.listManualSaveSlots();
+      expect(result.data[0].isCorrupted).toBe(true);
+      expect(result.data[0].saveName).toBe('slot1 (No Metadata)');
     });
 
     it('handles malformed metadata fields', async () => {
@@ -187,17 +187,17 @@ describe('SaveLoadService edge cases', () => {
       const compressed = pako.gzip(encode(obj));
       storageProvider.listFiles.mockResolvedValue(['manual_save_slot2.sav']);
       storageProvider.readFile.mockResolvedValue(compressed);
-      const slots = await service.listManualSaveSlots();
-      expect(slots[0].isCorrupted).toBe(true);
-      expect(slots[0].saveName).toBe('slot2 (Bad Metadata)');
+      const result = await service.listManualSaveSlots();
+      expect(result.data[0].isCorrupted).toBe(true);
+      expect(result.data[0].saveName).toBe('slot2 (Bad Metadata)');
     });
 
     it('marks slot corrupted when deserialization fails', async () => {
       storageProvider.listFiles.mockResolvedValue(['manual_save_bad.sav']);
       storageProvider.readFile.mockRejectedValue(new Error('read fail'));
-      const slots = await service.listManualSaveSlots();
-      expect(slots[0].isCorrupted).toBe(true);
-      expect(slots[0].saveName).toMatch(/Corrupted/);
+      const result = await service.listManualSaveSlots();
+      expect(result.data[0].isCorrupted).toBe(true);
+      expect(result.data[0].saveName).toMatch(/Corrupted/);
     });
   });
 

--- a/tests/services/saveLoadService.errorPaths.test.js
+++ b/tests/services/saveLoadService.errorPaths.test.js
@@ -102,8 +102,8 @@ describe('SaveLoadService error paths', () => {
 
   it('logs error when listFiles fails with non-not-found', async () => {
     storageProvider.listFiles.mockRejectedValue(new Error('permission'));
-    const slots = await service.listManualSaveSlots();
-    expect(slots).toEqual([]);
+    const result = await service.listManualSaveSlots();
+    expect(result.success).toBe(false);
     expect(logger.error).toHaveBeenCalled();
   });
 

--- a/tests/services/saveLoadService.privateHelpers.test.js
+++ b/tests/services/saveLoadService.privateHelpers.test.js
@@ -166,8 +166,8 @@ describe('SaveLoadService helper functions', () => {
   it('extracts save name for corrupted files', async () => {
     storageProvider.listFiles.mockResolvedValue(['manual_save_TestFile.sav']);
     storageProvider.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
-    const slots = await service.listManualSaveSlots();
-    expect(slots[0].saveName).toBe('TestFile (Corrupted)');
+    const result = await service.listManualSaveSlots();
+    expect(result.data[0].saveName).toBe('TestFile (Corrupted)');
   });
 });
 


### PR DESCRIPTION
Summary: Updated save file listing to use PersistenceResult objects and propagated failures to SaveLoadService, updating interfaces and tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`) – 540 errors reported
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`) – not executed


------
https://chatgpt.com/codex/tasks/task_e_685303d895a08331aa10b071554b70eb