### PR TITLE
[Feat] Helper for manual save path

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -4,7 +4,7 @@ import {
   FULL_MANUAL_SAVE_DIRECTORY_PATH,
   MANUAL_SAVE_PATTERN,
   extractSaveName,
-  manualSavePath,
+  getManualSavePath,
 } from '../utils/savePathUtils.js';
 import { validateSaveMetadataFields } from '../utils/saveMetadataUtils.js';
 import { MSG_FILE_READ_ERROR, MSG_EMPTY_FILE } from './persistenceMessages.js';
@@ -276,7 +276,7 @@ export default class SaveFileRepository extends BaseService {
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<import('../interfaces/ISaveLoadService.js').SaveFileMetadata>>}
    */
   async #parseManualSaveFile(fileName) {
-    const filePath = manualSavePath(fileName);
+    const filePath = getManualSavePath(extractSaveName(fileName));
     this.#logger.debug(`Processing file: ${filePath}`);
 
     try {

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -1,7 +1,7 @@
 import { ISaveLoadService } from '../interfaces/ISaveLoadService.js';
 import GameStateSerializer from './gameStateSerializer.js';
 import SaveValidationService from './saveValidationService.js';
-import { buildManualFileName, manualSavePath } from '../utils/savePathUtils.js';
+import { getManualSavePath } from '../utils/savePathUtils.js';
 import SaveFileRepository from './saveFileRepository.js';
 import BaseService from '../utils/serviceBase.js';
 import { prepareState } from './savePreparation.js';
@@ -244,8 +244,7 @@ class SaveLoadService extends BaseService {
       );
     }
 
-    const fileName = buildManualFileName(saveName);
-    const filePath = manualSavePath(fileName);
+    const filePath = getManualSavePath(saveName);
 
     const dirResult = await this.#ensureSaveDirectory();
     if (!dirResult.success) {

--- a/src/utils/savePathUtils.js
+++ b/src/utils/savePathUtils.js
@@ -58,3 +58,16 @@ export function extractSaveName(fileName) {
 export function manualSavePath(fileName) {
   return `${FULL_MANUAL_SAVE_DIRECTORY_PATH}/${fileName}`;
 }
+
+/**
+ * Creates the full path to a manual save from a raw save name.
+ *
+ * Combines {@link buildManualFileName} with {@link manualSavePath} for
+ * convenience.
+ *
+ * @param {string} saveName - Raw save name provided by the user.
+ * @returns {string} Fully-qualified manual save path.
+ */
+export function getManualSavePath(saveName) {
+  return manualSavePath(buildManualFileName(saveName));
+}

--- a/tests/utils/savePathUtils.test.js
+++ b/tests/utils/savePathUtils.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildManualFileName,
+  manualSavePath,
+  getManualSavePath,
+} from '../../src/utils/savePathUtils.js';
+
+describe('getManualSavePath', () => {
+  it('combines file name generation and path correctly', () => {
+    const name = 'My Save';
+    const fileName = buildManualFileName(name);
+    const expected = manualSavePath(fileName);
+    expect(getManualSavePath(name)).toBe(expected);
+  });
+
+  it('sanitizes save name before building path', () => {
+    const name = 'Bad*Name';
+    const expectedFileName = buildManualFileName(name);
+    expect(expectedFileName).toBe('manual_save_Bad_Name.sav');
+    expect(getManualSavePath(name)).toBe(manualSavePath(expectedFileName));
+  });
+});


### PR DESCRIPTION
Summary: Introduced a new utility function `getManualSavePath` to centralize manual save path creation and updated SaveLoadService and SaveFileRepository to use it. Added corresponding unit test.

Changes Made:
- Added `getManualSavePath` in `savePathUtils.js`.
- Replaced path construction logic in SaveLoadService and SaveFileRepository with the new helper.
- Created `tests/utils/savePathUtils.test.js` for helper coverage.

Testing Done:
- [x] Code formatted (`npm run format` then revert unintended changes, ran prettier on modified files)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6853789a92588331992b1bc430619749