### PR TITLE
[Agent] centralize createMockLogger

### DIFF
--- a/tests/unit/testUtils.js
+++ b/tests/unit/testUtils.js
@@ -2,6 +2,7 @@
 
 import { PrerequisiteEvaluationService } from '../../src/actions/validation/prerequisiteEvaluationService.js';
 import { jest } from '@jest/globals';
+import { createMockLogger } from '../common/mockFactories.js';
 
 // --- Mock PrerequisiteEvaluationService ---
 jest.mock('../../src/actions/validation/prerequisiteEvaluationService.js'); // Mock needs to be in the utility or called before import in test
@@ -30,19 +31,8 @@ export function createMockPrerequisiteEvaluationService() {
 }
 
 // --- Mock Logger ---
-/**
- * Creates a mock logger object with Jest mock functions for standard levels.
- *
- * @returns {{info: jest.Mock, warn: jest.Mock, error: jest.Mock, debug: jest.Mock}}
- */
-export function createMockLogger() {
-  return {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  };
-}
+// re-export createMockLogger from common utilities
+export { createMockLogger };
 
 /**
  * Creates a mock SaveValidationService with noop methods.


### PR DESCRIPTION
Summary: updated `tests/unit/testUtils.js` to import and re-export `createMockLogger` from the common mock factories. Ensures a single canonical implementation.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 541 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6855b6825e208331bbcc1bf55351b70d