### PR TITLE
[Agent] expose reset helper and update states

### DIFF
--- a/src/turns/handlers/baseTurnHandler.js
+++ b/src/turns/handlers/baseTurnHandler.js
@@ -380,6 +380,16 @@ export class BaseTurnHandler {
     );
   }
 
+  /**
+   * Public wrapper that delegates to the internal resource resetter.
+   *
+   * @param {string} reason - Contextual reason for the reset.
+   * @returns {void}
+   */
+  resetStateAndResources(reason) {
+    this._resetTurnStateAndResources(reason);
+  }
+
   /* ───────────────────────────── PUBLIC API ──────────────────────────── */
 
   async startTurn(_actor) {

--- a/src/turns/interfaces/ITurnStateHost.js
+++ b/src/turns/interfaces/ITurnStateHost.js
@@ -32,6 +32,18 @@ export class ITurnStateHost {
     throw new Error('ITurnStateHost.getTurnContext must be implemented.');
   }
 
+  /**
+   * Resets the host's turn state and related resources.
+   *
+   * @param {string} reason - Contextual reason for the reset.
+   * @returns {void}
+   */
+  resetStateAndResources(reason) {
+    throw new Error(
+      'ITurnStateHost.resetStateAndResources must be implemented.'
+    );
+  }
+
   // ───────────────────────────────────────────
   // Higher-level helpers invoked by states
   // ───────────────────────────────────────────

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -93,8 +93,8 @@ export class AbstractTurnState extends ITurnState {
    * @returns {Promise<void>}
    */
   async _resetToIdle(reason) {
-    if (typeof this._handler?._resetTurnStateAndResources === 'function') {
-      this._handler._resetTurnStateAndResources(reason);
+    if (typeof this._handler?.resetStateAndResources === 'function') {
+      this._handler.resetStateAndResources(reason);
     }
     if (typeof this._handler?.requestIdleStateTransition === 'function') {
       await this._handler.requestIdleStateTransition();

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -91,18 +91,16 @@ export async function handleProcessingException(
           endTurnError
         );
         if (
-          state._handler?._resetTurnStateAndResources &&
-          state._handler?._transitionToState
+          state._handler?.resetStateAndResources &&
+          state._handler?.requestIdleStateTransition
         ) {
           logger.warn(
             `${state.getStateName()}: Resetting handler due to failure in turnCtx.endTurn().`
           );
-          await state._handler._resetTurnStateAndResources(
+          await state._handler.resetStateAndResources(
             `exception-endTurn-failed-${state.getStateName()}`
           );
-          await state._handler._transitionToState(
-            new TurnIdleState(state._handler)
-          );
+          await state._handler.requestIdleStateTransition();
         }
       }
     } else {
@@ -110,15 +108,13 @@ export async function handleProcessingException(
         `${state.getStateName()}: Cannot call turnCtx.endTurn(); ITurnContext or its endTurn method is unavailable.`
       );
       if (
-        state._handler?._resetTurnStateAndResources &&
-        state._handler?._transitionToState
+        state._handler?.resetStateAndResources &&
+        state._handler?.requestIdleStateTransition
       ) {
-        await state._handler._resetTurnStateAndResources(
+        await state._handler.resetStateAndResources(
           `exception-no-context-end-${state.getStateName()}`
         );
-        await state._handler._transitionToState(
-          new TurnIdleState(state._handler)
-        );
+        await state._handler.requestIdleStateTransition();
       } else {
         logger.error(
           `${state.getStateName()}: CRITICAL - Cannot end turn OR reset handler. System may be unstable.`

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -103,7 +103,7 @@ export class TurnEndingState extends AbstractTurnState {
     }
 
     /* 3️⃣  Cleanup ----------------------------------------------------------- */
-    handler._resetTurnStateAndResources(
+    handler.resetStateAndResources(
       `enterState-TurnEndingState-actor-${this.#actorToEndId}`
     );
 
@@ -143,7 +143,7 @@ export class TurnEndingState extends AbstractTurnState {
     // Capture context *before* we clear resources so we can still use it
     const ctx = handler.getTurnContext?.();
 
-    handler._resetTurnStateAndResources(
+    handler.resetStateAndResources(
       `destroy-TurnEndingState-actor-${this.#actorToEndId}`
     );
 

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -23,9 +23,9 @@ export class TurnIdleState extends AbstractTurnState {
 
     const logger = this._resolveLogger(null, handler);
     logger.debug(
-      `${this.getStateName()}: Ensuring clean state by calling handler._resetTurnStateAndResources().`
+      `${this.getStateName()}: Ensuring clean state by calling handler.resetStateAndResources().`
     );
-    handler._resetTurnStateAndResources(`enterState-${this.getStateName()}`);
+    handler.resetStateAndResources(`enterState-${this.getStateName()}`);
     logger.debug(
       `${this.getStateName()}: Entry complete. Handler is now idle.`
     );
@@ -72,12 +72,8 @@ export class TurnIdleState extends AbstractTurnState {
     if (!actorEntity || typeof actorEntity.id === 'undefined') {
       const errorMsg = `${this.getStateName()}: startTurn called with invalid actorEntity.`;
       logger.error(errorMsg);
-      handler._resetTurnStateAndResources(
-        `invalid-actor-${this.getStateName()}`
-      );
-      handler._transitionToState(
-        handler._turnStateFactory.createIdleState(handler)
-      );
+      handler.resetStateAndResources(`invalid-actor-${this.getStateName()}`);
+      handler.requestIdleStateTransition();
       throw new Error(errorMsg);
     }
   }
@@ -93,12 +89,8 @@ export class TurnIdleState extends AbstractTurnState {
     if (!turnCtx) {
       const errorMsg = `${this.getStateName()}: ITurnContext is missing or invalid. Expected concrete handler to set it up. Actor: ${actorIdForLog}.`;
       logger.error(errorMsg);
-      handler._resetTurnStateAndResources(
-        `missing-context-${this.getStateName()}`
-      );
-      handler._transitionToState(
-        handler._turnStateFactory.createIdleState(handler)
-      );
+      handler.resetStateAndResources(`missing-context-${this.getStateName()}`);
+      handler.requestIdleStateTransition();
       throw new Error(errorMsg);
     }
   }
@@ -116,12 +108,8 @@ export class TurnIdleState extends AbstractTurnState {
     if (!contextActor || contextActor.id !== actorEntity.id) {
       const errorMsg = `${this.getStateName()}: Actor in ITurnContext ('${contextActor?.id}') does not match actor provided to state's startTurn ('${actorEntity.id}').`;
       logger.error(errorMsg);
-      handler._resetTurnStateAndResources(
-        `actor-mismatch-${this.getStateName()}`
-      );
-      handler._transitionToState(
-        handler._turnStateFactory.createIdleState(handler)
-      );
+      handler.resetStateAndResources(`actor-mismatch-${this.getStateName()}`);
+      handler.requestIdleStateTransition();
       throw new Error(errorMsg);
     }
     return contextActor;
@@ -146,12 +134,8 @@ export class TurnIdleState extends AbstractTurnState {
         `${this.getStateName()}: Failed to transition to AwaitingActorDecisionState for ${actor.id}. Error: ${error.message}`,
         error
       );
-      handler._resetTurnStateAndResources(
-        `transition-fail-${this.getStateName()}`
-      );
-      await handler._transitionToState(
-        handler._turnStateFactory.createIdleState(handler)
-      );
+      handler.resetStateAndResources(`transition-fail-${this.getStateName()}`);
+      await handler.requestIdleStateTransition();
       throw error;
     }
   }

--- a/tests/integration/humanAiTurnParity.integration.test.js
+++ b/tests/integration/humanAiTurnParity.integration.test.js
@@ -24,6 +24,9 @@ function buildHandler(logger) {
     getLogger: () => logger,
     getTurnContext: () => null,
     _resetTurnStateAndResources: jest.fn(),
+    resetStateAndResources: jest.fn(function (reason) {
+      this._resetTurnStateAndResources(reason);
+    }),
     requestIdleStateTransition: jest.fn(),
     requestProcessingCommandStateTransition: jest.fn(),
   };

--- a/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -90,6 +90,9 @@ const makeMockTurnHandler = () => ({
   getLogger: jest.fn().mockReturnValue(makeMockLogger()),
   getTurnContext: jest.fn(),
   _resetTurnStateAndResources: jest.fn(),
+  resetStateAndResources: jest.fn(function (reason) {
+    this._resetTurnStateAndResources(reason);
+  }),
   requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
 });
 

--- a/tests/turns/states/awaitingExternalTurnEndState.test.js
+++ b/tests/turns/states/awaitingExternalTurnEndState.test.js
@@ -9,13 +9,7 @@ jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
 
 import { AwaitingExternalTurnEndState } from '../../../src/turns/states/awaitingExternalTurnEndState.js';
 import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 describe('AwaitingExternalTurnEndState – action propagation', () => {
   // In the implementation TIMEOUT_MS is 3 000 ms when NODE_ENV === "test"
@@ -67,6 +61,8 @@ describe('AwaitingExternalTurnEndState – action propagation', () => {
     mockHandler = {
       getLogger: () => mockLogger,
       getTurnContext: () => mockCtx,
+      resetStateAndResources: jest.fn(),
+      requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
       _transitionToState: jest.fn(),
       _resetTurnStateAndResources: jest.fn(),
     };

--- a/tests/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/turns/states/awaitingPlayerInputState.test.js
@@ -92,6 +92,9 @@ const createMockBaseTurnHandler = (loggerInstance = mockLogger) => {
     getTurnContext: jest.fn().mockReturnValue(null),
     _transitionToState: jest.fn().mockResolvedValue(undefined),
     _resetTurnStateAndResources: jest.fn(),
+    resetStateAndResources: jest.fn(function (reason) {
+      handlerMock._resetTurnStateAndResources(reason);
+    }),
     getCurrentActor: jest.fn().mockReturnValue(null),
     // NEW: Add the new transition method used for recovery.
     requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),

--- a/tests/turns/states/processingCommandState.coverage.test.js
+++ b/tests/turns/states/processingCommandState.coverage.test.js
@@ -46,6 +46,9 @@ beforeEach(() => {
   mockHandler = {
     getTurnContext: jest.fn(),
     _resetTurnStateAndResources: jest.fn(),
+    resetStateAndResources: jest.fn(function (reason) {
+      mockHandler._resetTurnStateAndResources(reason);
+    }),
     _transitionToState: jest.fn().mockResolvedValue(undefined),
     requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
     getLogger: jest.fn().mockReturnValue(mockLogger),

--- a/tests/turns/states/processingCommandState.enterState.test.js
+++ b/tests/turns/states/processingCommandState.enterState.test.js
@@ -227,6 +227,9 @@ describe('ProcessingCommandState', () => {
         }
       }),
       _resetTurnStateAndResources: jest.fn(),
+      resetStateAndResources: jest.fn(function (reason) {
+        mockHandler._resetTurnStateAndResources(reason);
+      }),
       requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
       getLogger: jest.fn().mockReturnValue(mockLogger),
       _currentState: null,

--- a/tests/turns/states/processingCommandState.helpers.test.js
+++ b/tests/turns/states/processingCommandState.helpers.test.js
@@ -5,6 +5,9 @@ const mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
 const mockHandler = {
   getTurnContext: jest.fn(),
   _resetTurnStateAndResources: jest.fn(),
+  resetStateAndResources: jest.fn(function (reason) {
+    mockHandler._resetTurnStateAndResources(reason);
+  }),
   _transitionToState: jest.fn(),
   getLogger: jest.fn(() => mockLogger),
   _turnStateFactory: { createIdleState: jest.fn(() => ({})) },

--- a/tests/turns/states/processingCommandState.test.js
+++ b/tests/turns/states/processingCommandState.test.js
@@ -295,6 +295,9 @@ describe('ProcessingCommandState', () => {
         }
       }),
       _resetTurnStateAndResources: jest.fn(),
+      resetStateAndResources: jest.fn(function (reason) {
+        mockHandler._resetTurnStateAndResources(reason);
+      }),
       getLogger: jest.fn().mockReturnValue(mockLogger),
       _currentState: null,
     };

--- a/tests/turns/states/turnEndingState.test.js
+++ b/tests/turns/states/turnEndingState.test.js
@@ -101,6 +101,9 @@ const createMockBaseTurnHandler = (loggerInstance = mockSystemLogger) => {
       handlerMock._currentTurnContext = null;
       handlerMock._currentActor = null;
     }),
+    resetStateAndResources: jest.fn((reason) => {
+      handlerMock._resetTurnStateAndResources(reason);
+    }),
     signalNormalApparentTermination: jest.fn(),
     destroy: jest.fn(async () => {
       handlerMock._isDestroyed = true;

--- a/tests/turns/states/turnIdleState.helpers.test.js
+++ b/tests/turns/states/turnIdleState.helpers.test.js
@@ -3,11 +3,18 @@ import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js';
 
 const makeActor = (id = 'a1') => ({ id });
 
-const buildHandler = () => ({
-  _resetTurnStateAndResources: jest.fn(),
-  _transitionToState: jest.fn(),
-  _turnStateFactory: { createIdleState: jest.fn(() => ({})) },
-});
+const buildHandler = () => {
+  const handler = {
+    _resetTurnStateAndResources: jest.fn(),
+    resetStateAndResources: jest.fn((reason) => {
+      handler._resetTurnStateAndResources(reason);
+    }),
+    requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
+    _transitionToState: jest.fn(),
+    _turnStateFactory: { createIdleState: jest.fn(() => ({})) },
+  };
+  return handler;
+};
 
 const buildCtx = (actor) => ({
   getActor: () => actor,

--- a/tests/turns/states/turnIdleState.test.js
+++ b/tests/turns/states/turnIdleState.test.js
@@ -39,6 +39,10 @@ const buildHandler = (ctx = null) => {
     getTurnContext: jest.fn().mockReturnValue(ctx),
     getLogger: jest.fn(() => logger),
     _resetTurnStateAndResources: jest.fn(),
+    resetStateAndResources: jest.fn(function (reason) {
+      handler._resetTurnStateAndResources(reason);
+    }),
+    requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
     _transitionToState: jest.fn().mockResolvedValue(undefined),
     // createIdleState just returns another TurnIdleState instance
     _turnStateFactory: {
@@ -78,7 +82,7 @@ describe('TurnIdleState.startTurn', () => {
 
     // No error handling paths should fire
     expect(handler._resetTurnStateAndResources).not.toHaveBeenCalled();
-    expect(handler._transitionToState).not.toHaveBeenCalled();
+    expect(handler.requestIdleStateTransition).not.toHaveBeenCalled();
   });
 
   it('throws & resets when actorEntity is null/invalid', async () => {
@@ -90,7 +94,7 @@ describe('TurnIdleState.startTurn', () => {
     );
 
     expect(handler._resetTurnStateAndResources).toHaveBeenCalledTimes(1);
-    expect(handler._transitionToState).toHaveBeenCalledTimes(1);
+    expect(handler.requestIdleStateTransition).toHaveBeenCalledTimes(1);
   });
 
   it('throws & recovers when ITurnContext is missing', async () => {
@@ -103,7 +107,7 @@ describe('TurnIdleState.startTurn', () => {
     );
 
     expect(handler._resetTurnStateAndResources).toHaveBeenCalledTimes(1);
-    expect(handler._transitionToState).toHaveBeenCalledTimes(1);
+    expect(handler.requestIdleStateTransition).toHaveBeenCalledTimes(1);
   });
 
   it('throws & recovers on actor/context mismatch', async () => {
@@ -117,7 +121,7 @@ describe('TurnIdleState.startTurn', () => {
     );
 
     expect(handler._resetTurnStateAndResources).toHaveBeenCalledTimes(1);
-    expect(handler._transitionToState).toHaveBeenCalledTimes(1);
+    expect(handler.requestIdleStateTransition).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Summary:
- add `resetStateAndResources` to ITurnStateHost
- implement resetStateAndResources in BaseTurnHandler
- use resetStateAndResources and requestIdleStateTransition in states
- adjust tests to mock new interface method

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: lint errors in repo)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6853131407f88331b708dd2676c2738d