### PR TITLE
[Agent] consolidate engine test bed setup

### DIFF
--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -1,16 +1,9 @@
 // tests/engine/gameEngine.test.js
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
@@ -39,24 +32,13 @@ import {
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
-  const MOCK_WORLD_NAME = 'TestWorld';
-
-  beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
-  });
-
+describeGameEngineSuite('GameEngine', (getBed) => {
   describe('Constructor', () => {
     it('should instantiate and resolve all core services successfully', () => {
-      gameEngine = new GameEngine({ container: testBed.env.mockContainer }); // Instantiation for this test
+      const testBed = getBed();
+      const gameEngine = new GameEngine({
+        container: testBed.env.mockContainer,
+      }); // Instantiation for this test
       expect(testBed.env.mockContainer.resolve).toHaveBeenCalledWith(
         tokens.ILogger
       );
@@ -78,6 +60,7 @@ describe('GameEngine', () => {
     });
 
     it('should throw an error if ILogger cannot be resolved', () => {
+      const testBed = getBed();
       testBed.withTokenOverride(tokens.ILogger, () => {
         throw new Error('Logger failed to resolve');
       });
@@ -98,6 +81,7 @@ describe('GameEngine', () => {
       ['PlaytimeTracker', tokens.PlaytimeTracker],
       ['ISafeEventDispatcher', tokens.ISafeEventDispatcher],
     ])('should throw an error if %s cannot be resolved', (_, failingToken) => {
+      const testBed = getBed();
       const resolutionError = new Error(`${String(failingToken)} failed`);
       testBed.withTokenOverride(failingToken, () => {
         throw resolutionError;

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -1,14 +1,10 @@
 // tests/engine/loadGame.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import {
+  createGameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 
@@ -22,18 +18,9 @@ import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
-
-  beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
-  });
   describe('loadGame', () => {
     const SAVE_ID = 'savegame-001.sav';
     const mockSaveData = {
@@ -45,6 +32,7 @@ describe('GameEngine', () => {
     let prepareSpy, executeSpy, finalizeSpy, handleFailureSpy;
 
     beforeEach(() => {
+      testBed = getBed();
       gameEngine = testBed.engine; // Ensure gameEngine is fresh
       // Spies are on the gameEngine instance created here
       prepareSpy = jest

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -1,14 +1,10 @@
 // tests/engine/showLoadGameUI.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import {
+  createGameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -21,17 +17,12 @@ import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
   describe('showLoadGameUI', () => {
     beforeEach(() => {

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -1,14 +1,10 @@
 // tests/engine/showSaveGameUI.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import {
+  createGameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import {
   REQUEST_SHOW_SAVE_GAME_UI,
   CANNOT_SAVE_GAME_INFO,
@@ -24,19 +20,14 @@ import {
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
   describe('showSaveGameUI', () => {
     beforeEach(async () => {

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -1,14 +1,7 @@
 // tests/engine/startNewGame.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import {
   expectDispatchSequence,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
@@ -30,19 +23,14 @@ import {
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
 
   describe('startNewGame', () => {

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -1,14 +1,10 @@
 // tests/engine/stop.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import {
+  createGameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -21,19 +17,14 @@ import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
   describe('stop', () => {
     beforeEach(() => {

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -1,14 +1,10 @@
 // tests/engine/triggerManualSave.test.js
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { createGameEngineTestBed } from '../../common/engine/gameEngineTestBed.js';
+import {
+  createGameEngineTestBed,
+  describeGameEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
@@ -25,17 +21,12 @@ import {
 /** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
-describe('GameEngine', () => {
+describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   beforeEach(() => {
-    testBed = createGameEngineTestBed();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
   describe('triggerManualSave', () => {
     const SAVE_NAME = 'MySaveFile';


### PR DESCRIPTION
## Summary
- use `describeGameEngineSuite` helper across engine unit tests
- drop local bed lifecycle management
- reference test bed with `getBed()`

## Testing
- `npm run lint` *(fails: 552 errors, 2195 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d3c6a60c8331978dbeb5c3ac364f