### PR TITLE
[Agent] Add tests for loader helpers

### DIFF
--- a/tests/loaders/contentLoadManager.test.js
+++ b/tests/loaders/contentLoadManager.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import ContentLoadManager from '../../src/loaders/ContentLoadManager.js';
+
+class MockLoader {
+  constructor(responses) {
+    this.responses = responses;
+    this.loadItemsForMod = jest.fn(async (modId) => {
+      const res = this.responses[modId];
+      if (res instanceof Error) {
+        throw res;
+      }
+      return res;
+    });
+  }
+}
+
+describe('ContentLoadManager.loadContent', () => {
+  /** @type {jest.Mocked<any>} */
+  let logger;
+  /** @type {jest.Mocked<any>} */
+  let dispatcher;
+
+  beforeEach(() => {
+    logger = { debug: jest.fn(), error: jest.fn() };
+    dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('aggregates loader results across mods and dispatches on errors', async () => {
+    const loader = new MockLoader({
+      modA: { count: 1, overrides: 0, errors: 0 },
+      modB: new Error('boom'),
+    });
+    const manager = new ContentLoadManager({
+      logger,
+      validatedEventDispatcher: dispatcher,
+      contentLoadersConfig: [
+        {
+          loader,
+          contentKey: 'items',
+          contentTypeDir: 'items',
+          typeName: 'items',
+        },
+      ],
+    });
+
+    const manifests = new Map([
+      ['moda', { content: { items: ['a.json'] } }],
+      ['modb', { content: { items: ['b.json'] } }],
+    ]);
+    const totals = {};
+
+    const results = await manager.loadContent(
+      ['modA', 'modB'],
+      manifests,
+      totals
+    );
+
+    expect(results).toEqual({ modA: 'success', modB: 'failed' });
+    expect(totals).toEqual({ items: { count: 1, overrides: 0, errors: 1 } });
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      'initialization:world_loader:content_load_failed',
+      expect.objectContaining({ modId: 'modB', typeName: 'items' }),
+      expect.any(Object)
+    );
+  });
+});

--- a/tests/loaders/loadResultAggregator.test.js
+++ b/tests/loaders/loadResultAggregator.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import LoadResultAggregator from '../../src/loaders/LoadResultAggregator.js';
+
+describe('LoadResultAggregator', () => {
+  /** @type {import('../../src/loaders/LoadResultAggregator.js').TotalResultsSummary} */
+  let totals;
+  /** @type {LoadResultAggregator} */
+  let agg;
+
+  beforeEach(() => {
+    totals = {};
+    agg = new LoadResultAggregator(totals);
+  });
+
+  it('aggregates multiple results and updates totals', () => {
+    agg.aggregate({ count: 2, overrides: 1, errors: 0 }, 'actions');
+    agg.aggregate({ count: 1, overrides: 0, errors: 1 }, 'events');
+
+    expect(agg.modResults).toEqual({
+      actions: { count: 2, overrides: 1, errors: 0 },
+      events: { count: 1, overrides: 0, errors: 1 },
+    });
+    expect(totals).toEqual({
+      actions: { count: 2, overrides: 1, errors: 0 },
+      events: { count: 1, overrides: 0, errors: 1 },
+    });
+  });
+
+  it('recordFailure increments error counts in both summaries', () => {
+    agg.aggregate({ count: 1, overrides: 0, errors: 0 }, 'rules');
+    agg.recordFailure('rules');
+    agg.recordFailure('missing');
+
+    expect(agg.modResults.rules.errors).toBe(1);
+    expect(agg.modResults.missing.errors).toBe(1);
+    expect(totals.rules.errors).toBe(1);
+    expect(totals.missing.errors).toBe(1);
+  });
+});

--- a/tests/loaders/modManifestProcessor.test.js
+++ b/tests/loaders/modManifestProcessor.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import ModManifestProcessor from '../../src/loaders/ModManifestProcessor.js';
+import ModDependencyError from '../../src/errors/modDependencyError.js';
+
+class DummyManifestLoader {
+  constructor(map) {
+    this.map = map;
+    this.loadRequestedManifests = jest.fn(async () => this.map);
+  }
+}
+
+describe('ModManifestProcessor.processManifests', () => {
+  /** @type {DummyManifestLoader} */
+  let manifestLoader;
+  /** @type {jest.Mocked<any>} */
+  let logger;
+  /** @type {jest.Mocked<any>} */
+  let registry;
+  /** @type {jest.Mocked<any>} */
+  let dispatcher;
+  /** @type {jest.Mocked<any>} */
+  let modDependencyValidator;
+  /** @type {jest.Mock} */
+  let modVersionValidator;
+  /** @type {jest.Mocked<any>} */
+  let modLoadOrderResolver;
+  /** @type {ModManifestProcessor} */
+  let processor;
+  /** @type {Map<string, any>} */
+  let manifestMap;
+
+  beforeEach(() => {
+    manifestMap = new Map([
+      ['modA', { id: 'modA', version: '1.0.0' }],
+      ['modB', { id: 'modB', version: '1.0.0' }],
+    ]);
+    manifestLoader = new DummyManifestLoader(manifestMap);
+    logger = { debug: jest.fn(), warn: jest.fn() };
+    registry = { store: jest.fn() };
+    dispatcher = { dispatch: jest.fn() };
+    modDependencyValidator = { validate: jest.fn() };
+    modVersionValidator = jest.fn();
+    modLoadOrderResolver = { resolveOrder: jest.fn(() => ['modA', 'modB']) };
+    processor = new ModManifestProcessor({
+      modManifestLoader: manifestLoader,
+      logger,
+      registry,
+      validatedEventDispatcher: dispatcher,
+      modDependencyValidator,
+      modVersionValidator,
+      modLoadOrderResolver,
+    });
+  });
+
+  it('processes manifests successfully', async () => {
+    const result = await processor.processManifests(['modA', 'modB']);
+
+    expect(manifestLoader.loadRequestedManifests).toHaveBeenCalledWith([
+      'modA',
+      'modB',
+    ]);
+    expect(modDependencyValidator.validate).toHaveBeenCalledWith(
+      expect.any(Map),
+      logger
+    );
+    expect(modVersionValidator).toHaveBeenCalledWith(
+      expect.any(Map),
+      logger,
+      dispatcher
+    );
+    expect(modLoadOrderResolver.resolveOrder).toHaveBeenCalledWith(
+      ['modA', 'modB'],
+      expect.any(Map),
+      logger
+    );
+    expect(registry.store).toHaveBeenCalledWith(
+      'mod_manifests',
+      'moda',
+      manifestMap.get('modA')
+    );
+    expect(registry.store).toHaveBeenCalledWith(
+      'mod_manifests',
+      'modb',
+      manifestMap.get('modB')
+    );
+    expect(registry.store).toHaveBeenCalledWith('meta', 'final_mod_order', [
+      'modA',
+      'modB',
+    ]);
+    expect(result.finalOrder).toEqual(['modA', 'modB']);
+    expect(result.loadedManifestsMap.size).toBe(2);
+    expect(result.incompatibilityCount).toBe(0);
+  });
+
+  it('throws and logs when version validation fails', async () => {
+    const error = new ModDependencyError(
+      'modA incompatible\nmodB incompatible'
+    );
+    modVersionValidator.mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(processor.processManifests(['modA', 'modB'])).rejects.toBe(
+      error
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Encountered 1 engine version incompatibilities'),
+      error
+    );
+    expect(modLoadOrderResolver.resolveOrder).not.toHaveBeenCalled();
+    expect(registry.store).not.toHaveBeenCalledWith(
+      'meta',
+      'final_mod_order',
+      expect.anything()
+    );
+  });
+});

--- a/tests/loaders/worldLoader.integration.test.js
+++ b/tests/loaders/worldLoader.integration.test.js
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 // --- SUT ---
 import WorldLoader from '../../src/loaders/worldLoader.js';
+import ModManifestProcessor from '../../src/loaders/ModManifestProcessor.js';
+import ContentLoadManager from '../../src/loaders/ContentLoadManager.js';
 
 // --- Dependencies to Mock ---
 // mocks will be injected via constructor rather than jest.mock
@@ -62,6 +64,10 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
   let mockModManifestLoader;
   /** @type {jest.Mocked<ValidatedEventDispatcher>} */
   let mockValidatedEventDispatcher;
+  /** @type {jest.SpyInstance} */
+  let processManifestsSpy;
+  /** @type {jest.SpyInstance} */
+  let loadContentSpy;
 
   // --- Mock Data ---
   /** @type {ModManifest} */
@@ -306,6 +312,17 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       modLoadOrderResolver: mockModLoadOrderResolver,
       contentLoadersConfig: null,
     });
