### PR TITLE
[Agent] add skipKeys to placeholder resolver

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -141,40 +141,6 @@ function resolvePlaceholderPath(
  * @param {Iterable<string>} [skipKeys] - Keys to skip when processing objects.
  * @returns {*} Resolved value or the original input when unchanged.
  */
-function _resolveStructure(value, resolver, sources, fallback, skipKeys = []) {
-  if (
-    value &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    !(value instanceof Date)
-  ) {
-    let changed = false;
-    const resolvedObj = {};
-    for (const key in value) {
-      if (Object.prototype.hasOwnProperty.call(value, key)) {
-        if (
-          (skipKeys instanceof Set && skipKeys.has(key)) ||
-          (Array.isArray(skipKeys) && skipKeys.includes(key))
-        ) {
-          resolvedObj[key] = value[key];
-        } else {
-          const resolvedVal = resolver.resolveStructure(
-            value[key],
-            sources,
-            fallback
-          );
-          if (resolvedVal !== value[key]) {
-            changed = true;
-          }
-          resolvedObj[key] = resolvedVal;
-        }
-      }
-    }
-    return changed ? resolvedObj : value;
-  }
-
-  return resolver.resolveStructure(value, sources, fallback);
-}
 
 /**
  * Recursively resolves placeholder strings (e.g., "{actor.id}", "{context.variableName}") within an input structure
@@ -205,5 +171,5 @@ export function resolvePlaceholders(
   const { sources, fallback } =
     PlaceholderResolver.buildResolutionSources(executionContext);
 
-  return _resolveStructure(input, resolver, sources, fallback, skipKeys);
+  return resolver.resolveStructure(input, sources, fallback, skipKeys);
 }

--- a/tests/logic/contextUtils.test.js
+++ b/tests/logic/contextUtils.test.js
@@ -486,6 +486,29 @@ describe('resolvePlaceholders (contextUtils.js)', () => {
         skip: '{context.other}',
       });
     });
+
+    test('7.2 should not skip nested object keys', () => {
+      const context = createMockExecutionContext({ other: 'unused' });
+      const input = {
+        outer: {
+          skip: '{context.other}',
+        },
+        key1: '{context.varA}',
+      };
+      const result = resolvePlaceholders(
+        input,
+        context,
+        mockLogger,
+        '',
+        new Set(['skip'])
+      );
+      expect(result).toEqual({
+        outer: {
+          skip: 'unused',
+        },
+        key1: 'valueA',
+      });
+    });
   });
 
   describe('resolveEntityNameFallback helper', () => {


### PR DESCRIPTION
Summary: 
- add optional `skipKeys` parameter to `PlaceholderResolver.resolveStructure`
- remove helper recursion from `contextUtils.resolvePlaceholders`
- ensure skipKeys works and add nested key test

Testing Done:
- [x] Code formatted `npx prettier`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536e452e3c8331b790b940fcb44f7f