### PR TITLE
[Agent] implement default adapters

### DIFF
--- a/src/adapters/DefaultComponentPolicy.js
+++ b/src/adapters/DefaultComponentPolicy.js
@@ -1,0 +1,87 @@
+import { cloneDeep } from 'lodash';
+import { IDefaultComponentPolicy } from '../ports/IDefaultComponentPolicy.js';
+import {
+  ACTOR_COMPONENT_ID,
+  SHORT_TERM_MEMORY_COMPONENT_ID,
+  NOTES_COMPONENT_ID,
+  GOALS_COMPONENT_ID,
+} from '../constants/componentIds.js';
+
+/**
+ * Determine if a validation result is successful.
+ *
+ * @param {any} rawResult
+ * @returns {boolean}
+ */
+function validationSucceeded(rawResult) {
+  if (rawResult === undefined || rawResult === null) return true;
+  if (typeof rawResult === 'boolean') return rawResult;
+  return !!rawResult.isValid;
+}
+
+/**
+ * Format validation errors for logging.
+ *
+ * @param {any} rawResult
+ * @returns {string}
+ */
+function formatValidationErrors(rawResult) {
+  if (rawResult && typeof rawResult === 'object' && rawResult.errors) {
+    return JSON.stringify(rawResult.errors, null, 2);
+  }
+  return '(validator returned false)';
+}
+
+/**
+ * Policy that injects engine-required default components into actor entities.
+ *
+ * @implements {IDefaultComponentPolicy}
+ */
+class DefaultComponentPolicy extends IDefaultComponentPolicy {
+  /**
+   * Apply the policy to the given entity.
+   *
+   * @param {import('../entities/entity.js').default} entity
+   * @param {{ validator: { validate: Function }, logger: { debug: Function, error: Function } }} deps
+   */
+  apply(entity, { validator, logger }) {
+    if (!entity.hasComponent(ACTOR_COMPONENT_ID)) {
+      return;
+    }
+
+    const componentsToInject = [
+      {
+        id: SHORT_TERM_MEMORY_COMPONENT_ID,
+        data: { thoughts: [], maxEntries: 10 },
+        name: 'STM',
+      },
+      { id: NOTES_COMPONENT_ID, data: { notes: [] }, name: 'Notes' },
+      { id: GOALS_COMPONENT_ID, data: { goals: [] }, name: 'Goals' },
+    ];
+
+    for (const comp of componentsToInject) {
+      if (entity.hasComponent(comp.id)) continue;
+
+      logger.debug(
+        `Injecting ${comp.name} for ${entity.id} (def: ${entity.definitionId})`
+      );
+      try {
+        const clone = cloneDeep(comp.data);
+        const result = validator.validate(comp.id, clone);
+        if (!validationSucceeded(result)) {
+          const details = formatValidationErrors(result);
+          const msg = `Default ${comp.name} component injection for entity ${entity.id} Errors:\n${details}`;
+          logger.error(msg);
+          throw new Error(msg);
+        }
+        entity.addComponent(comp.id, clone);
+      } catch (e) {
+        logger.error(
+          `Failed to inject default component ${comp.id} for entity ${entity.id}: ${e.message}`
+        );
+      }
+    }
+  }
+}
+
+export default DefaultComponentPolicy;

--- a/src/adapters/InMemoryEntityRepository.js
+++ b/src/adapters/InMemoryEntityRepository.js
@@ -1,0 +1,57 @@
+import MapManager from '../utils/mapManagerUtils.js';
+import { IEntityRepository } from '../ports/IEntityRepository.js';
+
+/**
+ * @class InMemoryEntityRepository
+ * @description Stores entities in memory using a {@link MapManager}.
+ * Implements the {@link IEntityRepository} interface.
+ */
+class InMemoryEntityRepository extends IEntityRepository {
+  /** @type {MapManager} */
+  #map;
+
+  constructor() {
+    super();
+    this.#map = new MapManager({ throwOnInvalidId: false });
+  }
+
+  /** @inheritdoc */
+  add(entity) {
+    if (entity && typeof entity === 'object') {
+      this.#map.add(entity.id, entity);
+    } else {
+      this.#map.add(undefined, entity);
+    }
+  }
+
+  /** @inheritdoc */
+  get(id) {
+    return this.#map.get(id);
+  }
+
+  /** @inheritdoc */
+  has(id) {
+    return this.#map.has(id);
+  }
+
+  /** @inheritdoc */
+  remove(id) {
+    return this.#map.remove(id);
+  }
+
+  /** @inheritdoc */
+  clear() {
+    this.#map.clear();
+  }
+
+  /**
+   * Returns an iterator over all stored entities.
+   *
+   * @returns {IterableIterator<object>}
+   */
+  entities() {
+    return this.#map.values();
+  }
+}
+
+export default InMemoryEntityRepository;

--- a/src/adapters/LodashCloner.js
+++ b/src/adapters/LodashCloner.js
@@ -1,0 +1,12 @@
+import { cloneDeep } from 'lodash';
+
+/**
+ * Deeply clones the provided object using lodash.
+ *
+ * @template T
+ * @param {T} obj - The object to clone.
+ * @returns {T} The cloned object.
+ */
+export default function LodashCloner(obj) {
+  return cloneDeep(obj);
+}

--- a/src/adapters/UuidGenerator.js
+++ b/src/adapters/UuidGenerator.js
@@ -1,0 +1,10 @@
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Generates a new UUID v4 string.
+ *
+ * @returns {string} The generated identifier.
+ */
+export default function UuidGenerator() {
+  return uuidv4();
+}

