### PR TITLE
[Agent] add saveStateUtils tests

### DIFF
--- a/tests/utils/saveStateUtils.test.js
+++ b/tests/utils/saveStateUtils.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import * as saveStateUtils from '../../src/utils/saveStateUtils.js';
+import { PersistenceErrorCodes } from '../../src/persistence/persistenceErrors.js';
+import * as objectUtils from '../../src/utils/objectUtils.js';
+
+jest.mock('../../src/utils/objectUtils.js', () => ({
+  safeDeepClone: jest.fn(),
+}));
+
+const { cloneValidatedState, cloneAndValidateSaveState } = saveStateUtils;
+
+describe('saveStateUtils', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { error: jest.fn() };
+    jest.clearAllMocks();
+  });
+
+  it('returns success when clone is valid with gameState', () => {
+    const obj = { gameState: { foo: 'bar' } };
+    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+
+    const result = cloneValidatedState(obj, logger);
+
+    expect(objectUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
+    expect(result).toEqual({ success: true, data: obj });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('propagates failure from safeDeepClone', () => {
+    const obj = { any: 'value' };
+    const err = { code: 'ERR', message: 'bad' };
+    objectUtils.safeDeepClone.mockReturnValue({ success: false, error: err });
+
+    const result = cloneValidatedState(obj, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe('ERR');
+    expect(result.error.message).toBe('bad');
+  });
+
+  it('fails when cloned object lacks gameState', () => {
+    const obj = { notGameState: true };
+    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+
+    const result = cloneValidatedState(obj, logger);
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.INVALID_GAME_STATE);
+  });
+
+  it('cloneAndValidateSaveState returns same result as cloneValidatedState', () => {
+    const obj = { gameState: {} };
+    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+
+    const viaWrapper = cloneAndValidateSaveState(obj, logger);
+
+    expect(viaWrapper).toEqual({ success: true, data: obj });
+    expect(objectUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
+  });
+});


### PR DESCRIPTION
Summary: add comprehensive unit tests for `saveStateUtils` to cover cloning success, error propagation, invalid gameState handling and wrapper function. Now all suites pass and coverage of this module reaches 100%.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint tests/utils/saveStateUtils.test.js --fix`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68545b33a9108331a8984753f88f36c6