### PR TITLE
[Agent] Extract save preparation

### DIFF
--- a/src/persistence/savePreparation.js
+++ b/src/persistence/savePreparation.js
@@ -1,0 +1,58 @@
+// src/persistence/savePreparation.js
+
+import { cloneAndValidateSaveState } from '../utils/saveStateUtils.js';
+import { createPersistenceSuccess } from '../utils/persistenceResultUtils.js';
+import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
+
+/**
+ * Deep clones and augments the provided game state for saving.
+ *
+ * @param {string} saveName - Name of the save slot.
+ * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} obj - Original game state object.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for error reporting.
+ * @returns {import('./persistenceTypes.js').PersistenceResult<import('../interfaces/ISaveLoadService.js').SaveGameStructure>}
+ *   Result containing the cloned object or error.
+ */
+export function cloneAndPrepareState(saveName, obj, logger) {
+  const cloneResult = cloneAndValidateSaveState(obj, logger);
+  if (!cloneResult.success || !cloneResult.data) {
+    return { success: false, error: cloneResult.error };
+  }
+
+  /** @type {import('../interfaces/ISaveLoadService.js').SaveGameStructure} */
+  const cloned = cloneResult.data;
+  cloned.metadata = { ...(cloned.metadata || {}), saveName };
+  cloned.integrityChecks = { ...(cloned.integrityChecks || {}) };
+  return createPersistenceSuccess(cloned);
+}
+
+/**
+ * Prepares and serializes game state data for saving.
+ *
+ * @param {string} saveName - Name of the save slot.
+ * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} gameStateObject - Raw game state object.
+ * @param {import('./gameStateSerializer.js').default} serializer - Serializer instance.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for error reporting.
+ * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Uint8Array>>}
+ *   Result containing compressed data.
+ */
+export async function prepareState(
+  saveName,
+  gameStateObject,
+  serializer,
+  logger
+) {
+  const cloneResult = cloneAndPrepareState(saveName, gameStateObject, logger);
+  if (!cloneResult.success || !cloneResult.data) {
+    return { success: false, error: cloneResult.error };
+  }
+
+  return wrapPersistenceOperation(logger, async () => {
+    const { compressedData } = await serializer.serializeAndCompress(
+      cloneResult.data
+    );
+    return { success: true, data: compressedData };
+  });
+}
+
+export default prepareState;


### PR DESCRIPTION
## Summary
- move cloning and preparation into `savePreparation.js`
- delegate SaveLoadService save logic to the new module
- update SaveLoadService tests to spy on the new module

## Testing Done
- `npm run format`
- `npx eslint src/persistence/saveLoadService.js src/persistence/savePreparation.js tests/persistence/saveLoadService.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68531e96aa8c8331b282b071c5061f9f