### PR TITLE
[Agent] Simplify modsLoader integration test setup

### DIFF
--- a/tests/integration/loaders/modsLoader.integration.test.js
+++ b/tests/integration/loaders/modsLoader.integration.test.js
@@ -1,234 +1,26 @@
-// Filename: src/tests/loaders/modsLoader.integration.test.js
-
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-
-// --- SUT ---
-import ModsLoader from '../../../src/loaders/modsLoader.js';
-import ModManifestProcessor from '../../../src/loaders/ModManifestProcessor.js';
-import ContentLoadManager from '../../../src/loaders/ContentLoadManager.js';
-
-// --- Dependencies to Mock ---
-// mocks will be injected via constructor rather than jest.mock
 import { CORE_MOD_ID } from '../../../src/constants/core.js';
+import { createTestEnvironment } from '../../common/loaders/modsLoader.test-setup.js';
+import { setupManifests } from '../../common/loaders/modsLoader.test-utils.js';
 
-// --- Type‑only JSDoc imports for Mocks ---
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/interfaces/coreServices.js').ISchemaValidator} ISchemaValidator */
-/** @typedef {import('../../../src/interfaces/coreServices.js').IDataRegistry} IDataRegistry */
-/** @typedef {import('../../../src/interfaces/coreServices.js').IConfiguration} IConfiguration */
-/** @typedef {import('../../../src/interfaces/coreServices.js').IPathResolver} IPathResolver */
-/** @typedef {import('../../../src/interfaces/coreServices.js').IDataFetcher} IDataFetcher */
-/** @typedef {import('../../../src/loaders/actionLoader.js').default} ActionLoader */
-/** @typedef {import('../../../src/loaders/eventLoader.js').default} EventLoader */
-/** @typedef {import('../../../src/loaders/macroLoader.js').default} MacroLoader */
-/** @typedef {import('../../../src/loaders/componentLoader.js').default} ComponentLoader */
-/** @typedef {import('../../../src/loaders/ruleLoader.js').default} RuleLoader */
-/** @typedef {import('../../../src/loaders/conditionLoader.js').default} ConditionLoader */
-/** @typedef {import('../../../src/loaders/schemaLoader.js').default} SchemaLoader */
-/** @typedef {import('../../../src/loaders/gameConfigLoader.js').default} GameConfigLoader */
-/** @typedef {import('../../../src/modding/modManifestLoader.js').default} ModManifestLoader */
-/** @typedef {import('../../../src/loaders/entityDefinitionLoader.js').default} EntityLoader */
-/** @typedef {import('../../../data/schemas/mod.manifest.schema.json').ModManifest} ModManifest */
-/** @typedef {import('../../services/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../../common/loaders/modsLoader.test-setup.js').TestEnvironment} TestEnvironment */
 
 describe('ModsLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
-  /** @type {ModsLoader} */
-  let modsLoader;
-
-  // --- Mock Instances ---
-  /** @type {jest.Mocked<IDataRegistry>} */
-  let mockRegistry;
-  /** @type {jest.Mocked<ILogger>} */
-  let mockLogger;
-  /** @type {jest.Mocked<SchemaLoader>} */
-  let mockSchemaLoader; // Note: Not a direct ModsLoader dependency, but used in test setup
-  /** @type {jest.Mocked<ComponentLoader>} */
-  let mockComponentLoader;
-  /** @type {jest.Mocked<RuleLoader>} */
-  let mockRuleLoader;
-  /** @type {jest.Mocked<ConditionLoader>} */
-  let mockConditionLoader;
-  /** @type {jest.Mocked<ActionLoader>} */
-  let mockActionLoader;
-  /** @type {jest.Mocked<EventLoader>} */
-  let mockEventLoader;
-  /** @type {jest.Mocked<MacroLoader>} */
-  let mockMacroLoader;
-  /** @type {jest.Mocked<EntityLoader>} */
-  let mockEntityLoader;
-  /** @type {jest.Mocked<ISchemaValidator>} */
-  let mockValidator;
-  /** @type {jest.Mocked<IConfiguration>} */
-  let mockConfiguration;
-  /** @type {jest.Mocked<IPathResolver>} */
-  let mockPathResolver; // Added
-  /** @type {jest.Mocked<IDataFetcher>} */
-  let mockDataFetcher; // Added
-  /** @type {jest.Mocked<GameConfigLoader>} */
-  let mockGameConfigLoader;
-  /** @type {jest.Mocked<ModManifestLoader>} */
-  let mockModManifestLoader; // This is an instance of the ModManifestLoader class
-  /** @type {jest.Mocked<ValidatedEventDispatcher>} */
-  let mockValidatedEventDispatcher;
-  /** @type {jest.Mocked<import('../../../src/loaders/worldLoader.js').default>} */
-  let mockWorldLoader;
-  /** @type {jest.Mocked<import('../../../src/loaders/promptTextLoader.js').default>} */
-  let mockPromptTextLoader;
-  /** @type {jest.Mocked<import('../../../src/loaders/entityInstanceLoader.js').default>} */
-  let mockEntityInstanceLoader;
-
+  /** @type {TestEnvironment} */
+  let env;
   /** @type {jest.SpyInstance} */
   let processManifestsSpy;
   /** @type {jest.SpyInstance} */
   let loadContentSpy;
 
-  // --- Mock Data ---
-  /** @type {ModManifest} */
-  let mockCoreManifest;
-  /** @type {Map<string, ModManifest>} */
-  let mockManifestMap;
+  /** @type {Map<string, object>} */
+  let manifestMap;
   const worldName = 'testWorldSimple';
 
-  // --- Mocked helper implementations (declare with let if they are re-assigned in beforeEach, or const if not) ---
-  const mockModDependencyValidator = { validate: jest.fn() };
-  const mockModVersionValidator = jest.fn(); // This is a jest.fn() directly, can be const
-  const mockModLoadOrderResolver = { resolveOrder: jest.fn() };
-  // mockPromptTextLoader and mockEntityInstanceLoader are declared above with let and fully initialized in beforeEach
-
-  const mockedModDependencyValidator = mockModDependencyValidator.validate;
-  const mockedValidateModEngineVersions = mockModVersionValidator;
-  const mockedResolveOrder = mockModLoadOrderResolver.resolveOrder;
-
   beforeEach(() => {
-    jest.clearAllMocks();
+    env = createTestEnvironment();
 
-    // Resetting specific mocks
-    mockModDependencyValidator.validate.mockReset();
-    mockModVersionValidator.mockReset(); // Since it's jest.fn()
-    mockModLoadOrderResolver.resolveOrder.mockReset();
-    // mockPromptTextLoader and mockEntityInstanceLoader will be fully re-initialized below
-
-    // --- 1. Create Mocks ---
-    mockRegistry = {
-      store: jest.fn(),
-      get: jest.fn(),
-      getAll: jest.fn(() => []),
-      clear: jest.fn(),
-      getAllSystemRules: jest.fn(() => []),
-      getManifest: jest.fn(() => null),
-      setManifest: jest.fn(),
-      getEntityDefinition: jest.fn(),
-      getItemDefinition: jest.fn(),
-      getLocationDefinition: jest.fn(),
-      getConnectionDefinition: jest.fn(),
-      getBlockerDefinition: jest.fn(),
-      getActionDefinition: jest.fn(),
-      getEventDefinition: jest.fn(),
-      getComponentDefinition: jest.fn(),
-      getAllEntityDefinitions: jest.fn(() => []),
-      getAllItemDefinitions: jest.fn(() => []),
-      getAllLocationDefinitions: jest.fn(() => []),
-      getAllConnectionDefinitions: jest.fn(() => []),
-      getAllBlockerDefinitions: jest.fn(() => []),
-      getAllActionDefinitions: jest.fn(() => []),
-      getAllEventDefinitions: jest.fn(() => []),
-      getAllComponentDefinitions: jest.fn(() => []),
-      getStartingPlayerId: jest.fn(() => null),
-      getStartingLocationId: jest.fn(() => null),
-      loadItemsForMod: jest
-        .fn()
-        .mockResolvedValue({ count: 0, overrides: 0, errors: 0 }), // Correctly assigned
-    };
-    mockLogger = {
-      info: jest.fn(),
-      debug: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
-    mockSchemaLoader = {
-      // Used by test setup, not directly by ModsLoader constructor
-      loadAndCompileAllSchemas: jest.fn(),
-    };
-    mockValidator = {
-      // This is for ISchemaValidator
-      isSchemaLoaded: jest.fn(),
-      addSchema: jest.fn(),
-      removeSchema: jest.fn(),
-      getValidator: jest.fn(),
-      validate: jest.fn(),
-    };
-    mockConfiguration = {
-      getContentTypeSchemaId: jest.fn(),
-      getBaseDataPath: jest.fn(() => './data'),
-      getSchemaFiles: jest.fn(() => []),
-      getSchemaBasePath: jest.fn(() => 'schemas'),
-      getContentBasePath: jest.fn(() => 'content'),
-      getGameConfigFilename: jest.fn(() => 'game.json'),
-      getModsBasePath: jest.fn(() => 'mods'),
-      getModManifestFilename: jest.fn(() => 'mod.manifest.json'),
-      getPromptsBasePath: jest.fn(() => 'prompts'),
-      getCorePromptFileName: jest.fn(() => 'corePromptText.json'),
-    };
-    mockPathResolver = {
-      // Added
-      resolve: jest.fn((path) => `resolved/${path}`),
-      resolveDataPath: jest.fn((filename) => `resolved/data/${filename}`),
-      resolveSchemaPath: jest.fn((filename) => `resolved/schemas/${filename}`),
-      resolveModPath: jest.fn((modId) => `resolved/mods/${modId}`),
-      resolveModManifestPath: jest.fn(
-        (modId) => `resolved/mods/${modId}/mod.manifest.json`
-      ),
-      resolveModContentPath: jest.fn(
-        (modId, type, file) => `resolved/mods/${modId}/${type}/${file}`
-      ),
-      resolveGameConfigPath: jest.fn(() => 'resolved/game.json'),
-      resolvePromptsPath: jest.fn((filename) => `resolved/prompts/${filename}`),
-    };
-    mockDataFetcher = {
-      // Added
-      fetch: jest.fn().mockResolvedValue({}), // Generic fetch
-      fetchContentBatch: jest.fn().mockResolvedValue([]), // For loaders that use batch
-    };
-    mockGameConfigLoader = {
-      loadConfig: jest.fn(),
-    };
-    // This mockModManifestLoader is for the CLASS INSTANCE passed to ModsLoader constructor
-    mockModManifestLoader = {
-      loadRequestedManifests: jest.fn(),
-      loadManifest: jest.fn(), // Added for completeness if ModManifestLoader class has it
-    };
-
-    // Specific loader mocks (instances of classes used by ModsLoader internally or passed to it)
-    mockActionLoader = { loadItemsForMod: jest.fn() };
-    mockComponentLoader = { loadItemsForMod: jest.fn() };
-    mockEventLoader = { loadItemsForMod: jest.fn() };
-    mockMacroLoader = { loadItemsForMod: jest.fn() };
-    mockRuleLoader = { loadItemsForMod: jest.fn() };
-    mockConditionLoader = { loadItemsForMod: jest.fn() };
-    mockEntityLoader = { loadItemsForMod: jest.fn() }; // This is EntityDefinitionLoader
-
-    mockValidatedEventDispatcher = {
-      dispatch: jest.fn().mockResolvedValue(undefined),
-    };
-
-    // Dependencies for ModsLoader constructor - these are initialized here
-    mockWorldLoader = {
-      // Implements IWorldLoader
-      loadWorlds: jest.fn().mockResolvedValue(undefined),
-    };
-    mockPromptTextLoader = {
-      // Implements IPromptTextLoader
-      loadPromptText: jest.fn().mockResolvedValue({}), // Correctly assigned
-    };
-    mockEntityInstanceLoader = {
-      // Implements IEntityInstanceLoader
-      loadItemsForMod: jest
-        .fn()
-        .mockResolvedValue({ count: 0, overrides: 0, errors: 0 }), // Correctly assigned
-    };
-
-    // --- Define Mock Data First ---
-    mockCoreManifest = {
+    const coreManifest = {
       id: CORE_MOD_ID,
       version: '1.0.0',
       name: 'Core Game Systems',
@@ -240,296 +32,98 @@ describe('ModsLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
         macros: ['core/logSuccess.macro.json'],
       },
     };
-    mockManifestMap = new Map(); // Ensure it's a fresh Map
-    mockManifestMap.set(CORE_MOD_ID.toLowerCase(), mockCoreManifest);
 
-    // Spies on prototypes (must be set AFTER mock data is ready)
+    manifestMap = new Map([[CORE_MOD_ID.toLowerCase(), coreManifest]]);
+    setupManifests(env, manifestMap, [CORE_MOD_ID]);
+
     processManifestsSpy = jest
-      .spyOn(ModManifestProcessor.prototype, 'processManifests')
+      .spyOn(env.modsLoader._modManifestProcessor, 'processManifests')
       .mockResolvedValue({
-        loadedManifestsMap: mockManifestMap, // Use the fresh mockManifestMap
+        loadedManifestsMap: manifestMap,
         finalOrder: [CORE_MOD_ID],
         incompatibilityCount: 0,
       });
+
     loadContentSpy = jest
-      .spyOn(ContentLoadManager.prototype, 'loadContent')
+      .spyOn(env.modsLoader._contentLoadManager, 'loadContent')
       .mockResolvedValue({});
-
-    // --- 3. Configure Mocks (Default Success Paths) ---
-    mockSchemaLoader.loadAndCompileAllSchemas.mockResolvedValue(undefined);
-
-    // Configure IConfiguration to return IDs for essential schemas
-    mockConfiguration.getContentTypeSchemaId.mockImplementation((type) => {
-      if (type === 'goals') return 'http://example.com/schemas/goal.schema.json';
-      if (type === 'game') return 'http://example.com/schemas/game.schema.json';
-      if (type === 'components') return 'http://example.com/schemas/component.schema.json';
-      if (type === 'mod-manifest') return 'http://example.com/schemas/mod.manifest.schema.json';
-      if (type === 'entityDefinitions') return 'http://example.com/schemas/entity-definition.schema.json';
-      if (type === 'entityInstances') return 'http://example.com/schemas/entity-instance.schema.json';
-      if (type === 'actions') return 'http://example.com/schemas/action.schema.json';
-      if (type === 'events') return 'http://example.com/schemas/event.schema.json';
-      if (type === 'rules') return 'http://example.com/schemas/rule.schema.json';
-      if (type === 'conditions') return 'http://example.com/schemas/condition.schema.json';
-      return undefined;
-    });
-
-    // *** FIX: Configure ISchemaValidator to return TRUE for ALL essential schemas checked by ModsLoader ***
-    mockValidator.isSchemaLoaded.mockImplementation((schemaId) => {
-      const essentialSchemas = [
-        'http://example.com/schemas/game.schema.json',
-        'http://example.com/schemas/component.schema.json',
-        'http://example.com/schemas/mod.manifest.schema.json',
-        'http://example.com/schemas/entity-definition.schema.json',
-        'http://example.com/schemas/action.schema.json',
-        'http://example.com/schemas/event.schema.json',
-        'http://example.com/schemas/rule.schema.json',
-        'http://example.com/schemas/condition.schema.json',
-        'http://example.com/schemas/entity-instance.schema.json',
-        'http://example.com/schemas/goal.schema.json',
-      ];
-      const isLoaded = essentialSchemas.includes(schemaId);
-      return isLoaded;
-    });
-
-    // Configure GameConfigLoader
-    mockGameConfigLoader.loadConfig.mockResolvedValue([CORE_MOD_ID]);
-
-    // Configure ModManifestLoader (the service, not the class mock)
-    mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
-      mockManifestMap
-    );
-
-    // Configure ModDependencyValidator
-    mockedModDependencyValidator.mockImplementation(() => {});
-
-    // Configure ModVersionValidator
-    mockedValidateModEngineVersions.mockImplementation(() => true);
-
-    // Configure ModLoadOrderResolver
-    mockedResolveOrder.mockImplementation((manifests) =>
-      Array.from(manifests.keys())
-    );
-
-    // Configure Registry.get for manifest lookup
-    mockRegistry.get.mockImplementation((type, id) => {
-      if (type === 'mod_manifests' && id === CORE_MOD_ID.toLowerCase()) {
-        return mockCoreManifest;
-      }
-      return undefined;
-    });
-
-    // Configure Content Loaders Mocks
-    const setupContentLoaderMock = (loaderMock, typeName, count) => {
-      loaderMock.loadItemsForMod.mockImplementation(
-        async (
-          modIdArg,
-          manifestArg,
-          contentKeyArg,
-          contentTypeDirArg,
-          typeNameArg
-        ) => {
-          if (
-            modIdArg.toLowerCase() === CORE_MOD_ID.toLowerCase() &&
-            typeNameArg === typeName
-          ) {
-            mockLogger.debug(
-              `Mock ${typeName}Loader: Loading ${count} items for ${modIdArg}`
-            );
-            for (let i = 0; i < count; i++) {
-              const itemId = `${modIdArg}:${typeName}_item_${i}`;
-              const itemData = {
-                id: itemId,
-                data: `mock ${typeName} data ${i}`,
-              };
-              const storeType =
-                typeName === 'entityDefinitions'
-                  ? 'entity_definitions'
-                  : typeName;
-              mockRegistry.store(storeType, itemId, itemData);
-            }
-            // Simulate the expected return structure {count, overrides, errors}
-            return { count: count, overrides: 0, errors: 0 };
-          }
-          mockLogger.error(`Mock ${typeName}Loader unexpectedly called with:`, {
-            modIdArg,
-            typeNameArg,
-          });
-          throw new Error(`Mock ${typeName}Loader unexpectedly called`);
-        }
-      );
-    };
-
-    setupContentLoaderMock(mockActionLoader, 'actions', 2);
-    setupContentLoaderMock(mockComponentLoader, 'components', 1);
-    setupContentLoaderMock(mockMacroLoader, 'macros', 2);
-    setupContentLoaderMock(mockEntityLoader, 'entityDefinitions', 1);
-
-    // --- 4. Instantiate SUT (ModsLoader) ---
-    // ModsLoader expects a single object with dependencies as properties.
-    modsLoader = new ModsLoader({
-      registry: mockRegistry,
-      logger: mockLogger,
-      schemaLoader: mockSchemaLoader,
-      componentLoader: mockComponentLoader,
-      conditionLoader: mockConditionLoader,
-      ruleLoader: mockRuleLoader,
-      macroLoader: mockMacroLoader,
-      actionLoader: mockActionLoader,
-      eventLoader: mockEventLoader,
-      entityLoader: mockEntityLoader, // This is EntityDefinitionLoader
-      entityInstanceLoader: mockEntityInstanceLoader,
-      validator: mockValidator, // ISchemaValidator
-      configuration: mockConfiguration, // IConfiguration
-      gameConfigLoader: mockGameConfigLoader,
-      promptTextLoader: mockPromptTextLoader,
-      modManifestLoader: mockModManifestLoader, // Instance of ModManifestLoader class
-      validatedEventDispatcher: mockValidatedEventDispatcher,
-      modDependencyValidator: mockModDependencyValidator,
-      modVersionValidator: mockModVersionValidator,
-      modLoadOrderResolver: mockModLoadOrderResolver,
-      worldLoader: mockWorldLoader,
-      // pathResolver and dataFetcher are not direct dependencies of ModsLoader constructor
-      // but are used by other services like ModManifestLoader.
-      // They are correctly mocked and available in the test scope for those services.
-      contentLoadersConfig: null, // Use default config
-    });
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  // --- Test Cases ---
-  // ── Test Case: Basic Successful Load ───────────────────────────────────
   it('should successfully load world with only the core mod', async () => {
-    // --- Action ---
-    await expect(modsLoader.loadWorld(worldName)).resolves.not.toThrow();
+    await expect(env.modsLoader.loadWorld(worldName)).resolves.not.toThrow();
 
-    // --- Assertions ---
-
-    // 1. Verify registry.clear was called once.
-    expect(mockRegistry.clear).toHaveBeenCalledTimes(1);
-    const clearCalls = mockRegistry.clear.mock.calls.length; // Store count for later check
-
-    // 2. Verify schemaLoader.loadAndCompileAllSchemas was called.
-    expect(mockSchemaLoader.loadAndCompileAllSchemas).toHaveBeenCalledTimes(1);
-
-    // 3. *** FIX: Verify essential schema checks passed for ALL required schemas ***
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith('http://example.com/schemas/game.schema.json');
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/component.schema.json'
-    );
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/mod.manifest.schema.json'
-    );
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/entity-definition.schema.json'
-    );
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith('http://example.com/schemas/action.schema.json');
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith('http://example.com/schemas/event.schema.json');
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith('http://example.com/schemas/rule.schema.json');
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/condition.schema.json'
-    );
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/entity-instance.schema.json'
-    );
-    expect(mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
-      'http://example.com/schemas/goal.schema.json'
+    expect(env.mockRegistry.clear).toHaveBeenCalledTimes(1);
+    expect(env.mockSchemaLoader.loadAndCompileAllSchemas).toHaveBeenCalledTimes(
+      1
     );
 
-    // 4. Verify gameConfigLoader.loadConfig was called.
-    expect(mockGameConfigLoader.loadConfig).toHaveBeenCalledTimes(1);
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:game'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:components'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:mod-manifest'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:entityDefinitions'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:actions'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:events'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:rules'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:conditions'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:entityInstances'
+    );
+    expect(env.mockValidator.isSchemaLoaded).toHaveBeenCalledWith(
+      'schema:goals'
+    );
 
-    // 5. Verify ModManifestProcessor.processManifests was called by ModsLoader
+    expect(env.mockGameConfigLoader.loadConfig).toHaveBeenCalledTimes(1);
     expect(processManifestsSpy).toHaveBeenCalledTimes(1);
     expect(processManifestsSpy).toHaveBeenCalledWith([CORE_MOD_ID]);
 
-    // The processManifestsSpy returns a mocked object that includes the finalOrder and loadedManifestsMap.
-    // We've already configured this spy to return what we need:
-    // { loadedManifestsMap: mockManifestMap, finalOrder: [CORE_MOD_ID], incompatibilityCount: 0 }
-    // So, ModsLoader will use this. Assertions on mockModManifestLoader.loadRequestedManifests
-    // are now redundant and incorrect because the original processManifests is not run.
-
-    // 6. Verify registry.store was called for the core manifest (this would be done by the original ModManifestProcessor or its dependencies).
-    // Since processManifests is fully mocked, this specific call might not occur via the same path.
-    // Let's rely on the fact that loadedManifestsMap (from the spy's return) is correct.
-    // If ModsLoader needs to explicitly store the manifest itself after processManifests, that's a different check.
-    // Based on ModsLoader implementation, it relies on ModManifestProcessor to handle manifest storage.
-    // The spy now returns loadedManifestsMap: mockManifestMap, so that data is available.
-
-    // 7. Verify ModDependencyValidator.validate was called.
-    // This is called within the original ModManifestProcessor.processManifests.
-    // Since processManifestsSpy mocks the entire method, this internal call won't happen through the spy.
-    // If testing this interaction is critical, the spy on processManifests needs to be more nuanced,
-    // potentially using .mockImplementation to call parts of the original or related mocks.
-    // For now, given the full mock of processManifests, direct checks on its internal dependencies like
-    // ModDependencyValidator, ModVersionValidator, and ModLoadOrderResolver (via their direct mocks)
-    // might not be hit if they were supposed to be called by the *original* processManifests.
-
-    // Let's assume the spy on processManifests is the integration point we are testing with ModsLoader.
-    // ModsLoader gets the result from processManifests (which is { loadedManifestsMap, finalOrder, ... })
-    // and proceeds.
-
-    // Ensure helper classes were called (or rather, their main methods that ModsLoader interacts with)
-    // processManifestsSpy is already checked.
     expect(loadContentSpy).toHaveBeenCalledTimes(1);
-    // Further check on loadContentSpy arguments if necessary, e.g.:
     expect(loadContentSpy).toHaveBeenCalledWith(
-      [CORE_MOD_ID], // finalOrder from processManifestsSpy
-      mockManifestMap, // loadedManifestsMap from processManifestsSpy
-      expect.any(Object) // totalCounts
+      [CORE_MOD_ID],
+      manifestMap,
+      expect.any(Object)
     );
 
-    // 11. Verify Content Loader calls (these happen within loadContentSpy's original logic,
-    // but loadContentSpy itself is also fully mocked, so these internal calls won't be seen unless
-    // loadContentSpy is set up with mockImplementation to call them).
-
-    // If loadContentSpy is fully mocked (as it is with .mockResolvedValue({})),
-    // then we cannot assert these internal calls to mockActionLoader.loadItemsForMod etc.
-    // The previous version of this test was likely asserting these because loadContentSpy
-    // might have been a spy that called the original implementation.
-
-    // Given loadContentSpy = jest.spyOn(ContentLoadManager.prototype, 'loadContent').mockResolvedValue({});
-    // these assertions will fail.
-    // For this test to pass with the current full mock of loadContent, these must be removed.
-    // If the intent is to check that ModsLoader correctly passes data to ContentLoadManager,
-    // the assertion on loadContentSpy above is sufficient.
-
-    // Let's assume for now that the .mockResolvedValue({}) on loadContentSpy means we are not testing its internals.
-
-    // 13. Verify registry.store calls from content loaders.
-    // Similar to point 11, if loadContent is fully mocked, these won't be called.
-    // The mockRegistry.store calls for 'actions', 'components' etc. would happen inside the
-    // *original* ContentLoadManager.loadContent method (or the item loaders it calls).
-    // Since ContentLoadManager.prototype.loadContent is spied on and mocked to return an empty object,
-    // these specific store calls will not occur.
-
-    // Verify WorldLoader.loadWorlds was called
-    expect(mockWorldLoader.loadWorlds).toHaveBeenCalledTimes(1);
-    expect(mockWorldLoader.loadWorlds).toHaveBeenCalledWith(
-      [CORE_MOD_ID], // finalOrder
-      mockManifestMap, // loadedManifestsMap
-      expect.any(Object) // totalCounts
+    expect(env.mockWorldLoader.loadWorlds).toHaveBeenCalledTimes(1);
+    expect(env.mockWorldLoader.loadWorlds).toHaveBeenCalledWith(
+      [CORE_MOD_ID],
+      manifestMap,
+      expect.any(Object)
     );
 
-    // Final check: ensure no unexpected errors were logged at a high level by ModsLoader itself.
-    expect(mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
+    expect(env.mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
       'initialization:world_loader:failed',
       expect.anything(),
       expect.anything()
     );
-    expect(mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
+    expect(env.mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
       'initialization:world_loader:mod_load_failed',
       expect.anything(),
       expect.anything()
     );
-    expect(mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
+    expect(env.mockValidatedEventDispatcher.dispatch).not.toHaveBeenCalledWith(
       'initialization:world_loader:content_load_failed',
       expect.anything(),
       expect.anything()
     );
   });
 });
-
-


### PR DESCRIPTION
## Summary
- simplify `modsLoader.integration.test.js` by using `createTestEnvironment`
- configure manifests via `setupManifests`
- spy on `processManifests` and `loadContent`

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855aed90cf483319daa28184d21cad2