### PR TITLE
[Agent] Remove private export from locationUtils

### DIFF
--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -176,18 +176,13 @@ export function getExitByDirection(
     return null;
   }
 
-  const locationEntity = _resolveLocationEntity(
+  const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,
     log,
     dispatcher
   );
 
-  if (!locationEntity) {
-    return null;
-  }
-
-  const exitsData = _readExitsComponent(locationEntity, log);
   if (!exitsData || exitsData.length === 0) {
     return null;
   }
@@ -236,17 +231,12 @@ export function getAvailableExits(
   logger
 ) {
   const log = getModuleLogger('locationUtils', logger);
-  const locationEntity = _resolveLocationEntity(
+  const exitsData = _getExitsComponentData(
     locationEntityOrId,
     entityManager,
     log,
     dispatcher
   );
-  if (!locationEntity) {
-    return [];
-  }
-
-  const exitsData = _readExitsComponent(locationEntity, log);
   if (!exitsData || exitsData.length === 0) {
     return [];
   }
@@ -273,5 +263,3 @@ export function getAvailableExits(
   }
   return validExits;
 }
-
-export { _getExitsComponentData };


### PR DESCRIPTION
Summary: Removed `_getExitsComponentData` from public exports and updated `getExitByDirection` and `getAvailableExits` to call this helper internally. This keeps exit retrieval logic encapsulated within the module.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68530f889c748331a774da637b121232