### PR TITLE
[Agent] refactor fetch retry helpers and tests

### DIFF
--- a/tests/utils/httpUtils.fetchWithRetry.helpers.test.js
+++ b/tests/utils/httpUtils.fetchWithRetry.helpers.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { fetchWithRetry } from '../../src/utils/httpUtils.js';
+
+jest.useFakeTimers();
+
+let dispatcher;
+
+const mockResponse = (status, body, ok = true, headersObj = {}) => ({
+  ok,
+  status,
+  statusText: `HTTP ${status}`,
+  headers: { get: (h) => headersObj[h] },
+  json: jest.fn().mockResolvedValue(body),
+  text: jest.fn(),
+});
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.clearAllMocks();
+  dispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+});
+
+describe('fetchWithRetry helper scenarios', () => {
+  const url = 'https://api.test.local';
+  const opts = { method: 'GET' };
+
+  test('returns data on first success', async () => {
+    const resp = mockResponse(200, { ok: true }, true);
+    fetch.mockResolvedValueOnce(resp);
+
+    const result = await fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries HTTP error then succeeds', async () => {
+    const first = mockResponse(500, { msg: 'oops' }, false, {}, true);
+    first.json.mockResolvedValue({ msg: 'oops' });
+    const okResp = mockResponse(200, { ok: true }, true, {}, true);
+    okResp.json.mockResolvedValue({ ok: true });
+    fetch.mockResolvedValueOnce(first).mockResolvedValueOnce(okResp);
+
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
+    await jest.runOnlyPendingTimersAsync();
+    const result = await promise;
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+
+    timeoutSpy.mockRestore();
+    randomSpy.mockRestore();
+  });
+
+  test('retries network error then succeeds', async () => {
+    const success = mockResponse(200, { ok: true });
+    fetch
+      .mockRejectedValueOnce(new TypeError('network request failed'))
+      .mockResolvedValueOnce(success);
+
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    const promise = fetchWithRetry(
+      url,
+      opts,
+      2,
+      100,
+      1000,
+      dispatcher,
+      undefined,
+      fetch
+    );
+    await jest.runOnlyPendingTimersAsync();
+    const result = await promise;
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+
+    randomSpy.mockRestore();
+    timeoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Summary:
- introduce private helpers `_handleResponse` and `_handleNetworkError` in `httpUtils`
- refactor `attemptFetchRecursive` to use these helpers
- add unit tests for success and retry scenarios

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 544 errors, 2001 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68531c688ab88331a7667abb38a3eee8