### PR TITLE
[Agent] Add compressPreparedState for optimized save

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -177,6 +177,19 @@ class GameStateSerializer {
   }
 
   /**
+   * Compresses a pre-cloned and validated save object.
+   *
+   * @description Compresses a pre-cloned and validated save object.
+   * @param {object} saveObj - Prepared save object.
+   * @returns {Promise<{compressedData: Uint8Array, finalSaveObject: object}>}
+   *   Compressed data and original object.
+   */
+  async compressPreparedState(saveObj) {
+    await this.#applyChecksum(saveObj);
+    return this.#encodeAndCompress(saveObj);
+  }
+
+  /**
    * Decompresses Gzip-compressed data.
    *
    * @param {Uint8Array} data - Compressed data.

--- a/src/persistence/savePreparation.js
+++ b/src/persistence/savePreparation.js
@@ -48,7 +48,7 @@ export async function prepareState(
   }
 
   return wrapPersistenceOperation(logger, async () => {
-    const { compressedData } = await serializer.serializeAndCompress(
+    const { compressedData } = await serializer.compressPreparedState(
       cloneResult.data
     );
     return { success: true, data: compressedData };

--- a/tests/entities/entityManager.addComponent.invalidData.test.js
+++ b/tests/entities/entityManager.addComponent.invalidData.test.js
@@ -12,7 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 
 const createMockDataRegistry = () => ({
   getEntityDefinition: jest.fn(),
@@ -60,9 +60,14 @@ describe('EntityManager.addComponent invalid componentData handling', () => {
     validator = createMockSchemaValidator();
     logger = createMockLogger();
     spatial = createMockSpatialIndexManager();
-    mockEventDispatcher = createMockSafeEventDispatcher()
+    mockEventDispatcher = createMockSafeEventDispatcher();
 
-    manager = new EntityManager(registry, validator, logger, mockEventDispatcher);
+    manager = new EntityManager(
+      registry,
+      validator,
+      logger,
+      mockEventDispatcher
+    );
 
     const definitionData = {
       components: {

--- a/tests/entities/entityManager.addComponent.test.js
+++ b/tests/entities/entityManager.addComponent.test.js
@@ -9,7 +9,7 @@ import {
   afterEach,
 } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 // Entity import might not be needed if only interacting via EntityManager
 import { POSITION_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import { EntityNotFoundError } from '../../src/errors/entityNotFoundError.js';
@@ -165,7 +165,11 @@ describe('EntityManager.addComponent', () => {
     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
       COMPONENT_ADDED_ID,
-      { entity: testEntityInstance, componentTypeId: NEW_COMPONENT_TYPE_ID, componentData: dataToAdd }
+      {
+        entity: testEntityInstance,
+        componentTypeId: NEW_COMPONENT_TYPE_ID,
+        componentData: dataToAdd,
+      }
     );
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -205,7 +209,11 @@ describe('EntityManager.addComponent', () => {
     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
       COMPONENT_ADDED_ID,
-      { entity: testEntityInstance, componentTypeId: INITIAL_COMPONENT_TYPE_ID, componentData: dataToUpdate }
+      {
+        entity: testEntityInstance,
+        componentTypeId: INITIAL_COMPONENT_TYPE_ID,
+        componentData: dataToUpdate,
+      }
     );
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -240,11 +248,15 @@ describe('EntityManager.addComponent', () => {
       expect(
         entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
       ).toEqual(POSITION_DATA_NEW);
-      
+
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
         COMPONENT_ADDED_ID,
-        { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+        {
+          entity: testEntityInstance,
+          componentTypeId: POSITION_COMPONENT_ID,
+          componentData: positionDataForEvent,
+        }
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`
@@ -263,11 +275,15 @@ describe('EntityManager.addComponent', () => {
       expect(
         entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
       ).toEqual(POSITION_DATA_NO_LOCATION);
-      
+
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
         COMPONENT_ADDED_ID,
-        { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+        {
+          entity: testEntityInstance,
+          componentTypeId: POSITION_COMPONENT_ID,
+          componentData: positionDataForEvent,
+        }
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`
@@ -286,11 +302,15 @@ describe('EntityManager.addComponent', () => {
       expect(
         entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
       ).toEqual(POSITION_DATA_NULL_LOCATION);
-      
+
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
         COMPONENT_ADDED_ID,
-        { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+        {
+          entity: testEntityInstance,
+          componentTypeId: POSITION_COMPONENT_ID,
+          componentData: positionDataForEvent,
+        }
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`
@@ -309,8 +329,10 @@ describe('EntityManager.addComponent', () => {
 
       it('Success Case (Update Position Component): should update position, return true, and dispatch COMPONENT_ADDED_ID event', () => {
         expect(
-          entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
-            ?.locationId
+          entityManager.getComponentData(
+            MOCK_INSTANCE_ID,
+            POSITION_COMPONENT_ID
+          )?.locationId
         ).toBe(INITIAL_LOCATION_ID);
 
         const positionDataForEvent = { ...POSITION_DATA_NEW };
@@ -322,13 +344,20 @@ describe('EntityManager.addComponent', () => {
 
         expect(result).toBe(true);
         expect(
-          entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
+          entityManager.getComponentData(
+            MOCK_INSTANCE_ID,
+            POSITION_COMPONENT_ID
+          )
         ).toEqual(POSITION_DATA_NEW);
-        
+
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
           COMPONENT_ADDED_ID,
-          { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+          {
+            entity: testEntityInstance,
+            componentTypeId: POSITION_COMPONENT_ID,
+            componentData: positionDataForEvent,
+          }
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`
@@ -345,13 +374,20 @@ describe('EntityManager.addComponent', () => {
 
         expect(result).toBe(true);
         expect(
-          entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
+          entityManager.getComponentData(
+            MOCK_INSTANCE_ID,
+            POSITION_COMPONENT_ID
+          )
         ).toEqual(POSITION_DATA_NULL_LOCATION);
-        
+
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
           COMPONENT_ADDED_ID,
-          { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+          {
+            entity: testEntityInstance,
+            componentTypeId: POSITION_COMPONENT_ID,
+            componentData: positionDataForEvent,
+          }
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`
@@ -368,13 +404,20 @@ describe('EntityManager.addComponent', () => {
 
         expect(result).toBe(true);
         expect(
-          entityManager.getComponentData(MOCK_INSTANCE_ID, POSITION_COMPONENT_ID)
+          entityManager.getComponentData(
+            MOCK_INSTANCE_ID,
+            POSITION_COMPONENT_ID
+          )
         ).toEqual(POSITION_DATA_NO_LOCATION);
 
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
           COMPONENT_ADDED_ID,
-          { entity: testEntityInstance, componentTypeId: POSITION_COMPONENT_ID, componentData: positionDataForEvent }
+          {
+            entity: testEntityInstance,
+            componentTypeId: POSITION_COMPONENT_ID,
+            componentData: positionDataForEvent,
+          }
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           `Successfully added/updated component '${POSITION_COMPONENT_ID}' data on entity '${MOCK_INSTANCE_ID}'.`

--- a/tests/entities/entityManager.auxiliary.test.js
+++ b/tests/entities/entityManager.auxiliary.test.js
@@ -10,7 +10,7 @@ import {
 } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
 import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../src/entities/entityInstanceData.js';
 import { POSITION_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import { ENTITY_REMOVED_ID } from '../../src/constants/eventIds.js';
@@ -161,7 +161,8 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
       let mockEntityWithoutPos;
       beforeEach(() => {
         // Use a mock entity that can be added to the real map instance
-        mockEntityWithoutPos = { // Renamed for clarity
+        mockEntityWithoutPos = {
+          // Renamed for clarity
           id: INSTANCE_ID_1,
           hasComponent: jest.fn().mockReturnValue(false),
         };
@@ -179,14 +180,19 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
         expect(entityManager.activeEntities.has(INSTANCE_ID_1)).toBe(false);
       });
 
-      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => { // Updated description
+      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => {
+        // Updated description
         expect(ENTITY_REMOVED_ID).toBe('core:entity_removed'); // Added check
         entityManager.removeEntityInstance(INSTANCE_ID_1);
         expect(mockSpatialIndex.removeEntity).not.toHaveBeenCalled();
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(ENTITY_REMOVED_ID, { entity: mockEntityWithoutPos }); // Added event check
+        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+          ENTITY_REMOVED_ID,
+          { entity: mockEntityWithoutPos }
+        ); // Added event check
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       });
-      it('should log info message about removal', () => { // Added test for generic log
+      it('should log info message about removal', () => {
+        // Added test for generic log
         entityManager.removeEntityInstance(INSTANCE_ID_1);
         expect(mockLogger.info).toHaveBeenCalledWith(
           `Entity instance ${INSTANCE_ID_1} removed from EntityManager.`
@@ -220,17 +226,23 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
         expect(entityManager.activeEntities.has(INSTANCE_ID_2_POS)).toBe(false);
       });
 
-      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => { // Updated description and assertion
+      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => {
+        // Updated description and assertion
         expect(ENTITY_REMOVED_ID).toBe('core:entity_removed'); // Added check
         entityManager.removeEntityInstance(INSTANCE_ID_2_POS);
         expect(mockSpatialIndex.removeEntity).not.toHaveBeenCalled(); // No direct call
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(ENTITY_REMOVED_ID, { entity: mockEntityWithPos }); // Added event check
+        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+          ENTITY_REMOVED_ID,
+          { entity: mockEntityWithPos }
+        ); // Added event check
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       });
 
-      it('should log info message about removal and NOT log spatial index specific debug message', () => { // Updated description
+      it('should log info message about removal and NOT log spatial index specific debug message', () => {
+        // Updated description
         entityManager.removeEntityInstance(INSTANCE_ID_2_POS);
-        expect(mockLogger.debug).not.toHaveBeenCalledWith( // Ensure old debug log is gone
+        expect(mockLogger.debug).not.toHaveBeenCalledWith(
+          // Ensure old debug log is gone
           expect.stringContaining('from spatial index')
         );
         expect(mockLogger.info).toHaveBeenCalledWith(
@@ -245,7 +257,8 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
 
       beforeEach(() => {
         // Entity with position component but no locationId in it (invalid for spatial index)
-        mockEntityInvalidPos = { // Renamed for clarity
+        mockEntityInvalidPos = {
+          // Renamed for clarity
           id: instanceIdInvalidPos,
           hasComponent: jest.fn((id) => id === POSITION_COMPONENT_ID),
           getComponentData: jest.fn().mockReturnValue({ x: 0, y: 0 }),
@@ -266,20 +279,26 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
         );
       });
 
-      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => { // Updated description and assertion
+      it('should dispatch ENTITY_REMOVED_ID event and NOT call ISpatialIndexManager.removeEntity', () => {
+        // Updated description and assertion
         expect(ENTITY_REMOVED_ID).toBe('core:entity_removed'); // Added check
         entityManager.removeEntityInstance(instanceIdInvalidPos);
         expect(mockSpatialIndex.removeEntity).not.toHaveBeenCalled(); // No direct call
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(ENTITY_REMOVED_ID, { entity: mockEntityInvalidPos }); // Added event check
+        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+          ENTITY_REMOVED_ID,
+          { entity: mockEntityInvalidPos }
+        ); // Added event check
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
       });
 
-      it('should log info about removal and NOT specific spatial debug messages', () => { // Updated description
+      it('should log info about removal and NOT specific spatial debug messages', () => {
+        // Updated description
         entityManager.removeEntityInstance(instanceIdInvalidPos);
-        expect(mockLogger.debug).not.toHaveBeenCalledWith( // Ensure old debug log is gone
-           expect.stringContaining('from spatial index')
+        expect(mockLogger.debug).not.toHaveBeenCalledWith(
+          // Ensure old debug log is gone
+          expect.stringContaining('from spatial index')
         );
-         expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.info).toHaveBeenCalledWith(
           `Entity instance ${instanceIdInvalidPos} removed from EntityManager.`
         );
       });
@@ -317,19 +336,22 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
       mockLogger.warn.mockClear(); // Clear before test
     });
 
-    it('should log a deprecation warning', () => { // New test for warning
+    it('should log a deprecation warning', () => {
+      // New test for warning
       entityManager.getEntitiesInLocation(queryLocationId);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'EntityManager.getEntitiesInLocation: This method is deprecated as EntityManager is decoupled from SpatialIndexManager. Returning an empty set. Consumers should rely on events to maintain their own spatial data.'
       );
     });
-    
-    it('should NOT call ISpatialIndexManager.getEntitiesInLocation', () => { // Updated
+
+    it('should NOT call ISpatialIndexManager.getEntitiesInLocation', () => {
+      // Updated
       entityManager.getEntitiesInLocation(queryLocationId);
       expect(mockSpatialIndex.getEntitiesInLocation).not.toHaveBeenCalled();
     });
 
-    it('should return an empty Set', () => { // Updated
+    it('should return an empty Set', () => {
+      // Updated
       const result = entityManager.getEntitiesInLocation(queryLocationId);
       expect(result).toEqual(new Set()); // Check for empty set
       expect(result.size).toBe(0);
@@ -353,7 +375,8 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
       expect(entityManager.activeEntities.size).toBe(0);
     });
 
-    it('should log info messages about clearing entities and definition cache', () => { // Updated
+    it('should log info messages about clearing entities and definition cache', () => {
+      // Updated
       entityManager.clearAll();
       expect(mockLogger.info).toHaveBeenCalledWith(
         'All entity instances removed from EntityManager.'
@@ -364,10 +387,13 @@ describe('EntityManager - Auxiliary Methods (Lifecycle & Spatial Index)', () => 
       expect(mockLogger.info).toHaveBeenCalledTimes(2); // Ensure only these two info logs
     });
 
-    it('should NOT call ISpatialIndexManager.clearIndex and NOT log about spatial index', () => { // Updated
+    it('should NOT call ISpatialIndexManager.clearIndex and NOT log about spatial index', () => {
+      // Updated
       entityManager.clearAll();
       expect(mockSpatialIndex.clearIndex).not.toHaveBeenCalled();
-      expect(mockLogger.debug).not.toHaveBeenCalledWith('Spatial index cleared.');
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(
+        'Spatial index cleared.'
+      );
     });
   });
 });

--- a/tests/entities/entityManager.defaultInjectionValidation.test.js
+++ b/tests/entities/entityManager.defaultInjectionValidation.test.js
@@ -1,5 +1,5 @@
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import {
   ACTOR_COMPONENT_ID,
   NOTES_COMPONENT_ID,
@@ -58,7 +58,6 @@ const makeStubs = (validator) => {
 const createMockSafeEventDispatcher = () => ({
   dispatch: jest.fn(),
 });
-
 
 describe('EntityManager default component injection uses validated data', () => {
   let validator;

--- a/tests/entities/entityManager.definitionMutation.test.js
+++ b/tests/entities/entityManager.definitionMutation.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 
 const makeDeps = (definition) => {
   const registry = {
@@ -44,7 +44,6 @@ describe('EntityManager.createEntityInstance does not mutate definitions', () =>
     const deps = makeDeps(definition);
     mockEventDispatcher = createMockSafeEventDispatcher();
 
-
     const em = new EntityManager(
       deps.registry,
       deps.validator,
@@ -65,7 +64,6 @@ describe('EntityManager.createEntityInstance does not mutate definitions', () =>
     const deps = makeDeps(definition);
 
     mockEventDispatcher = createMockSafeEventDispatcher();
-
 
     const em = new EntityManager(
       deps.registry,

--- a/tests/entities/entityManager.getEntitiesWithComponent.test.js
+++ b/tests/entities/entityManager.getEntitiesWithComponent.test.js
@@ -10,7 +10,7 @@ import {
 } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
 import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../src/entities/entityInstanceData.js';
 
 // --- Mock Implementations ---
@@ -43,7 +43,6 @@ describe('EntityManager.getEntitiesWithComponent', () => {
   let mockSpatialIndex;
   let entityManager;
   let mockEventDispatcher;
-
 
   // --- Test Constants ---
   const COMPONENT_A = 'core:component_a';

--- a/tests/entities/entityManager.goals.test.js
+++ b/tests/entities/entityManager.goals.test.js
@@ -2,7 +2,7 @@
 
 import EntityManager from '../../src/entities/entityManager.js';
 import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import {
   ACTOR_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,

--- a/tests/entities/entityManager.notes.test.js
+++ b/tests/entities/entityManager.notes.test.js
@@ -8,7 +8,7 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import {
   ACTOR_COMPONENT_ID,
   NOTES_COMPONENT_ID,
@@ -93,7 +93,11 @@ describe('EntityManager - core:notes injection', () => {
           };
         }
         // For all other components, assume validation passes and provide cloned data.
-        return { isValid: true, errors: null, validatedData: deepClone(dataToValidate) };
+        return {
+          isValid: true,
+          errors: null,
+          validatedData: deepClone(dataToValidate),
+        };
       }),
     };
 

--- a/tests/entities/entityManager.reconstructEntity.test.js
+++ b/tests/entities/entityManager.reconstructEntity.test.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../src/entities/entityInstanceData.js';
 import { POSITION_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import { ENTITY_CREATED_ID } from '../../src/constants/eventIds.js';
@@ -82,7 +82,10 @@ describe('EntityManager.reconstructEntity', () => {
 
     expect(entity).not.toBeNull();
     expect(manager.activeEntities.get('e1')).toBe(entity);
-    expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(ENTITY_CREATED_ID, { entity, wasReconstructed: true });
+    expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+      ENTITY_CREATED_ID,
+      { entity, wasReconstructed: true }
+    );
   });
 
   it('returns null on validation failure', () => {

--- a/tests/entities/entityManager.removeComponent.test.js
+++ b/tests/entities/entityManager.removeComponent.test.js
@@ -11,7 +11,7 @@ import {
 import EntityManager from '../../src/entities/entityManager.js';
 // Entity import might not be directly needed if we only interact via EntityManager
 // import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import { POSITION_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import { EntityNotFoundError } from '../../src/errors/entityNotFoundError.js';
 import { COMPONENT_REMOVED_ID } from '../../src/constants/eventIds.js'; // Added import
@@ -168,7 +168,9 @@ describe('EntityManager.removeComponent', () => {
 
     expect(mockLogger.error).not.toHaveBeenCalled();
     expect(mockLogger.warn).not.toHaveBeenCalled();
-    const debugCalls = mockLogger.debug.mock.calls.filter(call => call[0].startsWith('EntityManager.removeComponent: Component override'));
+    const debugCalls = mockLogger.debug.mock.calls.filter((call) =>
+      call[0].startsWith('EntityManager.removeComponent: Component override')
+    );
     expect(debugCalls.length).toBe(1);
     expect(mockLogger.debug).toHaveBeenCalledWith(
       `EntityManager.removeComponent: Component override '${COMPONENT_TYPE_ID_NAME}' removed from entity '${MOCK_INSTANCE_ID}'.`
@@ -222,15 +224,17 @@ describe('EntityManager.removeComponent', () => {
 
     expect(mockLogger.error).not.toHaveBeenCalled();
     expect(mockLogger.warn).not.toHaveBeenCalled();
-    
+
     // Check for the generic component removal log
-    const genericLogCall = mockLogger.debug.mock.calls.find(call => 
-      call[0] === `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
+    const genericLogCall = mockLogger.debug.mock.calls.find(
+      (call) =>
+        call[0] ===
+        `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
     );
     expect(genericLogCall).toBeDefined();
 
     // Ensure the specific spatial index log is NOT present
-    const spatialIndexLogCall = mockLogger.debug.mock.calls.find(call =>
+    const spatialIndexLogCall = mockLogger.debug.mock.calls.find((call) =>
       call[0].includes('removed from spatial index')
     );
     expect(spatialIndexLogCall).toBeUndefined();
@@ -269,15 +273,17 @@ describe('EntityManager.removeComponent', () => {
       COMPONENT_REMOVED_ID,
       { entity: entityInstance, componentTypeId: POSITION_COMPONENT_ID }
     );
-    
+
     // Check for the generic component removal log
-    const genericLogCall = mockLogger.debug.mock.calls.find(call => 
-      call[0] === `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
+    const genericLogCall = mockLogger.debug.mock.calls.find(
+      (call) =>
+        call[0] ===
+        `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
     );
     expect(genericLogCall).toBeDefined();
 
     // Ensure the specific log about 'undefined' location is NOT present as a separate call (or adjust if it's part of the generic one)
-    const specificUndefinedLogCall = mockLogger.debug.mock.calls.find(call =>
+    const specificUndefinedLogCall = mockLogger.debug.mock.calls.find((call) =>
       call[0].includes("Old override location was 'undefined'")
     );
     expect(specificUndefinedLogCall).toBeUndefined();
@@ -321,19 +327,21 @@ describe('EntityManager.removeComponent', () => {
       COMPONENT_REMOVED_ID,
       { entity: entityInstance, componentTypeId: POSITION_COMPONENT_ID }
     );
-    
+
     expect(mockLogger.error).not.toHaveBeenCalled();
     expect(mockLogger.warn).not.toHaveBeenCalled();
 
     // Check for the generic component removal log
-    const genericLogCall = mockLogger.debug.mock.calls.find(call => 
-      call[0] === `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
+    const genericLogCall = mockLogger.debug.mock.calls.find(
+      (call) =>
+        call[0] ===
+        `EntityManager.removeComponent: Component override '${POSITION_COMPONENT_ID}' removed from entity '${MOCK_INSTANCE_ID}'.`
     );
     expect(genericLogCall).toBeDefined();
-    
+
     // Ensure the specific spatial index log is NOT present
-    const spatialIndexLogCall = mockLogger.debug.mock.calls.find(call =>
-      call[0].includes('removed from spatial index') 
+    const spatialIndexLogCall = mockLogger.debug.mock.calls.find((call) =>
+      call[0].includes('removed from spatial index')
     );
     expect(spatialIndexLogCall).toBeUndefined();
   });
@@ -367,7 +375,8 @@ describe('EntityManager.removeComponent', () => {
     ).toBe(true); // NAME (from definition) should still be there
     expect(mockSpatialIndex.removeEntity).not.toHaveBeenCalled();
     expect(mockEventDispatcher.dispatch).not.toHaveBeenCalled();
-    expect(mockLogger.debug).toHaveBeenCalledWith( // Changed from info to debug
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      // Changed from info to debug
       `EntityManager.removeComponent: Component '${COMPONENT_TYPE_ID_NAME}' not found as an override on entity '${MOCK_INSTANCE_ID}'. Nothing to remove at instance level.` // Updated message
     );
   });
@@ -382,7 +391,10 @@ describe('EntityManager.removeComponent', () => {
     expect(entityInstance).toBeDefined();
 
     expect(
-      entityManager.hasComponent(MOCK_INSTANCE_ID, COMPONENT_TYPE_ID_NON_EXISTENT)
+      entityManager.hasComponent(
+        MOCK_INSTANCE_ID,
+        COMPONENT_TYPE_ID_NON_EXISTENT
+      )
     ).toBe(false); // NON_EXISTENT is not there at all
 
     const result = entityManager.removeComponent(
@@ -392,7 +404,8 @@ describe('EntityManager.removeComponent', () => {
 
     expect(result).toBe(false);
     expect(mockEventDispatcher.dispatch).not.toHaveBeenCalled();
-    expect(mockLogger.debug).toHaveBeenCalledWith( // Changed from info to debug
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      // Changed from info to debug
       `EntityManager.removeComponent: Component '${COMPONENT_TYPE_ID_NON_EXISTENT}' not found as an override on entity '${MOCK_INSTANCE_ID}'. Nothing to remove at instance level.` // Updated message
     );
   });

--- a/tests/integration/entityCreationFromDefAndInstance.integration.test.js
+++ b/tests/integration/entityCreationFromDefAndInstance.integration.test.js
@@ -5,7 +5,7 @@
 
 import EntityManager from '../../src/entities/entityManager.js';
 import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import InMemoryDataRegistry from '../../src/data/inMemoryDataRegistry.js';
 
 // Mocks for constructor dependencies

--- a/tests/persistence/gameStateSerializer.test.js
+++ b/tests/persistence/gameStateSerializer.test.js
@@ -30,7 +30,7 @@ describe('GameStateSerializer persistence tests', () => {
     serializer = new GameStateSerializer({ logger, crypto: webcrypto });
   });
 
-  it('round trips via serializeAndCompress/decompress/deserialize', async () => {
+  it('round trips via compressPreparedState/decompress/deserialize', async () => {
     const obj = {
       metadata: { title: 'Test' },
       modManifest: {},
@@ -39,7 +39,7 @@ describe('GameStateSerializer persistence tests', () => {
     };
 
     const { compressedData, finalSaveObject } =
-      await serializer.serializeAndCompress(obj);
+      await serializer.compressPreparedState(obj);
     const dec = serializer.decompress(compressedData);
     expect(dec.success).toBe(true);
     const des = serializer.deserialize(dec.data);

--- a/tests/persistence/saveLoadService.test.js
+++ b/tests/persistence/saveLoadService.test.js
@@ -46,7 +46,7 @@ const createMemoryStorageProvider = () => {
  * @returns {jest.Mocked<GameStateSerializer>} Mock serializer
  */
 const createMockGameStateSerializer = () => ({
-  serializeAndCompress: jest.fn(async (obj) => ({
+  compressPreparedState: jest.fn(async (obj) => ({
     compressedData: new Uint8Array([1, 2, 3]),
     finalSaveObject: obj,
   })),
@@ -111,14 +111,14 @@ describe('SaveLoadService', () => {
         expectedPath,
         expect.any(Uint8Array)
       );
-      expect(serializer.serializeAndCompress).toHaveBeenCalledTimes(1);
+      expect(serializer.compressPreparedState).toHaveBeenCalledTimes(1);
       expect(prepareSpy).toHaveBeenCalledWith(
         name,
         state,
         serializer,
         expect.anything()
       );
-      const passedObj = serializer.serializeAndCompress.mock.calls[0][0];
+      const passedObj = serializer.compressPreparedState.mock.calls[0][0];
       expect(passedObj.metadata.saveName).toBe(name);
       expect(passedObj.integrityChecks).toEqual({});
     });
@@ -132,7 +132,7 @@ describe('SaveLoadService', () => {
       expect(result.error).toBeInstanceOf(PersistenceError);
       expect(result.error.code).toBe(PersistenceErrorCodes.INVALID_SAVE_NAME);
       expect(storageProvider.writeFileAtomically).not.toHaveBeenCalled();
-      expect(serializer.serializeAndCompress).not.toHaveBeenCalled();
+      expect(serializer.compressPreparedState).not.toHaveBeenCalled();
       expect(prepareSpy).not.toHaveBeenCalled();
     });
   });

--- a/tests/smoke/newCharacterMemory.test.js
+++ b/tests/smoke/newCharacterMemory.test.js
@@ -9,7 +9,7 @@
 // -----------------------------------------------------------------------------
 
 import EntityManager from '../../src/entities/entityManager.js';
-import EntityDefinition from '../../src/entities/EntityDefinition.js';
+import EntityDefinition from '../../src/entities/entityDefinition.js';
 import {
   ACTOR_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
@@ -71,7 +71,7 @@ describe('Smoke › New Character › Short-Term Memory bootstrap', () => {
   let mockEventDispatcher;
 
   test('EntityManager injects default short-term memory', () => {
-    mockEventDispatcher = createMockSafeEventDispatcher()
+    mockEventDispatcher = createMockSafeEventDispatcher();
 
     const { registry, validator, logger, spatialIndexManager } = makeStubs();
 


### PR DESCRIPTION
Summary: 
- add `compressPreparedState` to GameStateSerializer for already-cloned objects
- have savePreparation use new method
- update persistence tests accordingly and fix import paths

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 2678 problems)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685455d6877883318458bc5a0f15f152