### PR TITLE
[Agent] consolidate jest mock cleanup

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -3,7 +3,9 @@
  * @see tests/common/engine/gameEngineTestBed.js
  */
 
+import { jest } from '@jest/globals';
 import { createTestEnvironment } from './gameEngine.test-environment.js';
+import { clearMockFunctions } from '../jestHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -129,23 +131,15 @@ export class GameEngineTestBed {
    */
   resetMocks() {
     jest.clearAllMocks();
-    const services = [
+    clearMockFunctions(
       this.mocks.logger,
       this.mocks.entityManager,
       this.mocks.turnManager,
       this.mocks.gamePersistenceService,
       this.mocks.playtimeTracker,
       this.mocks.safeEventDispatcher,
-      this.mocks.initializationService,
-    ];
-
-    services.forEach((svc) => {
-      Object.values(svc).forEach((fn) => {
-        if (fn && typeof fn.mockClear === 'function') {
-          fn.mockClear();
-        }
-      });
-    });
+      this.mocks.initializationService
+    );
   }
 }
 

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -22,6 +22,7 @@ import {
   createMockSafeEventDispatcher,
   createSimpleMockDataRegistry,
 } from '../mockFactories.js';
+import { clearMockFunctions } from '../jestHelpers.js';
 
 // --- Centralized Mocks (REMOVED) ---
 // Mock creation functions are now imported.
@@ -168,6 +169,12 @@ export class TestBed {
   cleanup() {
     // Clear call history on all mocks
     jest.clearAllMocks();
+    clearMockFunctions(
+      this.mocks.registry,
+      this.mocks.validator,
+      this.mocks.logger,
+      this.mocks.eventDispatcher
+    );
 
     // Reset specific mock implementations that tests commonly override
     this.mocks.registry.getEntityDefinition.mockReset();

--- a/tests/common/jestHelpers.js
+++ b/tests/common/jestHelpers.js
@@ -1,0 +1,15 @@
+/**
+ * Clears jest mock call histories on all functions within the supplied objects.
+ *
+ * @param {...object} targets - Objects containing jest.fn mocks.
+ * @returns {void}
+ */
+export function clearMockFunctions(...targets) {
+  for (const obj of targets) {
+    for (const val of Object.values(obj)) {
+      if (val && typeof val.mockClear === 'function') {
+        val.mockClear();
+      }
+    }
+  }
+}

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -13,6 +13,7 @@ import {
   createMockPromptBuilder,
   createMockEntity,
 } from '../mockFactories.js';
+import { clearMockFunctions } from '../jestHelpers.js';
 
 /**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
@@ -102,6 +103,13 @@ export class AIPromptPipelineTestBed {
    */
   cleanup() {
     jest.clearAllMocks();
+    clearMockFunctions(
+      this.llmAdapter,
+      this.gameStateProvider,
+      this.promptContentProvider,
+      this.promptBuilder,
+      this.logger
+    );
   }
 
   /**

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -10,6 +10,7 @@ import {
   createMockEntityManager,
   createMockValidatedEventBus,
 } from '../mockFactories.js';
+import { clearMockFunctions } from '../jestHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -104,6 +105,13 @@ export class TurnManagerTestBed {
    */
   async cleanup() {
     jest.clearAllMocks();
+    clearMockFunctions(
+      this.turnOrderService,
+      this.entityManager,
+      this.logger,
+      this.dispatcher,
+      this.turnHandlerResolver
+    );
     if (this.turnManager && typeof this.turnManager.stop === 'function') {
       await this.turnManager.stop();
     }


### PR DESCRIPTION
## Summary
- add `clearMockFunctions` helper for wiping jest mocks
- call helper in entity, engine, turn, and prompt testbeds

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855b68f4acc83319cd2f8eeb65d732a