### PR TITLE
[Agent] simplify dispatch test helper

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -18,27 +18,24 @@ import {
 export const DEFAULT_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';
 
 /**
- * Compares dispatch mock calls with an expected array of
- * [eventId, payload] pairs.
- *
- * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
- * @param {Array<[string, any]>} expected - Expected calls.
- * @returns {void}
- */
-export function expectDispatchCalls(mock, expected) {
-  expect(mock.mock.calls).toEqual(expected);
-}
-
-/**
  * Asserts that dispatch calls match the provided event sequence.
  * Usage: expectDispatchSequence(mock, [id, payload], [id, payload], ...)
+ * or expectDispatchSequence(mock, [[id, payload], [id, payload], ...])
  *
  * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
- * @param {...Array} events - Sequence of [eventId, payload] pairs.
+ * @param {...Array} events - Sequence of [eventId, payload] pairs or a single
+ *   array of such pairs.
  * @returns {void}
  */
 export function expectDispatchSequence(mock, ...events) {
-  expect(mock.mock.calls).toEqual(events);
+  const expected =
+    events.length === 1 &&
+    Array.isArray(events[0]) &&
+    Array.isArray(events[0][0])
+      ? events[0]
+      : events;
+
+  expect(mock.mock.calls).toEqual(expected);
 }
 
 /**
@@ -91,9 +88,11 @@ export function expectEngineStatus(engine, expectedStatus) {
   expect(engine.getEngineStatus()).toEqual(expectedStatus);
 }
 
+export { expectDispatchSequence as expectDispatchCalls };
+
 export default {
-  expectDispatchCalls,
   expectDispatchSequence,
   buildSaveDispatches,
   expectEngineStatus,
+  expectDispatchCalls: expectDispatchSequence,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -22,6 +22,17 @@ describe('dispatchTestUtils', () => {
       expect(() => expectDispatchSequence(mock, eventA, eventB)).not.toThrow();
     });
 
+    it('accepts a single array of events', () => {
+      const mock = jest.fn();
+      const events = [
+        ['eventA', { a: 1 }],
+        ['eventB', { b: 2 }],
+      ];
+      events.forEach((e) => mock(...e));
+
+      expect(() => expectDispatchSequence(mock, events)).not.toThrow();
+    });
+
     it('throws when sequences differ', () => {
       const mock = jest.fn();
       mock('eventA', { a: 1 });

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -16,7 +16,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchCalls } from '../../common/engine/dispatchTestUtils.js';
+import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -76,7 +76,7 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
           [
             COMPONENT_ADDED_ID,
             {
@@ -135,7 +135,7 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
           [
             COMPONENT_ADDED_ID,
             {
@@ -322,7 +322,7 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
           [
             COMPONENT_REMOVED_ID,
             {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -18,7 +18,7 @@ import {
   ENTITY_CREATED_ID,
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchCalls } from '../../common/engine/dispatchTestUtils.js';
+import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import MapManager from '../../../src/utils/mapManagerUtils.js';
 
@@ -125,7 +125,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createEntity('basic');
 
       // Assert
-      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
         [
           ENTITY_CREATED_ID,
           {
@@ -281,7 +281,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       );
 
       // Assert event was dispatched
-      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
         [
           ENTITY_CREATED_ID,
           {
@@ -407,7 +407,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expectDispatchCalls(mocks.eventDispatcher.dispatch, [
+      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
         [
           ENTITY_REMOVED_ID,
           {


### PR DESCRIPTION
Summary: enhance `expectDispatchSequence` to accept a single array or variadic event pairs. Remove old helper and update entity manager tests. Added new test coverage.

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 544 errors, 2195 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855d1acdeb08331a4bb980cca6a15b6