### PR TITLE
[Agent] Expand utils index exports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,7 @@ Familiarize yourself with the main project directories:
 
 - **Single Responsibility Principle (SRP)**: Functions and classes should be small, focused, and do one thing well.
 - **Modularity**: Adhere to the project structure. Create clear module interfaces using `export`.
+- **Centralized Utility Imports**: Use `src/utils/index.js` to import common utilities like logger helpers and object helpers.
 - **Minimize Side Effects**: Prefer pure functions where possible, especially for data transformation and game logic.
 - **Immutability**: Favor immutable data structures and updates where practical to simplify state management and
   debugging.

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,11 @@
+// src/utils/index.js
+/**
+ * Consolidated exports for utility functions. Import utilities from this
+ * central index to reduce relative paths.
+ *
+ * @example
+ * import { fetchWithRetry, getModuleLogger } from '../utils/index.js';
+ */
 export { fetchWithRetry } from './httpUtils.js';
+export * from './loggerUtils.js';
+export * from './objectUtils.js';

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -1,6 +1,11 @@
 // src/utils/loggerUtils.js
 // --- FILE START ---
 /* eslint-disable no-console */
+/**
+ * @file Utility functions for logging.
+ * @description Re-exported from {@link src/utils/index.js}. Prefer importing
+ * from the central index.
+ */
 
 import { validateDependency } from './validationUtils.js';
 

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -12,6 +12,8 @@ import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * @file Utility functions for working with plain JavaScript objects.
+ * @description Re-exported from {@link src/utils/index.js}. Import from there
+ * for convenience.
  */
 
 /**


### PR DESCRIPTION
Summary: Expanded `src/utils/index.js` to re-export logger and object utility modules and added documentation guiding developers to import utilities via this central index. Updated related utility files with file-level JSDoc notes and added a note in `CONTRIBUTING.md` about centralized imports.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint src/utils/index.js src/utils/loggerUtils.js src/utils/objectUtils.js CONTRIBUTING.md`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685306df18e08331927b9095cd9a4a40