### PR TITLE
[Agent] move resolution source builder

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -131,49 +131,6 @@ function resolvePlaceholderPath(
 }
 
 /**
- * Builds the data sources for placeholder resolution.
- *
- * @private
- * @description Creates the base, root context, and fallback sources used by
- * {@link PlaceholderResolver}.
- * @param {object} executionContext - Execution context supplying actor, target,
- *   and evaluationContext data.
- * @returns {{sources: object[], fallback: object}} Sources array and fallback
- *   object for {@link PlaceholderResolver#resolveStructure}.
- */
-function _buildResolutionSources(executionContext) {
-  const contextSource = {
-    context:
-      executionContext?.evaluationContext?.context &&
-      typeof executionContext.evaluationContext.context === 'object'
-        ? executionContext.evaluationContext.context
-        : {},
-  };
-
-  const fallback = {};
-  const actorName = resolveEntityNameFallback('actor.name', executionContext);
-  if (actorName !== undefined) {
-    fallback.actor = { name: actorName };
-  }
-  const targetName = resolveEntityNameFallback('target.name', executionContext);
-  if (targetName !== undefined) {
-    if (!fallback.target) fallback.target = {};
-    fallback.target.name = targetName;
-  }
-
-  const baseSource = { ...(executionContext ?? {}) };
-  delete baseSource.context;
-  const rootContextSource =
-    executionContext &&
-    Object.prototype.hasOwnProperty.call(executionContext, 'context')
-      ? { context: executionContext.context }
-      : {};
-  const sources = [rootContextSource, baseSource, contextSource];
-
-  return { sources, fallback };
-}
-
-/**
  * Resolves placeholders within a structure using a provided resolver.
  *
  * @private
@@ -245,7 +202,8 @@ export function resolvePlaceholders(
   skipKeys = []
 ) {
   const resolver = new PlaceholderResolver(logger);
-  const { sources, fallback } = _buildResolutionSources(executionContext);
+  const { sources, fallback } =
+    PlaceholderResolver.buildResolutionSources(executionContext);
 
   return _resolveStructure(input, resolver, sources, fallback, skipKeys);
 }

--- a/tests/utils/placeholderResolverUtils.test.js
+++ b/tests/utils/placeholderResolverUtils.test.js
@@ -10,6 +10,7 @@ import {
 } from '@jest/globals';
 import { PlaceholderResolver } from '../../src/utils/placeholderResolverUtils.js'; // Adjust path as needed
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed (assuming testUtils.js from previous adjustment)
+import { NAME_COMPONENT_ID } from '../../src/constants/componentIds.js';
 
 describe('PlaceholderResolver', () => {
   let mockLogger;
@@ -272,6 +273,23 @@ describe('PlaceholderResolver', () => {
       const result = resolver.resolveStructure(input, { value: 1 });
       expect(result).toBeUndefined();
       expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildResolutionSources', () => {
+    it('should build sources from execution context and resolve placeholders', () => {
+      const executionContext = {
+        evaluationContext: { context: { val: 'foo' } },
+        actor: { components: { [NAME_COMPONENT_ID]: { text: 'Hero' } } },
+      };
+      const { sources, fallback } =
+        PlaceholderResolver.buildResolutionSources(executionContext);
+      const result = resolver.resolveStructure(
+        '{context.val} {actor.name}',
+        sources,
+        fallback
+      );
+      expect(result).toBe('foo Hero');
     });
   });
 });


### PR DESCRIPTION
## Summary
- move resolution source building logic into `PlaceholderResolver`
- update `contextUtils` to use new helper
- cover the new behavior with a unit test

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536642b3508331b45baf945544fc99