### PR TITLE
[Agent] inline manual save helpers

### DIFF
--- a/src/persistence/manualSaveCoordinator.js
+++ b/src/persistence/manualSaveCoordinator.js
@@ -19,6 +19,8 @@ export default class ManualSaveCoordinator extends BaseService {
   #saveLoadService;
 
   /**
+   * Creates a new ManualSaveCoordinator.
+   *
    * @param {object} deps - Constructor dependencies.
    * @param {ILogger} deps.logger - Logging service.
    * @param {GameStateCaptureService} deps.gameStateCaptureService - Service capturing current game state.
@@ -38,43 +40,7 @@ export default class ManualSaveCoordinator extends BaseService {
     });
     this.#gameStateCaptureService = gameStateCaptureService;
     this.#saveLoadService = saveLoadService;
-  }
-
-  /**
-   * Captures the current game state via GameStateCaptureService.
-   *
-   * @param {string | null | undefined} activeWorldName - Active world name.
-   * @returns {import('../interfaces/ISaveLoadService.js').SaveGameStructure} Game state object.
-   * @private
-   */
-  _captureGameState(activeWorldName) {
-    return this.#gameStateCaptureService.captureCurrentGameState(
-      activeWorldName
-    );
-  }
-
-  /**
-   * Ensures metadata is present and sets the save name.
-   *
-   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} state - Game state object.
-   * @param {string} saveName - Desired save name.
-   * @private
-   */
-  _setSaveMetadata(state, saveName) {
-    if (!state.metadata) state.metadata = {};
-    state.metadata.saveName = saveName;
-  }
-
-  /**
-   * Delegates saving to ISaveLoadService.
-   *
-   * @param {string} saveName - Save slot name.
-   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} state - Prepared game state.
-   * @returns {ReturnType<ISaveLoadService['saveManualGame']>}
-   * @private
-   */
-  _delegateManualSave(saveName, state) {
-    return this.#saveLoadService.saveManualGame(saveName, state);
+    this.#logger.debug('ManualSaveCoordinator: Instance created.');
   }
 
   /**
@@ -85,8 +51,11 @@ export default class ManualSaveCoordinator extends BaseService {
    * @returns {ReturnType<ISaveLoadService['saveManualGame']>} Result from save service.
    */
   async saveGame(saveName, activeWorldName) {
-    const state = this._captureGameState(activeWorldName);
-    this._setSaveMetadata(state, saveName);
-    return this._delegateManualSave(saveName, state);
+    this.#logger.debug(`ManualSaveCoordinator.saveGame: Saving "${saveName}".`);
+    const state =
+      this.#gameStateCaptureService.captureCurrentGameState(activeWorldName);
+    if (!state.metadata) state.metadata = {};
+    state.metadata.saveName = saveName;
+    return this.#saveLoadService.saveManualGame(saveName, state);
   }
 }

--- a/tests/services/manualSaveCoordinator.test.js
+++ b/tests/services/manualSaveCoordinator.test.js
@@ -23,17 +23,19 @@ describe('ManualSaveCoordinator', () => {
     });
   });
 
-  it('_setSaveMetadata ensures metadata and sets name', () => {
-    const state = {};
-    coordinator._setSaveMetadata(state, 'Slot');
-    expect(state.metadata.saveName).toBe('Slot');
-  });
-
-  it('saveGame captures state and delegates to saveLoadService', async () => {
+  it('saveGame adds metadata and delegates to saveLoadService', async () => {
+    captureService.captureCurrentGameState.mockReturnValueOnce({});
     await coordinator.saveGame('Slot', 'World');
     expect(captureService.captureCurrentGameState).toHaveBeenCalledWith(
       'World'
     );
+    expect(saveLoadService.saveManualGame).toHaveBeenCalledWith('Slot', {
+      metadata: { saveName: 'Slot' },
+    });
+  });
+
+  it('saveGame preserves existing state fields', async () => {
+    await coordinator.saveGame('Slot', 'World');
     expect(saveLoadService.saveManualGame).toHaveBeenCalledWith('Slot', {
       metadata: { saveName: 'Slot' },
       gameState: {},


### PR DESCRIPTION
## Summary
- inline private helper methods in manual save coordinator
- rewrite tests to exercise saveGame directly

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536dcc07a08331a5b6469937f0675c