### PR TITLE
[Agent] remove redundant constant

### DIFF
--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -4,19 +4,13 @@
 import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { CLOUD_API_TYPES } from './constants/llmConstants.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
  * @typedef {import('./services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
  * @typedef {import('../interfaces/ILogger.js').ILogger} ILogger
  */
-
-/**
- * @description List of apiType values that are considered "cloud services" requiring proxy key handling.
- * This should be consistent with any other definitions (e.g., in ConfigurableLLMAdapter).
- * @type {string[]}
- */
-const CLOUD_API_TYPES = ['openrouter', 'openai', 'anthropic'];
 
 /**
  * @class ClientApiKeyProvider


### PR DESCRIPTION
Summary: removed local CLOUD_API_TYPES definition in clientApiKeyProvider and instead import it from llmConstants for reuse.

Testing Done:
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68530dc5ea7883319b7cd7d0d340e225