### PR TITLE
[Agent] inject display name resolver

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -20,6 +20,7 @@ import {
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { getEntityDisplayName } from '../utils/entityUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 export class ActionDiscoveryService extends IActionDiscoveryService {
@@ -109,7 +110,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       actionDef,
       targetCtx,
       this.#entityManager,
-      formatterOptions
+      formatterOptions,
+      getEntityDisplayName
     );
 
     if (formattedCommand === null) {
@@ -181,7 +183,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
         actionDef,
         targetCtx,
         this.#entityManager,
-        formatterOptions
+        formatterOptions,
+        getEntityDisplayName
       );
 
       if (formattedCommand === null) {
@@ -238,7 +241,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
         actionDef,
         targetCtx,
         this.#entityManager,
-        formatterOptions
+        formatterOptions,
+        getEntityDisplayName
       );
 
       if (formattedCommand === null) {

--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -25,14 +25,17 @@ import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
  * @param {boolean} [options.debug] - If true, logs additional debug information.
  * @param {ILogger} [options.logger] - Logger instance used for diagnostic output. Defaults to console.
  * @param {ISafeEventDispatcher} options.safeEventDispatcher - Dispatcher used for error events.
+ * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} [displayNameFn=getEntityDisplayName] -
+ *  Function used to resolve entity display names.
  * @returns {string | null} The formatted command string, or null if inputs are invalid.
- * @throws {Error} If critical dependencies (entityManager, getEntityDisplayName) are missing or invalid during processing.
+ * @throws {Error} If critical dependencies (entityManager, displayNameFn) are missing or invalid during processing.
  */
 export function formatActionCommand(
   actionDefinition,
   targetContext,
   entityManager,
-  options = {}
+  options = {},
+  displayNameFn = getEntityDisplayName
 ) {
   const { debug = false, logger = console, safeEventDispatcher } = options;
   const dispatcher = resolveSafeDispatcher(null, safeEventDispatcher, logger);
@@ -69,7 +72,7 @@ export function formatActionCommand(
       'formatActionCommand: entityManager parameter must be a valid EntityManager instance.'
     );
   }
