### PR TITLE
[Agent] add describeGameEngineSuite helper and tests

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -6,6 +6,7 @@
 import { jest } from '@jest/globals';
 import { createTestEnvironment } from './gameEngine.test-environment.js';
 import BaseTestBed from '../baseTestBed.js';
+import { suppressConsoleError } from '../jestHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -136,6 +137,31 @@ export class GameEngineTestBed extends BaseTestBed {
  */
 export function createGameEngineTestBed(overrides = {}) {
   return new GameEngineTestBed(overrides);
+}
+
+/**
+ * Defines a test suite with automatic {@link GameEngineTestBed} setup.
+ *
+ * @param {string} title - Suite title passed to `describe`.
+ * @param {(getBed: () => GameEngineTestBed) => void} suiteFn - Callback
+ *   containing the tests. Receives a getter for the active test bed.
+ * @param {{[token: string]: any}} [overrides] - Optional DI overrides.
+ * @returns {void}
+ */
+export function describeGameEngineSuite(title, suiteFn, overrides = {}) {
+  describe(title, () => {
+    let testBed;
+    let consoleSpy;
+    beforeEach(() => {
+      consoleSpy = suppressConsoleError();
+      testBed = new GameEngineTestBed(overrides);
+    });
+    afterEach(async () => {
+      await testBed.cleanup();
+      consoleSpy.mockRestore();
+    });
+    suiteFn(() => testBed);
+  });
 }
 
 export default GameEngineTestBed;

--- a/tests/common/jestHelpers.js
+++ b/tests/common/jestHelpers.js
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 /**
  * Clears jest mock call histories on all functions within the supplied objects.
  *
@@ -12,4 +14,13 @@ export function clearMockFunctions(...targets) {
       }
     }
   }
+}
+
+/**
+ * Creates a spy that suppresses output from `console.error` during a test.
+ *
+ * @returns {import('@jest/globals').Mock} Jest spy on `console.error`.
+ */
+export function suppressConsoleError() {
+  return jest.spyOn(console, 'error').mockImplementation(() => {});
 }

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -4,7 +4,10 @@
  */
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { GameEngineTestBed } from '../../../common/engine/gameEngineTestBed.js';
+import {
+  GameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../../common/engine/gameEngineTestBed.js';
 import GameEngine from '../../../../src/engine/gameEngine.js';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 
@@ -136,5 +139,36 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     expect(
       testBed.initializationService.runInitializationSequence
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('describeGameEngineSuite', () => {
+  let cleanupCalls = 0;
+  const originalCleanup = GameEngineTestBed.prototype.cleanup;
+  const cleanupSpy = jest
+    .spyOn(GameEngineTestBed.prototype, 'cleanup')
+    .mockImplementation(async function (...args) {
+      cleanupCalls++;
+      return originalCleanup.apply(this, args);
+    });
+
+  describeGameEngineSuite('inner', (getBed) => {
+    it('instantiates a test bed', () => {
+      expect(getBed()).toBeInstanceOf(GameEngineTestBed);
+    });
+
+    it('suppresses console.error', () => {
+      expect(jest.isMockFunction(console.error)).toBe(true);
+      console.error('oops');
+      expect(console.error).toHaveBeenCalledWith('oops');
+    });
+  });
+
+  afterAll(() => {
+    cleanupSpy.mockRestore();
+  });
+
+  it('calls cleanup after each test', () => {
+    expect(cleanupCalls).toBe(2);
   });
 });


### PR DESCRIPTION
Summary: Added a `suppressConsoleError` helper and a new `describeGameEngineSuite` utility for easier GameEngine testing. Extended the GameEngine test bed to provide suite management with automatic cleanup and console error suppression. Added unit tests verifying suite behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint fails (existing repository issues) `npm run lint`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855d1432cf88331b0b890d16eb77f85