### PR TITLE
[Agent] add helper for location ID logging

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -13,7 +13,10 @@
 
 import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
-import { getAvailableExits } from '../utils/locationUtils.js';
+import {
+  getAvailableExits,
+  getLocationIdForLog,
+} from '../utils/locationUtils.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
@@ -253,10 +256,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     /* ── Resolve actor location via utility ───────── */
     let currentLocation = getActorLocation(actorEntity.id, this.#entityManager);
 
-    const locIdForLog =
-      typeof currentLocation === 'string'
-        ? currentLocation
-        : (currentLocation?.id ?? 'unknown');
+    const locIdForLog = getLocationIdForLog(currentLocation);
 
     /* ── iterate over action definitions ─────────────────────────────────── */
     for (const actionDef of allDefs) {

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -10,6 +10,18 @@ import {
 } from './entityValidationUtils.js';
 import { resolveEntityInstance } from './componentAccessUtils.js';
 
+/**
+ * Get the identifier string for a location entity or ID for logging.
+ *
+ * @param {Entity | string | null | undefined} locationEntityOrId - Location entity or ID.
+ * @returns {string} Identifier string for logs.
+ */
+export function getLocationIdForLog(locationEntityOrId) {
+  return typeof locationEntityOrId === 'string'
+    ? locationEntityOrId
+    : locationEntityOrId?.id || 'unknown';
+}
+
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('../interfaces/ILogger.js').ILogger} ILogger */
@@ -75,10 +87,11 @@ function _resolveLocationEntity(
   );
 
   if (!isValidEntity(locationEntity)) {
-    const id =
+    const id = getLocationIdForLog(
       typeof locationEntityOrId === 'string'
         ? locationEntityOrId
-        : locationEntity?.id || 'unknown';
+        : locationEntity
+    );
     log.warn(
       `_resolveLocationEntity: Location entity not found or invalid for ID/object: ${id}`
     );
@@ -189,10 +202,7 @@ export function getExitByDirection(
       if (isNonBlankString(exit.target)) {
         return exit;
       }
-      const locId =
-        typeof locationEntityOrId === 'string'
-          ? locationEntityOrId
-          : locationEntityOrId?.id || 'unknown';
+      const locId = getLocationIdForLog(locationEntityOrId);
       log.warn(
         `getExitByDirection: Found exit for direction '${directionName}' in location '${locId}', but its target ID ('target' property) is invalid: ${JSON.stringify(
           // CHANGED warning message
@@ -202,10 +212,7 @@ export function getExitByDirection(
       return null; // Return null if target is invalid for the found direction
     }
   }
-  const locId =
-    typeof locationEntityOrId === 'string'
-      ? locationEntityOrId
-      : locationEntityOrId?.id || 'unknown';
+  const locId = getLocationIdForLog(locationEntityOrId);
   log.debug(
     `getExitByDirection: No exit found for direction '${directionName}' in location '${locId}'.`
   );
@@ -245,10 +252,7 @@ export function getAvailableExits(
   }
 
   const validExits = [];
-  const locIdForLog =
-    typeof locationEntityOrId === 'string'
-      ? locationEntityOrId
-      : locationEntityOrId?.id || 'unknown';
+  const locIdForLog = getLocationIdForLog(locationEntityOrId);
 
   for (const exit of exitsData) {
     if (

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -17,7 +17,10 @@ import { ActionValidationService } from '../../src/actions/validation/actionVali
 import ConsoleLogger from '../../src/logging/consoleLogger.js';
 import { formatActionCommand as formatActionCommandFn } from '../../src/actions/actionFormatter.js';
 import { getEntityIdsForScopes as getEntityIdsForScopesFn } from '../../src/entities/entityScopeService.js';
-import { getAvailableExits } from '../../src/utils/locationUtils.js';
+import {
+  getAvailableExits,
+  getLocationIdForLog,
+} from '../../src/utils/locationUtils.js';
 
 // --- Helper Mocks/Types ---
 import { ActionTargetContext } from '../../src/models/actionTargetContext.js';
@@ -46,6 +49,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   let mockFormatActionCommandFn;
   let mockGetEntityIdsForScopesFn;
   let mockGetAvailableExits;
+  let mockGetLocationIdForLog;
   let availableExits;
   let mockSafeEventDispatcher;
 
@@ -99,6 +103,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
     mockFormatActionCommandFn = formatActionCommandFn;
     mockGetEntityIdsForScopesFn = getEntityIdsForScopesFn;
     mockGetAvailableExits = getAvailableExits;
+    mockGetLocationIdForLog = getLocationIdForLog;
     mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockHeroEntity = new Entity(HERO_INSTANCE_ID, HERO_DEFINITION_ID);
@@ -160,6 +165,9 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       { direction: 'out to town', target: TOWN_DEFINITION_ID, blocker: null },
     ];
     mockGetAvailableExits.mockReturnValue(availableExits);
+    mockGetLocationIdForLog.mockImplementation((loc) =>
+      typeof loc === 'string' ? loc : (loc?.id ?? 'unknown')
+    );
 
     mockValidationService.isValid.mockImplementation(
       (actionDef, actor, targetContext) => {


### PR DESCRIPTION
## Summary
- factor out log ID resolution in `locationUtils`
- use `getLocationIdForLog` in `actionDiscoveryService`
- update go action discovery tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2536 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6853089cda808331a05deb4cb1dec30f