### PR TITLE
[Feat] Remove obsolete persistence helpers

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -100,49 +100,6 @@ class GamePersistenceService extends IGamePersistenceService {
   }
 
   /**
-   * @description Captures the current game state via GameStateCaptureService.
-   * @param {string | null | undefined} activeWorldName - Name of the currently active world.
-   * @returns {SaveGameStructure} Captured game state object.
-   * @private
-   */
-  _captureGameState(activeWorldName) {
-    return this.#gameStateCaptureService.captureCurrentGameState(
-      activeWorldName
-    );
-  }
-
-  /**
-   * @description Ensures metadata is present and sets the save name.
-   * @param {SaveGameStructure} state - Game state object to update.
-   * @param {string} saveName - Desired save name.
-   * @returns {void}
-   * @private
-   */
-  _setSaveMetadata(state, saveName) {
-    if (!state.metadata) state.metadata = {};
-    state.metadata.saveName = saveName;
-  }
-
-  /**
-   * @description Persists game state via SaveLoadService.
-   * @param {string} saveName - Name of the save slot.
-   * @param {SaveGameStructure} state - Game state to persist.
-   * @returns {Promise<{success: boolean, message?: string, error?: string, filePath?: string}>}
-   *   Result from SaveLoadService.
-   * @private
-   */
-  async _delegateManualSave(saveName, state) {
-    return this.#saveLoadService.saveManualGame(saveName, state);
-  }
-
-  /**
-   * Builds the active mods manifest section for the save data.
-   *
-   * @returns {{modId: string, version: string}[]} Array of active mod info.
-   * @private
-   */
-
-  /**
    * Captures the current game state.
    *
    * @param {string | null | undefined} activeWorldName - The name of the currently active world, passed from GameEngine.

--- a/tests/services/gamePersistenceService.privateHelpers.test.js
+++ b/tests/services/gamePersistenceService.privateHelpers.test.js
@@ -57,35 +57,6 @@ describe('GamePersistenceService private helpers', () => {
     context = makeService();
   });
 
-  it('_captureGameState delegates to capture service', () => {
-    context.captureService.captureCurrentGameState.mockReturnValue({
-      test: true,
-    });
-    const result = context.service._captureGameState('World');
-    expect(context.captureService.captureCurrentGameState).toHaveBeenCalledWith(
-      'World'
-    );
-    expect(result).toEqual({ test: true });
-  });
-
-  it('_setSaveMetadata ensures metadata and sets name', () => {
-    const state = {};
-    context.service._setSaveMetadata(state, 'Slot');
-    expect(state.metadata.saveName).toBe('Slot');
-  });
-
-  it('_delegateManualSave calls SaveLoadService', async () => {
-    context.saveLoadService.saveManualGame.mockResolvedValue({ success: true });
-    const res = await context.service._delegateManualSave('Slot', {
-      gameState: {},
-    });
-    expect(context.saveLoadService.saveManualGame).toHaveBeenCalledWith(
-      'Slot',
-      { gameState: {} }
-    );
-    expect(res).toEqual({ success: true });
-  });
-
   it('_validateRestoreData fails when gameState missing', () => {
     const res = context.restorer._validateRestoreData({});
     expect(res.success).toBe(false);


### PR DESCRIPTION
Summary: Eliminated redundant helper methods from GamePersistenceService and updated tests.

Changes Made:
- Deleted `_captureGameState`, `_setSaveMetadata`, and `_delegateManualSave` from GamePersistenceService.
- Updated the private helper test suite to cover only GameStateRestorer helpers.
- Manual save now solely delegates to ManualSaveCoordinator.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68530deb6838833194824feb92bf72e0