### PR TITLE
[Agent] Refactor AIPromptPipeline tests to use helper

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -117,10 +117,12 @@ describe('AIPromptPipeline', () => {
     const context = defaultContext;
     const actions = [...defaultActions, { id: 'a1' }];
 
-    testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue('llm1');
-    testBed.gameStateProvider.buildGameState.mockResolvedValue({ state: true });
-    testBed.promptContentProvider.getPromptData.mockResolvedValue({ pd: true });
-    testBed.promptBuilder.build.mockResolvedValue('FINAL');
+    testBed.setupMockSuccess({
+      llmId: 'llm1',
+      gameState: { state: true },
+      promptData: { pd: true },
+      finalPrompt: 'FINAL',
+    });
 
     const prompt = await pipeline.generatePrompt(actor, context, actions);
 
@@ -164,9 +166,11 @@ describe('AIPromptPipeline', () => {
     const context = defaultContext;
     const actions = [...defaultActions, { id: 'act' }];
 
-    testBed.gameStateProvider.buildGameState.mockResolvedValue({});
-    testBed.promptContentProvider.getPromptData.mockResolvedValue({});
-    testBed.promptBuilder.build.mockResolvedValue('prompt');
+    testBed.setupMockSuccess({
+      gameState: {},
+      promptData: {},
+      finalPrompt: 'prompt',
+    });
 
     await pipeline.generatePrompt(actor, context, actions);
 


### PR DESCRIPTION
Summary: replace direct mock setup with `setupMockSuccess` helper for clearer test preparation.

Changes Made:
- updated `AIPromptPipeline.test.js` to use the new helper with specific parameters.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - errors remain in repo)
- [x] Root tests pass (`npm run test`)
- [x] Proxy tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_685597df9bb88331987bdded3ff9653b