### PR TITLE
[Agent] extend testbed init helper

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -43,6 +43,19 @@ export class GameEngineTestBed {
   }
 
   /**
+   * Initializes the engine using a default successful initialization result.
+   *
+   * @param {string} [world] - World name to initialize.
+   * @returns {Promise<void>} Promise resolving when the engine has started.
+   */
+  async init(world = 'TestWorld') {
+    this.env.initializationService.runInitializationSequence.mockResolvedValue({
+      success: true,
+    });
+    await this.engine.startNewGame(world);
+  }
+
+  /**
    * Presets initialization results and starts a new game.
    *
    * @param {string} worldName - Name of the world to initialize.

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -44,6 +44,20 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     ).resolves.toEqual(initResult);
   });
 
+  it('init mocks successful initialization and starts default world', async () => {
+    await testBed.init();
+
+    expect(engine.startNewGame).toHaveBeenCalledWith('TestWorld');
+    await expect(
+      testBed.env.initializationService.runInitializationSequence()
+    ).resolves.toEqual({ success: true });
+  });
+
+  it('init accepts custom world name', async () => {
+    await testBed.init('Custom');
+    expect(engine.startNewGame).toHaveBeenCalledWith('Custom');
+  });
+
   it('stop only stops engine when initialized', async () => {
     engine.getEngineStatus.mockReturnValue({ isInitialized: true });
     await testBed.stop();

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -402,7 +402,7 @@ describe('GameEngine', () => {
 
     describe('when engine is initialized', () => {
       beforeEach(async () => {
-        await testBed.start(MOCK_ACTIVE_WORLD_FOR_SAVE);
+        await testBed.init(MOCK_ACTIVE_WORLD_FOR_SAVE);
         gameEngine = testBed.engine;
         testBed.mocks.safeEventDispatcher.dispatch.mockClear();
         testBed.mocks.logger.info.mockClear();
@@ -811,7 +811,7 @@ describe('GameEngine', () => {
     beforeEach(async () => {
       gameEngine = testBed.engine;
       // Start the game to ensure this.#isEngineInitialized is true for isSavingAllowed check
-      await testBed.start(MOCK_WORLD_NAME);
+      await testBed.init(MOCK_WORLD_NAME);
       testBed.mocks.safeEventDispatcher.dispatch.mockClear();
       testBed.mocks.logger.info.mockClear();
       testBed.mocks.logger.warn.mockClear();


### PR DESCRIPTION
Summary: Added `init` method to `GameEngineTestBed` for simplified engine setup. Updated relevant engine tests to use the new helper and expanded its test suite.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 2710 problems)*
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855933b781c8331b8a6efb57400679d