### PR TITLE
[Agent] remove duplicate DefaultComponentData

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -41,14 +41,6 @@ export const TestData = {
     GOALS_COMPONENT_ID,
     NAME_COMPONENT_ID,
   },
-  DefaultComponentData: {
-    [GOALS_COMPONENT_ID]: { goals: [] },
-    [NOTES_COMPONENT_ID]: { notes: [] },
-    [SHORT_TERM_MEMORY_COMPONENT_ID]: {
-      thoughts: [],
-      maxEntries: 10,
-    },
-  },
   DefinitionIDs: {
     BASIC: 'test-def:basic',
     ACTOR: 'test-def:actor',


### PR DESCRIPTION
Summary: Removed an extra `DefaultComponentData` object from the test helper so that only a single definition remains.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 544 errors)*
- [x] Root tests `npm run test`
- [ ] Proxy tests *(none modified)*
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6855b4433b8483319941f3f8b24eb08d