--- a/tests/unit/adapters/coreAdapters.test.js
+++ b/tests/unit/adapters/coreAdapters.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect } from '@jest/globals';
+import InMemoryEntityRepository from '../../../src/adapters/InMemoryEntityRepository.js';
+import UuidGenerator from '../../../src/adapters/UuidGenerator.js';
+import LodashCloner from '../../../src/adapters/LodashCloner.js';
+import DefaultComponentPolicy from '../../../src/adapters/DefaultComponentPolicy.js';
+import {
+  createMockLogger,
+  createMockSchemaValidator,
+} from '../../common/mockFactories.js';
+import EntityDefinition from '../../../src/entities/entityDefinition.js';
+import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
+import Entity from '../../../src/entities/entity.js';
+import {
+  ACTOR_COMPONENT_ID,
+  GOALS_COMPONENT_ID,
+  NOTES_COMPONENT_ID,
+  SHORT_TERM_MEMORY_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+
+describe('InMemoryEntityRepository', () => {
+  it('stores and retrieves entities', () => {
+    const repo = new InMemoryEntityRepository();
+    const e = { id: 'e1', name: 'entity' };
+    repo.add(e);
+    expect(repo.has('e1')).toBe(true);
+    expect(repo.get('e1')).toBe(e);
+    expect(Array.from(repo.entities())).toEqual([e]);
+    expect(repo.remove('e1')).toBe(true);
+    expect(repo.has('e1')).toBe(false);
+    repo.add({ id: 'e2' });
+    repo.clear();
+    expect(repo.has('e2')).toBe(false);
+  });
+
+  it('handles invalid ids gracefully', () => {
+    const repo = new InMemoryEntityRepository();
+    expect(repo.get('')).toBeUndefined();
+    expect(repo.has(null)).toBe(false);
+    expect(repo.remove(undefined)).toBe(false);
+  });
+});
+
+describe('UuidGenerator', () => {
+  it('generates unique ids', () => {
+    const id1 = UuidGenerator();
+    const id2 = UuidGenerator();
+    expect(typeof id1).toBe('string');
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe('LodashCloner', () => {
+  it('deep clones objects', () => {
+    const obj = { a: { b: 1 }, arr: [1, 2] };
+    const clone = LodashCloner(obj);
+    expect(clone).toEqual(obj);
+    clone.a.b = 2;
+    expect(obj.a.b).toBe(1);
+  });
+});
+
+describe('DefaultComponentPolicy', () => {
+  it('injects default components for actors', () => {
+    const validator = createMockSchemaValidator();
+    const logger = createMockLogger();
+    const def = new EntityDefinition('actor', {
+      components: { [ACTOR_COMPONENT_ID]: {} },
+    });
+    const data = new EntityInstanceData('e1', def);
+    const entity = new Entity(data);
+
+    const policy = new DefaultComponentPolicy();
+    policy.apply(entity, { validator, logger });
+
+    expect(entity.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(true);
+    expect(entity.hasComponent(NOTES_COMPONENT_ID)).toBe(true);
+    expect(entity.hasComponent(GOALS_COMPONENT_ID)).toBe(true);
+    expect(validator.validate).toHaveBeenCalledWith(
+      SHORT_TERM_MEMORY_COMPONENT_ID,
+      expect.any(Object)
+    );
+    expect(validator.validate).toHaveBeenCalledWith(
+      NOTES_COMPONENT_ID,
+      expect.any(Object)
+    );
+    expect(validator.validate).toHaveBeenCalledWith(
+      GOALS_COMPONENT_ID,
+      expect.any(Object)
+    );
+  });
+
+  it('does not override existing components', () => {
+    const validator = createMockSchemaValidator();
+    const logger = createMockLogger();
+    const def = new EntityDefinition('actor', {
+      components: {
+        [ACTOR_COMPONENT_ID]: {},
+        [GOALS_COMPONENT_ID]: { goals: [{ text: 'x' }] },
+      },
+    });
+    const data = new EntityInstanceData('e2', def);
+    const entity = new Entity(data);
+
+    const policy = new DefaultComponentPolicy();
+    policy.apply(entity, { validator, logger });
+
+    expect(entity.getComponentData(GOALS_COMPONENT_ID)).toEqual({
+      goals: [{ text: 'x' }],
+    });
+    expect(validator.validate).not.toHaveBeenCalledWith(
+      GOALS_COMPONENT_ID,
+      expect.anything()
+    );
+  });
+
+  it('does nothing for non-actor entities', () => {
+    const validator = createMockSchemaValidator();
+    const logger = createMockLogger();
+    const def = new EntityDefinition('basic', { components: {} });
+    const data = new EntityInstanceData('e3', def);
+    const entity = new Entity(data);
+
+    const policy = new DefaultComponentPolicy();
+    policy.apply(entity, { validator, logger });
+
+    expect(entity.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(false);
+    expect(entity.hasComponent(NOTES_COMPONENT_ID)).toBe(false);
+    expect(entity.hasComponent(GOALS_COMPONENT_ID)).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary: Added production implementations for core ports under `src/adapters` and unit tests verifying each. New adapters cover in-memory entity storage, UUID generation, lodash-based cloning, and default component policy logic.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (reports pre-existing warnings)
- [x] Root tests `npm run test` *(fails coverage threshold)*
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6855c3b5b118833190df0ead45d8111c