### PR TITLE
[Agent] remove default export from BaseService

### DIFF
--- a/src/entities/EntityDefinition.js
+++ b/src/entities/EntityDefinition.js
@@ -1,0 +1,2 @@
+export { default } from './entityDefinition.js';
+export * from './entityDefinition.js';

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -1,7 +1,7 @@
 // src/logic/jsonLogicEvaluationService.js
 import jsonLogic from 'json-logic-js';
 import { validateServiceDeps } from '../utils/serviceInitializerUtils.js';
-import BaseService from '../utils/baseService.js';
+import { BaseService } from '../utils/baseService.js';
 import { warnOnBracketPaths } from '../utils/jsonLogicUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -4,7 +4,7 @@
 // -----------------------------------------------------------------------------
 
 import { resolvePlaceholders } from '../utils/contextUtils.js';
-import BaseService from '../utils/baseService.js';
+import { BaseService } from '../utils/baseService.js';
 import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -4,7 +4,7 @@
 
 /** @typedef {import('./defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-import BaseService from '../utils/baseService.js';
+import { BaseService } from '../utils/baseService.js';
 import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 class OperationRegistry extends BaseService {

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -8,7 +8,7 @@ import { createNestedExecutionContext } from './contextAssembler.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
-import BaseService from '../utils/baseService.js';
+import { BaseService } from '../utils/baseService.js';
 import { executeActionSequence } from './actionSequence.js';
 import { buildRuleCache } from '../utils/ruleCacheUtils.js';
 import { isEmptyCondition } from '../utils/jsonLogicUtils.js';

--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -3,7 +3,7 @@
 
 import { CURRENT_ACTOR_COMPONENT_ID } from '../constants/componentIds.js';
 import { CHECKSUM_PENDING } from '../constants/persistence.js';
-import BaseService from '../utils/serviceBase.js';
+import { BaseService } from '../utils/serviceBase.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -46,13 +46,13 @@ class GameStateCaptureService extends BaseService {
    * @param {ActiveModsManifestBuilder} deps.activeModsManifestBuilder - Builder for active mods manifest.
    */
   constructor({
-                logger,
-                entityManager,
-                playtimeTracker,
-                componentCleaningService,
-                metadataBuilder,
-                activeModsManifestBuilder,
-              }) {
+    logger,
+    entityManager,
+    playtimeTracker,
+    componentCleaningService,
+    metadataBuilder,
+    activeModsManifestBuilder,
+  }) {
     super();
     this.#logger = this._init('GameStateCaptureService', logger, {
       entityManager: { value: entityManager },

--- a/src/persistence/manualSaveCoordinator.js
+++ b/src/persistence/manualSaveCoordinator.js
@@ -1,4 +1,4 @@
-import BaseService from '../utils/serviceBase.js';
+import { BaseService } from '../utils/serviceBase.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -15,7 +15,7 @@ import {
   createPersistenceSuccess,
 } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
-import BaseService from '../utils/serviceBase.js';
+import { BaseService } from '../utils/serviceBase.js';
 
 // Precompile manual save file regex once for reuse
 const manualSaveRegex = MANUAL_SAVE_PATTERN;

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -4,7 +4,7 @@ import SaveValidationService from './saveValidationService.js';
 import { getManualSavePath } from '../utils/savePathUtils.js';
 import SaveFileRepository from './saveFileRepository.js';
 import { ISaveFileRepository } from '../interfaces/ISaveFileRepository.js';
-import BaseService from '../utils/serviceBase.js';
+import { BaseService } from '../utils/serviceBase.js';
 import { prepareState } from './savePreparation.js';
 import { PersistenceErrorCodes } from './persistenceErrors.js';
 import {

--- a/src/utils/baseService.js
+++ b/src/utils/baseService.js
@@ -1,1 +1,1 @@
-export { BaseService as default, BaseService } from './serviceBase.js';
+export { BaseService } from './serviceBase.js';


### PR DESCRIPTION
Summary: Removed default export indirection in `baseService.js` and switched all imports to named imports. Added compatibility alias `EntityDefinition.js` to satisfy case-sensitive imports.

Changes Made:
- export only `BaseService` from `baseService.js`
- updated service classes and interpreters to import `{ BaseService }`
- added `src/entities/EntityDefinition.js` as forwarding module

Testing Done:
- [x] Code formatted (`npm run format` on changed files)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6854523032c08331b3133537faf13ba2