### PR TITLE
[Test] Add SimpleEntityManager helper

### DIFF
--- a/tests/common/entities/simpleEntityManager.js
+++ b/tests/common/entities/simpleEntityManager.js
@@ -1,0 +1,92 @@
+/**
+ * @file In-memory EntityManager stub used for integration tests.
+ * @see tests/common/entities/simpleEntityManager.js
+ */
+
+/**
+ * Minimal EntityManager implementation providing only the methods
+ * required by integration tests.
+ *
+ * @class
+ */
+export default class SimpleEntityManager {
+  /**
+   * Creates a new instance pre-populated with the provided entities.
+   *
+   * @param {Array<{id:string, components:object}>} [entities] - Seed entities.
+   */
+  constructor(entities = []) {
+    /** @type {Map<string, {id:string, components:Record<string, any>}>} */
+    this.entities = new Map();
+    for (const e of entities) {
+      this.entities.set(e.id, {
+        id: e.id,
+        components: { ...e.components },
+      });
+    }
+  }
+
+  /**
+   * Retrieves an entity instance by id.
+   *
+   * @param {string} id - Entity id.
+   * @returns {object|undefined} The entity object or undefined if not found.
+   */
+  getEntityInstance(id) {
+    return this.entities.get(id);
+  }
+
+  /**
+   * Gets component data for an entity.
+   *
+   * @param {string} id - Entity id.
+   * @param {string} type - Component type.
+   * @returns {any} Component data or null.
+   */
+  getComponentData(id, type) {
+    return this.entities.get(id)?.components[type] ?? null;
+  }
+
+  /**
+   * Determines whether an entity has a component.
+   *
+   * @param {string} id - Entity id.
+   * @param {string} type - Component type.
+   * @returns {boolean} True if the component exists.
+   */
+  hasComponent(id, type) {
+    return Object.prototype.hasOwnProperty.call(
+      this.entities.get(id)?.components || {},
+      type
+    );
+  }
+
+  /**
+   * Adds or replaces a component on an entity.
+   *
+   * @param {string} id - Entity id.
+   * @param {string} type - Component type.
+   * @param {object} data - Component data to set.
+   * @returns {void}
+   */
+  addComponent(id, type, data) {
+    const ent = this.entities.get(id);
+    if (ent) {
+      ent.components[type] = JSON.parse(JSON.stringify(data));
+    }
+  }
+
+  /**
+   * Removes a component from an entity.
+   *
+   * @param {string} id - Entity id.
+   * @param {string} type - Component type.
+   * @returns {void}
+   */
+  removeComponent(id, type) {
+    const ent = this.entities.get(id);
+    if (ent) {
+      delete ent.components[type];
+    }
+  }
+}


### PR DESCRIPTION
Summary: Introduces a reusable in-memory `SimpleEntityManager` for integration tests.

Changes Made:
- New `tests/common/entities/simpleEntityManager.js` provides minimal entity management methods used across integration suites.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root) *(fails: existing repository issues)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6855d761ab048331a16f32ccea3017e8