### PR TITLE
[Agent] inject domAdapter dependencies

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -160,7 +160,11 @@ export async function bootstrapApp() {
         document: document,
       },
       errorDetails,
-      logger
+      logger,
+      {
+        createElement: (tag) => document.createElement(tag),
+        alert,
+      }
     );
   }
 }
@@ -186,7 +190,11 @@ export async function beginGame(showLoadUI = false) {
         errorObject: errorObj,
         phase: currentPhaseForError,
       },
-      logger
+      logger,
+      {
+        createElement: (tag) => document.createElement(tag),
+        alert,
+      }
     );
     throw errorObj;
   }
@@ -206,7 +214,11 @@ export async function beginGame(showLoadUI = false) {
         errorObject: error,
         phase: currentPhaseForError,
       },
-      logger
+      logger,
+      {
+        createElement: (tag) => document.createElement(tag),
+        alert,
+      }
     );
     throw error;
   }

--- a/src/utils/errorUtils.js
+++ b/src/utils/errorUtils.js
@@ -25,14 +25,10 @@ export function showErrorInElement(targetEl, msg) {
  * @description Creates a temporary error element after the provided base element.
  * @param {HTMLElement | null | undefined} baseEl - Element to insert after.
  * @param {string} msg - Message for the new element.
- * @param {function(string): HTMLElement} [createElement] - Element creation function. Defaults to `document.createElement`.
+ * @param {function(string): HTMLElement} createElement - Element creation function.
  * @returns {HTMLElement | null} The created element, or null if not created.
  */
-export function createTemporaryErrorElement(
-  baseEl,
-  msg,
-  createElement = (tag) => document.createElement(tag)
-) {
+export function createTemporaryErrorElement(baseEl, msg, createElement) {
   if (!baseEl || !(baseEl instanceof HTMLElement)) {
     return null;
   }
@@ -201,7 +197,7 @@ function updateElements({
  * @param {FatalErrorUIElements} uiElements - References to key UI elements.
  * @param {FatalErrorDetails} errorDetails - Details about the error.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger instance.
- * @param {{createElement?: function(string): HTMLElement, alert?: function(string): void}} [domAdapter] - DOM adapter for custom element creation and alerts.
+ * @param {{createElement: function(string): HTMLElement, alert: function(string): void}} domAdapter - DOM adapter for custom element creation and alerts.
  */
 export function displayFatalStartupError(
   uiElements,
@@ -211,9 +207,8 @@ export function displayFatalStartupError(
 ) {
   const log = getModuleLogger('errorUtils', logger);
   const { outputDiv, errorDiv, titleElement, inputElement } = uiElements;
-  const create =
-    domAdapter?.createElement ?? ((tag) => document.createElement(tag));
-  const showAlert = domAdapter?.alert ?? alert;
+  const create = domAdapter.createElement;
+  const showAlert = domAdapter.alert;
   const {
     userMessage,
     consoleMessage,


### PR DESCRIPTION
Summary:
- displayFatalStartupError now requires createElement and alert via domAdapter parameter
- helper createTemporaryErrorElement uses injected createElement function
- main.js updated to pass a default domAdapter for fatal error display

Testing Done:
- [ ] `npm run format`
- [ ] `npm run lint` *(fails: 2543 problems)*
- [ ] `npm run test`
- [ ] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68531c4cd6248331b8589b0ab5be88d3