### PR TITLE
[Agent] precompile manual save regex

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -16,6 +16,9 @@ import {
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 import BaseService from '../utils/serviceBase.js';
 
+// Precompile manual save file regex once for reuse
+const manualSaveRegex = MANUAL_SAVE_PATTERN;
+
 /**
  * @class SaveFileRepository
  * @description Handles file system interactions for manual save files.
@@ -126,7 +129,7 @@ export default class SaveFileRepository extends BaseService {
     try {
       const files = await this.#storageProvider.listFiles(
         FULL_MANUAL_SAVE_DIRECTORY_PATH,
-        MANUAL_SAVE_PATTERN.source
+        manualSaveRegex.source
       );
       this.#logger.debug(
         `Found ${files.length} potential manual save files in ${FULL_MANUAL_SAVE_DIRECTORY_PATH}.`

--- a/tests/persistence/listManualSaveFiles.test.js
+++ b/tests/persistence/listManualSaveFiles.test.js
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
+import { createMockLogger } from '../testUtils.js';
+import { FULL_MANUAL_SAVE_DIRECTORY_PATH } from '../../src/utils/savePathUtils.js';
+
+/**
+ *
+ */
+function makeDeps() {
+  const logger = createMockLogger();
+  const storageProvider = {
+    writeFileAtomically: jest.fn(),
+    listFiles: jest.fn(),
+    readFile: jest.fn(),
+    deleteFile: jest.fn(),
+    fileExists: jest.fn(),
+    ensureDirectoryExists: jest.fn(),
+  };
+  const serializer = {};
+  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  return { repo, logger, storageProvider };
+}
+
+describe('SaveFileRepository.listManualSaveFiles', () => {
+  let repo;
+  let storageProvider;
+
+  beforeEach(() => {
+    ({ repo, storageProvider } = makeDeps());
+  });
+
+  it('filters filenames using manual save pattern', async () => {
+    const allFiles = [
+      'manual_save_one.sav',
+      'manual_save_two.sav',
+      'notes.txt',
+      'manual_save_three.tmp',
+    ];
+    storageProvider.listFiles.mockImplementation(async (_dir, pattern) => {
+      const regex = new RegExp(pattern);
+      return allFiles.filter((f) => regex.test(f));
+    });
+
+    const result = await repo.listManualSaveFiles();
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(['manual_save_one.sav', 'manual_save_two.sav']);
+    expect(storageProvider.listFiles).toHaveBeenCalledWith(
+      FULL_MANUAL_SAVE_DIRECTORY_PATH,
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- reuse `manualSaveRegex` in `SaveFileRepository`
- verify list filtering via new unit test

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 562 errors, 2001 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685366b36ef8833196fb22437c1e4232