### PR TITLE
[Agent] add helper for DI overrides in tests

### DIFF
--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { GameEngineTestBed } from '../../../common/engine/gameEngineTestBed.js';
 import GameEngine from '../../../../src/engine/gameEngine.js';
+import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 
 jest.mock('../../../../src/engine/gameEngine.js');
 
@@ -77,5 +78,18 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
 
     expect(engine.stop).toHaveBeenCalledTimes(1);
     expect(testBed.env.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('withTokenOverride replaces container resolve and resets on cleanup', async () => {
+    const custom = { foo: 'bar' };
+    testBed.withTokenOverride(tokens.PlaytimeTracker, custom);
+
+    const resolved = testBed.env.mockContainer.resolve(tokens.PlaytimeTracker);
+    expect(resolved).toBe(custom);
+
+    await testBed.cleanup();
+
+    const restored = testBed.env.mockContainer.resolve(tokens.PlaytimeTracker);
+    expect(restored).toBe(testBed.mocks.playtimeTracker);
   });
 });


### PR DESCRIPTION
## Summary
- add `withTokenOverride` to `GameEngineTestBed`
- reset token overrides during cleanup
- use the helper in `GameEngine` tests
- ensure `GameEngineTestBed` has tests for the new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 557 errors, 2152 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685597665d5c83319433dee7b83a5592