### PR TITLE
[Agent] add loader mock helper

### DIFF
--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -14,12 +14,12 @@ import {
   createMockGameConfigLoader,
   createMockModManifestLoader,
   createMockValidatedEventDispatcher,
-  createMockContentLoader,
   createMockModDependencyValidator,
   createMockModVersionValidator,
   createMockModLoadOrderResolver,
   createMockWorldLoader, // ← NEW import
 } from '../mockFactories.js';
+import { createLoaderMocks } from './modsLoader.test-utils.js';
 
 /**
  * List of loader types used when generating mock loaders.
@@ -56,10 +56,7 @@ export function createTestEnvironment() {
   const mockValidatedEventDispatcher = createMockValidatedEventDispatcher();
 
   /* ── Content-loader mocks ───────────────────────────────────────────── */
-  const loaders = {};
-  for (const type of loaderTypes) {
-    loaders[`mock${type}Loader`] = createMockContentLoader();
-  }
+  const loaders = createLoaderMocks(loaderTypes);
 
   /* ── Modding-helper mocks ───────────────────────────────────────────── */
   const mockModDependencyValidator = createMockModDependencyValidator();

--- a/tests/common/loaders/modsLoader.test-utils.js
+++ b/tests/common/loaders/modsLoader.test-utils.js
@@ -3,6 +3,8 @@
  * @see tests/common/loaders/modsLoader.test-utils.js
  */
 
+import { createMockContentLoader } from '../mockFactories.js';
+
 /**
  * Sets up manifest-related mocks for a ModsLoader test environment.
  *
@@ -39,4 +41,22 @@ export function setupManifests(env, manifestMap, finalOrder) {
  */
 export function getSummaryText(logger) {
   return logger.info.mock.calls.map((c) => c[0]).join('\n');
+}
+
+/**
+ * Generates mock loader objects for the given content types.
+ *
+ * @description Iterates over the supplied type names and returns an
+ *   object containing `{ mock${type}Loader: createMockContentLoader() }`
+ *   entries for each.
+ * @param {string[]} types - Content loader type names.
+ * @returns {Record<string, { loadItemsForMod: jest.Mock }>} Mapping of
+ *   mock loader names to loader mocks.
+ */
+export function createLoaderMocks(types) {
+  const loaders = {};
+  for (const type of types) {
+    loaders[`mock${type}Loader`] = createMockContentLoader();
+  }
+  return loaders;
 }


### PR DESCRIPTION
Summary: Added `createLoaderMocks` utility to streamline ModsLoader test setup.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6855cd8b0a408331824b0538703e5e74