+
+    processManifestsSpy = jest.spyOn(
+      ModManifestProcessor.prototype,
+      'processManifests'
+    );
+    loadContentSpy = jest.spyOn(ContentLoadManager.prototype, 'loadContent');
+  });
+
+  afterEach(() => {
+    processManifestsSpy.mockRestore();
+    loadContentSpy.mockRestore();
   });
 
   // ── Test Case: Basic Successful Load ───────────────────────────────────
@@ -385,6 +402,10 @@ describe('WorldLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
       expectedValidationMap,
       mockLogger
     );
+
+    // Ensure helper classes were called
+    expect(processManifestsSpy).toHaveBeenCalledTimes(1);
+    expect(loadContentSpy).toHaveBeenCalledTimes(1);
 
     // 10. Verify registry.store was called for final mod order.
     expect(mockRegistry.store).toHaveBeenCalledWith('meta', 'final_mod_order', [


### PR DESCRIPTION
Summary: Add unit tests for ModManifestProcessor, ContentLoadManager, and LoadResultAggregator. Updated worldLoader integration test to verify new helper calls.

Testing Done:
- [x] Code formatted `npx prettier -w tests/loaders/modManifestProcessor.test.js tests/loaders/contentLoadManager.test.js tests/loaders/loadResultAggregator.test.js tests/loaders/worldLoader.integration.test.js`
- [x] Lint executed `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68536bbf3ff0833196b7038833b1128e