### PR TITLE
[Agent] add buildDiscoveredAction

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -87,6 +87,50 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   }
 
   /**
+   * @description Builds a DiscoveredActionInfo object for a valid action.
+   * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef - The action definition.
+   * @param {Entity} actorEntity - The entity performing the action.
+   * @param {ActionTargetContext} targetCtx - The context of the action target.
+   * @param {object} formatterOptions - Options for formatting the command string.
+   * @param {object} params - Extra params to include in the result.
+   * @returns {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo|null} The info object or null.
+   */
+  // eslint-disable-next-line no-unused-private-class-members
+  #buildDiscoveredAction(
+    actionDef,
+    actorEntity,
+    targetCtx,
+    formatterOptions,
+    params = {}
+  ) {
+    if (
+      !this.#actionValidationService.isValid(actionDef, actorEntity, targetCtx)
+    ) {
+      return null;
+    }
+
+    const formattedCommand = this.#formatActionCommandFn(
+      actionDef,
+      targetCtx,
+      this.#entityManager,
+      formatterOptions,
+      getEntityDisplayName
+    );
+
+    if (formattedCommand === null) {
+      return null;
+    }
+
+    return {
+      id: actionDef.id,
+      name: actionDef.name || actionDef.commandVerb,
+      command: formattedCommand,
+      description: actionDef.description || '',
+      params,
+    };
+  }
+
+  /**
    * Handles discovery for actions targeting 'self' or having no target.
    *
    * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef


### PR DESCRIPTION
Summary: Added a new helper `#buildDiscoveredAction` in `ActionDiscoveryService` to centralize command formatting and validation logic. The method returns a `DiscoveredActionInfo` object or `null` and includes full JSDoc documentation.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685439b9cf1c8331b63b487980312aa0