### PR TITLE
[Agent] auto-assign mocks to test beds

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -13,7 +13,9 @@ export class BaseTestBed {
   /**
    * Creates a new BaseTestBed instance.
    *
-   * @param {Record<string, object>} [mocks] - The mocks used by the test bed.
+   * @param {Record<string, object>} [mocks] - The mocks used by the test bed. Each
+   *   provided mock is also assigned directly as a property on the instance for
+   *   easier access.
    */
   constructor(mocks = {}) {
     /**
@@ -22,6 +24,10 @@ export class BaseTestBed {
      * @type {Record<string, object>}
      */
     this.mocks = mocks;
+
+    Object.entries(mocks).forEach(([key, value]) => {
+      this[key] = value;
+    });
   }
 
   /**

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -20,16 +20,6 @@ import BaseTestBed from '../baseTestBed.js';
  * @class
  */
 export class AIPromptPipelineTestBed extends BaseTestBed {
-  /** @type {jest.Mocked<import('../../src/turns/interfaces/ILLMAdapter.js').ILLMAdapter>} */
-  llmAdapter;
-  /** @type {jest.Mocked<import('../../src/turns/interfaces/IAIGameStateProvider.js').IAIGameStateProvider>} */
-  gameStateProvider;
-  /** @type {jest.Mocked<import('../../src/turns/interfaces/IAIPromptContentProvider.js').IAIPromptContentProvider>} */
-  promptContentProvider;
-  /** @type {jest.Mocked<import('../../src/interfaces/IPromptBuilder.js').IPromptBuilder>} */
-  promptBuilder;
-  /** @type {jest.Mocked<import('../../src/interfaces/coreServices.js').ILogger>} */
-  logger;
   /** @type {import('../../src/entities/entity.js').default} */
   defaultActor;
   /** @type {import('../../src/turns/interfaces/ITurnContext.js').ITurnContext} */
@@ -46,13 +36,6 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
       logger: createMockLogger(),
     };
     super(mocks);
-
-    // Preserve direct properties for backward compatibility
-    this.llmAdapter = this.mocks.llmAdapter;
-    this.gameStateProvider = this.mocks.gameStateProvider;
-    this.promptContentProvider = this.mocks.promptContentProvider;
-    this.promptBuilder = this.mocks.promptBuilder;
-    this.logger = this.mocks.logger;
     this.defaultActor = createMockEntity('actor');
     this.defaultContext = {};
     this.defaultActions = [];

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -18,16 +18,6 @@ import BaseTestBed from '../baseTestBed.js';
  * @class
  */
 export class TurnManagerTestBed extends BaseTestBed {
-  /** @type {ReturnType<typeof createMockLogger>} */
-  logger;
-  /** @type {ReturnType<typeof createMockEntityManager>} */
-  entityManager;
-  /** @type {ReturnType<typeof createMockValidatedEventBus>} */
-  dispatcher;
-  /** @type {{ isEmpty: jest.Mock, getNextEntity: jest.Mock, startNewRound: jest.Mock, clearCurrentRound: jest.Mock }} */
-  turnOrderService;
-  /** @type {{ resolveHandler: jest.Mock }} */
-  turnHandlerResolver;
   /** @type {TurnManager} */
   turnManager;
 
@@ -64,11 +54,6 @@ export class TurnManagerTestBed extends BaseTestBed {
       turnHandlerResolver,
     };
     super(mocks);
-    this.logger = logger;
-    this.entityManager = entityManager;
-    this.turnOrderService = turnOrderService;
-    this.turnHandlerResolver = turnHandlerResolver;
-    this.dispatcher = dispatcher;
 
     this.turnManager = new TurnManager({
       turnOrderService: this.turnOrderService,

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -31,8 +31,8 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
       container: testBed.env.mockContainer,
     });
     expect(testBed.engine).toBe(engine);
-    expect(testBed.mocks.logger).toBe(testBed.env.logger);
-    expect(testBed.mocks.turnManager).toBe(testBed.env.turnManager);
+    expect(testBed.logger).toBe(testBed.env.logger);
+    expect(testBed.turnManager).toBe(testBed.env.turnManager);
   });
 
   it('start presets initialization result and calls startNewGame', async () => {
@@ -90,7 +90,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     await testBed.cleanup();
 
     const restored = testBed.env.mockContainer.resolve(tokens.PlaytimeTracker);
-    expect(restored).toBe(testBed.mocks.playtimeTracker);
+    expect(restored).toBe(testBed.playtimeTracker);
   });
 
   it('constructor overrides return specified value', async () => {
@@ -107,36 +107,34 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
   });
 
   it('resetMocks clears all spy call history', () => {
-    testBed.mocks.logger.info('log');
-    testBed.mocks.entityManager.clearAll();
-    testBed.mocks.turnManager.start();
-    testBed.mocks.gamePersistenceService.saveGame();
-    testBed.mocks.playtimeTracker.startSession();
-    testBed.mocks.safeEventDispatcher.dispatch();
-    testBed.mocks.initializationService.runInitializationSequence();
+    testBed.logger.info('log');
+    testBed.entityManager.clearAll();
+    testBed.turnManager.start();
+    testBed.gamePersistenceService.saveGame();
+    testBed.playtimeTracker.startSession();
+    testBed.safeEventDispatcher.dispatch();
+    testBed.initializationService.runInitializationSequence();
 
-    expect(testBed.mocks.logger.info).toHaveBeenCalled();
-    expect(testBed.mocks.entityManager.clearAll).toHaveBeenCalled();
-    expect(testBed.mocks.turnManager.start).toHaveBeenCalled();
-    expect(testBed.mocks.gamePersistenceService.saveGame).toHaveBeenCalled();
-    expect(testBed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
-    expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalled();
+    expect(testBed.logger.info).toHaveBeenCalled();
+    expect(testBed.entityManager.clearAll).toHaveBeenCalled();
+    expect(testBed.turnManager.start).toHaveBeenCalled();
+    expect(testBed.gamePersistenceService.saveGame).toHaveBeenCalled();
+    expect(testBed.playtimeTracker.startSession).toHaveBeenCalled();
+    expect(testBed.safeEventDispatcher.dispatch).toHaveBeenCalled();
     expect(
-      testBed.mocks.initializationService.runInitializationSequence
+      testBed.initializationService.runInitializationSequence
     ).toHaveBeenCalled();
 
     testBed.resetMocks();
 
-    expect(testBed.mocks.logger.info).not.toHaveBeenCalled();
-    expect(testBed.mocks.entityManager.clearAll).not.toHaveBeenCalled();
-    expect(testBed.mocks.turnManager.start).not.toHaveBeenCalled();
+    expect(testBed.logger.info).not.toHaveBeenCalled();
+    expect(testBed.entityManager.clearAll).not.toHaveBeenCalled();
+    expect(testBed.turnManager.start).not.toHaveBeenCalled();
+    expect(testBed.gamePersistenceService.saveGame).not.toHaveBeenCalled();
+    expect(testBed.playtimeTracker.startSession).not.toHaveBeenCalled();
+    expect(testBed.safeEventDispatcher.dispatch).not.toHaveBeenCalled();
     expect(
-      testBed.mocks.gamePersistenceService.saveGame
-    ).not.toHaveBeenCalled();
-    expect(testBed.mocks.playtimeTracker.startSession).not.toHaveBeenCalled();
-    expect(testBed.mocks.safeEventDispatcher.dispatch).not.toHaveBeenCalled();
-    expect(
-      testBed.mocks.initializationService.runInitializationSequence
+      testBed.initializationService.runInitializationSequence
     ).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -20,24 +20,24 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
   it('instantiates TurnManager with mocks', () => {
     expect(TurnManager).toHaveBeenCalledTimes(1);
     expect(TurnManager).toHaveBeenCalledWith({
-      turnOrderService: testBed.mocks.turnOrderService,
-      entityManager: testBed.mocks.entityManager,
-      logger: testBed.mocks.logger,
-      dispatcher: testBed.mocks.dispatcher,
-      turnHandlerResolver: testBed.mocks.turnHandlerResolver,
+      turnOrderService: testBed.turnOrderService,
+      entityManager: testBed.entityManager,
+      logger: testBed.logger,
+      dispatcher: testBed.dispatcher,
+      turnHandlerResolver: testBed.turnHandlerResolver,
     });
   });
 
   it('setActiveEntities stores entities in the mock', () => {
     const entity = { id: 'e1' };
     testBed.setActiveEntities(entity);
-    expect(testBed.mocks.entityManager.activeEntities.get('e1')).toBe(entity);
-    expect(testBed.mocks.entityManager.getActiveEntities()).toContain(entity);
+    expect(testBed.entityManager.activeEntities.get('e1')).toBe(entity);
+    expect(testBed.entityManager.getActiveEntities()).toContain(entity);
   });
 
   it('trigger dispatches to subscribed handlers', () => {
     const handler = jest.fn();
-    testBed.mocks.dispatcher.subscribe('core:test', handler);
+    testBed.dispatcher.subscribe('core:test', handler);
     const payload = { ok: true };
 
     testBed.trigger('core:test', payload);
@@ -47,12 +47,12 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
 
   it('cleanup stops the manager and resets mocks', async () => {
     const stopSpy = testBed.turnManager.stop;
-    testBed.mocks.logger.debug('hi');
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledTimes(1);
+    testBed.logger.debug('hi');
+    expect(testBed.logger.debug).toHaveBeenCalledTimes(1);
 
     await testBed.cleanup();
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledTimes(0);
+    expect(testBed.logger.debug).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
## Summary
- automatically assign mock properties in BaseTestBed
- simplify TurnManagerTestBed and AIPromptPipelineTestBed constructors
- update GameEngineTestBed and TurnManagerTestBed unit tests

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 544 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855c9e198508331b441c42daa755e03