### PR TITLE
[Agent] remove unused stage re-export

### DIFF
--- a/src/bootstrapper/stages.js
+++ b/src/bootstrapper/stages.js
@@ -1,2 +1,0 @@
-// src/bootstrapper/stages.js
-export * from './stages/index.js';

--- a/tests/bootstrapper/stages.additional.test.js
+++ b/tests/bootstrapper/stages.additional.test.js
@@ -14,7 +14,7 @@ import {
   initializeGameEngineStage,
   setupGlobalEventListenersStage,
   startGameStage,
-} from '../../src/bootstrapper/stages';
+} from '../../src/bootstrapper/stages/index.js';
 import AppContainer from '../../src/dependencyInjection/appContainer.js';
 import StageError from '../../src/bootstrapper/StageError.js';
 

--- a/tests/bootstrapper/stages.menuListeners.test.js
+++ b/tests/bootstrapper/stages.menuListeners.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
-import { setupMenuButtonListenersStage } from '../../src/bootstrapper/stages';
+import { setupMenuButtonListenersStage } from '../../src/bootstrapper/stages/index.js';
 import StageError from '../../src/bootstrapper/StageError.js';
 
 /**

--- a/tests/bootstrapper/stages.test.js
+++ b/tests/bootstrapper/stages.test.js
@@ -1,4 +1,4 @@
-import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages';
+import { ensureCriticalDOMElementsStage } from '../../src/bootstrapper/stages/index.js';
 import StageError from '../../src/bootstrapper/StageError.js';
 import { UIBootstrapper } from '../../src/bootstrapper/UIBootstrapper.js';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';


### PR DESCRIPTION
Summary: Delete obsolete re-export file and update tests to use the existing index file directly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (errors remain but command executed)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68530911e12c833199645a900d4ffe2d