### PR TITLE
[Agent] Add EntityManager suite helper

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -223,4 +223,27 @@ export class TestBed {
   }
 }
 
+/**
+ * Creates a test suite for {@link EntityManager} utilizing {@link TestBed} for
+ * setup and cleanup. The provided suite function receives a getter that
+ * returns the current {@link TestBed} instance.
+ *
+ * @param {string} title - Title of the suite passed to `describe`.
+ * @param {(getTestBed: () => TestBed) => void} suiteFn - Function containing the
+ *   tests. It receives a callback that returns the active {@link TestBed}.
+ * @returns {void}
+ */
+export function describeEntityManagerSuite(title, suiteFn) {
+  describe(title, () => {
+    let tb;
+    beforeEach(() => {
+      tb = new TestBed();
+    });
+    afterEach(() => {
+      tb.cleanup();
+    });
+    suiteFn(() => tb);
+  });
+}
+
 export default TestBed;


### PR DESCRIPTION
Summary: Added new `describeEntityManagerSuite` utility in `tests/common/entities/testBed.js` to simplify EntityManager test suite setup/teardown.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: existing repo issues)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685597d0f4e083319bec2b4bedb25e8c