### PR TITLE
[Agent] add GameEngine test environment

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -1,0 +1,95 @@
+/**
+ * @file Test environment factory for GameEngine-related tests.
+ * @see tests/common/engine/gameEngine.test-environment.js
+ */
+
+import { jest } from '@jest/globals';
+import GameEngine from '../../../src/engine/gameEngine.js';
+import { tokens } from '../../../src/dependencyInjection/tokens.js';
+import {
+  createMockLogger,
+  createMockEntityManager,
+  createMockTurnManager,
+  createMockGamePersistenceService,
+  createMockPlaytimeTracker,
+  createMockSafeEventDispatcher,
+  createMockInitializationService,
+} from '../mockFactories.js';
+
+/**
+ * Creates a set of mocks and a container for GameEngine.
+ *
+ * @description Creates a fully mocked environment for GameEngine tests.
+ * @returns {{
+ *   mockContainer: { resolve: jest.Mock },
+ *   logger: ReturnType<typeof createMockLogger>,
+ *   entityManager: ReturnType<typeof createMockEntityManager>,
+ *   turnManager: ReturnType<typeof createMockTurnManager>,
+ *   gamePersistenceService: ReturnType<typeof createMockGamePersistenceService>,
+ *   playtimeTracker: ReturnType<typeof createMockPlaytimeTracker>,
+ *   safeEventDispatcher: ReturnType<typeof createMockSafeEventDispatcher>,
+ *   initializationService: ReturnType<typeof createMockInitializationService>,
+ *   createGameEngine: () => GameEngine,
+ *   cleanup: () => void,
+ * }} Test environment utilities and mocks.
+ */
+export function createTestEnvironment() {
+  jest.clearAllMocks();
+
+  const logger = createMockLogger();
+  const entityManager = createMockEntityManager();
+  const turnManager = createMockTurnManager();
+  const gamePersistenceService = createMockGamePersistenceService();
+  const playtimeTracker = createMockPlaytimeTracker();
+  const safeEventDispatcher = createMockSafeEventDispatcher();
+  const initializationService = createMockInitializationService();
+
+  const mockContainer = {
+    resolve: jest.fn((token) => {
+      switch (token) {
+        case tokens.ILogger:
+          return logger;
+        case tokens.IEntityManager:
+          return entityManager;
+        case tokens.ITurnManager:
+          return turnManager;
+        case tokens.GamePersistenceService:
+          return gamePersistenceService;
+        case tokens.PlaytimeTracker:
+          return playtimeTracker;
+        case tokens.ISafeEventDispatcher:
+          return safeEventDispatcher;
+        case tokens.IInitializationService:
+          return initializationService;
+        default: {
+          const tokenName =
+            Object.keys(tokens).find((key) => tokens[key] === token) ||
+            token?.toString();
+          throw new Error(
+            `gameEngine.test-environment: Unmocked token: ${tokenName}`
+          );
+        }
+      }
+    }),
+  };
+
+  const createGameEngine = () => new GameEngine({ container: mockContainer });
+
+  const cleanup = () => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  };
+
+  return {
+    mockContainer,
+    logger,
+    entityManager,
+    turnManager,
+    gamePersistenceService,
+    playtimeTracker,
+    safeEventDispatcher,
+    initializationService,
+    createGameEngine,
+    cleanup,
+  };
+}

