### PR TITLE
[Agent] modularize world loader helpers

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -1,0 +1,203 @@
+// src/loaders/ContentLoadManager.js
+
+/**
+ * @file Implements ContentLoadManager, coordinating per-mod content loading
+ * using configured content loaders.
+ */
+
+import LoadResultAggregator from './LoadResultAggregator.js';
+
+/** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../data/schemas/mod.manifest.schema.json').ModManifest} ModManifest */
+
+/**
+ * @description Manages loading of content for mods using various content loaders.
+ * @class
+ */
+export class ContentLoadManager {
+  #logger;
+  #validatedEventDispatcher;
+  #contentLoadersConfig;
+
+  /**
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logging service.
+   * @param {ValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher.
+   * @param {Array<{loader: *, contentKey: string, contentTypeDir: string, typeName: string}>} deps.contentLoadersConfig - Loader configuration.
+   */
+  constructor({ logger, validatedEventDispatcher, contentLoadersConfig }) {
+    this.#logger = logger;
+    this.#validatedEventDispatcher = validatedEventDispatcher;
+    this.#contentLoadersConfig = contentLoadersConfig;
+  }
+
+  /**
+   * Loads content for all mods in the provided order.
+   *
+   * @param {string[]} finalOrder - Resolved load order of mods.
+   * @param {Map<string, ModManifest>} manifests - Map of manifests keyed by ID.
+   * @param {TotalResultsSummary} totalCounts - Object to accumulate totals across mods.
+   * @returns {Promise<void>} Resolves when processing completes.
+   */
+  async loadContent(finalOrder, manifests, totalCounts) {
+    this.#logger.debug(
+      'WorldLoader: Beginning content loading based on final order...'
+    );
+
+    for (const modId of finalOrder) {
+      const manifest = /** @type {ModManifest | null} */ (
+        manifests.get(modId.toLowerCase())
+      );
+      await this.processMod(modId, manifest, totalCounts);
+    }
+
+    this.#logger.debug(
+      'WorldLoader: Completed content loading loop for all mods in final order.'
+    );
+  }
+
+  /**
+   * Processes content for a single mod using all configured loaders.
+   *
+   * @private
+   * @param {string} modId - Mod identifier.
+   * @param {ModManifest|null} manifest - Manifest for the mod.
+   * @param {TotalResultsSummary} totalCounts - Aggregated totals object.
+   * @returns {Promise<void>} Resolves when the mod has been processed.
+   */
+  async processMod(modId, manifest, totalCounts) {
+    this.#logger.debug(`--- Loading content for mod: ${modId} ---`);
+    const aggregator = new LoadResultAggregator(totalCounts);
+    let modDurationMs = 0;
+
+    try {
+      if (!manifest) {
+        const reason = `Manifest not found in registry for mod ID '${modId}'. Skipping content load.`;
+        this.#logger.error(`WorldLoader: ${reason}`);
+        await this.#validatedEventDispatcher
+          .dispatch(
+            'initialization:world_loader:mod_load_failed',
+            { modId, reason },
+            { allowSchemaNotFound: true }
+          )
+          .catch((dispatchError) =>
+            this.#logger.error(
+              `Failed dispatching mod_load_failed event for ${modId}: ${dispatchError.message}`,
+              dispatchError
+            )
+          );
+        return;
+      }
+
+      this.#logger.debug(
+        `WorldLoader [${modId}]: Manifest retrieved successfully. Processing content types...`
+      );
+      const modStartTime = performance.now();
+
+      for (const config of this.#contentLoadersConfig) {
+        const { loader, contentKey, contentTypeDir, typeName } = config;
+        const hasContent =
+          manifest.content &&
+          Array.isArray(manifest.content[contentKey]) &&
+          manifest.content[contentKey].length > 0;
+
+        if (hasContent) {
+          this.#logger.debug(
+            `WorldLoader [${modId}]: Found content for '${contentKey}'. Invoking loader '${loader.constructor.name}'.`
+          );
+          try {
+            const result = /** @type {LoadItemsResult} */ (
+              await loader.loadItemsForMod(
+                modId,
+                manifest,
+                contentKey,
+                contentTypeDir,
+                typeName
+              )
+            );
+            if (result && typeof result.count === 'number') {
+              aggregator.aggregate(result, typeName);
+            } else {
+              this.#logger.warn(
+                `WorldLoader [${modId}]: Loader for '${typeName}' returned an unexpected result format. Assuming 0 counts.`,
+                { result }
+              );
+              aggregator.aggregate(null, typeName);
+            }
+          } catch (loadError) {
+            const errorMessage = loadError?.message || String(loadError);
+            this.#logger.error(
+              `WorldLoader [${modId}]: Error loading content type '${typeName}'. Continuing...`,
+              { modId, typeName, error: errorMessage },
+              loadError
+            );
+            aggregator.recordError(typeName);
+            await this.#validatedEventDispatcher
+              .dispatch(
+                'initialization:world_loader:content_load_failed',
+                { modId, typeName, error: errorMessage },
+                { allowSchemaNotFound: true }
+              )
+              .catch((e) =>
+                this.#logger.error(
+                  `Failed dispatching content_load_failed event for ${modId}/${typeName}`,
+                  e
+                )
+              );
+          }
+        } else {
+          this.#logger.debug(
+            `WorldLoader [${modId}]: Skipping content type '${typeName}' (key: '${contentKey}') as it's not defined or empty in the manifest.`
+          );
+        }
+      }
+
+      const modEndTime = performance.now();
+      modDurationMs = modEndTime - modStartTime;
+      this.#logger.debug(
+        `WorldLoader [${modId}]: Content loading loop took ${modDurationMs.toFixed(2)} ms.`
+      );
+    } catch (error) {
+      this.#logger.error(
+        `WorldLoader [${modId}]: Unexpected error during processing for mod '${modId}'. Skipping remaining content for this mod.`,
+        { modId, error: error?.message },
+        error
+      );
+      await this.#validatedEventDispatcher
+        .dispatch(
+          'initialization:world_loader:mod_load_failed',
+          { modId, reason: `Unexpected error: ${error?.message}` },
+          { allowSchemaNotFound: true }
+        )
+        .catch((dispatchError) =>
+          this.#logger.error(
+            `Failed dispatching mod_load_failed event for ${modId} after unexpected error: ${dispatchError.message}`,
+            dispatchError
+          )
+        );
+      return;
+    }
+
+    const totalModOverrides = Object.values(aggregator.modResults).reduce(
+      (sum, res) => sum + (res.overrides || 0),
+      0
+    );
+    const totalModErrors = Object.values(aggregator.modResults).reduce(
+      (sum, res) => sum + (res.errors || 0),
+      0
+    );
+    const typeCountsString = Object.entries(aggregator.modResults)
+      .filter(([, result]) => result.count > 0)
+      .map(([t, result]) => `${t}(${result.count})`)
+      .sort()
+      .join(', ');
+    const summaryMessage = `Mod '${modId}' loaded in ${modDurationMs.toFixed(2)}ms: ${
+      typeCountsString.length > 0 ? typeCountsString : 'No items loaded'
+    }${typeCountsString.length > 0 ? ' ' : ''}-> Overrides(${totalModOverrides}), Errors(${totalModErrors})`;
+    this.#logger.debug(summaryMessage);
+    this.#logger.debug(`--- Finished loading content for mod: ${modId} ---`);
+  }
+}
+
+export default ContentLoadManager;

