### PR TITLE
[Agent] Improve schemaValidationUtils coverage

### DIFF
--- a/tests/unit/utils/schemaValidationUtils.additional.test.js
+++ b/tests/unit/utils/schemaValidationUtils.additional.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { validateAgainstSchema } from '../../../src/utils/schemaValidationUtils.js';
+import * as ajvUtils from '../../../src/utils/ajvUtils.js';
+import { createMockLogger } from '../testUtils.js';
+
+describe('validateAgainstSchema additional branches', () => {
+  let validator;
+  let logger;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    validator = {
+      isSchemaLoaded: jest.fn(),
+      validate: jest.fn(),
+    };
+  });
+
+  it('throws default message when schema missing without context', () => {
+    validator.isSchemaLoaded.mockReturnValue(false);
+    expect(() => validateAgainstSchema(validator, 'id', {}, logger)).toThrow(
+      "Schema 'id' not loaded."
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('throws default failure message when validation fails and no messages provided', () => {
+    validator.isSchemaLoaded.mockReturnValue(true);
+    const errors = [{ instancePath: '', message: 'bad', params: {} }];
+    validator.validate.mockReturnValue({ isValid: false, errors });
+    jest.spyOn(ajvUtils, 'formatAjvErrors').mockReturnValue('DETAILS');
+    expect(() =>
+      validateAgainstSchema(validator, 'schema', {}, logger)
+    ).toThrow('Schema validation failed.\nDetails:\nDETAILS');
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(ajvUtils.formatAjvErrors).toHaveBeenCalledWith(errors);
+  });
+});


### PR DESCRIPTION
Summary: Added additional unit tests to cover missing branches in `validateAgainstSchema`. New suite checks default error behavior when schema is missing and when validation fails without custom messages.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6855d924d8308331b2aa0e6e3afd3402