### PR TITLE
[Agent] rename targetContext parameter

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -19,7 +19,7 @@ import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
  * Formats a validated action and target into a user-facing command string.
  *
  * @param {ActionDefinition} actionDefinition - The validated action's definition. Must not be null/undefined.
- * @param {ActionTargetContext} validatedTargetContext - The validated target context. Must not be null/undefined.
+ * @param {ActionTargetContext} targetContext - The validated target context. Must not be null/undefined.
  * @param {EntityManager} entityManager - The entity manager for lookups. Must not be null/undefined.
  * @param {object} [options] - Optional parameters.
  * @param {boolean} [options.debug] - If true, logs additional debug information.
@@ -30,7 +30,7 @@ import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
  */
 export function formatActionCommand(
   actionDefinition,
-  validatedTargetContext,
+  targetContext,
   entityManager,
   options = {}
 ) {
@@ -51,11 +51,11 @@ export function formatActionCommand(
     );
     return null;
   }
-  if (!validatedTargetContext) {
+  if (!targetContext) {
     safeDispatchError(
       dispatcher,
-      'formatActionCommand: Invalid or missing validatedTargetContext.',
-      { validatedTargetContext }
+      'formatActionCommand: Invalid or missing targetContext.',
+      { targetContext }
     );
     return null;
   }
@@ -66,7 +66,7 @@ export function formatActionCommand(
       { entityManager }
     );
     throw new Error(
-      'formatActionCommand requires a valid EntityManager instance.'
+      'formatActionCommand: entityManager parameter must be a valid EntityManager instance.'
     );
   }
   if (typeof getEntityDisplayName !== 'function') {
@@ -75,12 +75,12 @@ export function formatActionCommand(
       'formatActionCommand: getEntityDisplayName utility function is not available.'
     );
     throw new Error(
-      'formatActionCommand requires the getEntityDisplayName utility function.'
+      'formatActionCommand: getEntityDisplayName parameter must be a function.'
     );
   }
 
   let command = actionDefinition.template;
-  const contextType = validatedTargetContext.type;
+  const contextType = targetContext.type;
 
   if (debug) {
     logger.debug(
@@ -92,7 +92,7 @@ export function formatActionCommand(
   try {
     switch (contextType) {
       case 'entity': {
-        const targetId = validatedTargetContext.entityId;
+        const targetId = targetContext.entityId;
         if (!targetId) {
           logger.warn(
             `formatActionCommand: Target context type is 'entity' but entityId is missing for action ${actionDefinition.id}. Template: "${command}"`
@@ -128,7 +128,7 @@ export function formatActionCommand(
       }
 
       case 'direction': {
-        const direction = validatedTargetContext.direction;
+        const direction = targetContext.direction;
         if (!direction) {
           logger.warn(
             `formatActionCommand: Target context type is 'direction' but direction string is missing for action ${actionDefinition.id}. Template: "${command}"`
@@ -158,7 +158,7 @@ export function formatActionCommand(
 
       default:
         logger.warn(
-          `formatActionCommand: Unknown validatedTargetContext type: ${contextType} for action ${actionDefinition.id}. Returning template unmodified.`
+          `formatActionCommand: Unknown targetContext type: ${contextType} for action ${actionDefinition.id}. Returning template unmodified.`
         );
         // Return template as-is for unknown types? Or null? Returning unmodified seems safer.
         break;

--- a/tests/actions/actionFormatter.test.js
+++ b/tests/actions/actionFormatter.test.js
@@ -98,7 +98,9 @@ describe('formatActionCommand', () => {
         {},
         { logger, safeEventDispatcher: dispatcher }
       )
-    ).toThrow('formatActionCommand requires a valid EntityManager instance.');
+    ).toThrow(
+      'formatActionCommand: entityManager parameter must be a valid EntityManager instance.'
+    );
   });
 
   it('warns on unknown target type', () => {
@@ -110,7 +112,7 @@ describe('formatActionCommand', () => {
     });
     expect(result).toBe('do it');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Unknown validatedTargetContext type')
+      expect.stringContaining('Unknown targetContext type')
     );
   });
 });


### PR DESCRIPTION
Summary:
- rename parameter in `formatActionCommand` to `targetContext`
- improve error messages that mention invalid params
- update calling tests to expect new error messages

Testing Done:
- `npm run lint` *(fails: 562 errors, 2019 warnings)*
- `npx eslint src/actions/actionFormatter.js tests/actions/actionFormatter.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test` in llm-proxy-server

------
https://chatgpt.com/codex/tasks/task_e_68536c2af8dc8331870d5015763750ca