### PR TITLE
[Agent] consolidate pipeline error tests

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -135,19 +135,22 @@ describe('AIPromptPipeline', () => {
     });
   });
 
-  test('generatePrompt errors when llmAdapter returns falsy', async () => {
-    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null);
-
+  test.each([
+    {
+      desc: 'llmAdapter returns falsy',
+      mutate: () =>
+        testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null),
+      error: 'Could not determine active LLM ID.',
+    },
+    {
+      desc: 'promptBuilder returns empty string',
+      mutate: () => testBed.promptBuilder.build.mockResolvedValue(''),
+      error: 'PromptBuilder returned an empty or invalid prompt.',
+    },
+  ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
+    mutate();
     await expect(pipeline.generatePrompt({ id: 'a' }, {}, [])).rejects.toThrow(
-      'Could not determine active LLM ID.'
-    );
-  });
-
-  test('generatePrompt errors when promptBuilder.build returns empty string', async () => {
-    testBed.promptBuilder.build.mockResolvedValue('');
-
-    await expect(pipeline.generatePrompt({ id: 'a' }, {}, [])).rejects.toThrow(
-      'PromptBuilder returned an empty or invalid prompt.'
+      error
     );
   });
 


### PR DESCRIPTION
Summary: unified AIPromptPipeline rejection scenarios using test.each for clarity

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68558df59e1c8331b37db25372a94ee8