### PR TITLE
[Agent] extend AIPromptPipelineTestBed defaults

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -11,6 +11,7 @@ import {
   createMockAIGameStateProvider,
   createMockAIPromptContentProvider,
   createMockPromptBuilder,
+  createMockEntity,
 } from '../mockFactories.js';
 
 /**
@@ -28,6 +29,12 @@ export class AIPromptPipelineTestBed {
   promptBuilder;
   /** @type {jest.Mocked<import('../../src/interfaces/coreServices.js').ILogger>} */
   logger;
+  /** @type {import('../../src/entities/entity.js').default} */
+  defaultActor;
+  /** @type {import('../../src/turns/interfaces/ITurnContext.js').ITurnContext} */
+  defaultContext;
+  /** @type {import('../../src/turns/dtos/actionComposite.js').ActionComposite[]} */
+  defaultActions;
 
   constructor() {
     this.llmAdapter = createMockLLMAdapter();
@@ -35,6 +42,9 @@ export class AIPromptPipelineTestBed {
     this.promptContentProvider = createMockAIPromptContentProvider();
     this.promptBuilder = createMockPromptBuilder();
     this.logger = createMockLogger();
+    this.defaultActor = createMockEntity('actor');
+    this.defaultContext = {};
+    this.defaultActions = [];
   }
 
   /**

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -2,11 +2,6 @@
 import { describe, beforeEach, afterEach, test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import { AIPromptPipelineTestBed } from '../../common/prompting/promptPipelineTestBed.js';
-import { createMockEntity } from '../../common/mockFactories.js';
-
-const defaultActor = createMockEntity('actor');
-const defaultContext = {};
-const defaultActions = [];
 
 describe('AIPromptPipeline', () => {
   /** @type {AIPromptPipelineTestBed} */
@@ -110,9 +105,9 @@ describe('AIPromptPipeline', () => {
   });
 
   test('generatePrompt orchestrates dependencies and returns prompt', async () => {
-    const actor = defaultActor;
-    const context = defaultContext;
-    const actions = [...defaultActions, { id: 'a1' }];
+    const actor = testBed.defaultActor;
+    const context = testBed.defaultContext;
+    const actions = [...testBed.defaultActions, { id: 'a1' }];
 
     testBed.setupMockSuccess({
       llmId: 'llm1',
@@ -154,14 +149,18 @@ describe('AIPromptPipeline', () => {
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
     mutate();
     await expect(
-      testBed.generate(defaultActor, defaultContext, defaultActions)
+      testBed.generate(
+        testBed.defaultActor,
+        testBed.defaultContext,
+        testBed.defaultActions
+      )
     ).rejects.toThrow(error);
   });
 
   test('availableActions are attached to DTO sent to getPromptData', async () => {
-    const actor = defaultActor;
-    const context = defaultContext;
-    const actions = [...defaultActions, { id: 'act' }];
+    const actor = testBed.defaultActor;
+    const context = testBed.defaultContext;
+    const actions = [...testBed.defaultActions, { id: 'act' }];
 
     testBed.setupMockSuccess({
       gameState: {},


### PR DESCRIPTION
Summary: Add default actor, context, and actions to `AIPromptPipelineTestBed` and update its usage in `AIPromptPipeline` tests.

Changes Made:
- Updated test bed to include `defaultActor`, `defaultContext`, and `defaultActions` fields.
- Adjusted `AIPromptPipeline.test.js` to rely on the new properties.
- Documented the new members with JSDoc.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint tests/common/prompting/promptPipelineTestBed.js tests/unit/prompting/AIPromptPipeline.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6855a28551e48331a08750d08254a067