### PR TITLE
[Feat] Refactor loader helpers naming

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -132,7 +132,7 @@ export class ContentLoadManager {
               { modId, typeName, error: errorMessage },
               loadError
             );
-            aggregator.recordError(typeName);
+            aggregator.recordFailure(typeName);
             await this.#validatedEventDispatcher
               .dispatch(
                 'initialization:world_loader:content_load_failed',

--- a/src/loaders/LoadResultAggregator.js
+++ b/src/loaders/LoadResultAggregator.js
@@ -74,12 +74,12 @@ export class LoadResultAggregator {
   }
 
   /**
-   * Records an error occurrence for a specific loader.
+   * Records a failure occurrence for a specific loader.
    *
-   * @param {string} typeName - Content type name for which an error occurred.
+   * @param {string} typeName - Content type name for which a failure occurred.
    * @returns {void}
    */
-  recordError(typeName) {
+  recordFailure(typeName) {
     if (!this.modResults[typeName]) {
       this.modResults[typeName] = { count: 0, overrides: 0, errors: 0 };
     }

--- a/src/loaders/ModManifestProcessor.js
+++ b/src/loaders/ModManifestProcessor.js
@@ -59,10 +59,10 @@ export class ModManifestProcessor {
     const loadedManifestsMap = new Map();
     const manifestsForValidation = new Map();
     for (const [modId, manifestObj] of loadedManifestsRaw.entries()) {
-      const lcModId = modId.toLowerCase();
-      this.#registry.store('mod_manifests', lcModId, manifestObj);
-      manifestsForValidation.set(lcModId, manifestObj);
-      loadedManifestsMap.set(lcModId, manifestObj);
+      const lowerCaseModId = modId.toLowerCase();
+      this.#registry.store('mod_manifests', lowerCaseModId, manifestObj);
+      manifestsForValidation.set(lowerCaseModId, manifestObj);
+      loadedManifestsMap.set(lowerCaseModId, manifestObj);
     }
     this.#logger.debug(
       `WorldLoader: Stored ${manifestsForValidation.size} mod manifests in the registry.`

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -390,7 +390,7 @@ class WorldLoader extends AbstractLoader {
    *
    * @returns {void}
    */
-  _checkEssentialSchemas() {
+  checkEssentialSchemas() {
     return this.#checkEssentialSchemas();
   }
 

--- a/tests/loaders/worldLoader.helpers.test.js
+++ b/tests/loaders/worldLoader.helpers.test.js
@@ -78,16 +78,16 @@ describe('WorldLoader helper methods', () => {
     jest.clearAllMocks();
   });
 
-  describe('_checkEssentialSchemas', () => {
+  describe('checkEssentialSchemas', () => {
     it('passes when all schemas are loaded', () => {
-      expect(() => worldLoader._checkEssentialSchemas()).not.toThrow();
+      expect(() => worldLoader.checkEssentialSchemas()).not.toThrow();
     });
 
     it('throws MissingSchemaError when a schema id is undefined', () => {
       configuration.getContentTypeSchemaId.mockImplementation((type) =>
         type === 'actions' ? undefined : `id:${type}`
       );
-      expect(() => worldLoader._checkEssentialSchemas()).toThrow(
+      expect(() => worldLoader.checkEssentialSchemas()).toThrow(
         MissingSchemaError
       );
       expect(logger.error).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe('WorldLoader helper methods', () => {
 
     it('throws MissingSchemaError when a schema is not loaded', () => {
       validator.isSchemaLoaded.mockImplementation((id) => id !== 'id:actions');
-      expect(() => worldLoader._checkEssentialSchemas()).toThrow(
+      expect(() => worldLoader.checkEssentialSchemas()).toThrow(
         MissingSchemaError
       );
       expect(logger.error).toHaveBeenCalledWith(
@@ -129,12 +129,12 @@ describe('WorldLoader helper methods', () => {
       expect(totals).toEqual({ events: { count: 0, overrides: 0, errors: 0 } });
     });
 
-    it('recordError increments error counts', () => {
+    it('recordFailure increments error counts', () => {
       const totals = { rules: { count: 1, overrides: 0, errors: 0 } };
       const agg = new LoadResultAggregator(totals);
       agg.modResults = { rules: { count: 1, overrides: 0, errors: 0 } };
-      agg.recordError('rules');
-      agg.recordError('rules');
+      agg.recordFailure('rules');
+      agg.recordFailure('rules');
       expect(agg.modResults.rules.errors).toBe(2);
       expect(totals.rules.errors).toBe(2);
     });

--- a/tests/loaders/worldLoader.privateHelpers.test.js
+++ b/tests/loaders/worldLoader.privateHelpers.test.js
@@ -24,10 +24,10 @@ describe('LoadResultAggregator utility', () => {
     });
   });
 
-  it('recordError increments error counts', () => {
+  it('recordFailure increments error counts', () => {
     aggregator.modResults = { events: { count: 5, overrides: 0, errors: 0 } };
-    aggregator.recordError('events');
-    aggregator.recordError('events');
+    aggregator.recordFailure('events');
+    aggregator.recordFailure('events');
 
     expect(aggregator.modResults.events.errors).toBe(2);
   });


### PR DESCRIPTION
Summary: Improve clarity of new loader helper classes and tests.

Changes Made:
- renamed `lcModId` to `lowerCaseModId` in `ModManifestProcessor`
- changed `recordError` to `recordFailure` in `LoadResultAggregator` and usage
- exposed schema check method as `checkEssentialSchemas`
- updated related unit tests

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy) *(fails: 544 errors)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68531be3d48c83318184487607c22d9a