### PR TITLE
[Test] Cover initEngineUIManager

### DIFF
--- a/tests/unit/bootstrapper/stages/auxiliary/initEngineUIManager.test.js
+++ b/tests/unit/bootstrapper/stages/auxiliary/initEngineUIManager.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { initEngineUIManager } from '../../../../../src/bootstrapper/stages/auxiliary/initEngineUIManager.js';
+import { resolveAndInitialize } from '../../../../../src/bootstrapper/helpers.js';
+
+jest.mock('../../../../../src/bootstrapper/helpers.js', () => ({
+  __esModule: true,
+  resolveAndInitialize: jest.fn(() => ({ success: true })),
+}));
+
+/**
+ * Create a simple logger mock used for testing.
+ *
+ * @returns {{debug: jest.Mock, warn: jest.Mock, error: jest.Mock}} Mock logger
+ *   implementing the expected methods.
+ */
+function createLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+const tokens = { EngineUIManager: 'EngineUIManager' };
+
+describe('initEngineUIManager', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls resolveAndInitialize with correct arguments', () => {
+    const container = {};
+    const logger = createLogger();
+
+    const result = initEngineUIManager({ container, logger, tokens });
+
+    expect(resolveAndInitialize).toHaveBeenCalledWith(
+      container,
+      tokens.EngineUIManager,
+      'initialize',
+      logger
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it('returns whatever resolveAndInitialize returns', () => {
+    const ret = { success: false, error: new Error('boom') };
+    resolveAndInitialize.mockReturnValueOnce(ret);
+    const container = {};
+    const logger = createLogger();
+
+    const result = initEngineUIManager({ container, logger, tokens });
+    expect(result).toBe(ret);
+  });
+});


### PR DESCRIPTION
Summary: Add missing test suite for auxiliary `initEngineUIManager` initializer to improve coverage.

Changes Made:
- Created `initEngineUIManager.test.js` verifying calls to `resolveAndInitialize` and result forwarding.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` — existing warnings remain)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6855c41cfdec8331a9d979d0af2a4600