### PR TITLE
[Agent] Add dispatch test utilities

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -4,11 +4,24 @@
  */
 
 import { expect } from '@jest/globals';
+import {
+  ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_READY_UI,
+  GAME_SAVED_ID,
+} from '../../../src/constants/eventIds.js';
 
 /**
- * @description Compares dispatch mock calls with an expected array of
+ * Default world used for save dispatch helper.
+ *
+ * @type {string}
+ */
+export const DEFAULT_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';
+
+/**
+ * Compares dispatch mock calls with an expected array of
  * [eventId, payload] pairs.
- * @param {jest.Mock} mock - Mocked dispatch function.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
  * @param {Array<[string, any]>} expected - Expected calls.
  * @returns {void}
  */
@@ -16,6 +29,58 @@ export function expectDispatchCalls(mock, expected) {
   expect(mock.mock.calls).toEqual(expected);
 }
 
+/**
+ * Asserts that dispatch calls match the provided event sequence.
+ * Usage: expectDispatchSequence(mock, [id, payload], [id, payload], ...)
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {...Array} events - Sequence of [eventId, payload] pairs.
+ * @returns {void}
+ */
+export function expectDispatchSequence(mock, ...events) {
+  expect(mock.mock.calls).toEqual(events);
+}
+
+/**
+ * Builds the dispatch sequence emitted during a manual save.
+ * When `filePath` is omitted, the GAME_SAVED_ID event is excluded, mimicking
+ * a failure scenario.
+ *
+ * @param {string} saveName - Name of the save file.
+ * @param {string} [filePath] - Optional saved file path.
+ * @returns {Array<[string, any]>} Dispatch call sequence.
+ */
+export function buildSaveDispatches(saveName, filePath) {
+  const sequence = [
+    [
+      ENGINE_OPERATION_IN_PROGRESS_UI,
+      {
+        titleMessage: 'Saving...',
+        inputDisabledMessage: `Saving game "${saveName}"...`,
+      },
+    ],
+  ];
+
+  if (filePath) {
+    sequence.push([
+      GAME_SAVED_ID,
+      { saveName, path: filePath, type: 'manual' },
+    ]);
+  }
+
+  sequence.push([
+    ENGINE_READY_UI,
+    {
+      activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+      message: 'Save operation finished. Ready.',
+    },
+  ]);
+
+  return sequence;
+}
+
 export default {
   expectDispatchCalls,
+  expectDispatchSequence,
+  buildSaveDispatches,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  expectDispatchSequence,
+  buildSaveDispatches,
+  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+} from './dispatchTestUtils.js';
+import {
+  ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_READY_UI,
+  GAME_SAVED_ID,
+} from '../../../src/constants/eventIds.js';
+
+describe('dispatchTestUtils', () => {
+  describe('expectDispatchSequence', () => {
+    it('verifies sequence equality', () => {
+      const mock = jest.fn();
+      const eventA = ['eventA', { a: 1 }];
+      const eventB = ['eventB', { b: 2 }];
+      mock(...eventA);
+      mock(...eventB);
+      expect(() => expectDispatchSequence(mock, eventA, eventB)).not.toThrow();
+    });
+
+    it('throws when sequences differ', () => {
+      const mock = jest.fn();
+      mock('eventA', { a: 1 });
+      expect(() =>
+        expectDispatchSequence(mock, ['eventA', { a: 2 }])
+      ).toThrow();
+    });
+  });
+
+  describe('buildSaveDispatches', () => {
+    it('builds success dispatch sequence with path', () => {
+      const result = buildSaveDispatches('Save1', 'path/to.sav');
+      expect(result).toEqual([
+        [
+          ENGINE_OPERATION_IN_PROGRESS_UI,
+          {
+            titleMessage: 'Saving...',
+            inputDisabledMessage: 'Saving game "Save1"...',
+          },
+        ],
+        [
+          GAME_SAVED_ID,
+          { saveName: 'Save1', path: 'path/to.sav', type: 'manual' },
+        ],
+        [
+          ENGINE_READY_UI,
+          {
+            activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+            message: 'Save operation finished. Ready.',
+          },
+        ],
+      ]);
+    });
+
+    it('omits GAME_SAVED_ID when path not provided', () => {
+      const result = buildSaveDispatches('Save1');
+      expect(result).toEqual([
+        [
+          ENGINE_OPERATION_IN_PROGRESS_UI,
+          {
+            titleMessage: 'Saving...',
+            inputDisabledMessage: 'Saving game "Save1"...',
+          },
+        ],
+        [
+          ENGINE_READY_UI,
+          {
+            activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+            message: 'Save operation finished. Ready.',
+          },
+        ],
+      ]);
+    });
+  });
+});

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -11,9 +11,12 @@ import {
 import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
-import { expectDispatchCalls } from '../../common/engine/dispatchTestUtils.js';
 import {
-  GAME_SAVED_ID,
+  expectDispatchSequence,
+  buildSaveDispatches,
+  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+} from '../../common/engine/dispatchTestUtils.js';
+import {
   // --- Import new UI Event IDs ---
   ENGINE_INITIALIZING_UI,
   ENGINE_READY_UI,
@@ -333,7 +336,7 @@ describe('GameEngine', () => {
 
   describe('triggerManualSave', () => {
     const SAVE_NAME = 'MySaveFile';
-    const MOCK_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';
+    const MOCK_ACTIVE_WORLD_FOR_SAVE = DEFAULT_ACTIVE_WORLD_FOR_SAVE;
 
     it('should dispatch error and not attempt save if engine is not initialized', async () => {
       const localBed = createGameEngineTestBed();
@@ -398,34 +401,9 @@ describe('GameEngine', () => {
 
         const result = await gameEngine.triggerManualSave(SAVE_NAME);
 
-        const expectedDispatches = [
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: 'Saving...',
-              inputDisabledMessage: `Saving game "${SAVE_NAME}"...`,
-            },
-          ],
-          [
-            GAME_SAVED_ID,
-            {
-              saveName: SAVE_NAME,
-              path: saveResultData.filePath,
-              type: 'manual',
-            },
-          ],
-          [
-            ENGINE_READY_UI,
-            {
-              activeWorld: MOCK_ACTIVE_WORLD_FOR_SAVE,
-              message: 'Save operation finished. Ready.',
-            },
-          ],
-        ];
-
-        expectDispatchCalls(
+        expectDispatchSequence(
           testBed.mocks.safeEventDispatcher.dispatch,
-          expectedDispatches
+          ...buildSaveDispatches(SAVE_NAME, saveResultData.filePath)
         );
 
         expect(
@@ -445,26 +423,9 @@ describe('GameEngine', () => {
 
         const result = await gameEngine.triggerManualSave(SAVE_NAME);
 
-        const expectedDispatches = [
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: 'Saving...',
-              inputDisabledMessage: `Saving game "${SAVE_NAME}"...`,
-            },
-          ],
-          [
-            ENGINE_READY_UI,
-            {
-              activeWorld: MOCK_ACTIVE_WORLD_FOR_SAVE,
-              message: 'Save operation finished. Ready.',
-            },
-          ],
-        ];
-
-        expectDispatchCalls(
+        expectDispatchSequence(
           testBed.mocks.safeEventDispatcher.dispatch,
-          expectedDispatches
+          ...buildSaveDispatches(SAVE_NAME)
         );
 
         expect(
@@ -481,26 +442,9 @@ describe('GameEngine', () => {
 
         const result = await gameEngine.triggerManualSave(SAVE_NAME);
 
-        const expectedDispatches = [
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: 'Saving...',
-              inputDisabledMessage: `Saving game "${SAVE_NAME}"...`,
-            },
-          ],
-          [
-            ENGINE_READY_UI,
-            {
-              activeWorld: MOCK_ACTIVE_WORLD_FOR_SAVE,
-              message: 'Save operation finished. Ready.',
-            },
-          ],
-        ];
-
-        expectDispatchCalls(
+        expectDispatchSequence(
           testBed.mocks.safeEventDispatcher.dispatch,
-          expectedDispatches
+          ...buildSaveDispatches(SAVE_NAME)
         );
 
         expect(
@@ -637,20 +581,13 @@ describe('GameEngine', () => {
       expect(localBed.mocks.logger.error).toHaveBeenCalledWith(
         `GameEngine.loadGame: ${rawErrorMsg}`
       );
-      const expectedDispatches = [
-        [
-          ENGINE_OPERATION_FAILED_UI,
-          {
-            errorMessage: rawErrorMsg,
-            errorTitle: 'Load Failed',
-          },
-        ],
-      ];
-
-      expectDispatchCalls(
-        localBed.mocks.safeEventDispatcher.dispatch,
-        expectedDispatches
-      );
+      expectDispatchSequence(localBed.mocks.safeEventDispatcher.dispatch, [
+        ENGINE_OPERATION_FAILED_UI,
+        {
+          errorMessage: rawErrorMsg,
+          errorTitle: 'Load Failed',
+        },
+      ]);
       expect(result).toEqual({
         success: false,
         error: rawErrorMsg,


### PR DESCRIPTION
## Summary
- add `expectDispatchSequence` and `buildSaveDispatches`
- reuse new helpers in GameEngine tests
- test `dispatchTestUtils`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 577 errors, 2174 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855a8fe032083318f94f2fd1277c3a8