### PR TITLE
[Refactor] rename getComponent util

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -43,7 +43,7 @@ function _isValidManager(mgr) {
  * @param {string} componentId - The component type ID to retrieve.
  * @returns {any | null} The component data if available, otherwise `null`.
  */
-export function getComponent(entity, componentId) {
+export function getComponentFromEntity(entity, componentId) {
   if (!_isValidId(componentId) || !_isValidManager(entity)) {
     return null;
   }

--- a/tests/utils/componentAccessUtils.test.js
+++ b/tests/utils/componentAccessUtils.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
-  getComponent,
+  getComponentFromEntity,
   getComponentFromManager,
   resolveEntityInstance,
 } from '../../src/utils/componentAccessUtils.js';
@@ -18,27 +18,27 @@ class MockEntity {
   }
 }
 
-describe('getComponent', () => {
+describe('getComponentFromEntity', () => {
   it('returns component data when present', () => {
     const ent = new MockEntity({ foo: { a: 1 } });
-    expect(getComponent(ent, 'foo')).toEqual({ a: 1 });
+    expect(getComponentFromEntity(ent, 'foo')).toEqual({ a: 1 });
   });
 
   it('returns null when component missing', () => {
     const ent = new MockEntity();
-    expect(getComponent(ent, 'foo')).toBeNull();
+    expect(getComponentFromEntity(ent, 'foo')).toBeNull();
   });
 
   it('returns null for invalid entity', () => {
-    expect(getComponent(null, 'foo')).toBeNull();
-    expect(getComponent({}, 'foo')).toBeNull();
+    expect(getComponentFromEntity(null, 'foo')).toBeNull();
+    expect(getComponentFromEntity({}, 'foo')).toBeNull();
   });
 
   it('returns null for invalid componentId', () => {
     const ent = new MockEntity({ foo: { a: 1 } });
-    expect(getComponent(ent, '')).toBeNull();
+    expect(getComponentFromEntity(ent, '')).toBeNull();
     // @ts-ignore - purposely pass non-string
-    expect(getComponent(ent, null)).toBeNull();
+    expect(getComponentFromEntity(ent, null)).toBeNull();
   });
 
   it('returns null when getComponentData throws', () => {
@@ -47,7 +47,7 @@ describe('getComponent', () => {
         throw new Error('boom');
       },
     };
-    expect(getComponent(ent, 'foo')).toBeNull();
+    expect(getComponentFromEntity(ent, 'foo')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Summary: Refactor utility naming for clarity.

Changes Made:
- rename `getComponent` to `getComponentFromEntity`
- update unit tests to use the new name

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (skipped)


------
https://chatgpt.com/codex/tasks/task_e_685306d66c4c8331a92cc0fdc1c06194