### PR TITLE
[Agent] introduce DomAdapter abstraction for error handling

### DIFF
--- a/src/interfaces/DomAdapter.js
+++ b/src/interfaces/DomAdapter.js
@@ -1,0 +1,55 @@
+// src/interfaces/DomAdapter.js
+/**
+ * @file Provides the DomAdapter interface used for limited DOM manipulation.
+ */
+
+/**
+ * @interface DomAdapter
+ * @description Abstraction layer over basic DOM operations to allow easier
+ * testing and platform flexibility.
+ */
+export class DomAdapter {
+  /**
+   * Creates a new element with the specified tag name.
+   *
+   * @param {string} tagName - Name of the element to create.
+   * @returns {HTMLElement}
+   */
+  createElement(tagName) {
+    throw new Error('DomAdapter.createElement not implemented');
+  }
+
+  /**
+   * Inserts `newNode` immediately after `referenceNode` in the DOM tree.
+   *
+   * @param {HTMLElement} referenceNode - Existing node to insert after.
+   * @param {HTMLElement} newNode - Node to insert.
+   * @returns {void}
+   */
+  insertAfter(referenceNode, newNode) {
+    throw new Error('DomAdapter.insertAfter not implemented');
+  }
+
+  /**
+   * Sets the text content of an element.
+   *
+   * @param {HTMLElement} element - Element to modify.
+   * @param {string} text - Text to set.
+   * @returns {void}
+   */
+  setTextContent(element, text) {
+    throw new Error('DomAdapter.setTextContent not implemented');
+  }
+
+  /**
+   * Sets a style property on an element.
+   *
+   * @param {HTMLElement} element - Element to modify.
+   * @param {string} property - CSS property name (camelCase or dash-separated).
+   * @param {string} value - CSS value to assign.
+   * @returns {void}
+   */
+  setStyle(element, property, value) {
+    throw new Error('DomAdapter.setStyle not implemented');
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -163,6 +163,13 @@ export async function bootstrapApp() {
       logger,
       {
         createElement: (tag) => document.createElement(tag),
+        insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+        setTextContent: (el, text) => {
+          el.textContent = text;
+        },
+        setStyle: (el, prop, val) => {
+          el.style[prop] = val;
+        },
         alert,
       }
     );
@@ -193,6 +200,13 @@ export async function beginGame(showLoadUI = false) {
       logger,
       {
         createElement: (tag) => document.createElement(tag),
+        insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+        setTextContent: (el, text) => {
+          el.textContent = text;
+        },
+        setStyle: (el, prop, val) => {
+          el.style[prop] = val;
+        },
         alert,
       }
     );
@@ -217,6 +231,13 @@ export async function beginGame(showLoadUI = false) {
       logger,
       {
         createElement: (tag) => document.createElement(tag),
+        insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+        setTextContent: (el, text) => {
+          el.textContent = text;
+        },
+        setStyle: (el, prop, val) => {
+          el.style[prop] = val;
+        },
         alert,
       }
     );

--- a/tests/bootstrapper/errorUtils.test.js
+++ b/tests/bootstrapper/errorUtils.test.js
@@ -33,6 +33,13 @@ describe('displayFatalStartupError', () => {
     const alertSpy = jest.fn();
     const domAdapter = {
       createElement: document.createElement.bind(document),
+      insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+      setTextContent: (el, text) => {
+        el.textContent = text;
+      },
+      setStyle: (el, prop, val) => {
+        el.style[prop] = val;
+      },
       alert: alertSpy,
     };
     const logger = {
@@ -77,6 +84,13 @@ describe('displayFatalStartupError', () => {
     const alertSpy = jest.fn();
     const domAdapter = {
       createElement: document.createElement.bind(document),
+      insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+      setTextContent: (el, text) => {
+        el.textContent = text;
+      },
+      setStyle: (el, prop, val) => {
+        el.style[prop] = val;
+      },
       alert: alertSpy,
     };
     const logger = {
@@ -111,6 +125,13 @@ describe('displayFatalStartupError', () => {
     const alertSpy = jest.fn();
     const domAdapter = {
       createElement: document.createElement.bind(document),
+      insertAfter: (ref, el) => ref.insertAdjacentElement('afterend', el),
+      setTextContent: (el, text) => {
+        el.textContent = text;
+      },
+      setStyle: (el, prop, val) => {
+        el.style[prop] = val;
+      },
       alert: alertSpy,
     };
     const logger = {


### PR DESCRIPTION
Summary: adds a DomAdapter interface and refactors error display helpers to use it, enabling easier DOM mocking.

Changes Made:
- added `DomAdapter` interface
- updated `errorUtils` functions and `displayFatalStartupError`
- modified `main.js` to pass full adapter
- adjusted related unit tests

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes (`npx eslint` on changed files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (not performed)


------
https://chatgpt.com/codex/tasks/task_e_68537ba8e32083319c9443f6ac0e4675