### PR TITLE
[Agent] add createMockContainer helper

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -14,6 +14,7 @@ import {
   createMockPlaytimeTracker,
   createMockSafeEventDispatcher,
   createMockInitializationService,
+  createMockContainer,
 } from '../mockFactories.js';
 
 /**
@@ -46,37 +47,17 @@ export function createTestEnvironment(overrides = {}) {
   const safeEventDispatcher = createMockSafeEventDispatcher();
   const initializationService = createMockInitializationService();
 
-  const mockContainer = {
-    resolve: jest.fn((token) => {
-      if (Object.prototype.hasOwnProperty.call(overrides, token)) {
-        return overrides[token];
-      }
-      switch (token) {
-        case tokens.ILogger:
-          return logger;
-        case tokens.IEntityManager:
-          return entityManager;
-        case tokens.ITurnManager:
-          return turnManager;
-        case tokens.GamePersistenceService:
-          return gamePersistenceService;
-        case tokens.PlaytimeTracker:
-          return playtimeTracker;
-        case tokens.ISafeEventDispatcher:
-          return safeEventDispatcher;
-        case tokens.IInitializationService:
-          return initializationService;
-        default: {
-          const tokenName =
-            Object.keys(tokens).find((key) => tokens[key] === token) ||
-            token?.toString();
-          throw new Error(
-            `gameEngine.test-environment: Unmocked token: ${tokenName}`
-          );
-        }
-      }
-    }),
+  const mapping = {
+    [tokens.ILogger]: logger,
+    [tokens.IEntityManager]: entityManager,
+    [tokens.ITurnManager]: turnManager,
+    [tokens.GamePersistenceService]: gamePersistenceService,
+    [tokens.PlaytimeTracker]: playtimeTracker,
+    [tokens.ISafeEventDispatcher]: safeEventDispatcher,
+    [tokens.IInitializationService]: initializationService,
   };
+
+  const mockContainer = createMockContainer(mapping, overrides);
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 

--- a/tests/common/mockFactories.js
+++ b/tests/common/mockFactories.js
@@ -379,3 +379,27 @@ export const createMockEntity = (
     return false;
   }),
 });
+
+/**
+ * Creates a minimal DI container mock.
+ *
+ * @description Provides a `resolve` method that returns predefined mocks based
+ * on token keys. Optional overrides can supply alternative return values for
+ * specific tokens during a test.
+ * @param {Record<string | symbol, any>} mapping - Base token–to–mock map.
+ * @param {Record<string | symbol, any>} [overrides={}] - Per-test override map.
+ * @returns {{ resolve: jest.Mock }} Object with a jest.fn `resolve` method.
+ */
+export const createMockContainer = (mapping, overrides = {}) => ({
+  resolve: jest.fn((token) => {
+    if (Object.prototype.hasOwnProperty.call(overrides, token)) {
+      return overrides[token];
+    }
+    if (Object.prototype.hasOwnProperty.call(mapping, token)) {
+      return mapping[token];
+    }
+    const tokenName =
+      typeof token === 'symbol' ? token.toString() : String(token);
+    throw new Error(`createMockContainer: Unmapped token: ${tokenName}`);
+  }),
+});


### PR DESCRIPTION
Summary: Introduced `createMockContainer` helper to simplify DI container stubs for tests. Refactored game engine test environment to use this helper.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (warnings remain)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start` (fails to bundle)


------
https://chatgpt.com/codex/tasks/task_e_6855c9eccc7c83319cea3382fda02022