### PR TITLE
[Agent] add tests for contextUtils internals

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -9,6 +9,10 @@ import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
 // Re-export for backward compatibility
 export { resolveEntityNameFallback };
 
+// Expose internals for testing purposes
+export const _extractContextPath = extractContextPath;
+export const _resolvePlaceholderPath = resolvePlaceholderPath;
+
 // PLACEHOLDER_FIND_REGEX and FULL_STRING_PLACEHOLDER_REGEX are imported from
 // placeholderResolverUtils.js to keep placeholder matching logic consistent.
 

--- a/tests/unit/utils/contextUtils.private.test.js
+++ b/tests/unit/utils/contextUtils.private.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  _extractContextPath,
+  _resolvePlaceholderPath,
+} from '../../../src/utils/contextUtils.js';
+import { safeResolvePath } from '../../../src/utils/objectUtils.js';
+import { resolveEntityNameFallback } from '../../../src/utils/entityNameFallbackUtils.js';
+
+jest.mock('../../../src/utils/objectUtils.js');
+jest.mock('../../../src/utils/entityNameFallbackUtils.js');
+
+const mockLogger = { warn: jest.fn() };
+
+describe('contextUtils private helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('_extractContextPath', () => {
+    it('returns root executionContext when path has no context prefix', () => {
+      const exec = { foo: 'bar' };
+      expect(_extractContextPath('actor.id', exec)).toEqual({
+        path: 'actor.id',
+        root: exec,
+      });
+    });
+
+    it('extracts path and context from evaluationContext', () => {
+      const ctx = { varA: 1 };
+      const exec = { evaluationContext: { context: ctx } };
+      expect(_extractContextPath('context.varA', exec)).toEqual({
+        path: 'varA',
+        root: ctx,
+      });
+    });
+
+    it('returns null when context prefix used but missing', () => {
+      const exec = { evaluationContext: {} };
+      expect(_extractContextPath('context.varA', exec)).toBeNull();
+    });
+  });
+
+  describe('_resolvePlaceholderPath', () => {
+    it('warns and returns undefined for empty path', () => {
+      expect(_resolvePlaceholderPath('', {}, mockLogger)).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to extract path from placeholder at '
+      );
+    });
+
+    it('warns and returns undefined for invalid execution context', () => {
+      expect(_resolvePlaceholderPath('a.b', null, mockLogger)).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Cannot resolve placeholder path "a.b" at : executionContext is not a valid object.'
+      );
+    });
+
+    it('warns when context prefix missing in executionContext', () => {
+      const exec = { evaluationContext: {} };
+      expect(
+        _resolvePlaceholderPath('context.x', exec, mockLogger)
+      ).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it('resolves path via safeResolvePath', () => {
+      safeResolvePath.mockReturnValue(42);
+      const exec = { actor: { id: 5 } };
+      expect(_resolvePlaceholderPath('actor.id', exec, mockLogger)).toBe(42);
+      expect(safeResolvePath).toHaveBeenCalledWith(
+        exec,
+        'actor.id',
+        mockLogger,
+        'resolvePlaceholderPath for "actor.id" at '
+      );
+    });
+
+    it('uses resolveEntityNameFallback when safe resolution fails', () => {
+      safeResolvePath.mockReturnValue(undefined);
+      resolveEntityNameFallback.mockReturnValue('Bob');
+      const exec = { actor: { id: 'a1' } };
+      expect(_resolvePlaceholderPath('actor.name', exec, mockLogger)).toBe(
+        'Bob'
+      );
+      expect(resolveEntityNameFallback).toHaveBeenCalledWith(
+        'actor.name',
+        exec,
+        mockLogger
+      );
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added new exports for internal functions in `contextUtils.js` and created a comprehensive Jest test suite to cover them. Ensures placeholder path utilities are now fully tested.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6855d30a697c83319b9bf8242d8ecdc1