### PR TITLE
[Agent] Refactor EntityManager constructor for adapter injection

### DIFF
--- a/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
+++ b/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
@@ -39,14 +39,16 @@ export function registerWorldAndEntity(container) {
 
   // --- IEntityManager (EntityManager implementation) ---
   r.singletonFactory(tokens.IEntityManager, (c) => {
-    return new EntityManager(
-      /** @type {IDataRegistry} */ (c.resolve(tokens.IDataRegistry)),
-      /** @type {ISchemaValidator} */ (c.resolve(tokens.ISchemaValidator)),
-      /** @type {ILogger} */ (c.resolve(tokens.ILogger)),
-      /** @type {ISafeEventDispatcher} */ (
+    return new EntityManager({
+      registry: /** @type {IDataRegistry} */ (c.resolve(tokens.IDataRegistry)),
+      validator: /** @type {ISchemaValidator} */ (
+        c.resolve(tokens.ISchemaValidator)
+      ),
+      logger: /** @type {ILogger} */ (c.resolve(tokens.ILogger)),
+      dispatcher: /** @type {ISafeEventDispatcher} */ (
         c.resolve(tokens.ISafeEventDispatcher)
-      )
-    );
+      ),
+    });
   });
   logger.debug(
     `World and Entity Registration: Registered ${String(tokens.IEntityManager)}.`

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -143,13 +143,13 @@ export class TestBed extends BaseTestBed {
       eventDispatcher: createMockSafeEventDispatcher(),
     };
 
-    this.entityManager = new EntityManager(
-      this.mocks.registry,
-      this.mocks.validator,
-      this.mocks.logger,
-      this.mocks.eventDispatcher,
-      entityManagerOptions
-    );
+    this.entityManager = new EntityManager({
+      registry: this.mocks.registry,
+      validator: this.mocks.validator,
+      logger: this.mocks.logger,
+      dispatcher: this.mocks.eventDispatcher,
+      ...entityManagerOptions,
+    });
   }
 
   /**

--- a/tests/integration/entityCreationFromDefAndInstance.integration.test.js
+++ b/tests/integration/entityCreationFromDefAndInstance.integration.test.js
@@ -50,12 +50,12 @@ describe('EntityManager Integration Tests', () => {
     mockEventDispatcher = createMockSafeEventDispatcher();
 
     // Instantiate EntityManager with real registry and mocked services
-    entityManager = new EntityManager(
-      dataRegistry,
-      mockSchemaValidator,
-      mockLogger,
-      mockEventDispatcher
-    );
+    entityManager = new EntityManager({
+      registry: dataRegistry,
+      validator: mockSchemaValidator,
+      logger: mockLogger,
+      dispatcher: mockEventDispatcher,
+    });
   });
 
   /**

--- a/tests/unit/common/entities/testBed.test.js
+++ b/tests/unit/common/entities/testBed.test.js
@@ -68,13 +68,12 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
         expect(EntityManager).toHaveBeenCalledTimes(1);
         // FIX: The constructor now receives a 5th `options` argument, which is `{}` by default.
         // We update the test to expect this new argument.
-        expect(EntityManager).toHaveBeenCalledWith(
-          testBed.mocks.registry,
-          testBed.mocks.validator,
-          testBed.mocks.logger,
-          testBed.mocks.eventDispatcher,
-          expect.any(Object) // It receives an options object, which is {} by default.
-        );
+        expect(EntityManager).toHaveBeenCalledWith({
+          registry: testBed.mocks.registry,
+          validator: testBed.mocks.validator,
+          logger: testBed.mocks.logger,
+          dispatcher: testBed.mocks.eventDispatcher,
+        });
       });
 
       it('should provide a public property `entityManager` with the SUT instance', () => {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -36,7 +36,13 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const EntityManager = getBed().entityManager.constructor;
 
       expect(
-        () => new EntityManager(null, validator, logger, eventDispatcher)
+        () =>
+          new EntityManager({
+            registry: null,
+            validator,
+            logger,
+            dispatcher: eventDispatcher,
+          })
       ).toThrow('Missing required dependency: IDataRegistry.');
     });
 
@@ -45,7 +51,13 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const EntityManager = getBed().entityManager.constructor;
 
       expect(
-        () => new EntityManager(registry, null, logger, eventDispatcher)
+        () =>
+          new EntityManager({
+            registry,
+            validator: null,
+            logger,
+            dispatcher: eventDispatcher,
+          })
       ).toThrow('Missing required dependency: ISchemaValidator.');
     });
 


### PR DESCRIPTION
Summary:
- inject adapters like repository, cloner and defaultPolicy via EntityManager constructor
- update DI registration and tests for new object-style constructor
- remove direct uuid and lodash imports, using adapter functions

Testing Done:
- `npm run format`
- `npm run lint` *(fails: ERR_MODULE_NOT_FOUND & lint errors)*
- `npm run test` *(fails due to coverage threshold)*

------
https://chatgpt.com/codex/tasks/task_e_6855c6cdf6a083318951cc9243272ce4