### PR TITLE
[Agent] use initLogger across llm modules

### DIFF
--- a/src/llms/LLMStrategyFactory.js
+++ b/src/llms/LLMStrategyFactory.js
@@ -6,6 +6,7 @@ import { ILogger } from '../interfaces/ILogger.js'; // Assuming ILogger is in ..
 import { ILLMStrategy } from './interfaces/ILLMStrategy.js'; // Assuming ILLMStrategy is in ./interfaces/
 import { ConfigurationError } from '../errors/configurationError';
 import { LLMStrategyFactoryError } from './errors/LLMStrategyFactoryError.js';
+import { initLogger } from '../utils/index.js';
 
 // Import concrete strategy implementations
 import { OpenRouterJsonSchemaStrategy } from './strategies/openRouterJsonSchemaStrategy.js';
@@ -53,18 +54,7 @@ export class LLMStrategyFactory {
    * @throws {Error} If httpClient or logger dependencies are invalid.
    */
   constructor({ httpClient, logger }) {
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const errorMsg =
-        'LLMStrategyFactory: Constructor requires a valid logger instance with info, warn, error, and debug methods.';
-      // Throwing an error is sufficient here because logging is unavailable.
-      throw new Error(errorMsg);
-    }
-    this.#logger = logger;
+    this.#logger = initLogger('LLMStrategyFactory', logger);
 
     if (!httpClient || typeof httpClient.request !== 'function') {
       const errorMsg =

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -4,6 +4,7 @@
 import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { initLogger } from '../utils/index.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -51,19 +52,7 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
   constructor({ logger, safeEventDispatcher }) {
     super();
 
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const errorMsg =
-        'ClientApiKeyProvider: Constructor requires a valid logger instance.';
-      // Use console.error as a last resort if logger is completely unusable
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    this.#logger = logger;
+    this.#logger = initLogger('ClientApiKeyProvider', logger);
     this.#dispatcher = resolveSafeDispatcher(
       null,
       safeEventDispatcher,

--- a/src/llms/environmentContext.js
+++ b/src/llms/environmentContext.js
@@ -12,6 +12,7 @@
 
 const DEFAULT_PROXY_SERVER_URL = 'http://localhost:3001/api/llm-request';
 const VALID_EXECUTION_ENVIRONMENTS = ['client', 'server', 'unknown'];
+import { initLogger } from '../utils/index.js';
 
 /**
  * @class EnvironmentContext
@@ -78,20 +79,7 @@ export class EnvironmentContext {
    * @throws {Error} If logger is invalid.
    */
   #validateLogger(logger) {
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const errorMsg =
-        'EnvironmentContext: Constructor requires a valid logger instance with info, warn, error, and debug methods.';
-      (logger && typeof logger.error === 'function' ? logger : console).error(
-        errorMsg
-      );
-      throw new Error(errorMsg);
-    }
-    this.#logger = logger;
+    this.#logger = initLogger('EnvironmentContext', logger);
   }
 
   /**

--- a/src/llms/retryHttpClient.js
+++ b/src/llms/retryHttpClient.js
@@ -5,7 +5,7 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
   SYSTEM_WARNING_OCCURRED_ID,
 } from '../constants/eventIds.js';
-import { fetchWithRetry } from '../utils/index.js';
+import { fetchWithRetry, initLogger } from '../utils/index.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -77,17 +77,7 @@ export class RetryHttpClient extends IHttpClient {
     super();
 
     /* ---------------- Dependency validation ---------------- */
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const msg =
-        'RetryHttpClient: Constructor requires a valid logger instance.';
-      (logger?.error ?? console.error)(msg);
-      throw new Error(msg);
-    }
+    this.#logger = initLogger('RetryHttpClient', logger);
     // *** CORRECTED VALIDATION: Check for `dispatch` ***
     if (!dispatcher || typeof dispatcher.dispatch !== 'function') {
       logger.error(
@@ -95,7 +85,6 @@ export class RetryHttpClient extends IHttpClient {
       );
       throw new Error('RetryHttpClient: dispatcher dependency invalid.');
     }
-    this.#logger = logger;
     this.#dispatcher = dispatcher;
 
     /* ---------------- Config validation (unchanged) --------- */

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -9,6 +9,7 @@ import {
 } from '../../llm-proxy-server/src/utils/IServerUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { initLogger } from '../utils/index.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -150,20 +151,7 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
     safeEventDispatcher,
   }) {
     super();
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const errorMsg =
-        'ServerApiKeyProvider: Constructor requires a valid logger instance.';
-      (logger && typeof logger.error === 'function' ? logger : console).error(
-        errorMsg
-      );
-      throw new Error(errorMsg);
-    }
-    this.#logger = logger;
+    this.#logger = initLogger('ServerApiKeyProvider', logger);
     this.#dispatcher = resolveSafeDispatcher(
       null,
       safeEventDispatcher,

