### PR TITLE
[Agent] extract memory storage provider util

### DIFF
--- a/tests/common/persistence/memoryStorageProvider.js
+++ b/tests/common/persistence/memoryStorageProvider.js
@@ -1,0 +1,37 @@
+/**
+ * @file Provides an in-memory implementation of the storage provider interface for tests.
+ * @see tests/common/persistence/memoryStorageProvider.js
+ */
+import { jest } from '@jest/globals';
+/** @typedef {import('../../../src/interfaces/IStorageProvider.js').IStorageProvider} IStorageProvider */
+
+/**
+ * Creates a simple in-memory storage provider.
+ *
+ * @description Returns a mock implementation of {@link IStorageProvider} that
+ * stores file data in an object and exposes asynchronous methods used by the
+ * persistence layer.
+ * @returns {IStorageProvider} In-memory provider
+ */
+export function createMemoryStorageProvider() {
+  const files = {};
+  return {
+    writeFileAtomically: jest.fn(async (path, data) => {
+      files[path] = data;
+      return { success: true };
+    }),
+    readFile: jest.fn(async (path) => files[path]),
+    listFiles: jest.fn(async () => Object.keys(files)),
+    deleteFile: jest.fn(async (path) => {
+      if (path in files) {
+        delete files[path];
+        return { success: true };
+      }
+      return { success: false, error: 'not found' };
+    }),
+    fileExists: jest.fn(async (path) => path in files),
+    ensureDirectoryExists: jest.fn(async () => {}),
+  };
+}
+
+export default createMemoryStorageProvider;

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -20,6 +20,7 @@ import ComponentCleaningService, {
 import receptionistDef from '../../data/mods/isekai/entities/definitions/receptionist.character.json';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../unit/testUtils.js';
+import { createMemoryStorageProvider } from '../common/persistence/memoryStorageProvider.js';
 
 beforeAll(() => {
   if (typeof window !== 'undefined') {
@@ -40,29 +41,6 @@ const makeLogger = () => ({
   error: jest.fn(),
   debug: jest.fn(),
 });
-
-/**
- * Creates an in-memory storage provider implementation for testing.
- *
- * @returns {import('../../src/interfaces/IStorageProvider.js').IStorageProvider} In-memory provider
- */
-const createMemoryStorageProvider = () => {
-  const files = {};
-  return {
-    writeFileAtomically: jest.fn(async (path, data) => {
-      files[path] = data;
-      return { success: true };
-    }),
-    readFile: jest.fn(async (path) => files[path]),
-    listFiles: jest.fn(async () => Object.keys(files)),
-    deleteFile: jest.fn(async (path) => {
-      delete files[path];
-      return { success: true };
-    }),
-    fileExists: jest.fn(async (path) => path in files),
-    ensureDirectoryExists: jest.fn(async () => {}),
-  };
-};
 
 const makeEntity = (id, def) => ({
   id,

--- a/tests/unit/persistence/saveLoadService.test.js
+++ b/tests/unit/persistence/saveLoadService.test.js
@@ -12,33 +12,8 @@ import {
 } from '../testUtils.js';
 
 /** @typedef {import('../../../src/interfaces/IStorageProvider.js').IStorageProvider} IStorageProvider */
+import { createMemoryStorageProvider } from '../../common/persistence/memoryStorageProvider.js';
 /** @typedef {import('../../../src/persistence/gameStateSerializer.js').default} GameStateSerializer */
-
-/**
- * Creates an in-memory storage provider for testing.
- *
- * @returns {IStorageProvider} In-memory provider
- */
-const createMemoryStorageProvider = () => {
-  const files = {};
-  return {
-    writeFileAtomically: jest.fn(async (path, data) => {
-      files[path] = data;
-      return { success: true };
-    }),
-    readFile: jest.fn(async (path) => files[path]),
-    listFiles: jest.fn(async () => Object.keys(files)),
-    deleteFile: jest.fn(async (path) => {
-      if (path in files) {
-        delete files[path];
-        return { success: true };
-      }
-      return { success: false, error: 'not found' };
-    }),
-    fileExists: jest.fn(async (path) => path in files),
-    ensureDirectoryExists: jest.fn(async () => {}),
-  };
-};
 
 /**
  * Creates a mock GameStateSerializer.


### PR DESCRIPTION
## Summary
- centralize test helper `createMemoryStorageProvider`
- reference helper in integration/unit persistence tests

## Testing Done
- `npm run lint` *(fails: 2739 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855d19e7f988331b56fd8e2eac13a38