### PR TITLE
[Fix] Simplify game state capture dependency handling

### DIFF
--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -158,13 +158,6 @@ class GameStateCaptureService extends BaseService {
       'GameStateCaptureService: Capturing current game state...'
     );
 
-    if (!this.#entityManager)
-      throw new Error('EntityManager not available for capturing game state.');
-    if (!this.#playtimeTracker)
-      throw new Error(
-        'PlaytimeTracker not available for capturing game state.'
-      );
-
     const entitiesData = [];
     for (const entity of this.#entityManager.activeEntities.values()) {
       entitiesData.push(this.#serializeEntity(entity));


### PR DESCRIPTION
Summary: Removed runtime dependency checks in `GameStateCaptureService.captureCurrentGameState` so the method now assumes validated services. This streamlines capture logic.

Changes Made:
- Deleted error throws for missing `entityManager` and `playtimeTracker`.
- Updated capture logic to run directly without dependency checks.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68536db52db483319043db9625924914