### PR TITLE
[Agent] Refactor save state cloning helpers

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -2,7 +2,7 @@
 
 import { encode, decode } from '@msgpack/msgpack';
 import pako from 'pako';
-import { cloneAndValidateSaveState } from '../utils/saveStateUtils.js';
+import { cloneValidatedState } from '../utils/saveStateUtils.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -119,10 +119,7 @@ class GameStateSerializer {
    * @private
    */
   #cloneForSerialization(gameStateObject) {
-    const cloneResult = cloneAndValidateSaveState(
-      gameStateObject,
-      this.#logger
-    );
+    const cloneResult = cloneValidatedState(gameStateObject, this.#logger);
     if (!cloneResult.success || !cloneResult.data) {
       throw cloneResult.error;
     }

--- a/src/persistence/savePreparation.js
+++ b/src/persistence/savePreparation.js
@@ -1,6 +1,6 @@
 // src/persistence/savePreparation.js
 
-import { cloneAndValidateSaveState } from '../utils/saveStateUtils.js';
+import { cloneValidatedState } from '../utils/saveStateUtils.js';
 import { createPersistenceSuccess } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 
@@ -14,7 +14,7 @@ import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
  *   Result containing the cloned object or error.
  */
 export function cloneAndPrepareState(saveName, obj, logger) {
-  const cloneResult = cloneAndValidateSaveState(obj, logger);
+  const cloneResult = cloneValidatedState(obj, logger);
   if (!cloneResult.success || !cloneResult.data) {
     return { success: false, error: cloneResult.error };
   }

--- a/src/utils/saveStateUtils.js
+++ b/src/utils/saveStateUtils.js
@@ -18,7 +18,7 @@ import {
  * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<object>}
  *   Clone result with validation outcome.
  */
-export function cloneAndValidateSaveState(obj, logger) {
+export function cloneValidatedState(obj, logger) {
   const cloneResult = safeDeepClone(obj, logger);
   if (!cloneResult.success || !cloneResult.data) {
     return createPersistenceFailure(
@@ -37,6 +37,19 @@ export function cloneAndValidateSaveState(obj, logger) {
   }
 
   return createPersistenceSuccess(cloned);
+}
+
+/**
+ * Wrapper for {@link cloneValidatedState} to maintain backward compatibility.
+ *
+ * @param {object} obj - Raw save state object to clone.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for
+ *   error reporting.
+ * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<object>}
+ *   Clone result with validation outcome.
+ */
+export function cloneAndValidateSaveState(obj, logger) {
+  return cloneValidatedState(obj, logger);
 }
 
 export default cloneAndValidateSaveState;


### PR DESCRIPTION
Summary: Centralized save state cloning and validation in new `cloneValidatedState` utility. Updated `GameStateSerializer` and `savePreparation` to use the helper before applying their own mutations.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on changed files `npx eslint src/utils/saveStateUtils.js src/persistence/gameStateSerializer.js src/persistence/savePreparation.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685432312d248331b9e4e2e4e4baaeb5