### PR TITLE
[Agent] Add GameEngine test bed helper

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -1,0 +1,90 @@
+/**
+ * @file Provides a minimal test bed for GameEngine unit tests.
+ * @see tests/common/engine/gameEngineTestBed.js
+ */
+
+import { createTestEnvironment } from './gameEngine.test-environment.js';
+
+/**
+ * @description Utility class that instantiates {@link GameEngine} using a mocked
+ * environment and exposes helpers for common test operations.
+ * @class
+ */
+export class GameEngineTestBed {
+  /** @type {ReturnType<typeof createTestEnvironment>} */
+  env;
+  /** @type {import('../../../src/engine/gameEngine.js').default} */
+  engine;
+  /**
+   * @type {{
+   *   logger: ReturnType<import('../mockFactories.js').createMockLogger>,
+   *   entityManager: ReturnType<import('../mockFactories.js').createMockEntityManager>,
+   *   turnManager: ReturnType<import('../mockFactories.js').createMockTurnManager>,
+   *   gamePersistenceService: ReturnType<import('../mockFactories.js').createMockGamePersistenceService>,
+   *   playtimeTracker: ReturnType<import('../mockFactories.js').createMockPlaytimeTracker>,
+   *   safeEventDispatcher: ReturnType<import('../mockFactories.js').createMockSafeEventDispatcher>,
+   *   initializationService: ReturnType<import('../mockFactories.js').createMockInitializationService>,
+   * }}
+   */
+  mocks;
+
+  constructor() {
+    this.env = createTestEnvironment();
+    this.engine = this.env.createGameEngine();
+    this.mocks = {
+      logger: this.env.logger,
+      entityManager: this.env.entityManager,
+      turnManager: this.env.turnManager,
+      gamePersistenceService: this.env.gamePersistenceService,
+      playtimeTracker: this.env.playtimeTracker,
+      safeEventDispatcher: this.env.safeEventDispatcher,
+      initializationService: this.env.initializationService,
+    };
+  }
+
+  /**
+   * Presets initialization results and starts a new game.
+   *
+   * @param {string} worldName - Name of the world to initialize.
+   * @param {import('../../src/interfaces/IInitializationService.js').InitializationResult} [initResult]
+   * @returns {Promise<void>} Promise resolving when the engine has started.
+   */
+  async start(worldName, initResult = { success: true }) {
+    this.env.initializationService.runInitializationSequence.mockResolvedValue(
+      initResult
+    );
+    await this.engine.startNewGame(worldName);
+  }
+
+  /**
+   * Stops the engine if it is initialized.
+   *
+   * @returns {Promise<void>} Promise resolving once stopped.
+   */
+  async stop() {
+    if (this.engine.getEngineStatus().isInitialized) {
+      await this.engine.stop();
+    }
+  }
+
+  /**
+   * Stops the engine and cleans up the environment.
+   *
+   * @returns {Promise<void>} Promise resolving when cleanup is complete.
+   */
+  async cleanup() {
+    await this.stop();
+    this.env.cleanup();
+  }
+}
+
+/**
+ * Creates a new {@link GameEngineTestBed} instance.
+ *
+ * @returns {GameEngineTestBed} Test bed instance.
+ */
+export function createGameEngineTestBed() {
+  return new GameEngineTestBed();
+}
+
+export default GameEngineTestBed;

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -1,0 +1,67 @@
+/**
+ * @file Test suite for the GameEngine test bed helper.
+ * @see tests/unit/common/engine/gameEngineTestBed.test.js
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { GameEngineTestBed } from '../../../common/engine/gameEngineTestBed.js';
+import GameEngine from '../../../../src/engine/gameEngine.js';
+
+jest.mock('../../../../src/engine/gameEngine.js');
+
+describe('GameEngine Test Helpers: GameEngineTestBed', () => {
+  let testBed;
+  let engine;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engine = {
+      startNewGame: jest.fn(),
+      stop: jest.fn(),
+      getEngineStatus: jest.fn().mockReturnValue({ isInitialized: false }),
+    };
+    GameEngine.mockImplementation(() => engine);
+    testBed = new GameEngineTestBed();
+  });
+
+  it('instantiates GameEngine with mocks', () => {
+    expect(GameEngine).toHaveBeenCalledTimes(1);
+    expect(GameEngine).toHaveBeenCalledWith({
+      container: testBed.env.mockContainer,
+    });
+    expect(testBed.engine).toBe(engine);
+    expect(testBed.mocks.logger).toBe(testBed.env.logger);
+    expect(testBed.mocks.turnManager).toBe(testBed.env.turnManager);
+  });
+
+  it('start presets initialization result and calls startNewGame', async () => {
+    const initResult = { success: false };
+    await testBed.start('World', initResult);
+
+    expect(engine.startNewGame).toHaveBeenCalledWith('World');
+    await expect(
+      testBed.env.initializationService.runInitializationSequence()
+    ).resolves.toEqual(initResult);
+  });
+
+  it('stop only stops engine when initialized', async () => {
+    engine.getEngineStatus.mockReturnValue({ isInitialized: true });
+    await testBed.stop();
+    expect(engine.stop).toHaveBeenCalledTimes(1);
+
+    engine.stop.mockClear();
+    engine.getEngineStatus.mockReturnValue({ isInitialized: false });
+    await testBed.stop();
+    expect(engine.stop).not.toHaveBeenCalled();
+  });
+
+  it('cleanup stops engine and calls env.cleanup', async () => {
+    jest.spyOn(testBed.env, 'cleanup').mockImplementation(() => {});
+    engine.getEngineStatus.mockReturnValue({ isInitialized: true });
+
+    await testBed.cleanup();
+
+    expect(engine.stop).toHaveBeenCalledTimes(1);
+    expect(testBed.env.cleanup).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add GameEngineTestBed class for engine tests
- cover helper with unit tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855844255788331ae25544bfc9f6971