### PR TITLE
[Agent] Add promptPipelineTestBed.generate helper

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -54,6 +54,19 @@ export class AIPromptPipelineTestBed {
   }
 
   /**
+   * Convenience method that creates a pipeline and generates a prompt.
+   *
+   * @param {import('../../../src/entities/entity.js').default} actor - The actor requesting the prompt.
+   * @param {import('../../../src/turns/interfaces/ITurnContext.js').ITurnContext} context - Turn context for the prompt.
+   * @param {import('../../../src/turns/dtos/actionComposite.js').ActionComposite[]} actions - Possible actions for the actor.
+   * @returns {Promise<string>} The generated prompt string.
+   */
+  async generate(actor, context, actions) {
+    const pipeline = this.createPipeline();
+    return pipeline.generatePrompt(actor, context, actions);
+  }
+
+  /**
    * Returns the dependency object used to construct the pipeline.
    *
    * @returns {{
@@ -62,7 +75,7 @@ export class AIPromptPipelineTestBed {
    *   promptContentProvider: ReturnType<typeof createMockAIPromptContentProvider>,
    *   promptBuilder: ReturnType<typeof createMockPromptBuilder>,
    *   logger: ReturnType<typeof createMockLogger>,
-   * }}
+   * }} The dependency object.
    */
   getDependencies() {
     return {
@@ -84,7 +97,7 @@ export class AIPromptPipelineTestBed {
   /**
    * Sets up mock resolved values for a successful pipeline run.
    *
-   * @param {object} [options]
+   * @param {object} [options] - Configuration options.
    * @param {string} [options.llmId] - LLM ID returned by the adapter.
    * @param {object} [options.gameState] - Game state returned by the provider.
    * @param {object} [options.promptData] - Prompt data returned by the content provider.

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -11,12 +11,9 @@ const defaultActions = [];
 describe('AIPromptPipeline', () => {
   /** @type {AIPromptPipelineTestBed} */
   let testBed;
-  /** @type {AIPromptPipeline} */
-  let pipeline;
 
   beforeEach(() => {
     testBed = new AIPromptPipelineTestBed();
-    pipeline = testBed.createPipeline();
 
     // Default success paths
     testBed.setupMockSuccess();
@@ -124,7 +121,7 @@ describe('AIPromptPipeline', () => {
       finalPrompt: 'FINAL',
     });
 
-    const prompt = await pipeline.generatePrompt(actor, context, actions);
+    const prompt = await testBed.generate(actor, context, actions);
 
     expect(prompt).toBe('FINAL');
     expect(testBed.llmAdapter.getCurrentActiveLlmId).toHaveBeenCalledTimes(1);
@@ -157,7 +154,7 @@ describe('AIPromptPipeline', () => {
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
     mutate();
     await expect(
-      pipeline.generatePrompt(defaultActor, defaultContext, defaultActions)
+      testBed.generate(defaultActor, defaultContext, defaultActions)
     ).rejects.toThrow(error);
   });
 
@@ -172,7 +169,7 @@ describe('AIPromptPipeline', () => {
       finalPrompt: 'prompt',
     });
 
-    await pipeline.generatePrompt(actor, context, actions);
+    await testBed.generate(actor, context, actions);
 
     expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
       expect.objectContaining({ availableActions: actions }),


### PR DESCRIPTION
## Summary
- add `generate` convenience method to promptPipelineTestBed
- refactor AIPromptPipeline tests to use helper

## Testing Done
- `npm run lint` *(fails: existing repo issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68559a838ce083318be2864df3c2967e