### PR TITLE
[Agent] add logger param to setupDIContainerStage

### DIFF
--- a/src/bootstrapper/stages/containerStages.js
+++ b/src/bootstrapper/stages/containerStages.js
@@ -25,25 +25,30 @@ import { stageSuccess, stageFailure } from '../helpers.js';
  * @param {ConfigureContainerFunction} containerConfigFunc - A reference to the configureContainer function.
  * @param {{ createAppContainer: function(): AppContainer }} options
  *  - Factory provider for an AppContainer instance.
+ * @param {{ error: function(...any): void, debug: function(...any): void }} [log]
+ *  - Logger with `error` and `debug` methods. Defaults to `console`.
  * @returns {Promise<StageResult>} Result object with the configured AppContainer on success.
  */
 export async function setupDIContainerStage(
   uiReferences,
   containerConfigFunc,
-  { createAppContainer }
+  { createAppContainer },
+  log = console
 ) {
   const container = createAppContainer();
+  log.debug('Bootstrap Stage: setupDIContainerStage starting...');
 
   try {
     containerConfigFunc(container, uiReferences);
   } catch (registrationError) {
     const errorMsg = `Fatal Error during service registration: ${registrationError.message}.`;
-    console.error(
+    log.error(
       `Bootstrap Stage: setupDIContainerStage failed. ${errorMsg}`,
       registrationError
     );
     return stageFailure('DI Container Setup', errorMsg, registrationError);
   }
+  log.debug('Bootstrap Stage: setupDIContainerStage completed successfully.');
   return stageSuccess(container);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,8 @@ export async function bootstrapApp() {
       configureContainer,
       {
         createAppContainer: () => new AppContainer(),
-      }
+      },
+      console
     );
     if (!diResult.success) throw diResult.error;
     container = diResult.payload;

--- a/tests/bootstrapper/stages.additional.test.js
+++ b/tests/bootstrapper/stages.additional.test.js
@@ -31,9 +31,15 @@ afterEach(() => {
 describe('setupDIContainerStage', () => {
   it('configures the container using provided function', async () => {
     const configFn = jest.fn();
-    const result = await setupDIContainerStage({}, configFn, {
-      createAppContainer: () => new AppContainer(),
-    });
+    const logger = createLogger();
+    const result = await setupDIContainerStage(
+      {},
+      configFn,
+      {
+        createAppContainer: () => new AppContainer(),
+      },
+      logger
+    );
     expect(result.success).toBe(true);
     expect(configFn).toHaveBeenCalledWith(result.payload, {});
     expect(result.payload).toBeInstanceOf(AppContainer);
@@ -43,9 +49,15 @@ describe('setupDIContainerStage', () => {
     const configFn = jest.fn(() => {
       throw new Error('fail');
     });
-    const result = await setupDIContainerStage({}, configFn, {
-      createAppContainer: () => new AppContainer(),
-    });
+    const logger = createLogger();
+    const result = await setupDIContainerStage(
+      {},
+      configFn,
+      {
+        createAppContainer: () => new AppContainer(),
+      },
+      logger
+    );
     expect(result.success).toBe(false);
     expect(result.error).toBeInstanceOf(StageError);
     expect(result.error.phase).toBe('DI Container Setup');
@@ -56,9 +68,15 @@ describe('setupDIContainerStage', () => {
     const cont = new AppContainer();
     const factory = jest.fn(() => cont);
 
-    const result = await setupDIContainerStage({}, configFn, {
-      createAppContainer: factory,
-    });
+    const logger = createLogger();
+    const result = await setupDIContainerStage(
+      {},
+      configFn,
+      {
+        createAppContainer: factory,
+      },
+      logger
+    );
 
     expect(factory).toHaveBeenCalled();
     expect(configFn).toHaveBeenCalledWith(cont, {});


### PR DESCRIPTION
## Summary
- inject an optional logger into setupDIContainerStage
- use log parameter for debug/error messages
- wire console logger in main.js
- update tests for new parameter

## Testing
- `npm run test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68530a35d3e8833192345b3e5c876dd9