### PR TITLE
[Agent] introduce logPreview helper

### DIFF
--- a/src/llms/strategies/base/baseCompletionLLMStrategy.js
+++ b/src/llms/strategies/base/baseCompletionLLMStrategy.js
@@ -2,6 +2,7 @@
 // --- UPDATED FILE START ---
 
 import { BaseLLMStrategy } from './baseLLMStrategy.js';
+import { logPreview } from '../../../utils/index.js';
 
 /**
  * @typedef {import('../../../interfaces/coreServices.js').ILogger} ILogger
@@ -45,8 +46,11 @@ export class BaseCompletionLLMStrategy extends BaseLLMStrategy {
     // unless the PromptBuilder is guaranteed to output perfectly trimmed strings.
     const finalPromptString = gameSummary.trim();
 
-    this.logger.debug(
-      `BaseCompletionLLMStrategy._constructPromptPayload: Using finalPromptString as the 'prompt'. Preview: ${finalPromptString.substring(0, 100) + (finalPromptString.length > 100 ? '...' : '')}`
+    logPreview(
+      this.logger,
+      "BaseCompletionLLMStrategy._constructPromptPayload: Using finalPromptString as the 'prompt'. Preview: ",
+      finalPromptString,
+      100
     );
     return { prompt: finalPromptString };
   }

--- a/src/llms/strategies/base/baseOpenRouterStrategy.js
+++ b/src/llms/strategies/base/baseOpenRouterStrategy.js
@@ -3,6 +3,7 @@
 import { BaseChatLLMStrategy } from './baseChatLLMStrategy.js';
 import { ConfigurationError } from '../../../errors/configurationError';
 import { LLMStrategyError } from '../../errors/LLMStrategyError.js';
+import { logPreview } from '../../../utils/index.js';
 // Assuming HttpClientError might be a specific type, if not, general Error is caught.
 // For actual HttpClientError type, it would be imported from its definition:
 // import { HttpClientError } from '../../retryHttpClient.js'; // Example path
@@ -308,13 +309,11 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
         body: JSON.stringify(finalPayload),
       });
 
-      this.logger.debug(
-        `${this.constructor.name} (${llmId}): Raw API response received.`,
-        {
-          llmId,
-          responsePreview:
-            JSON.stringify(responseData)?.substring(0, 250) + '...',
-        }
+      logPreview(
+        this.logger,
+        `${this.constructor.name} (${llmId}): Raw API response received. Preview: `,
+        JSON.stringify(responseData),
+        250
       );
 
       const extractedJsonString = await this._extractJsonOutput(

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -130,4 +130,20 @@ export function initLogger(serviceName, logger, { optional = false } = {}) {
   return ensureValidLogger(logger, serviceName);
 }
 
+/**
+ * Logs a truncated preview of `data` at the debug level.
+ * If `data` is not a string, it will be JSON stringified first.
+ *
+ * @param {ILogger} logger - Logger instance used to emit the preview.
+ * @param {string} label - Text to prepend to the preview message.
+ * @param {any} data - The data to preview.
+ * @param {number} [length] - Maximum number of characters to include.
+ * @returns {void}
+ */
+export function logPreview(logger, label, data, length = 100) {
+  const str = typeof data === 'string' ? data : JSON.stringify(data);
+  const preview = str.substring(0, length) + (str.length > length ? '...' : '');
+  logger.debug(`${label}${preview}`);
+}
+
 // --- FILE END ---

--- a/tests/utils/loggerUtils.test.js
+++ b/tests/utils/loggerUtils.test.js
@@ -12,6 +12,7 @@ import {
   getPrefixedLogger,
   getModuleLogger,
   initLogger,
+  logPreview,
 } from '../../src/utils/loggerUtils.js';
 import { validateDependency } from '../../src/utils/validationUtils.js';
 
@@ -95,5 +96,19 @@ describe('loggerUtils', () => {
     expect(validateDependency).not.toHaveBeenCalled();
     logger.error('oops');
     expect(consoleSpies.error).toHaveBeenCalledWith('Svc: ', 'oops');
+  });
+
+  it('logPreview logs truncated preview for long strings', () => {
+    const logger = { debug: jest.fn() };
+    logPreview(logger, 'label: ', 'a'.repeat(120), 100);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'label: ' + 'a'.repeat(100) + '...'
+    );
+  });
+
+  it('logPreview logs full string when shorter than limit', () => {
+    const logger = { debug: jest.fn() };
+    logPreview(logger, 'l: ', 'short', 100);
+    expect(logger.debug).toHaveBeenCalledWith('l: short');
   });
 });


### PR DESCRIPTION
## Summary
- add `logPreview` util for consistent preview logging
- log with `logPreview` in LLM strategies
- verify new helper in unit tests

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(on modified files)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685319475eb08331ac10ef8ef4734a9f