### PR TITLE
[Agent] use manifest utils in ModsLoader tests

### DIFF
--- a/tests/unit/loaders/modsLoader.entityMultiKey.test.js
+++ b/tests/unit/loaders/modsLoader.entityMultiKey.test.js
@@ -1,9 +1,13 @@
 // Filename: tests/unit/loaders/modsLoader.entityMultiKey.test.js
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 // --- The new Test Setup Factory ---
 import { createTestEnvironment } from '../../common/loaders/modsLoader.test-setup.js';
+import {
+  setupManifests,
+  getSummaryText,
+} from '../../common/loaders/modsLoader.test-utils.js';
 
 // --- Type‑only JSDoc imports for Mocks and SUT ---
 /** @typedef {import('../../../src/loaders/modsLoader.js').default} ModsLoader */
@@ -63,11 +67,7 @@ describe('ModsLoader Integration Test Suite - EntityDefinitionLoader Multi-Key H
     mockEventLoader = env.mockEventLoader;
 
     // 3. Layer test-specific mock implementations ON TOP of the defaults
-    env.mockGameConfigLoader.loadConfig.mockResolvedValue([testModId]);
-    env.mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
-      mockManifestMap
-    );
-    env.mockedResolveOrder.mockReturnValue(finalOrder);
+    setupManifests(env, mockManifestMap, finalOrder);
 
     // This test specifically needs entityLoader to return a result with a count of 3
     env.mockEntityLoader.loadItemsForMod.mockResolvedValue({
@@ -113,8 +113,7 @@ describe('ModsLoader Integration Test Suite - EntityDefinitionLoader Multi-Key H
     expect(mockEventLoader.loadItemsForMod).not.toHaveBeenCalled();
 
     // 3. Verify the results from the loader were correctly aggregated and logged.
-    const infoCalls = mockLogger.info.mock.calls;
-    const summaryText = infoCalls.map((call) => call[0]).join('\n');
+    const summaryText = getSummaryText(mockLogger);
 
     expect(summaryText).toContain('Content Loading Summary (Totals):');
     expect(summaryText).toMatch(/entityDefinitions\s+: C:3, O:0, E:0/);

--- a/tests/unit/loaders/modsLoader.errorHandling.test.js
+++ b/tests/unit/loaders/modsLoader.errorHandling.test.js
@@ -6,6 +6,10 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 // --- SUT & Dependencies ---
 import { CORE_MOD_ID } from '../../../src/constants/core.js';
 import { createTestEnvironment } from '../../common/loaders/modsLoader.test-setup.js';
+import {
+  setupManifests,
+  getSummaryText,
+} from '../../common/loaders/modsLoader.test-utils.js';
 
 // --- Type‑only JSDoc imports ---
 /** @typedef {import('../../../src/loaders/modsLoader.js').default} ModsLoader */
@@ -50,14 +54,7 @@ describe('ModsLoader Integration Test Suite - Error Handling (TEST-LOADER-7.4)',
     env = createTestEnvironment();
 
     // 3. Layer test-specific mock implementations ON TOP of the defaults
-    env.mockGameConfigLoader.loadConfig.mockResolvedValue([
-      CORE_MOD_ID,
-      badModId,
-    ]);
-    env.mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
-      mockManifestMap
-    );
-    env.mockedResolveOrder.mockReturnValue([CORE_MOD_ID, badModId]);
+    setupManifests(env, mockManifestMap, [CORE_MOD_ID, badModId]);
 
     // *** THE FIX IS HERE ***
     // This mock now correctly handles case-sensitivity.
@@ -154,9 +151,7 @@ describe('ModsLoader Integration Test Suite - Error Handling (TEST-LOADER-7.4)',
     expect(env.mockRegistry.get('rules', `${badModId}:rule1`)).toBeDefined();
     expect(env.mockRegistry.getAll('components')).toHaveLength(0);
 
-    const summaryText = env.mockLogger.info.mock.calls
-      .map((c) => c[0])
-      .join('\n');
+    const summaryText = getSummaryText(env.mockLogger);
     expect(summaryText).toMatch(/actions\s+: C:1, O:0, E:0/);
     expect(summaryText).toMatch(/components\s+: C:0, O:0, E:1/);
     expect(summaryText).toMatch(/rules\s+: C:1, O:0, E:0/);

--- a/tests/unit/loaders/modsLoader.preLoopErrors.test.js
+++ b/tests/unit/loaders/modsLoader.preLoopErrors.test.js
@@ -1,9 +1,10 @@
 // tests/unit/loaders/modsLoader.preLoopErrors.test.js
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 // --- The new Test Setup Factory ---
 import { createTestEnvironment } from '../../common/loaders/modsLoader.test-setup.js';
+import { setupManifests } from '../../common/loaders/modsLoader.test-utils.js';
 
 // --- SUT Dependencies & Errors ---
 import ModDependencyError from '../../../src/errors/modDependencyError.js';
@@ -57,11 +58,8 @@ describe('ModsLoader Integration Test Suite - Pre-Loop Error Handling (Refactore
     };
 
     // 3. Configure a default success path that tests can override
-    env.mockGameConfigLoader.loadConfig.mockResolvedValue([CORE_MOD_ID]);
     const defaultMap = new Map([[CORE_MOD_ID.toLowerCase(), coreManifest]]);
-    env.mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
-      defaultMap
-    );
+    setupManifests(env, defaultMap, [CORE_MOD_ID]);
     env.mockedResolveOrder.mockImplementation((ids) => ids); // Default to pass-through
   });
 

--- a/tests/unit/loaders/modsLoader.timingLogs.test.js
+++ b/tests/unit/loaders/modsLoader.timingLogs.test.js
@@ -1,10 +1,11 @@
 // Filename: src/tests/loaders/modsLoader.timingLogs.test.js
 // Sub-Ticket 9: Test - Verify Performance Timing Logs
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 // --- The new Test Setup Factory ---
 import { createTestEnvironment } from '../../common/loaders/modsLoader.test-setup.js';
+import { setupManifests } from '../../common/loaders/modsLoader.test-utils.js';
 
 // --- SUT Dependencies ---
 import { CORE_MOD_ID } from '../../../src/constants/core.js';
@@ -51,22 +52,7 @@ describe('ModsLoader Integration Test Suite - Performance Timing Logs (Refactore
     const finalOrder = [CORE_MOD_ID, fooModId];
 
     // 3. Configure Mocks
-    env.mockGameConfigLoader.loadConfig.mockResolvedValue(finalOrder);
-    env.mockModManifestLoader.loadRequestedManifests.mockResolvedValue(
-      mockManifestMap
-    );
-    env.mockedResolveOrder.mockReturnValue(finalOrder);
-
-    // The factory sets up loaders to return a default success result, which is sufficient here.
-    // Configure registry.get to return the correct manifest during the load loop.
-    env.mockRegistry.get.mockImplementation((type, id) => {
-      if (type === 'mod_manifests') {
-        const lcId = id.toLowerCase();
-        if (lcId === CORE_MOD_ID) return mockCoreManifest;
-        if (lcId === fooModId) return mockFooManifest;
-      }
-      return undefined;
-    });
+    setupManifests(env, mockManifestMap, finalOrder);
   });
 
   it('should log per-mod performance timing information at DEBUG level', async () => {


### PR DESCRIPTION
## Summary
- import `setupManifests` and `getSummaryText`
- simplify ModsLoader tests to use new helpers

## Testing Done
- `npm run lint` *(fails: 574 errors, 2183 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855aeb9f1ac833189bd66db252bcbde