### PR TITLE
[Agent] Add tests for worldLoader helpers and sequential schema loading

### DIFF
--- a/src/loaders/schemaLoader.js
+++ b/src/loaders/schemaLoader.js
@@ -147,15 +147,15 @@ class SchemaLoader extends AbstractLoader {
       `SchemaLoader: Processing ${schemaFiles.length} schemas listed in configuration...`
     );
 
-    const schemaPromises = schemaFiles.map((filename) =>
-      this.#loadAndAddSingleSchema(filename)
-    );
+    let loadedSchemaCount = 0;
 
     try {
-      const results = await Promise.all(schemaPromises);
-      const loadedSchemaCount = results.filter(
-        (result) => result === true
-      ).length;
+      for (const filename of schemaFiles) {
+        const result = await this.#loadAndAddSingleSchema(filename);
+        if (result === true) {
+          loadedSchemaCount += 1;
+        }
+      }
       this.#logger.debug(
         `SchemaLoader: Schema processing complete. Added ${loadedSchemaCount} new schemas to the validator (others may have been skipped).`
       );

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -372,6 +372,15 @@ class WorldLoader extends AbstractLoader {
   }
 
   /**
+   * Wrapper exposing the essential schema check for testing.
+   *
+   * @returns {void}
+   */
+  _checkEssentialSchemas() {
+    return this.#checkEssentialSchemas();
+  }
+
+  /**
    * Loads core prompt text used by the engine UI.
    *
    * @private

--- a/tests/loaders/worldLoader.helpers.test.js
+++ b/tests/loaders/worldLoader.helpers.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import WorldLoader from '../../src/loaders/worldLoader.js';
+import MissingSchemaError from '../../src/errors/missingSchemaError.js';
+
+/**
+ * Creates a WorldLoader instance with mocked dependencies for unit tests.
+ *
+ * @returns {{worldLoader: WorldLoader, configuration: any, validator: any, logger: any}}
+ */
+function createWorldLoader() {
+  const schemaIds = {
+    game: 'id:game',
+    components: 'id:components',
+    'mod-manifest': 'id:manifest',
+    entityDefinitions: 'id:defs',
+    entityInstances: 'id:instances',
+    actions: 'id:actions',
+    events: 'id:events',
+    rules: 'id:rules',
+    conditions: 'id:conditions',
+  };
+
+  const configuration = {
+    getContentTypeSchemaId: jest.fn((type) => schemaIds[type]),
+  };
+  const validator = {
+    isSchemaLoaded: jest.fn(() => true),
+  };
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const registry = { store: jest.fn(), get: jest.fn(), clear: jest.fn() };
+  const loaderMock = { loadItemsForMod: jest.fn() };
+  const schemaLoader = { loadAndCompileAllSchemas: jest.fn() };
+  const gameConfigLoader = { loadConfig: jest.fn().mockResolvedValue([]) };
+  const promptTextLoader = { loadPromptText: jest.fn() };
+  const modManifestLoader = {
+    loadRequestedManifests: jest.fn().mockResolvedValue(new Map()),
+  };
+  const validatedEventDispatcher = { dispatch: jest.fn() };
+
+  const worldLoader = new WorldLoader({
+    registry,
+    logger,
+    schemaLoader,
+    componentLoader: loaderMock,
+    conditionLoader: loaderMock,
+    ruleLoader: loaderMock,
+    macroLoader: loaderMock,
+    actionLoader: loaderMock,
+    eventLoader: loaderMock,
+    entityLoader: loaderMock,
+    entityInstanceLoader: loaderMock,
+    validator,
+    configuration,
+    gameConfigLoader,
+    promptTextLoader,
+    modManifestLoader,
+    validatedEventDispatcher,
+    contentLoadersConfig: null,
+  });
+
+  return { worldLoader, configuration, validator, logger };
+}
+
+describe('WorldLoader helper methods', () => {
+  let worldLoader;
+  let configuration;
+  let validator;
+  let logger;
+
+  beforeEach(() => {
+    ({ worldLoader, configuration, validator, logger } = createWorldLoader());
+    jest.clearAllMocks();
+  });
+
+  describe('_checkEssentialSchemas', () => {
+    it('passes when all schemas are loaded', () => {
+      expect(() => worldLoader._checkEssentialSchemas()).not.toThrow();
+    });
+
+    it('throws MissingSchemaError when a schema id is undefined', () => {
+      configuration.getContentTypeSchemaId.mockImplementation((type) =>
+        type === 'actions' ? undefined : `id:${type}`
+      );
+      expect(() => worldLoader._checkEssentialSchemas()).toThrow(
+        MissingSchemaError
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'WorldLoader: Essential schema missing or not configured: Unknown Essential Schema ID'
+      );
+    });
+
+    it('throws MissingSchemaError when a schema is not loaded', () => {
+      validator.isSchemaLoaded.mockImplementation((id) => id !== 'id:actions');
+      expect(() => worldLoader._checkEssentialSchemas()).toThrow(
+        MissingSchemaError
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'WorldLoader: Essential schema missing or not configured: id:actions'
+      );
+    });
+  });
+
+  describe('_aggregateLoaderResult', () => {
+    it('aggregates counts into mod and total summaries', () => {
+      const modRes = {};
+      const totals = {};
+      worldLoader._aggregateLoaderResult(modRes, totals, 'actions', {
+        count: 2,
+        overrides: 1,
+        errors: 0,
+      });
+      expect(modRes).toEqual({
+        actions: { count: 2, overrides: 1, errors: 0 },
+      });
+      expect(totals).toEqual({
+        actions: { count: 2, overrides: 1, errors: 0 },
+      });
+    });
+
+    it('handles invalid result objects', () => {
+      const modRes = {};
+      const totals = {};
+      worldLoader._aggregateLoaderResult(modRes, totals, 'events', null);
+      expect(modRes).toEqual({ events: { count: 0, overrides: 0, errors: 0 } });
+      expect(totals).toEqual({ events: { count: 0, overrides: 0, errors: 0 } });
+    });
+  });
+
+  describe('_recordLoaderError', () => {
+    it('increments error counts for mod and total', () => {
+      const modRes = { rules: { count: 1, overrides: 0, errors: 0 } };
+      const totals = { rules: { count: 1, overrides: 0, errors: 0 } };
+      worldLoader._recordLoaderError(modRes, totals, 'rules', 'fail');
+      worldLoader._recordLoaderError(modRes, totals, 'rules', 'fail again');
+      expect(modRes.rules.errors).toBe(2);
+      expect(totals.rules.errors).toBe(2);
+    });
+  });
+});

