### PR TITLE
[Agent] Make GameStateRestorer injectable

### DIFF
--- a/tests/services/gamePersistenceService.additional.test.js
+++ b/tests/services/gamePersistenceService.additional.test.js
@@ -211,5 +211,23 @@ describe('GamePersistenceService additional coverage', () => {
       expect(service.restoreGameState).toHaveBeenCalledWith(data);
       expect(res).toEqual({ success: true, data });
     });
+
+    it('uses provided gameStateRestorer instance', async () => {
+      const mockRestorer = {
+        restoreGameState: jest.fn().mockResolvedValue({ success: true }),
+      };
+      const svc = new GamePersistenceService({
+        logger,
+        saveLoadService,
+        entityManager,
+        playtimeTracker,
+        gameStateCaptureService: captureService,
+        manualSaveCoordinator,
+        gameStateRestorer: mockRestorer,
+      });
+      const payload = { gameState: {}, metadata: {} };
+      await svc.restoreGameState(payload);
+      expect(mockRestorer.restoreGameState).toHaveBeenCalledWith(payload);
+    });
   });
 });


### PR DESCRIPTION
Summary: Adds optional `gameStateRestorer` parameter to `GamePersistenceService` constructor so it can be injected. Default restorer is created when none is provided. Tests updated to cover custom restorer usage.

Changes Made:
- Updated constructor and dependency validation logic
- Added custom restorer test

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` and `npx eslint` on changed files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68530df64f708331a9cefa0193137391