### PR TITLE
[Agent] Add missing textUtils tests

### DIFF
--- a/tests/unit/utils/textUtils.formatPlaytime.test.js
+++ b/tests/unit/utils/textUtils.formatPlaytime.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatPlaytime } from '../../../src/utils/textUtils.js';
+
+// Cover edge cases and typical scenarios for formatPlaytime
+
+describe('formatPlaytime', () => {
+  it('returns "N/A" for non-number input', () => {
+    // @ts-ignore testing invalid type
+    expect(formatPlaytime('abc')).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN or negative numbers', () => {
+    expect(formatPlaytime(NaN)).toBe('N/A');
+    expect(formatPlaytime(-5)).toBe('N/A');
+  });
+
+  it('formats zero seconds correctly', () => {
+    expect(formatPlaytime(0)).toBe('00:00:00');
+  });
+
+  it('formats hours, minutes and seconds', () => {
+    // 1 hour, 1 minute, 1 second = 3661 seconds
+    expect(formatPlaytime(3661)).toBe('01:01:01');
+  });
+});

--- a/tests/unit/utils/textUtils.formatTimestamp.test.js
+++ b/tests/unit/utils/textUtils.formatTimestamp.test.js
@@ -12,8 +12,17 @@ describe('formatTimestamp', () => {
     expect(formatTimestamp('not-a-date')).toBe('Invalid Date');
   });
 
-  it('uses provided fallback on error', () => {
+  it('uses provided fallback when date parsing fails', () => {
     const fallback = 'N/A';
     expect(formatTimestamp('???', fallback)).toBe(fallback);
+  });
+
+  it('handles errors thrown during Date construction', () => {
+    const throwingInput = {
+      toString() {
+        throw new Error('boom');
+      },
+    };
+    expect(formatTimestamp(throwingInput, 'bad')).toBe('bad');
   });
 });


### PR DESCRIPTION
Summary: Added new unit tests for formatPlaytime and enhanced formatTimestamp tests to cover error cases, raising textUtils.js to full coverage.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails globally but no new errors)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start` *(fails: missing export during build)*

------
https://chatgpt.com/codex/tasks/task_e_6855cd01d19c83318adc2d3a619e45bb