### PR TITLE
[Agent] add container overrides and null-service tests

### DIFF
--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -7,23 +7,17 @@ import {
   it,
   jest,
 } from '@jest/globals';
-import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
 import {
   expectDispatchSequence,
-  buildSaveDispatches,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
 } from '../../common/engine/dispatchTestUtils.js';
 import {
   ENGINE_INITIALIZING_UI,
   ENGINE_READY_UI,
-  ENGINE_OPERATION_IN_PROGRESS_UI,
   ENGINE_OPERATION_FAILED_UI,
   ENGINE_STOPPED_UI,
-  REQUEST_SHOW_SAVE_GAME_UI,
-  REQUEST_SHOW_LOAD_GAME_UI,
-  CANNOT_SAVE_GAME_INFO,
 } from '../../../src/constants/eventIds.js';
 
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */


### PR DESCRIPTION
## Summary
- add override support to `AppContainer`
- refactor GameEngine tests with table-driven checks when services are null
- ensure tests use container overrides instead of bespoke resolves

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855b8b658ec8331aae62f1f05a03cb2