--- a/tests/common/mockFactories.js
+++ b/tests/common/mockFactories.js
@@ -9,6 +9,7 @@ import { jest } from '@jest/globals';
 
 /**
  * Creates a mock ILogger with jest functions.
+ *
  * @returns {jest.Mocked<import('../../src/interfaces/coreServices.js').ILogger>}
  */
 export const createMockLogger = () => ({
@@ -20,6 +21,7 @@ export const createMockLogger = () => ({
 
 /**
  * Creates a mock ISchemaValidator with jest functions.
+ *
  * @param {{ isValid: boolean }} [defaultValidationResult] - The default result for the validate method.
  * @returns {jest.Mocked<import('../../src/interfaces/coreServices.js').ISchemaValidator>}
  */
@@ -36,6 +38,7 @@ export const createMockSchemaValidator = (
 /**
  * Creates a simple, non-stateful mock IDataRegistry.
  * Useful for unit tests where only specific methods need to be mocked.
+ *
  * @returns {jest.Mocked<import('../../src/interfaces/coreServices.js').IDataRegistry>}
  */
 export const createSimpleMockDataRegistry = () => ({
@@ -50,6 +53,7 @@ export const createSimpleMockDataRegistry = () => ({
 /**
  * Creates a sophisticated, stateful mock IDataRegistry for integration testing.
  * It simulates an in-memory store.
+ *
  * @returns {jest.Mocked<import('../../src/interfaces/coreServices.js').IDataRegistry> & { _internalStore: object }}
  */
 export const createStatefulMockDataRegistry = () => {
@@ -111,6 +115,7 @@ export const createStatefulMockDataRegistry = () => {
 
 /**
  * Creates a mock IConfiguration service with common default values.
+ *
  * @returns {jest.Mocked<import('../../src/interfaces/coreServices.js').IConfiguration>}
  */
 export const createMockConfiguration = () => ({
@@ -124,10 +129,70 @@ export const createMockConfiguration = () => ({
   getModManifestFilename: jest.fn(() => 'mod.manifest.json'),
 });
 
+/**
+ * Mock for IEntityManager.
+ *
+ * @description Creates a mock IEntityManager service.
+ * @returns {jest.Mocked<import('../../src/interfaces/IEntityManager.js').IEntityManager>} Mocked IEntityManager
+ */
+export const createMockEntityManager = () => ({
+  clearAll: jest.fn(),
+  getActiveEntities: jest.fn().mockReturnValue([]),
+});
+
+/**
+ * Mock for ITurnManager.
+ *
+ * @description Creates a mock ITurnManager service.
+ * @returns {jest.Mocked<import('../../src/turns/interfaces/ITurnManager.js').ITurnManager>} Mocked turn manager
+ */
+export const createMockTurnManager = () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  nextTurn: jest.fn(),
+});
+
+/**
+ * Mock for IGamePersistenceService.
+ *
+ * @description Creates a mock IGamePersistenceService service.
+ * @returns {jest.Mocked<import('../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService>} Mocked persistence service
+ */
+export const createMockGamePersistenceService = () => ({
+  saveGame: jest.fn(),
+  loadAndRestoreGame: jest.fn(),
+  isSavingAllowed: jest.fn(),
+});
+
+/**
+ * Mock for PlaytimeTracker.
+ *
+ * @description Creates a mock PlaytimeTracker service.
+ * @returns {jest.Mocked<import('../../src/interfaces/IPlaytimeTracker.js').default>} Mocked playtime tracker
+ */
+export const createMockPlaytimeTracker = () => ({
+  reset: jest.fn(),
+  startSession: jest.fn(),
+  endSessionAndAccumulate: jest.fn(),
+  getTotalPlaytime: jest.fn().mockReturnValue(0),
+  setAccumulatedPlaytime: jest.fn(),
+});
+
+/**
+ * Mock for IInitializationService.
+ *
+ * @description Creates a mock IInitializationService service.
+ * @returns {jest.Mocked<import('../../src/interfaces/IInitializationService.js').IInitializationService>} Mocked initialization service
+ */
+export const createMockInitializationService = () => ({
+  runInitializationSequence: jest.fn(),
+});
+
 // --- Event Dispatcher Mocks ---
 
 /**
  * Creates a mock ISafeEventDispatcher with jest functions.
+ *
  * @returns {jest.Mocked<import('../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher>}
  */
 export const createMockSafeEventDispatcher = () => ({
@@ -136,6 +201,7 @@ export const createMockSafeEventDispatcher = () => ({
 
 /**
  * Creates a mock ValidatedEventDispatcher.
+ *
  * @returns {jest.Mocked<import('../../services/validatedEventDispatcher.js').default>}
  */
 export const createMockValidatedEventDispatcher = () => ({
@@ -146,6 +212,7 @@ export const createMockValidatedEventDispatcher = () => ({
 
 /**
  * Creates a generic mock for content loaders (e.g., ActionLoader, ComponentLoader).
+ *
  * @param {object} [defaultLoadResult] - The default result for loadItemsForMod.
  * @returns {jest.Mocked<import('../../../src/interfaces/coreServices.js').BaseManifestItemLoaderInterface>}
  */
@@ -157,6 +224,7 @@ export const createMockContentLoader = (
 
 /**
  * Creates a mock SchemaLoader.
+ *
  * @returns {jest.Mocked<import('../../src/loaders/schemaLoader.js').default>}
  */
 export const createMockSchemaLoader = () => ({
@@ -165,6 +233,7 @@ export const createMockSchemaLoader = () => ({
 
 /**
  * Creates a mock GameConfigLoader.
+ *
  * @returns {jest.Mocked<import('../../src/loaders/gameConfigLoader.js').default>}
  */
 export const createMockGameConfigLoader = () => ({
@@ -173,6 +242,7 @@ export const createMockGameConfigLoader = () => ({
 
 /**
  * Creates a mock ModManifestLoader.
+ *
  * @returns {jest.Mocked<import('../../src/modding/modManifestLoader.js').default>}
  */
 export const createMockModManifestLoader = () => ({
@@ -183,6 +253,7 @@ export const createMockModManifestLoader = () => ({
 
 /**
  * Creates a mock for the mod dependency validator.
+ *
  * @returns {{ validate: jest.Mock }}
  */
 export const createMockModDependencyValidator = () => ({
@@ -191,12 +262,14 @@ export const createMockModDependencyValidator = () => ({
 
 /**
  * Creates a mock for the mod version validator.
+ *
  * @returns {jest.Mock}
  */
 export const createMockModVersionValidator = () => jest.fn();
 
 /**
  * Creates a mock for the mod load order resolver.
+ *
  * @returns {{ resolveOrder: jest.Mock }}
  */
 export const createMockModLoadOrderResolver = () => ({


### PR DESCRIPTION
## Summary
- add GameEngine test environment factory
- mock engine dependencies in test mocks

## Testing
- `npm run lint` *(fails: 2699 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855730268c48331b89c0d8a87715b75