### PR TITLE
[Agent] clarify state logging variable

### DIFF
--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -148,9 +148,9 @@ export class AbstractTurnState extends ITurnState {
     }
 
     try {
-      const h = handler || this._handler;
-      if (h && typeof h.getLogger === 'function') {
-        const logger = h.getLogger();
+      const resolvedHandler = handler || this._handler;
+      if (resolvedHandler && typeof resolvedHandler.getLogger === 'function') {
+        const logger = resolvedHandler.getLogger();
         if (logger) {
           return logger;
         }

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -225,8 +225,8 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   /* --------------------------------------------------------------------- */
   async exitState(handler, nextState) {
     await super.exitState(handler, nextState);
-    const l = this._resolveLogger(this._getTurnContext());
-    l.debug(
+    const logger = this._resolveLogger(this._getTurnContext());
+    logger.debug(
       `${this.getStateName()}: ExitState cleanup (if any) specific to AwaitingActorDecisionState complete.`
     );
   }

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -121,7 +121,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {ITurnAction} turnAction - Action to process.
    * @returns {Promise<void>} Resolves when processing completes.
    */
-  // _processAction logic moved to ProcessingWorkflow
+  // _executeActionWorkflow logic moved to ProcessingWorkflow
 
   async _processCommandInternal(turnCtx, actor, turnAction) {
     return processCommandInternal(this, turnCtx, actor, turnAction);

--- a/src/turns/states/workflows/processingWorkflow.js
+++ b/src/turns/states/workflows/processingWorkflow.js
@@ -62,7 +62,7 @@ export class ProcessingWorkflow {
     const decisionMeta = turnCtx.getDecisionMeta?.() ?? {};
     await this._state._dispatchSpeech(turnCtx, actor, decisionMeta);
 
-    await this._processAction(turnCtx, actor, turnAction);
+    await this._executeActionWorkflow(turnCtx, actor, turnAction);
   }
 
   /**
@@ -178,7 +178,7 @@ export class ProcessingWorkflow {
    * @param {import('../interfaces/IActorTurnStrategy.js').ITurnAction} turnAction - Action to process.
    * @returns {Promise<void>} Resolves when processing completes.
    */
-  async _processAction(turnCtx, actor, turnAction) {
+  async _executeActionWorkflow(turnCtx, actor, turnAction) {
     try {
       await this._state._processCommandInternal(turnCtx, actor, turnAction);
     } catch (error) {

--- a/tests/turns/states/processingCommandState.helpers.test.js
+++ b/tests/turns/states/processingCommandState.helpers.test.js
@@ -59,14 +59,14 @@ describe('ProcessingCommandState helpers', () => {
     expect(dispatcher.dispatch).toHaveBeenCalled();
   });
 
-  test('_processAction calls _processCommandInternal', async () => {
+  test('_executeActionWorkflow calls _processCommandInternal', async () => {
     const actor = { id: 'a1' };
     const ctx = makeCtx(actor);
     const action = { actionDefinitionId: 'act' };
     const spy = jest
       .spyOn(state, '_processCommandInternal')
       .mockResolvedValue(undefined);
-    await workflow._processAction(ctx, actor, action);
+    await workflow._executeActionWorkflow(ctx, actor, action);
     expect(spy).toHaveBeenCalledWith(ctx, actor, action);
   });
 });


### PR DESCRIPTION
Summary: Renamed short logger variables for clarity and renamed ProcessingWorkflow's action handler to `_executeActionWorkflow`.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685365e9e18c83319a028d03d6c95dd1