### PR TITLE
[Feat] Refactor action discovery target collection

### DIFF
--- a/tests/actions/actionDiscoveryService.collectValidTargets.test.js
+++ b/tests/actions/actionDiscoveryService.collectValidTargets.test.js
@@ -1,0 +1,60 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import { ActionDiscoveryService } from '../../src/actions/actionDiscoveryService.js';
+
+/** Simple attack definition for testing */
+const attackDef = {
+  id: 'core:attack',
+  name: 'Attack',
+  commandVerb: 'attack',
+  description: 'Attack target',
+  target_domain: 'entity',
+};
+
+describe('ActionDiscoveryService collectValidTargets helper', () => {
+  let service;
+
+  beforeEach(() => {
+    const gameDataRepo = { getAllActionDefinitions: () => [attackDef] };
+    const entityManager = {
+      getEntityInstance: (id) => ({ id }),
+      getComponentData: () => null,
+    };
+    const actionValidationService = {
+      isValid: jest.fn((def, actor, ctx) => ctx.entityId === 'rat123'),
+    };
+    const formatActionCommandFn = jest.fn(
+      (def, ctx) => `attack ${ctx.entityId}`
+    );
+    const getEntityIdsForScopesFn = () => new Set(['rat123', 'bat456']);
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    };
+    const safeEventDispatcher = { dispatch: jest.fn() };
+
+    service = new ActionDiscoveryService({
+      gameDataRepository: gameDataRepo,
+      entityManager,
+      actionValidationService,
+      formatActionCommandFn,
+      getEntityIdsForScopesFn,
+      logger,
+      safeEventDispatcher,
+    });
+  });
+
+  it('returns actions only for valid targets', async () => {
+    const actor = { id: 'player1' };
+    const context = { currentLocation: null };
+    const actions = await service.getValidActions(actor, context);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      id: 'core:attack',
+      command: 'attack rat123',
+      params: { targetId: 'rat123' },
+    });
+  });
+});


### PR DESCRIPTION
Summary: Adds a helper to collect valid targets and updates directional/entity discovery logic.

Changes Made:
- Added `#collectValidTargets` to `ActionDiscoveryService`.
- Refactored directional and scoped entity discovery to use the helper.
- Added unit test for mixed-valid targets.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_68537b00bc108331bb073b703880892f