--- a/src/loaders/LoadResultAggregator.js
+++ b/src/loaders/LoadResultAggregator.js
@@ -1,0 +1,95 @@
+// src/loaders/LoadResultAggregator.js
+
+/**
+ * @file Provides LoadResultAggregator, a utility for collecting loader results
+ * per mod and across all mods.
+ */
+
+/**
+ * Structure to hold aggregated results per content type.
+ *
+ * @typedef {object} ContentTypeCounts
+ * @property {number} count - Number of items successfully loaded.
+ * @property {number} overrides - Number of items that replaced existing items.
+ * @property {number} errors - Number of errors encountered.
+ */
+
+/**
+ * Structure to hold aggregated results for a single mod.
+ * Maps typeName to {@link ContentTypeCounts}.
+ *
+ * @typedef {Record<string, ContentTypeCounts>} ModResultsSummary
+ */
+
+/**
+ * Structure to hold aggregated results across all mods.
+ * Maps typeName to {@link ContentTypeCounts}.
+ *
+ * @typedef {Record<string, ContentTypeCounts>} TotalResultsSummary
+ */
+
+/**
+ * @description Utility class used during content loading to aggregate loader
+ * results for a single mod and update overall totals.
+ * @class
+ */
+export class LoadResultAggregator {
+  /** @type {TotalResultsSummary} */
+  #totalCounts;
+  /** @type {ModResultsSummary} */
+  modResults = {};
+
+  /**
+   * @param {TotalResultsSummary} totalCounts - Object storing totals across all mods.
+   */
+  constructor(totalCounts) {
+    this.#totalCounts = totalCounts;
+  }
+
+  /**
+   * Aggregates a loader result into the per-mod and total summaries.
+   *
+   * @param {LoadItemsResult|null|undefined} result - Loader result to aggregate.
+   * @param {string} typeName - Content type name.
+   * @returns {void}
+   */
+  aggregate(result, typeName) {
+    const res =
+      result && typeof result.count === 'number'
+        ? {
+            count: result.count || 0,
+            overrides: result.overrides || 0,
+            errors: result.errors || 0,
+          }
+        : { count: 0, overrides: 0, errors: 0 };
+
+    this.modResults[typeName] = res;
+
+    if (!this.#totalCounts[typeName]) {
+      this.#totalCounts[typeName] = { count: 0, overrides: 0, errors: 0 };
+    }
+    this.#totalCounts[typeName].count += res.count;
+    this.#totalCounts[typeName].overrides += res.overrides;
+    this.#totalCounts[typeName].errors += res.errors;
+  }
+
+  /**
+   * Records an error occurrence for a specific loader.
+   *
+   * @param {string} typeName - Content type name for which an error occurred.
+   * @returns {void}
+   */
+  recordError(typeName) {
+    if (!this.modResults[typeName]) {
+      this.modResults[typeName] = { count: 0, overrides: 0, errors: 0 };
+    }
+    this.modResults[typeName].errors += 1;
+
+    if (!this.#totalCounts[typeName]) {
+      this.#totalCounts[typeName] = { count: 0, overrides: 0, errors: 0 };
+    }
+    this.#totalCounts[typeName].errors += 1;
+  }
+}
+
+export default LoadResultAggregator;

