### PR TITLE
[Feat] Add helper for nested execution contexts

### DIFF
--- a/src/logic/contextAssembler.js
+++ b/src/logic/contextAssembler.js
@@ -161,3 +161,38 @@ export function createJsonLogicContext(
 
   return evaluationContext;
 }
+
+/**
+ * @description Assemble the nested execution context used by SystemLogicInterpreter.
+ * Internally delegates to {@link createJsonLogicContext} for the evaluation context.
+ * @param {GameEvent} event - Event triggering rule evaluation.
+ * @param {EntityId} actorId - Optional actor entity ID.
+ * @param {EntityId} targetId - Optional target entity ID.
+ * @param {EntityManager} entityManager - Entity manager for lookups.
+ * @param {ILogger} logger - Logger instance.
+ * @returns {{event: GameEvent, actor: JsonLogicEntityContext|null, target: JsonLogicEntityContext|null, logger: ILogger, evaluationContext: JsonLogicEvaluationContext}}
+ *   The nested execution context structure.
+ */
+export function createNestedExecutionContext(
+  event,
+  actorId,
+  targetId,
+  entityManager,
+  logger
+) {
+  const ctx = createJsonLogicContext(
+    event,
+    actorId,
+    targetId,
+    entityManager,
+    logger
+  );
+
+  return {
+    event,
+    actor: ctx.actor,
+    target: ctx.target,
+    logger,
+    evaluationContext: ctx,
+  };
+}

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -4,7 +4,7 @@
 //  v2.7 — restores full-fidelity debug/error messages required by legacy tests
 // -----------------------------------------------------------------------------
 
-import { createJsonLogicContext } from './contextAssembler.js';
+import { createNestedExecutionContext } from './contextAssembler.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
@@ -171,10 +171,10 @@ class SystemLogicInterpreter extends BaseService {
       const targetId = event.payload?.targetId ?? null;
 
       this.#logger.debug(
-        `[Event: ${event.type}] Assembling JsonLogic context via createJsonLogicContext... (ActorID: ${actorId}, TargetID: ${targetId})`
+        `[Event: ${event.type}] Assembling execution context via createNestedExecutionContext... (ActorID: ${actorId}, TargetID: ${targetId})`
       );
 
-      const evalCtx = createJsonLogicContext(
+      nestedCtx = createNestedExecutionContext(
         event,
         actorId,
         targetId,
@@ -183,16 +183,8 @@ class SystemLogicInterpreter extends BaseService {
       );
 
       this.#logger.debug(
-        `[Event: ${event.type}] createJsonLogicContext returned a valid JsonLogicEvaluationContext.`
+        `[Event: ${event.type}] createNestedExecutionContext returned a valid ExecutionContext.`
       );
-
-      nestedCtx = {
-        event,
-        actor: evalCtx.actor,
-        target: evalCtx.target,
-        logger: this.#logger,
-        evaluationContext: evalCtx,
-      };
 
       this.#logger.debug(
         `[Event: ${event.type}] Final ExecutionContext (nested structure) assembled successfully.`

--- a/tests/logic/contextAssembler.nested.test.js
+++ b/tests/logic/contextAssembler.nested.test.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import {
+  createNestedExecutionContext,
+  createJsonLogicContext,
+} from '../../src/logic/contextAssembler.js';
+
+/** @typedef {import('../../src/interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../src/entities/entityManager.js').default} EntityManager */
+
+/** @type {jest.Mocked<ILogger>} */
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+/** @type {jest.Mocked<EntityManager>} */
+const mockEntityManager = {
+  getEntityInstance: jest.fn(),
+  getComponentData: jest.fn(),
+  hasComponent: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createNestedExecutionContext', () => {
+  test('returns structure matching createJsonLogicContext output', () => {
+    const event = { type: 'TEST', payload: { a: 1 } };
+    const actorId = 'actor1';
+    const targetId = 'target1';
+    mockEntityManager.getEntityInstance.mockImplementation((id) => ({ id }));
+
+    const expectedEval = createJsonLogicContext(
+      event,
+      actorId,
+      targetId,
+      mockEntityManager,
+      mockLogger
+    );
+
+    const nested = createNestedExecutionContext(
+      event,
+      actorId,
+      targetId,
+      mockEntityManager,
+      mockLogger
+    );
+
+    expect(nested).toEqual({
+      event,
+      actor: expectedEval.actor,
+      target: expectedEval.target,
+      logger: mockLogger,
+      evaluationContext: expectedEval,
+    });
+  });
+
+  test('actor and target reference evaluationContext properties', () => {
+    const event = { type: 'TEST2' };
+    const nested = createNestedExecutionContext(
+      event,
+      null,
+      null,
+      mockEntityManager,
+      mockLogger
+    );
+
+    expect(nested.actor).toBe(nested.evaluationContext.actor);
+    expect(nested.target).toBe(nested.evaluationContext.target);
+  });
+});

--- a/tests/logic/systemLogicInterpreter.integration.test.js
+++ b/tests/logic/systemLogicInterpreter.integration.test.js
@@ -239,12 +239,12 @@ describe('SystemLogicInterpreter Integration Tests', () => {
     // These logs should now be present and match
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        `[Event: ${eventType}] Assembling JsonLogic context via createJsonLogicContext... (ActorID: ${eventPayload.actorId}, TargetID: ${eventPayload.targetId})`
+        `[Event: ${eventType}] Assembling execution context via createNestedExecutionContext... (ActorID: ${eventPayload.actorId}, TargetID: ${eventPayload.targetId})`
       )
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        `[Event: ${eventType}] createJsonLogicContext returned a valid JsonLogicEvaluationContext.`
+        `[Event: ${eventType}] createNestedExecutionContext returned a valid ExecutionContext.`
       )
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -302,7 +302,7 @@ describe('SystemLogicInterpreter Integration Tests', () => {
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        `[Event: ${eventType}] Assembling JsonLogic context via createJsonLogicContext...`
+        `[Event: ${eventType}] Assembling execution context via createNestedExecutionContext...`
       )
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -375,7 +375,7 @@ describe('SystemLogicInterpreter Integration Tests', () => {
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining(
-        `[Event: ${eventType}] Assembling JsonLogic context via createJsonLogicContext...`
+        `[Event: ${eventType}] Assembling execution context via createNestedExecutionContext...`
       )
     );
     expect(mockLogger.debug).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary: Introduces a reusable helper to assemble nested execution contexts and updates SystemLogicInterpreter to use it.

Changes Made:
- Added `createNestedExecutionContext` in `contextAssembler`.
- Refactored `SystemLogicInterpreter.#handleEvent` to use the new helper.
- Updated integration tests for new log messages.
- Created unit tests for `createNestedExecutionContext`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint ...`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68536e51b8ec8331b4b058facce97ffa