### PR TITLE
[Agent] split world summary logger

### DIFF
--- a/src/loaders/WorldLoadSummaryLogger.js
+++ b/src/loaders/WorldLoadSummaryLogger.js
@@ -1,0 +1,76 @@
+// src/loaders/WorldLoadSummaryLogger.js
+
+/**
+ * @file Logs a summary of world loading results.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
+
+/**
+ * @description Utility for printing a formatted summary of the world load.
+ * @class
+ */
+export class WorldLoadSummaryLogger {
+  /**
+   * Logs a multi-line summary of what was loaded across all mods.
+   *
+   * @param {ILogger} logger - Logging service.
+   * @param {string} worldName - Identifier for the world being loaded.
+   * @param {string[]} requestedMods - Mods requested by the game configuration.
+   * @param {string[]} finalOrder - Resolved load order for all mods.
+   * @param {number} incompatibilityCount - Count of engine version mismatches.
+   * @param {TotalResultsSummary} totals - Map of content type totals.
+   * @returns {void}
+   */
+  logSummary(
+    logger,
+    worldName,
+    requestedMods,
+    finalOrder,
+    incompatibilityCount,
+    totals
+  ) {
+    logger.info(`— WorldLoader Load Summary (World: '${worldName}') —`);
+    logger.info(`  • Requested Mods (raw): [${requestedMods.join(', ')}]`);
+    logger.info(`  • Final Load Order     : [${finalOrder.join(', ')}]`);
+    if (incompatibilityCount > 0) {
+      logger.warn(
+        `  • Engine-version incompatibilities detected: ${incompatibilityCount}`
+      );
+    }
+    logger.info(`  • Content Loading Summary (Totals):`);
+    if (Object.keys(totals).length > 0) {
+      const sortedTypes = Object.keys(totals).sort();
+      for (const typeName of sortedTypes) {
+        const counts = totals[typeName];
+        const paddedTypeName = typeName.padEnd(20, ' ');
+        const details = `C:${counts.count}, O:${counts.overrides}, E:${counts.errors}`;
+        logger.info(`     - ${paddedTypeName}: ${details}`);
+      }
+      const grandTotalCount = Object.values(totals).reduce(
+        (sum, tc) => sum + tc.count,
+        0
+      );
+      const grandTotalOverrides = Object.values(totals).reduce(
+        (sum, tc) => sum + tc.overrides,
+        0
+      );
+      const grandTotalErrors = Object.values(totals).reduce(
+        (sum, tc) => sum + tc.errors,
+        0
+      );
+      logger.info(`     - ${''.padEnd(20, '-')}--------------------------`);
+      logger.info(
+        `     - ${'TOTAL'.padEnd(20, ' ')}: C:${grandTotalCount}, O:${grandTotalOverrides}, E:${grandTotalErrors}`
+      );
+    } else {
+      logger.info(
+        `     - No specific content items were processed by loaders in this run.`
+      );
+    }
+    logger.info('———————————————————————————————————————————');
+  }
+}
+
+export default WorldLoadSummaryLogger;

--- a/src/loaders/defaultLoaderConfig.js
+++ b/src/loaders/defaultLoaderConfig.js
@@ -1,0 +1,96 @@
+// src/loaders/defaultLoaderConfig.js
+
+/**
+ * @file Provides a helper to create the default content loaders configuration.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').BaseManifestItemLoaderInterface} BaseManifestItemLoaderInterface */
+
+/**
+ * Structure describing a content loader configuration entry.
+ *
+ * @typedef {object} LoaderConfigEntry
+ * @property {BaseManifestItemLoaderInterface} loader - Loader instance.
+ * @property {string} contentKey - Key within the manifest's `content` section.
+ * @property {string} contentTypeDir - Directory name under the mod root.
+ * @property {string} typeName - Registry key for the loaded content type.
+ */
+
+/**
+ * Creates the default loader configuration used by WorldLoader when a custom
+ * configuration isn't supplied.
+ *
+ * @param {object} deps - Loader instances used to build the config.
+ * @param {BaseManifestItemLoaderInterface} deps.componentDefinitionLoader - Component loader.
+ * @param {BaseManifestItemLoaderInterface} deps.eventLoader - Event loader.
+ * @param {BaseManifestItemLoaderInterface} deps.conditionLoader - Condition loader.
+ * @param {BaseManifestItemLoaderInterface} deps.macroLoader - Macro loader.
+ * @param {BaseManifestItemLoaderInterface} deps.actionLoader - Action loader.
+ * @param {BaseManifestItemLoaderInterface} deps.ruleLoader - Rule loader.
+ * @param {BaseManifestItemLoaderInterface} deps.entityDefinitionLoader - Entity definition loader.
+ * @param {BaseManifestItemLoaderInterface} deps.entityInstanceLoader - Entity instance loader.
+ * @returns {LoaderConfigEntry[]} Array describing loader configuration.
+ */
+export function createDefaultContentLoadersConfig({
+  componentDefinitionLoader,
+  eventLoader,
+  conditionLoader,
+  macroLoader,
+  actionLoader,
+  ruleLoader,
+  entityDefinitionLoader,
+  entityInstanceLoader,
+}) {
+  return [
+    {
+      loader: componentDefinitionLoader,
+      contentKey: 'components',
+      contentTypeDir: 'components',
+      typeName: 'components',
+    },
+    {
+      loader: eventLoader,
+      contentKey: 'events',
+      contentTypeDir: 'events',
+      typeName: 'events',
+    },
+    {
+      loader: conditionLoader,
+      contentKey: 'conditions',
+      contentTypeDir: 'conditions',
+      typeName: 'conditions',
+    },
+    {
+      loader: macroLoader,
+      contentKey: 'macros',
+      contentTypeDir: 'macros',
+      typeName: 'macros',
+    },
+    {
+      loader: actionLoader,
+      contentKey: 'actions',
+      contentTypeDir: 'actions',
+      typeName: 'actions',
+    },
+    {
+      loader: ruleLoader,
+      contentKey: 'rules',
+      contentTypeDir: 'rules',
+      typeName: 'rules',
+    },
+    {
+      loader: entityDefinitionLoader,
+      contentKey: 'entityDefinitions',
+      contentTypeDir: 'entities/definitions',
+      typeName: 'entityDefinitions',
+    },
+    {
+      loader: entityInstanceLoader,
+      contentKey: 'entityInstances',
+      contentTypeDir: 'entities/instances',
+      typeName: 'entityInstances',
+    },
+  ];
+}
+
+export default createDefaultContentLoadersConfig;


### PR DESCRIPTION
Summary: Extracted world load summary logging into new `WorldLoadSummaryLogger` class and moved default loader config to its own module. Updated `WorldLoader` to use these helpers.

Testing Done:
- [x] Code formatted `npx prettier`
- [x] Lint run (fails: 560 errors, 2066 warnings)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start` (fails: Cannot find package 'express')


------
https://chatgpt.com/codex/tasks/task_e_685380c13ad88331a644087e509aec35