### PR TITLE
[Agent] Add ModsLoader test utilities

### DIFF
--- a/tests/common/loaders/modsLoader.test-utils.js
+++ b/tests/common/loaders/modsLoader.test-utils.js
@@ -1,0 +1,42 @@
+/**
+ * @file Utility helpers for ModsLoader tests.
+ * @see tests/common/loaders/modsLoader.test-utils.js
+ */
+
+/**
+ * Sets up manifest-related mocks for a ModsLoader test environment.
+ *
+ * @param {object} env - Test environment returned by createTestEnvironment.
+ * @param {Map<string, object>} manifestMap - Map of mod IDs to manifests.
+ * @param {string[]} finalOrder - Final mod load order.
+ * @returns {void}
+ */
+export function setupManifests(env, manifestMap, finalOrder) {
+  env.mockGameConfigLoader.loadConfig.mockResolvedValue(finalOrder);
+  env.mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
+    manifestMap
+  );
+  env.mockedResolveOrder.mockReturnValue(finalOrder);
+
+  const defaultGet = (type, id) => env.mockRegistry._internalStore[type]?.[id];
+
+  env.mockRegistry.get.mockImplementation((type, id) => {
+    if (type === 'mod_manifests') {
+      const manifest = manifestMap.get(id.toLowerCase());
+      if (manifest) {
+        return manifest;
+      }
+    }
+    return defaultGet(type, id);
+  });
+}
+
+/**
+ * Concatenates all info log messages into a single string.
+ *
+ * @param {object} logger - Logger with a jest.fn `info` method.
+ * @returns {string} Summary text from logger.info calls.
+ */
+export function getSummaryText(logger) {
+  return logger.info.mock.calls.map((c) => c[0]).join('\n');
+}


### PR DESCRIPTION
Summary: Introduced helper utilities for ModsLoader test suites. `setupManifests` configures common manifest mocks and `getSummaryText` collects info log output.

Changes Made:
- Added `modsLoader.test-utils.js` providing `setupManifests` and `getSummaryText`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` – known failing globally)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6855acaf2358833193817994821d50e7