### PR TITLE
[Agent] introduce turn state subinterfaces

### DIFF
--- a/src/turns/interfaces/ICommandHandlingState.js
+++ b/src/turns/interfaces/ICommandHandlingState.js
@@ -1,0 +1,52 @@
+// src/turns/interfaces/ICommandHandlingState.js
+/**
+ * @interface ICommandHandlingState
+ * @description Interface for states that participate in command
+ * processing. Implementations handle command submission as well as
+ * the directive and result flow from the command pipeline.
+ */
+export class ICommandHandlingState {
+  /**
+   * Handles a command string submitted by an actor.
+   *
+   * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
+   * @param {string} commandString
+   * @param {import('../../entities/entity.js').default} actorEntity
+   * @returns {Promise<void>}
+   */
+  async handleSubmittedCommand(handler, commandString, actorEntity) {
+    throw new Error(
+      'ICommandHandlingState.handleSubmittedCommand must be implemented.'
+    );
+  }
+
+  /**
+   * Handles the result from the command processor.
+   *
+   * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
+   * @param {import('../../entities/entity.js').default} actor
+   * @param {import('../../types/commandResult.js').CommandResult} cmdProcResult
+   * @param {string} commandString
+   * @returns {Promise<void>}
+   */
+  async processCommandResult(handler, actor, cmdProcResult, commandString) {
+    throw new Error(
+      'ICommandHandlingState.processCommandResult must be implemented.'
+    );
+  }
+
+  /**
+   * Handles a directive emitted from the command pipeline.
+   *
+   * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
+   * @param {import('../../entities/entity.js').default} actor
+   * @param {import('../constants/turnDirectives.js').default} directive
+   * @param {import('../../types/commandResult.js').CommandResult} [cmdProcResult]
+   * @returns {Promise<void>}
+   */
+  async handleDirective(handler, actor, directive, cmdProcResult) {
+    throw new Error(
+      'ICommandHandlingState.handleDirective must be implemented.'
+    );
+  }
+}

--- a/src/turns/interfaces/ITurnLifecycleState.js
+++ b/src/turns/interfaces/ITurnLifecycleState.js
@@ -1,0 +1,36 @@
+// src/turns/interfaces/ITurnLifecycleState.js
+/**
+ * @typedef {import("../../constants/eventIds.js").SystemEventPayloads} SystemEventPayloads
+ * @typedef {import("../../constants/eventIds.js").TURN_ENDED_ID} TURN_ENDED_ID_TYPE
+ */
+
+/**
+ * @interface ITurnLifecycleState
+ * @description Interface for states involved in starting or ending
+ * an actor's turn.
+ */
+export class ITurnLifecycleState {
+  /**
+   * Called when a new turn begins for the provided actor.
+   *
+   * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
+   * @param {import('../../entities/entity.js').default} actorEntity
+   * @returns {Promise<void>}
+   */
+  async startTurn(handler, actorEntity) {
+    throw new Error('ITurnLifecycleState.startTurn must be implemented.');
+  }
+
+  /**
+   * Handles a `core:turn_ended` event payload.
+   *
+   * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
+   * @param {SystemEventPayloads[TURN_ENDED_ID_TYPE]} payload
+   * @returns {Promise<void>}
+   */
+  async handleTurnEndedEvent(handler, payload) {
+    throw new Error(
+      'ITurnLifecycleState.handleTurnEndedEvent must be implemented.'
+    );
+  }
+}

--- a/src/turns/interfaces/ITurnState.js
+++ b/src/turns/interfaces/ITurnState.js
@@ -1,3 +1,5 @@
+import { ICommandHandlingState } from './ICommandHandlingState.js';
+import { ITurnLifecycleState } from './ITurnLifecycleState.js';
 // src/turns/states/ITurnState.js
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -12,6 +14,8 @@
 
 /**
  * @interface ITurnState
+ * @implements {ICommandHandlingState}
+ * @implements {ITurnLifecycleState}
  * @description
  * Contract for all concrete state classes that manage a specific phase
  * of an actor's turn lifecycle.  States trigger transitions through the

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -2,6 +2,8 @@
 // --- FILE START ---
 
 /**
+ * @typedef {import("../interfaces/ICommandHandlingState.js").ICommandHandlingState} ICommandHandlingState
+ * @typedef {import("../interfaces/ITurnLifecycleState.js").ITurnLifecycleState} ITurnLifecycleState_Interface
  * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState_Interface
@@ -15,6 +17,8 @@ import { UNKNOWN_ENTITY_ID } from '../../constants/unknownIds.js';
 /**
  * @class TurnIdleState
  * @augments AbstractTurnState_Base
+ * @implements {ICommandHandlingState}
+ * @implements {ITurnLifecycleState_Interface}
  */
 export class TurnIdleState extends AbstractTurnState {
   /** @override */


### PR DESCRIPTION
Summary:
- add ICommandHandlingState and ITurnLifecycleState contracts
- implement these in ITurnState and TurnIdleState
- add specific type hints

Testing Done:
- `npm run format`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536bf291008331b078c1ea2f11b58e