### PR TITLE
[Agent] use TestBed for entity manager tests

### DIFF
--- a/tests/unit/entities/entityManager.definitionMutation.test.js
+++ b/tests/unit/entities/entityManager.definitionMutation.test.js
@@ -1,83 +1,40 @@
 // tests/unit/entities/entityManager.definitionMutation.test.js
 
-import { describe, test, expect, jest } from '@jest/globals';
-import { describeEntityManagerSuite } from '../../common/entities/testBed.js';
-import EntityManager from '../../../src/entities/entityManager.js';
+import { test, expect } from '@jest/globals';
+import {
+  describeEntityManagerSuite,
+  TestBed,
+} from '../../common/entities/testBed.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
-
-const makeDeps = (definition) => {
-  const registry = {
-    getEntityDefinition: jest.fn().mockImplementation((definitionId) => {
-      if (definitionId === definition.id) {
-        const definitionData = {
-          components: definition.components,
-          description: definition.description,
-        };
-        return new EntityDefinition(definition.id, definitionData);
-      }
-      return null;
-    }),
-  };
-  const validator = { validate: jest.fn().mockReturnValue({ isValid: true }) };
-  const logger = {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-  };
-  const spatialIndexManager = {
-    addEntity: jest.fn(),
-    removeEntity: jest.fn(),
-    updateEntityLocation: jest.fn(),
-    getEntitiesInLocation: jest.fn(() => new Set()),
-    clearIndex: jest.fn(),
-  };
-  return { registry, validator, logger, spatialIndexManager };
-};
-
-const createMockSafeEventDispatcher = () => ({
-  dispatch: jest.fn(),
-});
 
 describeEntityManagerSuite(
   'EntityManager.createEntityInstance does not mutate definitions',
   (getBed) => {
-    let mockEventDispatcher;
-
     test('components property remains unchanged when null', () => {
+      const tb = getBed();
       const definition = { id: 'test:nullComps', components: null };
-      const deps = makeDeps(definition);
-      mockEventDispatcher = createMockSafeEventDispatcher();
+      const regDef = new EntityDefinition(definition.id, {
+        components: definition.components,
+      });
+      tb.setupDefinitions(regDef);
 
-      const em = new EntityManager(
-        deps.registry,
-        deps.validator,
-        deps.logger,
-        mockEventDispatcher
-      );
-
-      const entity = em.createEntityInstance(definition.id);
+      const entity = tb.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toBeNull();
     });
 
     test('components property remains unchanged when valid object', () => {
+      const tb = getBed();
       const definition = {
         id: 'test:validComps',
         components: { 'core:name': { value: 'A' } },
       };
-      const deps = makeDeps(definition);
+      const regDef = new EntityDefinition(definition.id, {
+        components: definition.components,
+      });
+      tb.setupDefinitions(regDef);
 
-      mockEventDispatcher = createMockSafeEventDispatcher();
-
-      const em = new EntityManager(
-        deps.registry,
-        deps.validator,
-        deps.logger,
-        mockEventDispatcher
-      );
-
-      const entity = em.createEntityInstance(definition.id);
+      const entity = tb.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toEqual({ 'core:name': { value: 'A' } });
     });

--- a/tests/unit/smoke/newCharacterMemory.test.js
+++ b/tests/unit/smoke/newCharacterMemory.test.js
@@ -8,89 +8,38 @@
 // `core:short_term_memory`.
 // -----------------------------------------------------------------------------
 
-import EntityManager from '../../../src/entities/entityManager.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import {
   ACTOR_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
-import { describe, expect, test, jest } from '@jest/globals';
+import { expect, test } from '@jest/globals';
+import {
+  describeEntityManagerSuite,
+  TestBed,
+} from '../../common/entities/testBed.js';
 
 /**
- * Create minimalist stub implementations for the services EntityManager depends
- * on so we can exercise `createEntityInstance` exactly as production does,
- * without pulling in the entire engine stack.
+ * Uses {@link TestBed} to verify that the EntityManager injects the
+ * `core:short_term_memory` component when missing from an actor definition.
  */
-const makeStubs = () => {
-  // IDataRegistry stub returns a definition with an `actor` component and NO
-  // short-term memory so we can verify that EntityManager injects it.
-  const registry = {
-    getEntityDefinition: jest.fn().mockImplementation((definitionId) => {
-      if (definitionId === 'test:alice') {
-        const definitionData = {
-          components: {
-            [ACTOR_COMPONENT_ID]: {}, // minimal actor component payload
-          },
-        };
-        return new EntityDefinition(definitionId, definitionData);
-      }
-      return null;
-    }),
-  };
+describeEntityManagerSuite(
+  'Smoke › New Character › Short-Term Memory bootstrap',
+  (getBed) => {
+    test('EntityManager injects default short-term memory', () => {
+      const tb = getBed();
+      const definition = new EntityDefinition('test:alice', {
+        components: { [ACTOR_COMPONENT_ID]: {} },
+      });
+      tb.setupDefinitions(definition);
 
-  // ISchemaValidator stub – always succeeds.
-  const validator = {
-    validate: jest.fn().mockReturnValue({ isValid: true, errors: [] }),
-  };
+      const character = tb.entityManager.createEntityInstance(definition.id);
 
-  // ILogger stub – swallow logs.
-  const logger = {
-    info: jest.fn(),
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  };
+      expect(character).toBeDefined();
+      expect(character.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(true);
 
-  // ISpatialIndexManager stub – no-op implementations.
-  const spatialIndexManager = {
-    addEntity: jest.fn(),
-    removeEntity: jest.fn(),
-    updateEntityLocation: jest.fn(),
-    getEntitiesInLocation: jest.fn().mockReturnValue([]),
-    clearIndex: jest.fn(),
-  };
-
-  return { registry, validator, logger, spatialIndexManager };
-};
-
-const createMockSafeEventDispatcher = () => ({
-  dispatch: jest.fn(),
-});
-
-describe('Smoke › New Character › Short-Term Memory bootstrap', () => {
-  let mockEventDispatcher;
-
-  test('EntityManager injects default short-term memory', () => {
-    mockEventDispatcher = createMockSafeEventDispatcher();
-
-    const { registry, validator, logger, spatialIndexManager } = makeStubs();
-
-    // Arrange – instantiate EntityManager exactly as production would
-    const em = new EntityManager(
-      registry,
-      validator,
-      logger,
-      mockEventDispatcher
-    );
-
-    // Act – create a new entity using the real method under test
-    const character = em.createEntityInstance('test:alice');
-
-    // Assert – entity exists and has the injected component
-    expect(character).toBeDefined();
-    expect(character.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(true);
-
-    const stm = character.getComponentData(SHORT_TERM_MEMORY_COMPONENT_ID);
-    expect(stm).toEqual({ thoughts: [], maxEntries: 10 });
-  });
-});
+      const stm = character.getComponentData(SHORT_TERM_MEMORY_COMPONENT_ID);
+      expect(stm).toEqual({ thoughts: [], maxEntries: 10 });
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- leverage TestBed in definition-mutation tests
- simplify newCharacterMemory smoke test by using TestBed

## Testing Done
- `npm run lint` *(fails: 577 errors, 2176 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855a952ecd88331a77189f915b3dc00