### PR TITLE
[Agent] Rename context utils

### DIFF
--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -5,7 +5,6 @@
 import jsonLogic from 'json-logic-js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { setContextValue } from '../../utils/contextVariableUtils.js';
-import storeResult from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
@@ -86,7 +85,7 @@ class MathHandler {
       log
     );
     if (!stored) {
-      // storeResult already handled logging/dispatching
+      // writeContextVariable already handled logging/dispatching
     }
   }
 

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -36,7 +36,7 @@ function _validateContextAndName(variableName, execCtx, _logger) {
     return {
       valid: false,
       error: new Error(
-        'storeResult: evaluationContext.context is missing; cannot store result'
+        'writeContextVariable: evaluationContext.context is missing; cannot store value'
       ),
     };
   }
@@ -57,7 +57,13 @@ function _validateContextAndName(variableName, execCtx, _logger) {
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger used when no dispatcher is provided.
  * @returns {{success: boolean, error?: Error}} Result of the store operation.
  */
-export function storeResult(variableName, value, execCtx, dispatcher, logger) {
+export function writeContextVariable(
+  variableName,
+  value,
+  execCtx,
+  dispatcher,
+  logger
+) {
   const log = getModuleLogger('contextVariableUtils', logger);
   const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
   const { valid, error, name } = _validateContextAndName(
@@ -78,7 +84,7 @@ export function storeResult(variableName, value, execCtx, dispatcher, logger) {
     return { success: true };
   } catch (e) {
     const err = new Error(
-      `storeResult: Failed to write variable "${variableName}"`
+      `writeContextVariable: Failed to write variable "${variableName}"`
     );
     if (safeDispatcher) {
       safeDispatchError(safeDispatcher, err.message, {
@@ -92,7 +98,7 @@ export function storeResult(variableName, value, execCtx, dispatcher, logger) {
 }
 
 /**
- * Wrapper around {@link storeResult} that trims the variable name and validates
+ * Wrapper around {@link writeContextVariable} that trims the variable name and validates
  * it before storage.
  *
  * @param {string|null|undefined} variableName - Target context variable name.
@@ -103,7 +109,7 @@ export function storeResult(variableName, value, execCtx, dispatcher, logger) {
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger used when no dispatcher is provided.
  * @returns {boolean} `true` when the value was successfully stored.
  */
-export function setContextValueResult(
+export function tryWriteContextVariable(
   variableName,
   value,
   execCtx,
@@ -124,7 +130,13 @@ export function setContextValueResult(
     return { success: false, error: validation.error };
   }
 
-  return storeResult(validation.name, value, execCtx, dispatcher, logger);
+  return writeContextVariable(
+    validation.name,
+    value,
+    execCtx,
+    dispatcher,
+    logger
+  );
 }
 
 /**
@@ -142,8 +154,13 @@ export function setContextValue(
   dispatcher,
   logger
 ) {
-  return setContextValueResult(variableName, value, execCtx, dispatcher, logger)
-    .success;
+  return tryWriteContextVariable(
+    variableName,
+    value,
+    execCtx,
+    dispatcher,
+    logger
+  ).success;
 }
 
-export default storeResult;
+export default writeContextVariable;

--- a/tests/utils/contextVariableUtils.test.js
+++ b/tests/utils/contextVariableUtils.test.js
@@ -1,11 +1,11 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import storeResult, {
+import writeContextVariable, {
   setContextValue,
-  setContextValueResult,
+  tryWriteContextVariable,
 } from '../../src/utils/contextVariableUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 
-describe('storeResult', () => {
+describe('writeContextVariable', () => {
   test('stores value when context exists', () => {
     const ctx = { evaluationContext: { context: {} } };
     const dispatcher = { dispatch: jest.fn() };
@@ -15,7 +15,7 @@ describe('storeResult', () => {
       info: jest.fn(),
       debug: jest.fn(),
     };
-    const result = storeResult('foo', 123, ctx, dispatcher, logger);
+    const result = writeContextVariable('foo', 123, ctx, dispatcher, logger);
     expect(result).toEqual({ success: true });
     expect(ctx.evaluationContext.context.foo).toBe(123);
     expect(dispatcher.dispatch).not.toHaveBeenCalled();
@@ -25,7 +25,7 @@ describe('storeResult', () => {
     const ctx = { evaluationContext: null };
     const dispatcher = { dispatch: jest.fn() };
     const logger = { error: jest.fn() };
-    const result = storeResult('bar', 5, ctx, dispatcher, logger);
+    const result = writeContextVariable('bar', 5, ctx, dispatcher, logger);
     expect(result.success).toBe(false);
     expect(result.error).toBeInstanceOf(Error);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
@@ -50,7 +50,7 @@ describe('storeResult', () => {
       info: jest.fn(),
       debug: jest.fn(),
     };
-    const result = storeResult('baz', 7, ctx, undefined, logger);
+    const result = writeContextVariable('baz', 7, ctx, undefined, logger);
     await Promise.resolve();
     expect(result.success).toBe(false);
     expect(result.error).toBeInstanceOf(Error);
@@ -87,12 +87,12 @@ describe('setContextValue', () => {
   });
 });
 
-describe('setContextValueResult', () => {
+describe('tryWriteContextVariable', () => {
   test('returns error object when evaluation context missing', () => {
     const ctx = { evaluationContext: null };
     const dispatcher = { dispatch: jest.fn() };
     const logger = { error: jest.fn() };
-    const result = setContextValueResult('foo', 1, ctx, dispatcher, logger);
+    const result = tryWriteContextVariable('foo', 1, ctx, dispatcher, logger);
     expect(result.success).toBe(false);
     expect(result.error).toBeInstanceOf(Error);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary: Renamed `storeResult` to `writeContextVariable` and `setContextValueResult` to `tryWriteContextVariable`. Updated math handler and unit tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 563 errors)*
- [x] Root tests `npm run test` *(failures due to missing modules)*
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

🚫 tests failing—needs human review

------
https://chatgpt.com/codex/tasks/task_e_68542822975c8331b971dd8a7f0f652c