### PR TITLE
[Agent] refactor dispatch assertions

### DIFF
--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -15,6 +15,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
+import { expectDispatchCalls } from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -30,9 +31,9 @@ describeEntityManagerSuite(
 
       it('should add a new component to an existing entity and return true', () => {
         // Arrange
-        const { entityManager, mocks } = getBed();
+        const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        const entity = getBed().createEntity('basic', {
+        getBed().createEntity('basic', {
           instanceId: PRIMARY,
         });
         getBed().resetDispatchMock();
@@ -74,16 +75,17 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-          COMPONENT_ADDED_ID,
-          {
-            entity: entity,
-            componentTypeId: NEW_COMPONENT_ID,
-            componentData: NEW_COMPONENT_DATA,
-            oldComponentData: undefined,
-          }
-        );
+        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+          [
+            COMPONENT_ADDED_ID,
+            {
+              entity: entity,
+              componentTypeId: NEW_COMPONENT_ID,
+              componentData: NEW_COMPONENT_DATA,
+              oldComponentData: undefined,
+            },
+          ],
+        ]);
       });
 
       it('should update an existing component and return true', () => {
@@ -132,16 +134,17 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-          COMPONENT_ADDED_ID,
-          {
-            entity: entity,
-            componentTypeId: NAME_COMPONENT_ID,
-            componentData: UPDATED_NAME_DATA,
-            oldComponentData: originalNameData,
-          }
-        );
+        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+          [
+            COMPONENT_ADDED_ID,
+            {
+              entity: entity,
+              componentTypeId: NAME_COMPONENT_ID,
+              componentData: UPDATED_NAME_DATA,
+              oldComponentData: originalNameData,
+            },
+          ],
+        ]);
       });
 
       it('should throw EntityNotFoundError for a non-existent entity', () => {
@@ -325,15 +328,16 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-          COMPONENT_REMOVED_ID,
-          {
-            entity: entity,
-            componentTypeId: NAME_COMPONENT_ID,
-            oldComponentData: overrideData,
-          }
-        );
+        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+          [
+            COMPONENT_REMOVED_ID,
+            {
+              entity: entity,
+              componentTypeId: NAME_COMPONENT_ID,
+              oldComponentData: overrideData,
+            },
+          ],
+        ]);
       });
 
       it('should return false if component is not an override on the instance', () => {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -18,6 +18,7 @@ import {
   ENTITY_CREATED_ID,
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
+import { expectDispatchCalls } from '../../common/engine/dispatchTestUtils.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import MapManager from '../../../src/utils/mapManagerUtils.js';
 
@@ -112,14 +113,15 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createEntity('basic');
 
       // Assert
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENTITY_CREATED_ID,
-        {
-          entity,
-          wasReconstructed: false,
-        }
-      );
+      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        [
+          ENTITY_CREATED_ID,
+          {
+            entity,
+            wasReconstructed: false,
+          },
+        ],
+      ]);
     });
 
     it('should throw a DefinitionNotFoundError if the definitionId does not exist', () => {
@@ -267,14 +269,15 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       );
 
       // Assert event was dispatched
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENTITY_CREATED_ID,
-        {
-          entity,
-          wasReconstructed: true,
-        }
-      );
+      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        [
+          ENTITY_CREATED_ID,
+          {
+            entity,
+            wasReconstructed: true,
+          },
+        ],
+      ]);
     });
 
     it('should throw an error if the definition is not found', () => {
@@ -392,13 +395,14 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-      expect(mocks.eventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENTITY_REMOVED_ID,
-        {
-          entity,
-        }
-      );
+      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        [
+          ENTITY_REMOVED_ID,
+          {
+            entity,
+          },
+        ],
+      ]);
     });
 
     it('should throw an EntityNotFoundError when trying to remove a non-existent entity', () => {


### PR DESCRIPTION
Summary: replaced manual mock dispatch checks with `expectDispatchCalls` helper in entity manager tests.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 574 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6855a27d3db08331a115365075553b62