--- a/src/loaders/ModManifestProcessor.js
+++ b/src/loaders/ModManifestProcessor.js
@@ -1,0 +1,105 @@
+// src/loaders/ModManifestProcessor.js
+
+/**
+ * @file Defines ModManifestProcessor, responsible for loading and validating
+ * mod manifests and resolving final mod load order.
+ */
+
+import ModDependencyValidator from '../modding/modDependencyValidator.js';
+import validateModEngineVersions from '../modding/modVersionValidator.js';
+import { resolveOrder } from '../modding/modLoadOrderResolver.js';
+import ModDependencyError from '../errors/modDependencyError.js';
+
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../modding/modManifestLoader.js').default} ModManifestLoader */
+/** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../../data/schemas/mod.manifest.schema.json').ModManifest} ModManifest */
+
+/**
+ * @description Service used by WorldLoader to prepare mod manifests for loading.
+ * @class
+ */
+export class ModManifestProcessor {
+  #modManifestLoader;
+  #logger;
+  #registry;
+  #validatedEventDispatcher;
+
+  /**
+   * @param {object} deps - Constructor dependencies.
+   * @param {ModManifestLoader} deps.modManifestLoader - Loader for manifests.
+   * @param {ILogger} deps.logger - Logging service.
+   * @param {IDataRegistry} deps.registry - Registry for storing manifests.
+   * @param {ValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher for validation errors.
+   */
+  constructor({
+    modManifestLoader,
+    logger,
+    registry,
+    validatedEventDispatcher,
+  }) {
+    this.#modManifestLoader = modManifestLoader;
+    this.#logger = logger;
+    this.#registry = registry;
+    this.#validatedEventDispatcher = validatedEventDispatcher;
+  }
+
+  /**
+   * Loads, validates, and resolves manifests for the requested mod IDs.
+   *
+   * @param {string[]} requestedIds - IDs of mods requested by the game config.
+   * @returns {Promise<{loadedManifestsMap: Map<string, ModManifest>, finalOrder: string[], incompatibilityCount: number}>}
+   * Object containing the loaded manifests, resolved order and incompatibility count.
+   * @throws {ModDependencyError|Error} Propagates validation errors.
+   */
+  async processManifests(requestedIds) {
+    const loadedManifestsRaw =
+      await this.#modManifestLoader.loadRequestedManifests(requestedIds);
+    const loadedManifestsMap = new Map();
+    const manifestsForValidation = new Map();
+    for (const [modId, manifestObj] of loadedManifestsRaw.entries()) {
+      const lcModId = modId.toLowerCase();
+      this.#registry.store('mod_manifests', lcModId, manifestObj);
+      manifestsForValidation.set(lcModId, manifestObj);
+      loadedManifestsMap.set(lcModId, manifestObj);
+    }
+    this.#logger.debug(
+      `WorldLoader: Stored ${manifestsForValidation.size} mod manifests in the registry.`
+    );
+
+    ModDependencyValidator.validate(manifestsForValidation, this.#logger);
+    let incompatibilityCount = 0;
+    try {
+      validateModEngineVersions(
+        manifestsForValidation,
+        this.#logger,
+        this.#validatedEventDispatcher
+      );
+    } catch (e) {
+      if (e instanceof ModDependencyError) {
+        incompatibilityCount = (e.message.match(/\n/g) || []).length;
+        this.#logger.warn(
+          `WorldLoader: Encountered ${incompatibilityCount} engine version incompatibilities. Details:\n${e.message}`,
+          e
+        );
+        throw e;
+      }
+      throw e;
+    }
+
+    const finalOrder = resolveOrder(
+      requestedIds,
+      manifestsForValidation,
+      this.#logger
+    );
+    this.#logger.debug(
+      `WorldLoader: Final mod order resolved: [${finalOrder.join(', ')}]`
+    );
+    this.#registry.store('meta', 'final_mod_order', finalOrder);
+
+    return { loadedManifestsMap, finalOrder, incompatibilityCount };
+  }
+}
+
+export default ModManifestProcessor;

