### PR TITLE
[Agent] simplify test mock setup

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -80,6 +80,27 @@ export class AIPromptPipelineTestBed {
   cleanup() {
     jest.clearAllMocks();
   }
+
+  /**
+   * Sets up mock resolved values for a successful pipeline run.
+   *
+   * @param {object} [options]
+   * @param {string} [options.llmId] - LLM ID returned by the adapter.
+   * @param {object} [options.gameState] - Game state returned by the provider.
+   * @param {object} [options.promptData] - Prompt data returned by the content provider.
+   * @param {string} [options.finalPrompt] - Final prompt string returned by the builder.
+   */
+  setupMockSuccess({
+    llmId = 'llm-id',
+    gameState = {},
+    promptData = {},
+    finalPrompt = 'PROMPT',
+  } = {}) {
+    this.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(llmId);
+    this.gameStateProvider.buildGameState.mockResolvedValue(gameState);
+    this.promptContentProvider.getPromptData.mockResolvedValue(promptData);
+    this.promptBuilder.build.mockResolvedValue(finalPrompt);
+  }
 }
 
 export default AIPromptPipelineTestBed;

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,12 +1,5 @@
 /* eslint-env node */
-import {
-  describe,
-  beforeEach,
-  afterEach,
-  test,
-  expect,
-  jest,
-} from '@jest/globals';
+import { describe, beforeEach, afterEach, test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import { AIPromptPipelineTestBed } from '../../common/prompting/promptPipelineTestBed.js';
 
@@ -21,10 +14,7 @@ describe('AIPromptPipeline', () => {
     pipeline = testBed.createPipeline();
 
     // Default success paths
-    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue('llm-id');
-    testBed.gameStateProvider.buildGameState.mockResolvedValue({});
-    testBed.promptContentProvider.getPromptData.mockResolvedValue({});
-    testBed.promptBuilder.build.mockResolvedValue('PROMPT');
+    testBed.setupMockSuccess();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- extend `AIPromptPipelineTestBed` with a helper to set default mocks
- reuse the helper in `AIPromptPipeline.test.js` to streamline setup

## Testing Done
- `npm run test:single tests/unit/prompting/AIPromptPipeline.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685582c19c30833199a645143c673509