### PR TITLE
[Agent] improve error logging for service resolution

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -27,10 +27,20 @@ export async function getServiceFromContext(
   serviceNameForLog,
   actorIdForLog
 ) {
+  const logger = state._resolveLogger(turnCtx);
+  const dispatcher = state._getSafeEventDispatcher(turnCtx);
+
   if (!turnCtx || typeof turnCtx.getLogger !== 'function') {
-    console.error(
-      `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceNameForLog}, actor ${actorIdForLog}.`
-    );
+    const errorMsg = `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceNameForLog}, actor ${actorIdForLog}.`;
+    if (dispatcher) {
+      safeDispatchError(dispatcher, errorMsg, {
+        actorId: actorIdForLog,
+        service: serviceNameForLog,
+        method: methodName,
+      });
+    }
+    logger.error(errorMsg);
+
     if (state._isProcessing) {
       if (state._processingGuard) {
         state._processingGuard.finish();
@@ -40,8 +50,6 @@ export async function getServiceFromContext(
     }
     return null;
   }
-  const logger = turnCtx.getLogger();
-  const dispatcher = state._getSafeEventDispatcher(turnCtx);
   try {
     if (typeof turnCtx[methodName] !== 'function') {
       throw new Error(
@@ -57,6 +65,7 @@ export async function getServiceFromContext(
     return service;
   } catch (error) {
     const errorMsg = `${state.getStateName()}: Failed to retrieve ${serviceNameForLog} for actor ${actorIdForLog}. Error: ${error.message}`;
+    logger.error(errorMsg, error);
     if (dispatcher) {
       safeDispatchError(dispatcher, errorMsg, {
         actorId: actorIdForLog,
@@ -65,8 +74,6 @@ export async function getServiceFromContext(
         error: error.message,
         stack: error.stack,
       });
-    } else {
-      logger.error(errorMsg, error);
     }
     const serviceError = new Error(errorMsg);
     await handleProcessingException(

--- a/tests/turns/states/processingCommandState.coverage.test.js
+++ b/tests/turns/states/processingCommandState.coverage.test.js
@@ -9,7 +9,6 @@ import {
   afterEach,
 } from '@jest/globals';
 import { ProcessingCommandState } from '../../../src/turns/states/processingCommandState.js';
-import { TurnIdleState } from '../../../src/turns/states/turnIdleState.js';
 import {
   SYSTEM_ERROR_OCCURRED_ID,
   ENTITY_SPOKE_ID,
@@ -404,6 +403,39 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     );
     expect(result).toBeNull();
     expect(processingState['_isProcessing']).toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid turnCtx in _getServiceFromContext')
+    );
+    expect(mockHandler.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid turnCtx'),
+      })
+    );
+  });
+
+  test('should log error when turnCtx lacks getLogger', async () => {
+    processingState['_isProcessing'] = true;
+    const dummyCtx = {};
+
+    const result = await processingState['_getServiceFromContext'](
+      dummyCtx,
+      'getCommandProcessor',
+      'ICommandProcessor',
+      'actorMissingLogger'
+    );
+
+    expect(result).toBeNull();
+    expect(processingState['_isProcessing']).toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid turnCtx in _getServiceFromContext')
+    );
+    expect(mockHandler.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid turnCtx'),
+      })
+    );
   });
 
   test('should catch missing method on turnCtx and dispatch SYSTEM_ERROR_OCCURRED_ID, then return null', async () => {


### PR DESCRIPTION
Summary: ensure _getServiceFromContext logs errors via resolved logger and dispatches through event dispatcher when context is invalid

Testing Done:
- [x] Code formatted     `npx prettier --write src/turns/states/helpers/getServiceFromContext.js tests/turns/states/processingCommandState.coverage.test.js`
- [x] Lint passes        `npx eslint src/turns/states/helpers/getServiceFromContext.js tests/turns/states/processingCommandState.coverage.test.js`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68536bdd82488331b87645bf2a3aa48c