### PR TITLE
[Agent] add mock factory helpers and refactor prompt pipeline tests

### DIFF
--- a/tests/common/mockFactories.js
+++ b/tests/common/mockFactories.js
@@ -240,6 +240,45 @@ export const createMockInitializationService = () => ({
   runInitializationSequence: jest.fn(),
 });
 
+// --- Prompting Mocks ---
+
+/**
+ * Creates a mock ILLMAdapter.
+ *
+ * @returns {jest.Mocked<import('../../src/turns/interfaces/ILLMAdapter.js').ILLMAdapter>} Mocked LLM adapter
+ */
+export const createMockLLMAdapter = () => ({
+  getAIDecision: jest.fn(),
+  getCurrentActiveLlmId: jest.fn(),
+});
+
+/**
+ * Creates a mock IAIGameStateProvider.
+ *
+ * @returns {jest.Mocked<import('../../src/turns/interfaces/IAIGameStateProvider.js').IAIGameStateProvider>} Mocked game state provider
+ */
+export const createMockAIGameStateProvider = () => ({
+  buildGameState: jest.fn(),
+});
+
+/**
+ * Creates a mock IAIPromptContentProvider.
+ *
+ * @returns {jest.Mocked<import('../../src/turns/interfaces/IAIPromptContentProvider.js').IAIPromptContentProvider>} Mocked prompt content provider
+ */
+export const createMockAIPromptContentProvider = () => ({
+  getPromptData: jest.fn(),
+});
+
+/**
+ * Creates a mock IPromptBuilder.
+ *
+ * @returns {jest.Mocked<import('../../src/interfaces/IPromptBuilder.js').IPromptBuilder>} Mocked prompt builder
+ */
+export const createMockPromptBuilder = () => ({
+  build: jest.fn(),
+});
+
 // --- Event Dispatcher Mocks ---
 
 /**

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -5,7 +5,13 @@
 
 import { jest } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
-import { createMockLogger } from '../mockFactories.js';
+import {
+  createMockLogger,
+  createMockLLMAdapter,
+  createMockAIGameStateProvider,
+  createMockAIPromptContentProvider,
+  createMockPromptBuilder,
+} from '../mockFactories.js';
 
 /**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
@@ -24,19 +30,10 @@ export class AIPromptPipelineTestBed {
   logger;
 
   constructor() {
-    this.llmAdapter = {
-      getAIDecision: jest.fn(),
-      getCurrentActiveLlmId: jest.fn(),
-    };
-    this.gameStateProvider = {
-      buildGameState: jest.fn(),
-    };
-    this.promptContentProvider = {
-      getPromptData: jest.fn(),
-    };
-    this.promptBuilder = {
-      build: jest.fn(),
-    };
+    this.llmAdapter = createMockLLMAdapter();
+    this.gameStateProvider = createMockAIGameStateProvider();
+    this.promptContentProvider = createMockAIPromptContentProvider();
+    this.promptBuilder = createMockPromptBuilder();
     this.logger = createMockLogger();
   }
 
@@ -54,6 +51,27 @@ export class AIPromptPipelineTestBed {
       promptBuilder: this.promptBuilder,
       logger: this.logger,
     });
+  }
+
+  /**
+   * Returns the dependency object used to construct the pipeline.
+   *
+   * @returns {{
+   *   llmAdapter: ReturnType<typeof createMockLLMAdapter>,
+   *   gameStateProvider: ReturnType<typeof createMockAIGameStateProvider>,
+   *   promptContentProvider: ReturnType<typeof createMockAIPromptContentProvider>,
+   *   promptBuilder: ReturnType<typeof createMockPromptBuilder>,
+   *   logger: ReturnType<typeof createMockLogger>,
+   * }}
+   */
+  getDependencies() {
+    return {
+      llmAdapter: this.llmAdapter,
+      gameStateProvider: this.gameStateProvider,
+      promptContentProvider: this.promptContentProvider,
+      promptBuilder: this.promptBuilder,
+      logger: this.logger,
+    };
   }
 
   /**

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,18 +1,14 @@
 /* eslint-env node */
