### PR TITLE
[Agent] add mock environment helper

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -16,6 +16,7 @@ import {
   createMockInitializationService,
   createMockContainer,
 } from '../mockFactories.js';
+import { createMockEnvironment } from '../mockEnvironment.js';
 
 /**
  * Creates a set of mocks and a container for GameEngine.
@@ -37,44 +38,33 @@ import {
  *   replacement values used instead of defaults.
  */
 export function createTestEnvironment(overrides = {}) {
-  jest.clearAllMocks();
-
-  const logger = createMockLogger();
-  const entityManager = createMockEntityManager();
-  const turnManager = createMockTurnManager();
-  const gamePersistenceService = createMockGamePersistenceService();
-  const playtimeTracker = createMockPlaytimeTracker();
-  const safeEventDispatcher = createMockSafeEventDispatcher();
-  const initializationService = createMockInitializationService();
+  const { mocks, cleanup } = createMockEnvironment({
+    logger: createMockLogger,
+    entityManager: createMockEntityManager,
+    turnManager: createMockTurnManager,
+    gamePersistenceService: createMockGamePersistenceService,
+    playtimeTracker: createMockPlaytimeTracker,
+    safeEventDispatcher: createMockSafeEventDispatcher,
+    initializationService: createMockInitializationService,
+  });
 
   const mapping = {
-    [tokens.ILogger]: logger,
-    [tokens.IEntityManager]: entityManager,
-    [tokens.ITurnManager]: turnManager,
-    [tokens.GamePersistenceService]: gamePersistenceService,
-    [tokens.PlaytimeTracker]: playtimeTracker,
-    [tokens.ISafeEventDispatcher]: safeEventDispatcher,
-    [tokens.IInitializationService]: initializationService,
+    [tokens.ILogger]: mocks.logger,
+    [tokens.IEntityManager]: mocks.entityManager,
+    [tokens.ITurnManager]: mocks.turnManager,
+    [tokens.GamePersistenceService]: mocks.gamePersistenceService,
+    [tokens.PlaytimeTracker]: mocks.playtimeTracker,
+    [tokens.ISafeEventDispatcher]: mocks.safeEventDispatcher,
+    [tokens.IInitializationService]: mocks.initializationService,
   };
 
   const mockContainer = createMockContainer(mapping, overrides);
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 
-  const cleanup = () => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  };
-
   return {
     mockContainer,
-    logger,
-    entityManager,
-    turnManager,
-    gamePersistenceService,
-    playtimeTracker,
-    safeEventDispatcher,
-    initializationService,
+    ...mocks,
     createGameEngine,
     cleanup,
   };

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -1,0 +1,31 @@
+/**
+ * @file Utility for creating a mock environment for tests.
+ */
+
+import { jest } from '@jest/globals';
+
+/**
+ * Creates mocks using the provided factory functions.
+ *
+ * @description Given a mapping of keys to factory functions, this helper
+ *   instantiates each mock and returns them along with a cleanup function
+ *   that clears and restores jest mocks.
+ * @param {Record<string, () => any>} factories - Map of mock factory functions.
+ * @returns {{ mocks: Record<string, any>, cleanup: () => void }}
+ *   Generated mocks and a cleanup method.
+ */
+export function createMockEnvironment(factories) {
+  jest.clearAllMocks();
+
+  const mocks = {};
+  for (const [name, factory] of Object.entries(factories)) {
+    mocks[name] = factory();
+  }
+
+  const cleanup = () => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  };
+
+  return { mocks, cleanup };
+}

--- a/tests/integration/loaders/modsLoader.integration.test.js
+++ b/tests/integration/loaders/modsLoader.integration.test.js
@@ -50,7 +50,7 @@ describe('ModsLoader Integration Test Suite (TEST-LOADER-7.1)', () => {
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    env.cleanup();
   });
 
   it('should successfully load world with only the core mod', async () => {


### PR DESCRIPTION
## Summary
- add `createMockEnvironment` helper for generating mocks
- use helper in `createTestEnvironment` for game engine tests
- use helper in mods loader test setup
- switch integration test cleanup to new helper

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855d5789b9c8331aea7136fe740bf31