-  if (typeof getEntityDisplayName !== 'function') {
+  if (typeof displayNameFn !== 'function') {
     safeDispatchError(
       dispatcher,
       'formatActionCommand: getEntityDisplayName utility function is not available.'
@@ -107,8 +110,8 @@ export function formatActionCommand(
         const targetEntity = entityManager.getEntityInstance(targetId);
 
         if (targetEntity) {
-          // Use getEntityDisplayName utility with ID as fallback and pass logger
-          targetName = getEntityDisplayName(targetEntity, targetId, logger);
+          // Use provided displayNameFn utility with ID as fallback and pass logger
+          targetName = displayNameFn(targetEntity, targetId, logger);
           if (debug) {
             logger.debug(
               ` -> Found entity ${targetId}, display name: "${targetName}"`

--- a/tests/actions/actionDiscoverySystem.go.test.js
+++ b/tests/actions/actionDiscoverySystem.go.test.js
@@ -63,11 +63,23 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   const GUILD_INSTANCE_ID = 'guild-instance-uuid-integration-1';
 
   // Helper function to create entity instances for testing
-  const createTestEntity = (instanceId, definitionId, defComponents = {}, instanceOverrides = {}) => {
+  const createTestEntity = (
+    instanceId,
+    definitionId,
+    defComponents = {},
+    instanceOverrides = {}
+  ) => {
     // For this test, entities are created with base components on their definition
     // and specific test data as instance overrides.
-    const definition = new EntityDefinition(definitionId, { description: `Test Definition ${definitionId}`, components: defComponents });      
-    const instanceData = new EntityInstanceData(instanceId, definition, instanceOverrides);
+    const definition = new EntityDefinition(definitionId, {
+      description: `Test Definition ${definitionId}`,
+      components: defComponents,
+    });
+    const instanceData = new EntityInstanceData(
+      instanceId,
+      definition,
+      instanceOverrides
+    );
     return new Entity(instanceData);
   };
 
@@ -114,9 +126,19 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
     mockGetLocationIdForLog = getLocationIdForLog;
     mockSafeEventDispatcher = { dispatch: jest.fn() };
 
-    mockHeroEntity = createTestEntity(HERO_INSTANCE_ID, HERO_DEFINITION_ID, {}, heroEntityInitialComponents);
+    mockHeroEntity = createTestEntity(
+      HERO_INSTANCE_ID,
+      HERO_DEFINITION_ID,
+      {},
+      heroEntityInitialComponents
+    );
 
-    mockAdventurersGuildLocation = createTestEntity(GUILD_INSTANCE_ID, GUILD_DEFINITION_ID, {}, adventurersGuildEntityDefinitionData.components);
+    mockAdventurersGuildLocation = createTestEntity(
+      GUILD_INSTANCE_ID,
+      GUILD_DEFINITION_ID,
+      {},
+      adventurersGuildEntityDefinitionData.components
+    );
 
     mockGameDataRepo.getAllActionDefinitions.mockReturnValue([
       coreWaitActionDefinition,
@@ -276,13 +298,15 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       coreWaitActionDefinition,
       ActionTargetContext.noTarget(),
       mockEntityManager,
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(Function)
     );
     expect(mockFormatActionCommandFn).toHaveBeenCalledWith(
       coreGoActionDefinition,
       ActionTargetContext.forDirection('out to town'),
       mockEntityManager,
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(Function)
     );
 
     expect(mockGetEntityIdsForScopesFn).not.toHaveBeenCalled();

--- a/tests/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/actions/actionDiscoverySystem.wait.test.js
@@ -53,9 +53,21 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   const DUMMY_DEFINITION_ID = 'def:dummy-wait-test';
 
   // Helper function to create entity instances for testing
-  const createTestEntity = (instanceId, definitionId, defComponents = {}, instanceOverrides = {}) => {
-    const definition = new EntityDefinition(definitionId, { description: `Test Definition ${definitionId}`, components: defComponents });
-    const instanceData = new EntityInstanceData(instanceId, definition, instanceOverrides);
+  const createTestEntity = (
+    instanceId,
+    definitionId,
+    defComponents = {},
+    instanceOverrides = {}
+  ) => {
+    const definition = new EntityDefinition(definitionId, {
+      description: `Test Definition ${definitionId}`,
+      components: defComponents,
+    });
+    const instanceData = new EntityInstanceData(
+      instanceId,
+      definition,
+      instanceOverrides
+    );
     return new Entity(instanceData);
   };
 
@@ -84,7 +96,10 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
     mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockActorEntity = createTestEntity(ACTOR_INSTANCE_ID, DUMMY_DEFINITION_ID);
-    mockLocationEntity = createTestEntity(LOCATION_INSTANCE_ID, DUMMY_DEFINITION_ID);
+    mockLocationEntity = createTestEntity(
+      LOCATION_INSTANCE_ID,
+      DUMMY_DEFINITION_ID
+    );
 
     mockGameDataRepo.getAllActionDefinitions.mockReturnValue([
       coreWaitActionDefinition,
@@ -159,7 +174,8 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
       coreWaitActionDefinition,
       ActionTargetContext.noTarget(),
       mockEntityManager,
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(Function)
     );
 
     // Log messages: only start and finish

--- a/tests/actions/actionFormatter.additional.test.js
+++ b/tests/actions/actionFormatter.additional.test.js
@@ -2,10 +2,6 @@ import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import { formatActionCommand } from '../../src/actions/actionFormatter.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
-jest.mock('../../src/utils/entityUtils.js', () => ({
-  getEntityDisplayName: jest.fn(),
-}));
-
 const createMockLogger = () => ({
   debug: jest.fn(),
   info: jest.fn(),
@@ -17,11 +13,13 @@ describe('formatActionCommand additional cases', () => {
   let entityManager;
   let logger;
   let dispatcher;
+  let displayNameFn;
 
   beforeEach(() => {
     entityManager = { getEntityInstance: jest.fn() };
     logger = createMockLogger();
     dispatcher = { dispatch: jest.fn() };
+    displayNameFn = jest.fn();
     jest.clearAllMocks();
   });
 
@@ -29,10 +27,16 @@ describe('formatActionCommand additional cases', () => {
     const actionDef = { id: 'core:use', template: 'use {target}' };
     const context = { type: 'entity' };
 
-    const result = formatActionCommand(actionDef, context, entityManager, {
-      logger,
-      safeEventDispatcher: dispatcher,
-    });
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      {
+        logger,
+        safeEventDispatcher: dispatcher,
+      },
+      displayNameFn
+    );
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith(
@@ -44,10 +48,16 @@ describe('formatActionCommand additional cases', () => {
     const actionDef = { id: 'core:move', template: 'move {direction}' };
     const context = { type: 'direction' };
 
-    const result = formatActionCommand(actionDef, context, entityManager, {
-      logger,
-      safeEventDispatcher: dispatcher,
-    });
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      {
+        logger,
+        safeEventDispatcher: dispatcher,
+      },
+      displayNameFn
+    );
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith(
@@ -62,10 +72,16 @@ describe('formatActionCommand additional cases', () => {
     };
     const context = { type: 'none' };
 
-    const result = formatActionCommand(actionDef, context, entityManager, {
-      logger,
-      safeEventDispatcher: dispatcher,
-    });
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      {
+        logger,
+        safeEventDispatcher: dispatcher,
+      },
+      displayNameFn
+    );
 
     expect(result).toBe('wait {target} {direction}');
     expect(logger.warn).toHaveBeenCalledWith(
@@ -80,10 +96,16 @@ describe('formatActionCommand additional cases', () => {
       throw new Error('boom');
     });
 
-    const result = formatActionCommand(actionDef, context, entityManager, {
-      logger,
-      safeEventDispatcher: dispatcher,
-    });
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      {
+        logger,
+        safeEventDispatcher: dispatcher,
+      },
+      displayNameFn
+    );
 
     expect(result).toBeNull();
     expect(dispatcher.dispatch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- allow passing `displayNameFn` to `formatActionCommand`
- forward resolver in `ActionDiscoveryService`
- update action discovery and formatter tests

## Testing
- `npm run format`
- `npx eslint src/actions/actionDiscoveryService.js src/actions/actionFormatter.js tests/actions/actionDiscoverySystem.go.test.js tests/actions/actionDiscoverySystem.wait.test.js tests/actions/actionFormatter.additional.test.js tests/actions/actionFormatter.test.js`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68537b0f49e48331820f06da38804555