### PR TITLE
[Agent] Split actor/strategy validation

### DIFF
--- a/tests/turns/states/awaitingActorDecisionState.helpers.test.js
+++ b/tests/turns/states/awaitingActorDecisionState.helpers.test.js
@@ -19,14 +19,17 @@ describe('AwaitingActorDecisionState helpers', () => {
     state = new AwaitingActorDecisionState({ getLogger: () => logger });
   });
 
-  test('_validateActorAndStrategy returns actor and strategy', async () => {
+  test('validateActor returns actor', () => {
+    const actor = { id: 'a1' };
+    const ctx = makeCtx({ actor });
+    expect(state.validateActor(ctx)).toBe(actor);
+  });
+
+  test('retrieveStrategy returns strategy', () => {
     const actor = { id: 'a1' };
     const strategy = { decideAction: jest.fn() };
     const ctx = makeCtx({ actor, strategy });
-    await expect(state._validateActorAndStrategy(ctx)).resolves.toEqual({
-      actor,
-      strategy,
-    });
+    expect(state.retrieveStrategy(ctx, actor)).toBe(strategy);
   });
 
   test('_decideAction returns action info', async () => {


### PR DESCRIPTION
Summary: Split validation of actor and strategy into separate helpers for clearer logic.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68531c36f8d483319919b17cf5263c6c