### PR TITLE
[Agent] Implement ProcessingGuard for ProcessingCommandState

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -32,7 +32,11 @@ export async function getServiceFromContext(
       `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceNameForLog}, actor ${actorIdForLog}.`
     );
     if (state._isProcessing) {
-      state._isProcessing = false;
+      if (state._processingGuard) {
+        state._processingGuard.finish();
+      } else {
+        state._isProcessing = false;
+      }
     }
     return null;
   }

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -30,7 +30,11 @@ export async function handleProcessingException(
   shouldEndTurn = true
 ) {
   const wasProcessing = state._isProcessing;
-  state._isProcessing = false;
+  if (state._processingGuard) {
+    state._processingGuard.finish();
+  } else {
+    state._isProcessing = false;
+  }
 
   let logger = console;
   let currentActorIdForLog = actorIdContext;

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -144,12 +144,20 @@ export async function processCommandInternal(
       logger.debug(
         `${state.getStateName()}: Directive strategy executed for ${actorId}, state remains ${state.getStateName()}. Processing complete for this state instance.`
       );
-      state._isProcessing = false;
+      if (state._processingGuard) {
+        state._processingGuard.finish();
+      } else {
+        state._isProcessing = false;
+      }
     } else if (state._isProcessing) {
       logger.debug(
         `${state.getStateName()}: Directive strategy executed for ${actorId}, but state changed from ${state.getStateName()} to ${state._handler._currentState?.getStateName() ?? 'Unknown'}. Processing considered complete for previous state instance.`
       );
-      state._isProcessing = false;
+      if (state._processingGuard) {
+        state._processingGuard.finish();
+      } else {
+        state._isProcessing = false;
+      }
     }
   } catch (error) {
     const errorHandlingCtx = state._getTurnContext() ?? turnCtx;
@@ -174,7 +182,11 @@ export async function processCommandInternal(
       finalLogger.warn(
         `${state.getStateName()}: _isProcessing was unexpectedly true at the end of _processCommandInternal for ${actorId}. Forcing to false.`
       );
-      state._isProcessing = false;
+      if (state._processingGuard) {
+        state._processingGuard.finish();
+      } else {
+        state._isProcessing = false;
+      }
     }
   }
 }

--- a/src/turns/states/helpers/processingGuard.js
+++ b/src/turns/states/helpers/processingGuard.js
@@ -1,0 +1,39 @@
+/**
+ * @file processingGuard.js
+ * @description Utility to manage the _isProcessing flag for ProcessingCommandState.
+ */
+
+/**
+ * @class ProcessingGuard
+ * @description Manages a boolean processing flag for a state instance.
+ */
+export class ProcessingGuard {
+  /**
+   * @param {{ _isProcessing: boolean }} owner - Object owning the flag.
+   */
+  constructor(owner) {
+    this._owner = owner;
+  }
+
+  /**
+   * @description Marks processing as started.
+   * @returns {void}
+   */
+  start() {
+    if (this._owner) {
+      this._owner._isProcessing = true;
+    }
+  }
+
+  /**
+   * @description Marks processing as finished.
+   * @returns {void}
+   */
+  finish() {
+    if (this._owner) {
+      this._owner._isProcessing = false;
+    }
+  }
+}
+
+export default ProcessingGuard;

--- a/src/turns/states/workflows/processingWorkflow.js
+++ b/src/turns/states/workflows/processingWorkflow.js
@@ -45,7 +45,7 @@ export class ProcessingWorkflow {
       );
       return;
     }
-    this._state._isProcessing = true;
+    this._state._processingGuard.start();
 
     await AbstractTurnState.prototype.enterState.call(
       this._state,

--- a/tests/turns/states/processingGuard.test.js
+++ b/tests/turns/states/processingGuard.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { ProcessingCommandState } from '../../../src/turns/states/processingCommandState.js';
+import { ProcessingGuard } from '../../../src/turns/states/helpers/processingGuard.js';
+import { handleProcessingException } from '../../../src/turns/states/helpers/handleProcessingException.js';
+
+/** Simple logger mock */
+const mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+/** Dummy handler used by ProcessingCommandState */
+const makeHandler = () => ({
+  getLogger: () => mockLogger,
+  resetStateAndResources: jest.fn(),
+  requestIdleStateTransition: jest.fn(),
+  _currentState: null,
+});
+
+/** Dummy turn context */
+const makeTurnCtx = () => ({
+  getLogger: () => mockLogger,
+  getActor: () => ({ id: 'actor1' }),
+  getSafeEventDispatcher: () => ({
+    dispatch: jest.fn().mockResolvedValue(undefined),
+  }),
+  endTurn: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('ProcessingGuard', () => {
+  test('start and finish toggle flag on owner', () => {
+    const owner = { _isProcessing: false };
+    const guard = new ProcessingGuard(owner);
+    guard.start();
+    expect(owner._isProcessing).toBe(true);
+    guard.finish();
+    expect(owner._isProcessing).toBe(false);
+  });
+
+  test('finish via handleProcessingException clears flag when processing interrupted', async () => {
+    const handler = makeHandler();
+    const ctx = makeTurnCtx();
+    const state = new ProcessingCommandState(handler, null, null);
+    state._isProcessing = true;
+    await handleProcessingException(state, ctx, new Error('boom'), 'actor1');
+    expect(state._isProcessing).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper ProcessingGuard to manage `_isProcessing`
- use ProcessingGuard in ProcessingCommandState and related helpers
- cover ProcessingGuard behavior with new tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685365fdbb1c8331bb152d31d593f3c8