### PR TITLE
[Agent] Add tests for AIPromptPipeline

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,0 +1,133 @@
+/* eslint-env node */
+import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
+import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
+import { AIPromptPipelineTestBed } from '../../common/prompting/promptPipelineTestBed.js';
+
+/**
+ * Utility to create a full set of valid dependencies for the constructor tests.
+ */
+const makeDeps = () => ({
+  llmAdapter: { getAIDecision: jest.fn(), getCurrentActiveLlmId: jest.fn() },
+  gameStateProvider: { buildGameState: jest.fn() },
+  promptContentProvider: { getPromptData: jest.fn() },
+  promptBuilder: { build: jest.fn() },
+  logger: { info: jest.fn() },
+});
+
+describe('AIPromptPipeline', () => {
+  /** @type {AIPromptPipelineTestBed} */
+  let testBed;
+  /** @type {AIPromptPipeline} */
+  let pipeline;
+
+  beforeEach(() => {
+    testBed = new AIPromptPipelineTestBed();
+    pipeline = testBed.createPipeline();
+
+    // Default success paths
+    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue('llm-id');
+    testBed.gameStateProvider.buildGameState.mockResolvedValue({});
+    testBed.promptContentProvider.getPromptData.mockResolvedValue({});
+    testBed.promptBuilder.build.mockResolvedValue('PROMPT');
+  });
+
+  afterEach(() => {
+    testBed.cleanup();
+  });
+
+  describe('constructor validation', () => {
+    test.each([
+      ['llmAdapter missing', (d) => { delete d.llmAdapter; }, /ILLMAdapter/],
+      [
+        'llmAdapter.getAIDecision missing',
+        (d) => { delete d.llmAdapter.getAIDecision; },
+        /ILLMAdapter/,
+      ],
+      [
+        'llmAdapter.getCurrentActiveLlmId missing',
+        (d) => { delete d.llmAdapter.getCurrentActiveLlmId; },
+        /ILLMAdapter/,
+      ],
+      ['gameStateProvider missing', (d) => { delete d.gameStateProvider; }, /IAIGameStateProvider/],
+      [
+        'gameStateProvider.buildGameState missing',
+        (d) => { delete d.gameStateProvider.buildGameState; },
+        /IAIGameStateProvider/,
+      ],
+      ['promptContentProvider missing', (d) => { delete d.promptContentProvider; }, /IAIPromptContentProvider/],
+      [
+        'promptContentProvider.getPromptData missing',
+        (d) => { delete d.promptContentProvider.getPromptData; },
+        /IAIPromptContentProvider/,
+      ],
+      ['promptBuilder missing', (d) => { delete d.promptBuilder; }, /IPromptBuilder/],
+      ['promptBuilder.build missing', (d) => { delete d.promptBuilder.build; }, /IPromptBuilder/],
+      ['logger missing', (d) => { delete d.logger; }, /ILogger/],
+      ['logger.info missing', (d) => { delete d.logger.info; }, /ILogger/],
+    ])('throws when %s', (_desc, mutate, regex) => {
+      const deps = makeDeps();
+      mutate(deps);
+      expect(() => new AIPromptPipeline(deps)).toThrow(regex);
+    });
+  });
+
+  test('generatePrompt orchestrates dependencies and returns prompt', async () => {
+    const actor = { id: 'actor1' };
+    const context = {};
+    const actions = [{ id: 'a1' }];
+
+    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue('llm1');
+    testBed.gameStateProvider.buildGameState.mockResolvedValue({ state: true });
+    testBed.promptContentProvider.getPromptData.mockResolvedValue({ pd: true });
+    testBed.promptBuilder.build.mockResolvedValue('FINAL');
+
+    const prompt = await pipeline.generatePrompt(actor, context, actions);
+
+    expect(prompt).toBe('FINAL');
+    expect(testBed.llmAdapter.getCurrentActiveLlmId).toHaveBeenCalledTimes(1);
+    expect(testBed.gameStateProvider.buildGameState).toHaveBeenCalledWith(
+      actor,
+      context,
+      testBed.logger,
+    );
+    expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
+      expect.objectContaining({ state: true, availableActions: actions }),
+      testBed.logger,
+    );
+    expect(testBed.promptBuilder.build).toHaveBeenCalledWith('llm1', { pd: true });
+  });
+
+  test('generatePrompt errors when llmAdapter returns falsy', async () => {
+    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null);
+
+    await expect(
+      pipeline.generatePrompt({ id: 'a' }, {}, [])
+    ).rejects.toThrow('Could not determine active LLM ID.');
+  });
+
+  test('generatePrompt errors when promptBuilder.build returns empty string', async () => {
+    testBed.promptBuilder.build.mockResolvedValue('');
+
+    await expect(
+      pipeline.generatePrompt({ id: 'a' }, {}, [])
+    ).rejects.toThrow('PromptBuilder returned an empty or invalid prompt.');
+  });
+
+  test('availableActions are attached to DTO sent to getPromptData', async () => {
+    const actor = { id: 'actor2' };
+    const context = {};
+    const actions = [{ id: 'act' }];
+
+    testBed.gameStateProvider.buildGameState.mockResolvedValue({});
+    testBed.promptContentProvider.getPromptData.mockResolvedValue({});
+    testBed.promptBuilder.build.mockResolvedValue('prompt');
+
+    await pipeline.generatePrompt(actor, context, actions);
+
+    expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
+      expect.objectContaining({ availableActions: actions }),
+      testBed.logger,
+    );
+  });
+});
+


### PR DESCRIPTION
Summary: Adds comprehensive unit tests for `AIPromptPipeline` ensuring constructor validation, proper orchestration, and error handling.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68557b0aa7dc8331af32b810ea5fe12f