--- a/tests/loaders/worldLoader.privateHelpers.test.js
+++ b/tests/loaders/worldLoader.privateHelpers.test.js
@@ -1,59 +1,34 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import WorldLoader from '../../src/loaders/worldLoader.js';
+import LoadResultAggregator from '../../src/loaders/LoadResultAggregator.js';
 
-/**
- * Helper to create a bare WorldLoader instance without running the constructor.
- * This allows direct testing of private helper methods.
- *
- * @returns {WorldLoader}
- */
-function makeBareWorldLoader() {
-  return Object.create(WorldLoader.prototype);
-}
-
-describe('WorldLoader private helpers', () => {
-  let loader;
+describe('LoadResultAggregator utility', () => {
+  let aggregator;
 
   beforeEach(() => {
-    loader = makeBareWorldLoader();
+    aggregator = new LoadResultAggregator({});
   });
 
-  it('_aggregateLoaderResult updates mod and total counts', () => {
-    const modResults = {};
-    const totals = {};
+  it('aggregate updates mod and total counts', () => {
+    aggregator.aggregate({ count: 2, overrides: 1, errors: 0 }, 'actions');
 
-    loader._aggregateLoaderResult(modResults, totals, 'actions', {
-      count: 2,
-      overrides: 1,
-      errors: 0,
-    });
-
-    expect(modResults).toEqual({
+    expect(aggregator.modResults).toEqual({
       actions: { count: 2, overrides: 1, errors: 0 },
     });
-    expect(totals).toEqual({ actions: { count: 2, overrides: 1, errors: 0 } });
   });
 
-  it('_aggregateLoaderResult handles invalid results', () => {
-    const modResults = {};
-    const totals = {};
+  it('aggregate handles invalid results', () => {
+    aggregator.aggregate(null, 'rules');
 
-    loader._aggregateLoaderResult(modResults, totals, 'rules', null);
-
-    expect(modResults).toEqual({
+    expect(aggregator.modResults).toEqual({
       rules: { count: 0, overrides: 0, errors: 0 },
     });
-    expect(totals).toEqual({ rules: { count: 0, overrides: 0, errors: 0 } });
   });
 
-  it('_recordLoaderError increments error counts', () => {
-    const modResults = { events: { count: 5, overrides: 0, errors: 0 } };
-    const totals = { events: { count: 5, overrides: 0, errors: 0 } };
+  it('recordError increments error counts', () => {
+    aggregator.modResults = { events: { count: 5, overrides: 0, errors: 0 } };
+    aggregator.recordError('events');
+    aggregator.recordError('events');
 
-    loader._recordLoaderError(modResults, totals, 'events', 'boom');
-    loader._recordLoaderError(modResults, totals, 'events', 'boom again');
-
-    expect(modResults.events.errors).toBe(2);
-    expect(totals.events.errors).toBe(2);
+    expect(aggregator.modResults.events.errors).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- factor manifest processing into `ModManifestProcessor`
- factor content loading into `ContentLoadManager`
- track per-mod counts with `LoadResultAggregator`
- update `WorldLoader` to use new helpers
- adjust tests for the new utilities

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685317ea83d083318899377358a765e3