### PR TITLE
[Agent] add shared flushPromisesAndTimers utility

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -142,4 +142,14 @@ export function createTurnManagerTestBed() {
   return new TurnManagerTestBed();
 }
 
+/**
+ * Flushes pending promises and advances all Jest timers.
+ *
+ * @description Flushes pending promises and advances all Jest timers.
+ * @returns {Promise<void>} Resolves after timers have run.
+ */
+export const flushPromisesAndTimers = async () => {
+  await jest.runAllTimersAsync();
+};
+
 export default TurnManagerTestBed;

--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -19,6 +19,7 @@ import {
   test,
   afterEach,
 } from '@jest/globals';
+import { flushPromisesAndTimers } from '../../common/turns/turnManagerTestBed.js';
 
 // --- Mock Implementations ---
 class MockEntity {
@@ -124,19 +125,6 @@ describe('TurnManager - Error Handling', () => {
   let dispatcher;
   let turnHandlerResolver;
   let mockActor1, mockActor2, mockActor3;
-
-  /**
-   * Flushes pending promises and advances Jest's fake timers.
-   * Uses advanceTimersByTimeAsync for compatibility with modern fake timers
-   * and async operations triggered by timers. Simplified version.
-   */
-  const flushPromisesAndTimers = async () => {
-    // Advance timers by the smallest possible amount (0ms).
-    // The 'Async' version waits for microtasks (Promises) resolved
-    // as a result of the timers advancing.
-    await jest.advanceTimersByTimeAsync(0);
-    // No extra Promise.resolve() here - let's see if advanceTimersByTimeAsync is sufficient.
-  };
 
   beforeEach(() => {
     // Use MODERN fake timers explicitly


### PR DESCRIPTION
## Summary
- add a shared `flushPromisesAndTimers` helper in TurnManagerTestBed
- use the new helper in `turnManager.errorHandling.test.js`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(fails: missing llm configs)*


------
https://chatgpt.com/codex/tasks/task_e_68559ab7008483318c800762a9530dc6