### PR TITLE
[Agent] convert gameStateRestorer helpers to private methods

### DIFF
--- a/src/persistence/gameStateRestorer.js
+++ b/src/persistence/gameStateRestorer.js
@@ -62,7 +62,7 @@ class GameStateRestorer {
    * @returns {void}
    * @private
    */
-  _restoreEntity(savedEntityData) {
+  #restoreEntity(savedEntityData) {
     try {
       const restoredEntity =
         this.#entityManager.reconstructEntity(savedEntityData);
@@ -86,7 +86,7 @@ class GameStateRestorer {
    * @returns {{success: false, error: PersistenceError} | null} Failure object or null if validation passes.
    * @private
    */
-  _validateRestoreInput(data) {
+  #validateRestoreInput(data) {
     if (!data?.gameState) {
       const errorMsg =
         'Invalid save data structure provided (missing gameState).';
@@ -117,7 +117,7 @@ class GameStateRestorer {
    * @returns {{success: false, error: PersistenceError} | null} Failure object or null on success.
    * @private
    */
-  _clearEntities() {
+  #clearEntities() {
     try {
       this.#entityManager.clearAll();
       this.#logger.debug(
@@ -144,7 +144,7 @@ class GameStateRestorer {
    * @returns {void}
    * @private
    */
-  _restoreEntities(entitiesArray) {
+  #restoreEntities(entitiesArray) {
     const entitiesToRestore = entitiesArray;
     if (!Array.isArray(entitiesToRestore)) {
       this.#logger.warn(
@@ -159,7 +159,7 @@ class GameStateRestorer {
         );
         continue;
       }
-      this._restoreEntity(savedEntityData);
+      this.#restoreEntity(savedEntityData);
     }
     this.#logger.debug(
       'GameStateRestorer.restoreGameState: Entity restoration complete.'
@@ -174,7 +174,7 @@ class GameStateRestorer {
    * @returns {void}
    * @private
    */
-  _restorePlaytime(playtimeSeconds) {
+  #restorePlaytime(playtimeSeconds) {
     if (typeof playtimeSeconds === 'number') {
       try {
         this.#playtimeTracker.setAccumulatedPlaytime(playtimeSeconds);
@@ -203,7 +203,7 @@ class GameStateRestorer {
    * @returns {{success: true}}
    * @private
    */
-  _finalizeRestore() {
+  #finalizeRestore() {
     this.#logger.debug(
       'GameStateRestorer.restoreGameState: Skipping turn count restoration as TurnManager is restarted on load.'
     );
@@ -227,25 +227,25 @@ class GameStateRestorer {
       'GameStateRestorer.restoreGameState: Starting game state restoration...'
     );
 
-    let stepResult = this._validateRestoreInput(deserializedSaveData);
+    let stepResult = this.#validateRestoreInput(deserializedSaveData);
     if (!stepResult.success) return stepResult;
 
-    stepResult = this._clearEntities();
+    stepResult = this.#clearEntities();
     if (!stepResult.success) return stepResult;
 
     this.#logger.debug(
       'GameStateRestorer.restoreGameState: Restoring entities...'
     );
 
-    stepResult = this._restoreEntities(deserializedSaveData.gameState.entities);
+    stepResult = this.#restoreEntities(deserializedSaveData.gameState.entities);
     if (!stepResult.success) return stepResult;
 
-    stepResult = this._restorePlaytime(
+    stepResult = this.#restorePlaytime(
       deserializedSaveData.metadata?.playtimeSeconds
     );
     if (!stepResult.success) return stepResult;
 
-    stepResult = this._finalizeRestore();
+    stepResult = this.#finalizeRestore();
     if (!stepResult.success) return stepResult;
 
     return { success: true };

--- a/tests/services/gamePersistenceService.privateHelpers.test.js
+++ b/tests/services/gamePersistenceService.privateHelpers.test.js
@@ -57,42 +57,52 @@ describe('GamePersistenceService private helpers', () => {
     context = makeService();
   });
 
-  it('_validateRestoreInput fails when gameState missing', () => {
-    const res = context.restorer._validateRestoreInput({});
+  it('restoreGameState fails validation when gameState missing', async () => {
+    const res = await context.restorer.restoreGameState({});
     expect(res.success).toBe(false);
   });
 
-  it('_validateRestoreInput passes with required fields', () => {
-    const res = context.restorer._validateRestoreInput({ gameState: {} });
+  it('restoreGameState passes with required fields', async () => {
+    const res = await context.restorer.restoreGameState({
+      gameState: { entities: [] },
+    });
     expect(res.success).toBe(true);
   });
 
-  it('_clearEntities returns failure on exception', () => {
+  it('restoreGameState returns failure when entity clearing throws', async () => {
     context.entityManager.clearAll.mockImplementation(() => {
       throw new Error('x');
     });
-    const res = context.restorer._clearEntities();
+    const res = await context.restorer.restoreGameState({
+      gameState: { entities: [] },
+    });
     expect(res.success).toBe(false);
   });
 
-  it('_restoreEntities skips invalid data and restores valid', () => {
+  it('restoreGameState skips invalid entity data and restores valid entities', async () => {
     const valid = { instanceId: 'e1', definitionId: 'd1', components: {} };
-    const res = context.restorer._restoreEntities([valid, {}]);
+    const res = await context.restorer.restoreGameState({
+      gameState: { entities: [valid, {}] },
+    });
     expect(context.entityManager.reconstructEntity).toHaveBeenCalledWith(valid);
     expect(context.entityManager.reconstructEntity).toHaveBeenCalledTimes(1);
     expect(res.success).toBe(true);
   });
 
-  it('_restorePlaytime handles missing value', () => {
-    const res = context.restorer._restorePlaytime();
+  it('restoreGameState handles missing playtime metadata', async () => {
+    const res = await context.restorer.restoreGameState({
+      gameState: { entities: [] },
+    });
     expect(context.playtimeTracker.setAccumulatedPlaytime).toHaveBeenCalledWith(
       0
     );
     expect(res.success).toBe(true);
   });
 
-  it('_finalizeRestore logs completion', () => {
-    const res = context.restorer._finalizeRestore();
+  it('restoreGameState logs completion', async () => {
+    const res = await context.restorer.restoreGameState({
+      gameState: { entities: [] },
+    });
     expect(context.logger.debug).toHaveBeenCalled();
     expect(res.success).toBe(true);
   });


### PR DESCRIPTION
Summary: Renamed helper functions inside `GameStateRestorer` to use ECMAScript private method syntax and updated internal calls. Adjusted unit tests to use the public `restoreGameState` API for verification.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 562 errors, 2019 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536dc67f008331ac778c920ce69bf2