### PR TITLE
[Agent] Consolidate environment context validation

### DIFF
--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -6,6 +6,7 @@ import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { initLogger } from '../utils/index.js';
 import { CLOUD_API_TYPES } from './constants/llmConstants.js';
+import { isValidEnvironmentContext } from './environmentContext.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -75,10 +76,7 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = llmConfig?.configId || 'UnknownLLM'; // For logging context
 
-    if (
-      !environmentContext ||
-      typeof environmentContext.isClient !== 'function'
-    ) {
+    if (!isValidEnvironmentContext(environmentContext)) {
       safeDispatchError(
         this.#dispatcher,
         `ClientApiKeyProvider.getKey (${llmId}): Invalid environmentContext provided.`,

--- a/src/llms/environmentContext.js
+++ b/src/llms/environmentContext.js
@@ -15,6 +15,21 @@ const VALID_EXECUTION_ENVIRONMENTS = ['client', 'server', 'unknown'];
 import { initLogger } from '../utils/index.js';
 
 /**
+ * @description Checks if the provided object conforms to the EnvironmentContext interface.
+ * @param {any} ctx - Object to validate.
+ * @returns {boolean} True if the object exposes the expected methods.
+ */
+export function isValidEnvironmentContext(ctx) {
+  return (
+    !!ctx &&
+    typeof ctx.isClient === 'function' &&
+    typeof ctx.isServer === 'function' &&
+    typeof ctx.getExecutionEnvironment === 'function' &&
+    typeof ctx.getProjectRootPath === 'function'
+  );
+}
+
+/**
  * @class EnvironmentContext
  * @description Encapsulates and validates information about the application's execution environment.
  * This class centralizes environment-specific settings, making them explicitly available and testable.

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -10,6 +10,7 @@ import {
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { initLogger } from '../utils/index.js';
+import { isValidEnvironmentContext } from './environmentContext.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -24,20 +25,6 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   #environmentVariableReader;
   /** @type {ISafeEventDispatcher} */
   #dispatcher;
-  /**
-   * @private
-   * Checks if the provided context object appears to be a valid EnvironmentContext.
-   * @param {any} ctx - The context object to validate.
-   * @returns {boolean} True if the object exposes the required methods.
-   */
-  #isValidEnvironmentContext(ctx) {
-    return (
-      !!ctx &&
-      typeof ctx.isServer === 'function' &&
-      typeof ctx.getProjectRootPath === 'function' &&
-      typeof ctx.getExecutionEnvironment === 'function'
-    );
-  }
 
   /**
    * @private
@@ -187,7 +174,7 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = llmConfig?.id || 'UnknownLLM';
 
-    if (!this.#isValidEnvironmentContext(environmentContext)) {
+    if (!isValidEnvironmentContext(environmentContext)) {
       safeDispatchError(
         this.#dispatcher,
         `ServerApiKeyProvider.getKey (${llmId}): Invalid environmentContext provided.`,

--- a/tests/llms/clientApiKeyProvider.test.js
+++ b/tests/llms/clientApiKeyProvider.test.js
@@ -3,7 +3,8 @@
 
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ClientApiKeyProvider } from '../../src/llms/clientApiKeyProvider.js';
-import { EnvironmentContext } from '../../src/llms/environmentContext.js';
+import * as EnvironmentModule from '../../src/llms/environmentContext.js';
+const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
 /**
@@ -118,6 +119,7 @@ describe('ClientApiKeyProvider', () => {
     });
 
     test('should return null and log error if environmentContext is invalid', async () => {
+      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
@@ -127,6 +129,8 @@ describe('ClientApiKeyProvider', () => {
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
+      expect(spy).toHaveBeenCalledWith(null);
+      spy.mockRestore();
     });
 
     test('should return null and log error if environmentContext.isClient is not a function', async () => {
@@ -134,6 +138,7 @@ describe('ClientApiKeyProvider', () => {
         // isClient: 'not-a-function' // or missing
         getExecutionEnvironment: jest.fn().mockReturnValue('client'),
       };
+      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
       const key = await provider.getKey(
         llmConfig,
         /** @type {any} */ (invalidEc)
@@ -146,6 +151,8 @@ describe('ClientApiKeyProvider', () => {
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
+      expect(spy).toHaveBeenCalledWith(invalidEc);
+      spy.mockRestore();
     });
 
     test('should return null and log error if llmConfig is null', async () => {

--- a/tests/llms/serverApiKeyProvider.test.js
+++ b/tests/llms/serverApiKeyProvider.test.js
@@ -3,7 +3,8 @@
 
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ServerApiKeyProvider } from '../../src/llms/serverApiKeyProvider.js';
-import { EnvironmentContext } from '../../src/llms/environmentContext.js';
+import * as EnvironmentModule from '../../src/llms/environmentContext.js';
+const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 // Import the actual interfaces to ensure mocks align if needed, though not strictly used for type in JS tests
 // import { IFileSystemReader, IEnvironmentVariableReader } from '../../src/llms/interfaces/IServerUtils.js';
@@ -190,6 +191,7 @@ describe('ServerApiKeyProvider', () => {
     });
 
     test('should return null and log if environmentContext is invalid', async () => {
+      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
@@ -199,6 +201,8 @@ describe('ServerApiKeyProvider', () => {
             'ServerApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
+      expect(spy).toHaveBeenCalledWith(null);
+      spy.mockRestore();
     });
 
     describe('Environment Variable Retrieval', () => {


### PR DESCRIPTION
Summary: Adds an exported `isValidEnvironmentContext` helper and refactors API key providers to use it. Tests now spy on this shared validation.

Changes Made:
- export `isValidEnvironmentContext` from `environmentContext`
- update server and client providers to import and use this helper
- adjust unit tests to spy on helper usage

Testing Done:
- [x] Code formatted (`npx prettier` on modified files)
- [x] Lint checked (`npx eslint` on modified files)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6853665b416483318ef8b0f38f74f206