### PR TITLE
[Feat] Circular reference detection in prerequisites

### DIFF
--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -66,6 +66,23 @@ export class PrerequisiteEvaluationService {
   }
 
   /**
+   * Checks for circular condition references and throws an error if detected.
+   *
+   * @private
+   * @param {string} conditionId - The referenced condition ID.
+   * @param {Set<string>} visited - Set of already visited condition IDs.
+   * @param {string} actionId - The ID of the action being validated.
+   * @throws {Error} If a circular reference is detected.
+   */
+  _checkCircularReference(conditionId, visited, actionId) {
+    if (visited.has(conditionId)) {
+      throw new Error(
+        `Circular reference detected in prerequisites for action '${actionId}'. Path: ${[...visited, conditionId].join(' -> ')}`
+      );
+    }
+  }
+
+  /**
    * Recursively traverses a JSON Logic rule and replaces all `condition_ref`
    * objects with the actual logic from the referenced condition definition.
    *
@@ -95,11 +112,7 @@ export class PrerequisiteEvaluationService {
         throw new Error(`Invalid condition_ref value: not a string.`);
       }
 
-      if (visited.has(conditionId)) {
-        throw new Error(
-          `Circular reference detected in prerequisites for action '${actionId}'. Path: ${[...visited, conditionId].join(' -> ')}`
-        );
-      }
+      this._checkCircularReference(conditionId, visited, actionId);
       visited.add(conditionId);
 
       this.#logger.debug(

--- a/tests/services/prerequisiteEvaluationService.cycle.test.js
+++ b/tests/services/prerequisiteEvaluationService.cycle.test.js
@@ -1,0 +1,71 @@
+// src/tests/services/prerequisiteEvaluationService.cycle.test.js
+
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { PrerequisiteEvaluationService } from '../../src/actions/validation/prerequisiteEvaluationService.js';
+import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
+import { ActionValidationContextBuilder } from '../../src/actions/validation/actionValidationContextBuilder.js';
+
+jest.mock('../../src/logic/jsonLogicEvaluationService.js', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    evaluate: jest.fn(),
+    addOperation: jest.fn(),
+  })),
+}));
+
+jest.mock(
+  '../../src/actions/validation/actionValidationContextBuilder.js',
+  () => ({
+    __esModule: true,
+    ActionValidationContextBuilder: jest.fn().mockImplementation(() => ({
+      buildContext: jest.fn(),
+    })),
+  })
+);
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('PrerequisiteEvaluationService Circular Reference Detection', () => {
+  /** @type {PrerequisiteEvaluationService} */
+  let service;
+  /** @type {{getConditionDefinition: jest.Mock}} */
+  let mockGameDataRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGameDataRepository = {
+      getConditionDefinition: jest.fn(),
+    };
+
+    service = new PrerequisiteEvaluationService({
+      logger: mockLogger,
+      jsonLogicEvaluationService: new JsonLogicEvaluationService({
+        logger: mockLogger,
+      }),
+      actionValidationContextBuilder: new ActionValidationContextBuilder({
+        logger: mockLogger,
+      }),
+      gameDataRepository: mockGameDataRepository,
+    });
+  });
+
+  test('should throw error with reference path when circular condition_ref detected', () => {
+    mockGameDataRepository.getConditionDefinition.mockImplementation((id) => {
+      if (id === 'A') return { logic: { condition_ref: 'B' } };
+      if (id === 'B') return { logic: { condition_ref: 'C' } };
+      if (id === 'C') return { logic: { condition_ref: 'A' } };
+      return null;
+    });
+
+    expect(() =>
+      service._resolveConditionReferences({ condition_ref: 'A' }, 'testAction')
+    ).toThrow(
+      "Circular reference detected in prerequisites for action 'testAction'. Path: A -> B -> C -> A"
+    );
+  });
+});


### PR DESCRIPTION
Summary: Add circular reference detection for condition_ref resolution.

Changes Made:
- Introduced `_checkCircularReference` helper in `PrerequisiteEvaluationService`.
- Integrated helper into `_resolveConditionReferences` to detect cycles before visiting.
- Added unit test verifying error message includes reference path.

Testing Done:
- [x] Code formatted (`npx prettier src/actions/validation/prerequisiteEvaluationService.js tests/services/prerequisiteEvaluationService.cycle.test.js -w`)
- [x] Lint passes on changed files (`npx eslint src/actions/validation/prerequisiteEvaluationService.js tests/services/prerequisiteEvaluationService.cycle.test.js --fix`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68536c3dd74c8331aa46355ef1b32160