--- a/tests/services/schemaLoader.errors.test.js
+++ b/tests/services/schemaLoader.errors.test.js
@@ -37,9 +37,19 @@ const commonSchemaId = 'test://schemas/common';
 const entityDefinitionSchemaId = 'test://schemas/entity-definition';
 const entityInstanceSchemaId = 'test://schemas/entity-instance';
 const commonSchemaData = { $id: commonSchemaId, title: 'Common Test' };
-const entityDefinitionSchemaData = { $id: entityDefinitionSchemaId, title: 'Entity Definition Test' };
-const entityInstanceSchemaData = { $id: entityInstanceSchemaId, title: 'Entity Instance Test' };
-const defaultSchemaFiles = [commonSchemaFile, entityDefinitionSchemaFile, entityInstanceSchemaFile];
+const entityDefinitionSchemaData = {
+  $id: entityDefinitionSchemaId,
+  title: 'Entity Definition Test',
+};
+const entityInstanceSchemaData = {
+  $id: entityInstanceSchemaId,
+  title: 'Entity Instance Test',
+};
+const defaultSchemaFiles = [
+  commonSchemaFile,
+  entityDefinitionSchemaFile,
+  entityInstanceSchemaFile,
+];
 
 // --- Isolated Error Test Suite ---
 describe('SchemaLoader - Error Handling', () => {
@@ -83,11 +93,15 @@ describe('SchemaLoader - Error Handling', () => {
         return commonSchemaData;
       }
       if (path === entityDefinitionSchemaPath) {
-        console.log(`[Fetcher Mock] fetch resolving for: ${entityDefinitionSchemaPath}`);
+        console.log(
+          `[Fetcher Mock] fetch resolving for: ${entityDefinitionSchemaPath}`
+        );
         return entityDefinitionSchemaData;
       }
       if (path === entityInstanceSchemaPath) {
-        console.log(`[Fetcher Mock] fetch resolving for: ${entityInstanceSchemaPath}`);
+        console.log(
+          `[Fetcher Mock] fetch resolving for: ${entityInstanceSchemaPath}`
+        );
         return entityInstanceSchemaData;
       }
       console.error(`[Fetcher Mock] fetch throwing: Unknown path ${path}`);
@@ -145,8 +159,8 @@ describe('SchemaLoader - Error Handling', () => {
     console.log('[Fetch Error] Rejection confirmed.');
 
     // Assertions
-    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(defaultSchemaFiles.length);
-    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(defaultSchemaFiles.length);
+    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(2);
+    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(2);
 
     // addSchema only called for the successful one(s) before failure
     console.log(
@@ -213,21 +227,17 @@ describe('SchemaLoader - Error Handling', () => {
     console.log('[Missing $id] Rejection confirmed.');
 
     // Assertions
-    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(defaultSchemaFiles.length);
-    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(defaultSchemaFiles.length);
+    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(2);
+    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(2);
 
     // addSchema only called for the valid one
     console.log(
       `[Missing $id] Checking addSchema calls. Count: ${mockSchemaValidator.addSchema.mock.calls.length}`
     );
-    expect(mockSchemaValidator.addSchema).toHaveBeenCalledTimes(2);
+    expect(mockSchemaValidator.addSchema).toHaveBeenCalledTimes(1);
     expect(mockSchemaValidator.addSchema).toHaveBeenCalledWith(
       commonSchemaData,
       commonSchemaId
-    );
-    expect(mockSchemaValidator.addSchema).toHaveBeenCalledWith(
-      entityInstanceSchemaData,
-      entityInstanceSchemaId
     );
 
     // Check error logs
@@ -284,14 +294,14 @@ describe('SchemaLoader - Error Handling', () => {
     console.log('[addSchema Error] Rejection confirmed.');
 
     // Assertions
-    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(defaultSchemaFiles.length);
-    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(defaultSchemaFiles.length);
+    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(2);
+    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(2);
 
     // addSchema attempted for all
     console.log(
       `[addSchema Error] Checking addSchema calls. Count: ${mockSchemaValidator.addSchema.mock.calls.length}`
     );
-    expect(mockSchemaValidator.addSchema).toHaveBeenCalledTimes(defaultSchemaFiles.length);
+    expect(mockSchemaValidator.addSchema).toHaveBeenCalledTimes(2);
 
     // Check logs
     expect(mockLogger.error).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary
- ensure SchemaLoader loads schemas sequentially
- expose checkEssentialSchemas helper
- test worldLoader helper methods with mocks
- update SchemaLoader error tests for new behaviour

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685308294d948331a9db34d42361a2d5