### PR TITLE
[Agent] introduce ManualSaveCoordinator

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -26,6 +26,7 @@ import ComponentCleaningService, {
 } from '../../persistence/componentCleaningService.js';
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../persistence/gameStateCaptureService.js';
+import ManualSaveCoordinator from '../../persistence/manualSaveCoordinator.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
 import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuilder.js';
 import ReferenceResolver from '../../initializers/services/referenceResolver.js';
@@ -123,6 +124,17 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.GameStateCaptureService)}.`
   );
 
+  r.singletonFactory(tokens.ManualSaveCoordinator, (c) => {
+    return new ManualSaveCoordinator({
+      logger: c.resolve(tokens.ILogger),
+      gameStateCaptureService: c.resolve(tokens.GameStateCaptureService),
+      saveLoadService: c.resolve(tokens.ISaveLoadService),
+    });
+  });
+  logger.debug(
+    `Persistence Registration: Registered ${String(tokens.ManualSaveCoordinator)}.`
+  );
+
   r.singletonFactory(tokens.GamePersistenceService, (c) => {
     return new GamePersistenceService({
       logger: c.resolve(tokens.ILogger),
@@ -130,6 +142,7 @@ export function registerPersistence(container) {
       entityManager: c.resolve(tokens.IEntityManager),
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
       gameStateCaptureService: c.resolve(tokens.GameStateCaptureService),
+      manualSaveCoordinator: c.resolve(tokens.ManualSaveCoordinator),
     });
   });
   logger.debug(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -79,6 +79,7 @@ import { freeze } from '../utils/objectUtils.js';
  * @property {DiToken} ComponentCleaningService - Token for the service cleaning component data.
  * @property {DiToken} SaveFileRepository - Token for the save file repository service.
  * @property {DiToken} GameStateCaptureService - Token for the service capturing game state.
+ * @property {DiToken} ManualSaveCoordinator - Token coordinating manual save preparation.
  * @property {DiToken} GamePersistenceService - Token for the game state persistence service.
  * @property {DiToken} EntityDisplayDataProvider - Token for the service providing entity display data.
  * @property {DiToken} AlertRouter - Token for the service that routes alerts to the UI or console.
@@ -207,6 +208,7 @@ export const tokens = freeze({
   SaveMetadataBuilder: 'SaveMetadataBuilder',
   ActiveModsManifestBuilder: 'ActiveModsManifestBuilder',
   GameStateCaptureService: 'GameStateCaptureService',
+  ManualSaveCoordinator: 'ManualSaveCoordinator',
   GamePersistenceService: 'GamePersistenceService',
   EntityDisplayDataProvider: 'EntityDisplayDataProvider',
   AlertRouter: 'AlertRouter',

--- a/src/persistence/manualSaveCoordinator.js
+++ b/src/persistence/manualSaveCoordinator.js
@@ -1,0 +1,91 @@
+import { setupService } from '../utils/serviceInitializerUtils.js';
+
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('./gameStateCaptureService.js').default} GameStateCaptureService
+ * @typedef {import('../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService
+ */
+
+/**
+ * @class ManualSaveCoordinator
+ * @description Prepares game state and delegates manual save requests to ISaveLoadService.
+ */
+export default class ManualSaveCoordinator {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {GameStateCaptureService} */
+  #gameStateCaptureService;
+  /** @type {ISaveLoadService} */
+  #saveLoadService;
+
+  /**
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logging service.
+   * @param {GameStateCaptureService} deps.gameStateCaptureService - Service capturing current game state.
+   * @param {ISaveLoadService} deps.saveLoadService - Save/load service.
+   */
+  constructor({ logger, gameStateCaptureService, saveLoadService }) {
+    this.#logger = setupService('ManualSaveCoordinator', logger, {
+      gameStateCaptureService: {
+        value: gameStateCaptureService,
+        requiredMethods: ['captureCurrentGameState'],
+      },
+      saveLoadService: {
+        value: saveLoadService,
+        requiredMethods: ['saveManualGame'],
+      },
+    });
+    this.#gameStateCaptureService = gameStateCaptureService;
+    this.#saveLoadService = saveLoadService;
+  }
+
+  /**
+   * Captures the current game state via GameStateCaptureService.
+   *
+   * @param {string | null | undefined} activeWorldName - Active world name.
+   * @returns {import('../interfaces/ISaveLoadService.js').SaveGameStructure} Game state object.
+   * @private
+   */
+  _captureGameState(activeWorldName) {
+    return this.#gameStateCaptureService.captureCurrentGameState(
+      activeWorldName
+    );
+  }
+
+  /**
+   * Ensures metadata is present and sets the save name.
+   *
+   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} state - Game state object.
+   * @param {string} saveName - Desired save name.
+   * @private
+   */
+  _setSaveMetadata(state, saveName) {
+    if (!state.metadata) state.metadata = {};
+    state.metadata.saveName = saveName;
+  }
+
+  /**
+   * Delegates saving to ISaveLoadService.
+   *
+   * @param {string} saveName - Save slot name.
+   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} state - Prepared game state.
+   * @returns {ReturnType<ISaveLoadService['saveManualGame']>}
+   * @private
+   */
+  _delegateManualSave(saveName, state) {
+    return this.#saveLoadService.saveManualGame(saveName, state);
+  }
+
+  /**
+   * Prepares game state and performs the manual save.
+   *
+   * @param {string} saveName - Name of the save.
+   * @param {string | null | undefined} activeWorldName - Name of the active world.
+   * @returns {ReturnType<ISaveLoadService['saveManualGame']>} Result from save service.
+   */
+  async saveGame(saveName, activeWorldName) {
+    const state = this._captureGameState(activeWorldName);
+    this._setSaveMetadata(state, saveName);
+    return this._delegateManualSave(saveName, state);
+  }
+}

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -4,6 +4,7 @@ import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
+import ManualSaveCoordinator from '../../src/persistence/manualSaveCoordinator.js';
 import ComponentCleaningService, {
   buildDefaultComponentCleaners,
 } from '../../src/persistence/componentCleaningService.js';
@@ -139,12 +140,18 @@ describe('Persistence round-trip', () => {
       metadataBuilder,
       activeModsManifestBuilder,
     });
+    const manualSaveCoordinator = new ManualSaveCoordinator({
+      logger,
+      gameStateCaptureService: captureService,
+      saveLoadService,
+    });
     persistence = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       playtimeTracker,
       gameStateCaptureService: captureService,
+      manualSaveCoordinator,
     });
   });
 

--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -26,6 +26,7 @@ describe('GamePersistenceService additional coverage', () => {
   let componentCleaningService;
   let metadataBuilder;
   let activeModsManifestBuilder;
+  let manualSaveCoordinator;
   let service;
   let captureService;
 
@@ -69,12 +70,14 @@ describe('GamePersistenceService additional coverage', () => {
       metadataBuilder,
       activeModsManifestBuilder,
     });
+    manualSaveCoordinator = { saveGame: jest.fn() };
     service = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       playtimeTracker,
       gameStateCaptureService: captureService,
+      manualSaveCoordinator,
     });
   });
 
@@ -158,14 +161,11 @@ describe('GamePersistenceService additional coverage', () => {
       jest
         .spyOn(captureService, 'captureCurrentGameState')
         .mockReturnValue(state);
-      saveLoadService.saveManualGame.mockResolvedValue({ success: true });
+      manualSaveCoordinator.saveGame.mockResolvedValue({ success: true });
       const res = await service.saveGame('Save1', true, 'World');
-      expect(captureService.captureCurrentGameState).toHaveBeenCalledWith(
-        'World'
-      );
-      expect(saveLoadService.saveManualGame).toHaveBeenCalledWith(
+      expect(manualSaveCoordinator.saveGame).toHaveBeenCalledWith(
         'Save1',
-        state
+        'World'
       );
       expect(res.success).toBe(true);
     });

--- a/tests/services/gamePersistenceService.constructor.test.js
+++ b/tests/services/gamePersistenceService.constructor.test.js
@@ -16,6 +16,7 @@ function makeDeps() {
     entityManager: {},
     playtimeTracker: {},
     gameStateCaptureService: {},
+    manualSaveCoordinator: {},
   };
 }
 
@@ -26,6 +27,7 @@ describe('GamePersistenceService constructor validation', () => {
     'entityManager',
     'playtimeTracker',
     'gameStateCaptureService',
+    'manualSaveCoordinator',
   ];
 
   test.each(required)('throws if %s is missing', (prop) => {

--- a/tests/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/services/gamePersistenceService.edgeCases.test.js
@@ -35,6 +35,7 @@ describe('GamePersistenceService edge cases', () => {
   let metadataBuilder;
   let safeEventDispatcher;
   let activeModsManifestBuilder;
+  let manualSaveCoordinator;
   let service;
   let captureService;
 
@@ -83,12 +84,14 @@ describe('GamePersistenceService edge cases', () => {
       metadataBuilder,
       activeModsManifestBuilder,
     });
+    manualSaveCoordinator = { saveGame: jest.fn() };
     service = new GamePersistenceService({
       logger,
       saveLoadService,
       entityManager,
       playtimeTracker,
       gameStateCaptureService: captureService,
+      manualSaveCoordinator,
     });
   });
 
@@ -122,11 +125,11 @@ describe('GamePersistenceService edge cases', () => {
   });
 
   describe('saveGame error handling', () => {
-    it('returns failure when saveManualGame rejects', async () => {
+    it('returns failure when manual save rejects', async () => {
       jest
         .spyOn(captureService, 'captureCurrentGameState')
         .mockReturnValue({ metadata: {}, gameState: {}, modManifest: {} });
-      saveLoadService.saveManualGame.mockRejectedValue(new Error('boom'));
+      manualSaveCoordinator.saveGame.mockRejectedValue(new Error('boom'));
 
       const res = await service.saveGame('Save1', true, 'World');
       expect(res.success).toBe(false);
@@ -134,11 +137,11 @@ describe('GamePersistenceService edge cases', () => {
       expect(logger.error).toHaveBeenCalled();
     });
 
-    it('returns failure when saveManualGame resolves unsuccessfully', async () => {
+    it('returns failure when manual save resolves unsuccessfully', async () => {
       jest
         .spyOn(captureService, 'captureCurrentGameState')
         .mockReturnValue({ metadata: {}, gameState: {}, modManifest: {} });
-      saveLoadService.saveManualGame.mockResolvedValue({
+      manualSaveCoordinator.saveGame.mockResolvedValue({
         success: false,
         error: 'bad',
       });

--- a/tests/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/services/gamePersistenceService.errorPaths.test.js
@@ -74,6 +74,7 @@ describe('GamePersistenceService error paths', () => {
       entityManager,
       playtimeTracker,
       gameStateCaptureService: captureService,
+      manualSaveCoordinator: { saveGame: jest.fn() },
     });
   });
 

--- a/tests/services/gamePersistenceService.privateHelpers.test.js
+++ b/tests/services/gamePersistenceService.privateHelpers.test.js
@@ -24,6 +24,7 @@ function makeService() {
     getTotalPlaytime: jest.fn(),
     setAccumulatedPlaytime: jest.fn(),
   };
+  const manualSaveCoordinator = { saveGame: jest.fn() };
 
   const service = new GamePersistenceService({
     logger,
@@ -31,6 +32,7 @@ function makeService() {
     entityManager,
     playtimeTracker,
     gameStateCaptureService: captureService,
+    manualSaveCoordinator,
   });
   const restorer = new GameStateRestorer({
     logger,

--- a/tests/services/gamePersistenceService.test.js
+++ b/tests/services/gamePersistenceService.test.js
@@ -54,12 +54,14 @@ describe('GamePersistenceService', () => {
     const captureService = {
       captureCurrentGameState: jest.fn(),
     };
+    const manualSaveCoordinator = { saveGame: jest.fn() };
     service = new GamePersistenceService({
       logger: mockLogger,
       saveLoadService: mockSaveLoadService,
       entityManager: mockEntityManager,
       playtimeTracker: mockPlaytimeTracker,
       gameStateCaptureService: captureService,
+      manualSaveCoordinator,
     });
     // Clear the logger.info/debug calls made by the constructor, if any,
     // to not interfere with test-specific logger assertions.

--- a/tests/services/manualSaveCoordinator.test.js
+++ b/tests/services/manualSaveCoordinator.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import ManualSaveCoordinator from '../../src/persistence/manualSaveCoordinator.js';
+import { createMockLogger } from '../testUtils.js';
+
+describe('ManualSaveCoordinator', () => {
+  let logger;
+  let captureService;
+  let saveLoadService;
+  let coordinator;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    captureService = {
+      captureCurrentGameState: jest.fn(() => ({ metadata: {}, gameState: {} })),
+    };
+    saveLoadService = {
+      saveManualGame: jest.fn().mockResolvedValue({ success: true }),
+    };
+    coordinator = new ManualSaveCoordinator({
+      logger,
+      gameStateCaptureService: captureService,
+      saveLoadService,
+    });
+  });
+
+  it('_setSaveMetadata ensures metadata and sets name', () => {
+    const state = {};
+    coordinator._setSaveMetadata(state, 'Slot');
+    expect(state.metadata.saveName).toBe('Slot');
+  });
+
+  it('saveGame captures state and delegates to saveLoadService', async () => {
+    await coordinator.saveGame('Slot', 'World');
+    expect(captureService.captureCurrentGameState).toHaveBeenCalledWith(
+      'World'
+    );
+    expect(saveLoadService.saveManualGame).toHaveBeenCalledWith('Slot', {
+      metadata: { saveName: 'Slot' },
+      gameState: {},
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added a ManualSaveCoordinator class to encapsulate manual save preparation and delegation to ISaveLoadService. GamePersistenceService now injects this coordinator and uses it within saveGame. Updated DI registration and tokens accordingly. Tests were adjusted and new unit tests added.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685306af821483319a1b3bd3a4dd7cab