--- a/tests/llms/LLMStrategyFactory.test.js
+++ b/tests/llms/LLMStrategyFactory.test.js
@@ -86,18 +86,22 @@ describe('LLMStrategyFactory', () => {
     });
 
     test('should throw error if logger is invalid or missing', () => {
-      const invalidLoggers = [null, undefined, {}, { info: 'not a function' }];
-      invalidLoggers.forEach((invalidLogger) => {
-        expect(
-          () =>
-            new LLMStrategyFactory({
-              httpClient,
-              logger: /** @type {any} */ (invalidLogger),
-            })
-        ).toThrow(
-          'LLMStrategyFactory: Constructor requires a valid logger instance with info, warn, error, and debug methods.'
-        );
-      });
+      expect(
+        () => new LLMStrategyFactory({ httpClient, logger: null })
+      ).toThrow('Missing required dependency: logger.');
+      expect(
+        () => new LLMStrategyFactory({ httpClient, logger: undefined })
+      ).toThrow('Missing required dependency: logger.');
+      expect(() => new LLMStrategyFactory({ httpClient, logger: {} })).toThrow(
+        "Invalid or missing method 'info' on dependency 'logger'."
+      );
+      expect(
+        () =>
+          new LLMStrategyFactory({
+            httpClient,
+            logger: { info: 'not a function' },
+          })
+      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
     });
 
     test('should throw error if httpClient is invalid or missing', () => {

--- a/tests/llms/clientApiKeyProvider.test.js
+++ b/tests/llms/clientApiKeyProvider.test.js
@@ -66,10 +66,10 @@ describe('ClientApiKeyProvider', () => {
 
     test('should throw error if logger is invalid or missing', () => {
       expect(() => new ClientApiKeyProvider({ logger: null })).toThrow(
-        'ClientApiKeyProvider: Constructor requires a valid logger instance.'
+        'Missing required dependency: logger.'
       );
       expect(() => new ClientApiKeyProvider({ logger: {} })).toThrow(
-        'ClientApiKeyProvider: Constructor requires a valid logger instance.'
+        "Invalid or missing method 'info' on dependency 'logger'."
       );
     });
   });

--- a/tests/llms/environmentContext.test.js
+++ b/tests/llms/environmentContext.test.js
@@ -34,9 +34,7 @@ describe('EnvironmentContext', () => {
               logger: null,
               executionEnvironment: 'client',
             })
-        ).toThrow(
-          'EnvironmentContext: Constructor requires a valid logger instance with info, warn, error, and debug methods.'
-        );
+        ).toThrow('Missing required dependency: logger.');
       });
 
       test('should throw error if logger is an empty object', () => {
@@ -46,9 +44,7 @@ describe('EnvironmentContext', () => {
               logger: {},
               executionEnvironment: 'client',
             })
-        ).toThrow(
-          'EnvironmentContext: Constructor requires a valid logger instance with info, warn, error, and debug methods.'
-        );
+        ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
       });
 
       ['warn', 'error', 'debug'].forEach((method) => {
@@ -62,7 +58,7 @@ describe('EnvironmentContext', () => {
                 executionEnvironment: 'client',
               })
           ).toThrow(
-            'EnvironmentContext: Constructor requires a valid logger instance with info, warn, error, and debug methods.'
+            `Invalid or missing method '${method}' on dependency 'logger'.`
           );
         });
       });
@@ -85,7 +81,7 @@ describe('EnvironmentContext', () => {
           // Expected to throw
         }
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          'EnvironmentContext: Constructor requires a valid logger instance with info, warn, error, and debug methods.'
+          "Invalid or missing method 'error' on dependency 'logger'."
         );
         consoleErrorSpy.mockRestore();
       });

--- a/tests/llms/serverApiKeyProvider.test.js
+++ b/tests/llms/serverApiKeyProvider.test.js
@@ -90,9 +90,7 @@ describe('ServerApiKeyProvider', () => {
             environmentVariableReader,
             safeEventDispatcher: dispatcher,
           })
-      ).toThrow(
-        'ServerApiKeyProvider: Constructor requires a valid logger instance.'
-      );
+      ).toThrow('Missing required dependency: logger.');
     });
 
     test('should throw error if fileSystemReader is invalid', () => {


### PR DESCRIPTION
## Summary
- refactor LLM strategy & key provider modules to use `initLogger`
- update environment context and retry HTTP client to init logger via utils
- adjust related tests to expect new validation messages

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2545 problems)*
- `npm run test:single tests/llms`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68530dd788e08331aa679b233dd5fa06