-import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
+import {
+  describe,
+  beforeEach,
+  afterEach,
+  test,
+  expect,
+  jest,
+} from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import { AIPromptPipelineTestBed } from '../../common/prompting/promptPipelineTestBed.js';
-
-/**
- * Utility to create a full set of valid dependencies for the constructor tests.
- */
-const makeDeps = () => ({
-  llmAdapter: { getAIDecision: jest.fn(), getCurrentActiveLlmId: jest.fn() },
-  gameStateProvider: { buildGameState: jest.fn() },
-  promptContentProvider: { getPromptData: jest.fn() },
-  promptBuilder: { build: jest.fn() },
-  logger: { info: jest.fn() },
-});
 
 describe('AIPromptPipeline', () => {
   /** @type {AIPromptPipelineTestBed} */
@@ -37,35 +33,85 @@ describe('AIPromptPipeline', () => {
 
   describe('constructor validation', () => {
     test.each([
-      ['llmAdapter missing', (d) => { delete d.llmAdapter; }, /ILLMAdapter/],
+      [
+        'llmAdapter missing',
+        (d) => {
+          delete d.llmAdapter;
+        },
+        /ILLMAdapter/,
+      ],
       [
         'llmAdapter.getAIDecision missing',
-        (d) => { delete d.llmAdapter.getAIDecision; },
+        (d) => {
+          delete d.llmAdapter.getAIDecision;
+        },
         /ILLMAdapter/,
       ],
       [
         'llmAdapter.getCurrentActiveLlmId missing',
-        (d) => { delete d.llmAdapter.getCurrentActiveLlmId; },
+        (d) => {
+          delete d.llmAdapter.getCurrentActiveLlmId;
+        },
         /ILLMAdapter/,
       ],
-      ['gameStateProvider missing', (d) => { delete d.gameStateProvider; }, /IAIGameStateProvider/],
       [
-        'gameStateProvider.buildGameState missing',
-        (d) => { delete d.gameStateProvider.buildGameState; },
+        'gameStateProvider missing',
+        (d) => {
+          delete d.gameStateProvider;
+        },
         /IAIGameStateProvider/,
       ],
-      ['promptContentProvider missing', (d) => { delete d.promptContentProvider; }, /IAIPromptContentProvider/],
       [
-        'promptContentProvider.getPromptData missing',
-        (d) => { delete d.promptContentProvider.getPromptData; },
+        'gameStateProvider.buildGameState missing',
+        (d) => {
+          delete d.gameStateProvider.buildGameState;
+        },
+        /IAIGameStateProvider/,
+      ],
+      [
+        'promptContentProvider missing',
+        (d) => {
+          delete d.promptContentProvider;
+        },
         /IAIPromptContentProvider/,
       ],
-      ['promptBuilder missing', (d) => { delete d.promptBuilder; }, /IPromptBuilder/],
-      ['promptBuilder.build missing', (d) => { delete d.promptBuilder.build; }, /IPromptBuilder/],
-      ['logger missing', (d) => { delete d.logger; }, /ILogger/],
-      ['logger.info missing', (d) => { delete d.logger.info; }, /ILogger/],
+      [
+        'promptContentProvider.getPromptData missing',
+        (d) => {
+          delete d.promptContentProvider.getPromptData;
+        },
+        /IAIPromptContentProvider/,
+      ],
+      [
+        'promptBuilder missing',
+        (d) => {
+          delete d.promptBuilder;
+        },
+        /IPromptBuilder/,
+      ],
+      [
+        'promptBuilder.build missing',
+        (d) => {
+          delete d.promptBuilder.build;
+        },
+        /IPromptBuilder/,
+      ],
+      [
+        'logger missing',
+        (d) => {
+          delete d.logger;
+        },
+        /ILogger/,
+      ],
+      [
+        'logger.info missing',
+        (d) => {
+          delete d.logger.info;
+        },
+        /ILogger/,
+      ],
     ])('throws when %s', (_desc, mutate, regex) => {
-      const deps = makeDeps();
+      const deps = testBed.getDependencies();
       mutate(deps);
       expect(() => new AIPromptPipeline(deps)).toThrow(regex);
     });
@@ -88,29 +134,31 @@ describe('AIPromptPipeline', () => {
     expect(testBed.gameStateProvider.buildGameState).toHaveBeenCalledWith(
       actor,
       context,
-      testBed.logger,
+      testBed.logger
     );
     expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
       expect.objectContaining({ state: true, availableActions: actions }),
-      testBed.logger,
+      testBed.logger
     );
-    expect(testBed.promptBuilder.build).toHaveBeenCalledWith('llm1', { pd: true });
+    expect(testBed.promptBuilder.build).toHaveBeenCalledWith('llm1', {
+      pd: true,
+    });
   });
 
   test('generatePrompt errors when llmAdapter returns falsy', async () => {
     testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null);
 
-    await expect(
-      pipeline.generatePrompt({ id: 'a' }, {}, [])
-    ).rejects.toThrow('Could not determine active LLM ID.');
+    await expect(pipeline.generatePrompt({ id: 'a' }, {}, [])).rejects.toThrow(
+      'Could not determine active LLM ID.'
+    );
   });
 
   test('generatePrompt errors when promptBuilder.build returns empty string', async () => {
     testBed.promptBuilder.build.mockResolvedValue('');
 
-    await expect(
-      pipeline.generatePrompt({ id: 'a' }, {}, [])
-    ).rejects.toThrow('PromptBuilder returned an empty or invalid prompt.');
+    await expect(pipeline.generatePrompt({ id: 'a' }, {}, [])).rejects.toThrow(
+      'PromptBuilder returned an empty or invalid prompt.'
+    );
   });
 
   test('availableActions are attached to DTO sent to getPromptData', async () => {
@@ -126,8 +174,7 @@ describe('AIPromptPipeline', () => {
 
     expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
       expect.objectContaining({ availableActions: actions }),
-      testBed.logger,
+      testBed.logger
     );
   });
 });
-


### PR DESCRIPTION
Summary:
- add helper factories for AIPromptPipeline tests
- use factories in promptPipelineTestBed and expose getDependencies
- refactor AIPromptPipeline constructor tests to use test bed dependencies

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test` *(fails coverage threshold)*
- [x] `cd llm-proxy-server && npm run lint`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68557fe3ec88833197257d417379920f