### PR TITLE
[Agent] reset mock implementations in TestBed cleanup

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -174,9 +174,14 @@ export class TestBed {
    * This should be called in an `afterEach` block to ensure test isolation.
    */
   cleanup() {
-    // FIX: Clear mocks first to make the call to clearAll() testable.
-    // This doesn't change the external behavior, which is to reset the test environment.
+    // Clear call history on all mocks
     jest.clearAllMocks();
+
+    // Reset specific mock implementations that tests commonly override
+    this.mocks.registry.getEntityDefinition.mockReset();
+    this.mocks.validator.validate.mockReset();
+    // Restore default behavior for validate after reset
+    this.mocks.validator.validate.mockReturnValue({ isValid: true });
 
     if (
       this.entityManager &&


### PR DESCRIPTION
Summary:
- reset `getEntityDefinition` and `validate` mocks during `cleanup`
- restore default validator behaviour

Testing Done:
- `npm run format`
- `npm run lint` *(fails: many existing errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855934388608331be42ea3da825962d