### PR TITLE
[Agent] add InvalidDispatcherError for safe dispatch

### DIFF
--- a/src/utils/safeDispatchErrorUtils.js
+++ b/src/utils/safeDispatchErrorUtils.js
@@ -10,13 +10,28 @@
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 
 /**
+ * Error thrown when `safeDispatchError` receives an invalid dispatcher.
+ */
+export class InvalidDispatcherError extends Error {
+  /**
+   * @param {string} message - The error message.
+   * @param {object} [details] - Optional diagnostic details.
+   */
+  constructor(message, details) {
+    super(message);
+    this.name = 'InvalidDispatcherError';
+    if (details) this.details = details;
+  }
+}
+
+/**
  * Sends a `core:system_error_occurred` event with a consistent payload structure.
  * The dispatcher is validated before dispatching.
  *
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
  * @param {string} message - Human readable error message.
  * @param {object} [details] - Additional structured details for debugging.
- * @throws {Error} If the dispatcher is missing or invalid.
+ * @throws {InvalidDispatcherError} If the dispatcher is missing or invalid.
  * @returns {void}
  * @example
  * safeDispatchError(safeEventDispatcher, 'Invalid action', { id: 'bad-action' });
@@ -27,7 +42,7 @@ export function safeDispatchError(dispatcher, message, details = {}) {
     const errorMsg =
       "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'.";
     console.error(errorMsg);
-    throw new Error(errorMsg);
+    throw new InvalidDispatcherError(errorMsg);
   }
 
   dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });

--- a/tests/utils/safeDispatchErrorUtils.test.js
+++ b/tests/utils/safeDispatchErrorUtils.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { safeDispatchError } from '../../src/utils/safeDispatchErrorUtils.js';
+import {
+  safeDispatchError,
+  InvalidDispatcherError,
+} from '../../src/utils/safeDispatchErrorUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 describe('safeDispatchError', () => {
@@ -14,7 +17,9 @@ describe('safeDispatchError', () => {
 
   it('throws if dispatcher is invalid', () => {
     expect(() => safeDispatchError({}, 'oops')).toThrow(
-      "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
+      new InvalidDispatcherError(
+        "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
+      )
     );
   });
 });


### PR DESCRIPTION
## Summary
- add `InvalidDispatcherError` class for dispatcher validation
- use the new error when `dispatch` is missing
- expect new error in `safeDispatchError` unit test

## Testing Done
- [x] `npm run format`
- [ ] `npm run lint` *(fails: many pre-existing issues)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685306f5b55c8331b2864d856472ed82