### PR TITLE
[Agent] simplify condition reference resolution

### DIFF
--- a/tests/services/prerequisiteEvaluationService.test.js
+++ b/tests/services/prerequisiteEvaluationService.test.js
@@ -395,5 +395,46 @@ describe('PrerequisiteEvaluationService', () => {
     );
   });
 
+  /**
+   * Test Case: _resolveConditionReferences object and array resolution
+   */
+  test('_resolveConditionReferences should resolve condition_ref objects', () => {
+    mockGameDataRepository.getConditionDefinition.mockReturnValueOnce({
+      logic: { '==': [1, 1] },
+    });
+
+    const result = service._resolveConditionReferences(
+      { condition_ref: 'condA' },
+      'testAction'
+    );
+
+    expect(result).toEqual({ '==': [1, 1] });
+    expect(mockGameDataRepository.getConditionDefinition).toHaveBeenCalledWith(
+      'condA'
+    );
+  });
+
+  test('_resolveConditionReferences should resolve arrays of logic blocks', () => {
+    mockGameDataRepository.getConditionDefinition.mockImplementation((id) => {
+      if (id === 'A') return { logic: { '!': false } };
+      if (id === 'B') return { logic: { var: 'actor.components.health' } };
+      return null;
+    });
+
+    const input = [
+      { condition_ref: 'A' },
+      { condition_ref: 'B' },
+      { '==': [1, 1] },
+    ];
+
+    const result = service._resolveConditionReferences(input, 'testAction');
+
+    expect(result).toEqual([
+      { '!': false },
+      { var: 'actor.components.health' },
+      { '==': [1, 1] },
+    ]);
+  });
+
   /* --- Obsolete tests commented out --- */
 }); // End describe('PrerequisiteEvaluationService')


### PR DESCRIPTION
Summary:
- split `_resolveConditionReferences` into private helpers for arrays and objects
- add tests covering object and array reference resolution

Testing Done:
- [x] `npx prettier -w src/actions/validation/prerequisiteEvaluationService.js tests/services/prerequisiteEvaluationService.test.js`
- [x] `npm run lint` *(fails: 560 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68537b2d1a6c8331a5622a4399cd5273