### PR TITLE
[Agent] Add pure macro expansion helper

### DIFF
--- a/src/utils/macroUtils.js
+++ b/src/utils/macroUtils.js
@@ -26,33 +26,85 @@ export function expandMacros(actions, registry, logger) {
           logger?.warn?.(`expandMacros: macro '${action.macro}' not found.`);
           continue;
         }
-        const expanded = expandMacros(macro.actions, registry, logger);
+        const expanded = expandActionArray(macro.actions, registry, logger);
         result.push(...expanded);
         continue;
       }
 
       const params = action.parameters;
       if (params && typeof params === 'object') {
+        const newParams = { ...params };
+        let changed = false;
+
         if (Array.isArray(params.then_actions)) {
-          params.then_actions = expandMacros(
+          newParams.then_actions = expandActionArray(
             params.then_actions,
             registry,
             logger
           );
+          changed = true;
         }
         if (Array.isArray(params.else_actions)) {
-          params.else_actions = expandMacros(
+          newParams.else_actions = expandActionArray(
             params.else_actions,
             registry,
             logger
           );
+          changed = true;
         }
         if (Array.isArray(params.actions)) {
-          params.actions = expandMacros(params.actions, registry, logger);
+          newParams.actions = expandActionArray(
+            params.actions,
+            registry,
+            logger
+          );
+          changed = true;
+        }
+
+        if (changed) {
+          result.push({ ...action, parameters: newParams });
+          continue;
         }
       }
     }
     result.push(action);
   }
+  return result;
+}
+
+/**
+ * Recursively expands macro references in an array of action objects.
+ *
+ * @param {object[]} actions - Array of action or macro reference objects.
+ * @param {import('../interfaces/coreServices.js').IDataRegistry} registry - Data registry used to resolve macros.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for warnings.
+ * @returns {object[]} A new array with all macros expanded.
+ */
+export function expandActionArray(actions, registry, logger) {
+  if (!Array.isArray(actions)) return [];
+  /** @type {object[]} */
+  const result = [];
+
+  for (const action of actions) {
+    if (
+      action &&
+      typeof action === 'object' &&
+      typeof action.macro === 'string'
+    ) {
+      const macro = registry.get('macros', action.macro);
+      if (!macro || !Array.isArray(macro.actions)) {
+        logger?.warn?.(`expandMacros: macro '${action.macro}' not found.`);
+        continue;
+      }
+      const expanded = expandActionArray(macro.actions, registry, logger);
+      result.push(...expanded);
+    } else if (action && typeof action === 'object') {
+      const [expanded] = expandMacros([action], registry, logger);
+      result.push(expanded);
+    } else {
+      result.push(action);
+    }
+  }
+
   return result;
 }


### PR DESCRIPTION
Summary: Introduces `expandActionArray` to expand macro arrays without mutating inputs and updates `expandMacros` to use it.

Changes Made:
- Implemented `expandActionArray` helper and refactored `expandMacros` to create new action objects.
- Added purity test ensuring original actions remain unchanged.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint src/utils/macroUtils.js tests/utils/macroUtils.test.js --fix`)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_68531c5cb6308331b96045595474549f