### PR TITLE
[Agent] add logging to component access utilities

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -41,17 +41,26 @@ function _isValidManager(mgr) {
  * @param {Entity | any} entity - The entity instance to query. Must expose a
  *   `getComponentData` method.
  * @param {string} componentId - The component type ID to retrieve.
+ * @param {import('../interfaces/ILogger.js').ILogger} [logger] - Optional logger
+ *   for debug messages.
  * @returns {any | null} The component data if available, otherwise `null`.
  */
-export function getComponentFromEntity(entity, componentId) {
+export function getComponentFromEntity(entity, componentId, logger) {
+  const log = getPrefixedLogger(logger, '[componentAccessUtils] ');
+
   if (!_isValidId(componentId) || !_isValidManager(entity)) {
+    log.debug('getComponentFromEntity: invalid entity or componentId.');
     return null;
   }
 
   try {
     const data = entity.getComponentData(componentId);
     return data ?? null;
-  } catch {
+  } catch (error) {
+    log.debug(
+      'getComponentFromEntity: error retrieving component data.',
+      error
+    );
     return null;
   }
 }
@@ -68,21 +77,35 @@ export function getComponentFromEntity(entity, componentId) {
  * @param {string} entityId - The ID of the entity instance to query.
  * @param {string} componentId - The component type ID to retrieve.
  * @param {IEntityManager} entityManager - Manager used to access component data.
+ * @param logger
  * @returns {any | null} The component data if available, otherwise `null`.
  */
-export function getComponentFromManager(entityId, componentId, entityManager) {
+export function getComponentFromManager(
+  entityId,
+  componentId,
+  entityManager,
+  logger
+) {
+  const log = getPrefixedLogger(logger, '[componentAccessUtils] ');
+
   if (!_isValidId(entityId) || !_isValidId(componentId)) {
+    log.debug('getComponentFromManager: invalid entityId or componentId.');
     return null;
   }
 
   if (!_isValidManager(entityManager)) {
+    log.debug('getComponentFromManager: invalid entityManager provided.');
     return null;
   }
 
   try {
     const data = entityManager.getComponentData(entityId, componentId);
     return data ?? null;
-  } catch {
+  } catch (error) {
+    log.debug(
+      `getComponentFromManager: error retrieving '${componentId}' for entity '${entityId}'.`,
+      error
+    );
     return null;
   }
 }

--- a/tests/utils/componentAccessUtils.test.js
+++ b/tests/utils/componentAccessUtils.test.js
@@ -4,6 +4,7 @@ import {
   getComponentFromManager,
   resolveEntityInstance,
 } from '../../src/utils/componentAccessUtils.js';
+import { createMockLogger } from '../testUtils.js';
 
 class MockEntity {
   constructor(data = {}) {
@@ -27,6 +28,25 @@ describe('getComponentFromEntity', () => {
   it('returns null when component missing', () => {
     const ent = new MockEntity();
     expect(getComponentFromEntity(ent, 'foo')).toBeNull();
+  });
+
+  it('logs debug for invalid entity', () => {
+    const logger = createMockLogger();
+    expect(getComponentFromEntity(null, 'foo', logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[componentAccessUtils] getComponentFromEntity: invalid entity or componentId.'
+    );
+  });
+
+  it('logs debug when getComponentData throws', () => {
+    const logger = createMockLogger();
+    const ent = {
+      getComponentData() {
+        throw new Error('boom');
+      },
+    };
+    expect(getComponentFromEntity(ent, 'foo', logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalled();
   });
 
   it('returns null for invalid entity', () => {
@@ -81,13 +101,24 @@ describe('getComponentFromManager', () => {
     expect(getComponentFromManager('e1', 'foo', null)).toBeNull();
   });
 
+  it('logs debug for invalid parameters', () => {
+    const logger = createMockLogger();
+    const mgr = new MockManager();
+    expect(getComponentFromManager('', 'foo', mgr, logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[componentAccessUtils] getComponentFromManager: invalid entityId or componentId.'
+    );
+  });
+
   it('returns null when getComponentData throws', () => {
     const mgr = {
       getComponentData() {
         throw new Error('boom');
       },
     };
-    expect(getComponentFromManager('e1', 'foo', mgr)).toBeNull();
+    const logger = createMockLogger();
+    expect(getComponentFromManager('e1', 'foo', mgr, logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Summary: Added optional logger support to `getComponentFromEntity` and `getComponentFromManager`. Both now log debug info when given invalid input or when component lookup throws. Updated tests to verify new logging behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68530d1dc3fc833188b9058d018d716b