### PR TITLE
[Agent] Consolidate TurnManager test setup

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -1,15 +1,8 @@
 // tests/turns/turnManager.advanceTurn.actorIdentification.test.js
 // --- FILE START (Corrected) ---
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from '@jest/globals';
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
@@ -19,212 +12,254 @@ import { createMockEntity } from '../../common/mockFactories.js';
 
 // --- Test Suite ---
 
-describe('TurnManager: advanceTurn() - Actor Identification & Handling (Queue Not Empty)', () => {
-  let testBed;
-  let stopSpy;
-  let capturedTurnEndedHandler;
+describeTurnManagerSuite(
+  'TurnManager: advanceTurn() - Actor Identification & Handling (Queue Not Empty)',
+  (getBed) => {
+    let testBed;
+    let stopSpy;
+    let capturedTurnEndedHandler;
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
-    capturedTurnEndedHandler = null;
-    testBed = new TurnManagerTestBed();
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      capturedTurnEndedHandler = null;
+      testBed = getBed();
 
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
-      createMockEntity('initial-actor-for-start', { isActor: true, isPlayer: false })
-    );
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        createMockEntity('initial-actor-for-start', {
+          isActor: true,
+          isPlayer: false,
+        })
+      );
 
-    testBed.mocks.dispatcher.dispatch.mockClear().mockResolvedValue(true);
-    testBed.mocks.dispatcher.subscribe
-      .mockClear()
-      .mockImplementation((eventType, handler) => {
-        if (eventType === TURN_ENDED_ID) {
-          capturedTurnEndedHandler = handler;
-        }
-        return jest.fn(); // Return mock unsubscribe
+      testBed.mocks.dispatcher.dispatch.mockClear().mockResolvedValue(true);
+      testBed.mocks.dispatcher.subscribe
+        .mockClear()
+        .mockImplementation((eventType, handler) => {
+          if (eventType === TURN_ENDED_ID) {
+            capturedTurnEndedHandler = handler;
+          }
+          return jest.fn(); // Return mock unsubscribe
+        });
+      testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
+
+      // Set default resolution for the resolver
+      testBed.mocks.turnHandlerResolver.resolveHandler
+        .mockClear()
+        .mockResolvedValue({
+          startTurn: jest.fn().mockResolvedValue(undefined),
+          destroy: jest.fn().mockResolvedValue(undefined),
+        });
+
+      stopSpy = jest
+        .spyOn(testBed.turnManager, 'stop')
+        .mockImplementation(async () => {});
+
+      await testBed.turnManager.start();
+
+      expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
+
+      testBed.mocks.logger.info.mockClear();
+      testBed.mocks.logger.debug.mockClear();
+      testBed.mocks.logger.warn.mockClear();
+      testBed.mocks.logger.error.mockClear();
+      testBed.mocks.dispatcher.dispatch.mockClear();
+      testBed.mocks.turnOrderService.isEmpty.mockClear();
+      testBed.mocks.turnOrderService.getNextEntity.mockClear();
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.dispatcher.dispatch.mockResolvedValue(true);
+    });
+
+    afterEach(async () => {
+      if (stopSpy) {
+        stopSpy.mockRestore();
+      }
+      capturedTurnEndedHandler = null;
+      jest.useRealTimers();
+    });
+
+    test('Player actor identified: resolves handler, calls startTurn, dispatches event', async () => {
+      jest.useFakeTimers();
+
+      const playerActor = createMockEntity('player-1', {
+        isActor: true,
+        isPlayer: true,
       });
-    testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
+      const entityType = 'player';
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        playerActor
+      );
 
-    // Set default resolution for the resolver
-    testBed.mocks.turnHandlerResolver.resolveHandler
-      .mockClear()
-      .mockResolvedValue({
+      const mockHandler = {
         startTurn: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      );
+
+      await testBed.turnManager.advanceTurn();
+
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        'core:turn_started',
+        {
+          entityId: playerActor.id,
+          entityType: entityType,
+        }
+      );
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(playerActor);
+      expect(mockHandler.startTurn).toHaveBeenCalledWith(playerActor);
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `TurnManager now WAITING for 'core:turn_ended' event.`
+        )
+      );
+      expect(stopSpy).not.toHaveBeenCalled();
+
+      expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
+      capturedTurnEndedHandler({
+        type: TURN_ENDED_ID,
+        payload: { entityId: playerActor.id, success: true },
       });
 
-    stopSpy = jest.spyOn(testBed.turnManager, 'stop').mockImplementation(async () => {});
+      await jest.runAllTimersAsync();
+      expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 
-    await testBed.turnManager.start();
-
-    expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
-
-    testBed.mocks.logger.info.mockClear();
-    testBed.mocks.logger.debug.mockClear();
-    testBed.mocks.logger.warn.mockClear();
-    testBed.mocks.logger.error.mockClear();
-    testBed.mocks.dispatcher.dispatch.mockClear();
-    testBed.mocks.turnOrderService.isEmpty.mockClear();
-    testBed.mocks.turnOrderService.getNextEntity.mockClear();
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    testBed.mocks.dispatcher.dispatch.mockResolvedValue(true);
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
-    if (stopSpy) {
-      stopSpy.mockRestore();
-    }
-    capturedTurnEndedHandler = null;
-    jest.useRealTimers();
-  });
-
-  test('Player actor identified: resolves handler, calls startTurn, dispatches event', async () => {
-    jest.useFakeTimers();
-
-    const playerActor = createMockEntity('player-1', { isActor: true, isPlayer: true });
-    const entityType = 'player';
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(playerActor);
-    
-    const mockHandler = {
-      startTurn: jest.fn().mockResolvedValue(undefined),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler);
-
-    await testBed.turnManager.advanceTurn();
-
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith('core:turn_started', {
-      entityId: playerActor.id,
-      entityType: entityType,
-    });
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(
-      playerActor
-    );
-    expect(mockHandler.startTurn).toHaveBeenCalledWith(playerActor);
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `TurnManager now WAITING for 'core:turn_ended' event.`
-      )
-    );
-    expect(stopSpy).not.toHaveBeenCalled();
-
-    expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
-    capturedTurnEndedHandler({
-      type: TURN_ENDED_ID,
-      payload: { entityId: playerActor.id, success: true },
+      jest.useRealTimers();
     });
 
-    await jest.runAllTimersAsync();
-    expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
+    test('AI actor identified: resolves handler, calls startTurn, dispatches event', async () => {
+      jest.useFakeTimers();
 
-    jest.useRealTimers();
-  });
+      const aiActor = createMockEntity('ai-goblin', {
+        isActor: true,
+        isPlayer: false,
+      });
+      const entityType = 'ai';
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(aiActor);
 
-  test('AI actor identified: resolves handler, calls startTurn, dispatches event', async () => {
-    jest.useFakeTimers();
+      const mockHandler = {
+        startTurn: jest.fn().mockResolvedValue(undefined),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      );
 
-    const aiActor = createMockEntity('ai-goblin', { isActor: true, isPlayer: false });
-    const entityType = 'ai';
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(aiActor);
-    
-    const mockHandler = {
-      startTurn: jest.fn().mockResolvedValue(undefined),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler);
+      await testBed.turnManager.advanceTurn();
 
-    await testBed.turnManager.advanceTurn();
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        'core:turn_started',
+        {
+          entityId: aiActor.id,
+          entityType: entityType,
+        }
+      );
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(aiActor);
+      expect(mockHandler.startTurn).toHaveBeenCalledWith(aiActor);
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `TurnManager now WAITING for 'core:turn_ended' event.`
+        )
+      );
+      expect(stopSpy).not.toHaveBeenCalled();
 
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith('core:turn_started', {
-      entityId: aiActor.id,
-      entityType: entityType,
+      expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
+      capturedTurnEndedHandler({
+        type: TURN_ENDED_ID,
+        payload: { entityId: aiActor.id, success: true },
+      });
+
+      await jest.runAllTimersAsync();
+      expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
     });
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(
-      aiActor
-    );
-    expect(mockHandler.startTurn).toHaveBeenCalledWith(aiActor);
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `TurnManager now WAITING for 'core:turn_ended' event.`
-      )
-    );
-    expect(stopSpy).not.toHaveBeenCalled();
 
-    expect(capturedTurnEndedHandler).toBeInstanceOf(Function);
-    capturedTurnEndedHandler({
-      type: TURN_ENDED_ID,
-      payload: { entityId: aiActor.id, success: true },
+    test('Non-actor entity: logs warning, does not resolve handler or dispatch events', async () => {
+      const nonActor = createMockEntity('non-actor', {
+        isActor: false,
+        isPlayer: false,
+      });
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(nonActor);
+
+      await testBed.turnManager.advanceTurn();
+
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledTimes(0);
+      expect(testBed.mocks.dispatcher.dispatch).not.toHaveBeenCalledWith(
+        'core:turn_started',
+        expect.any(Object)
+      );
+      expect(stopSpy).not.toHaveBeenCalled();
     });
 
-    await jest.runAllTimersAsync();
-    expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
+    test('Entity manager error: logs error, stops manager', async () => {
+      const entityError = new Error('Entity not found');
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
 
-    jest.useRealTimers();
-  });
+      await testBed.turnManager.advanceTurn();
 
-  test('Non-actor entity: logs warning, does not resolve handler or dispatch events', async () => {
-    const nonActor = createMockEntity('non-actor', { isActor: false, isPlayer: false });
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(nonActor);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.'
+      );
+      expect(stopSpy).toHaveBeenCalled();
+    });
 
-    await testBed.turnManager.advanceTurn();
+    test('Handler resolution error: logs error, stops manager', async () => {
+      const resolveError = new Error('Handler resolution failed');
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
+        resolveError
+      );
 
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledTimes(0);
-    expect(testBed.mocks.dispatcher.dispatch).not.toHaveBeenCalledWith(
-      'core:turn_started',
-      expect.any(Object)
-    );
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
+      await testBed.turnManager.advanceTurn();
 
-  test('Entity manager error: logs error, stops manager', async () => {
-    const entityError = new Error('Entity not found');
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
+        resolveError
+      );
+      expect(stopSpy).toHaveBeenCalled();
+    });
 
-    await testBed.turnManager.advanceTurn();
+    test('Handler startTurn error: logs error, stops manager', async () => {
+      const startError = new Error('Handler start failed');
+      const mockHandler = {
+        startTurn: jest.fn().mockRejectedValue(startError),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      );
 
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.'
-    );
-    expect(stopSpy).toHaveBeenCalled();
-  });
+      await testBed.turnManager.advanceTurn();
 
-  test('Handler resolution error: logs error, stops manager', async () => {
-    const resolveError = new Error('Handler resolution failed');
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(resolveError);
-
-    await testBed.turnManager.advanceTurn();
-
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
-      resolveError
-    );
-    expect(stopSpy).toHaveBeenCalled();
-  });
-
-  test('Handler startTurn error: logs error, stops manager', async () => {
-    const startError = new Error('Handler start failed');
-    const mockHandler = {
-      startTurn: jest.fn().mockRejectedValue(startError),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler);
-
-    await testBed.turnManager.advanceTurn();
-
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Error during handler.startTurn() initiation for entity initial-actor-for-start (Object): Handler start failed'),
-      startError
-    );
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
-});
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Error during handler.startTurn() initiation for entity initial-actor-for-start (Object): Handler start failed'
+        ),
+        startError
+      );
+      expect(stopSpy).not.toHaveBeenCalled();
+    });
+  }
+);
 // --- FILE END ---

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -1,15 +1,11 @@
 // src/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
 // --- FILE START (Entire file content as requested, with corrections) ---
 
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from '@jest/globals';
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+  describeTurnManagerSuite,
+  TurnManagerTestBed,
+} from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
@@ -22,297 +18,338 @@ import { createMockEntity } from '../../common/mockFactories.js';
 
 // --- Test Suite ---
 
-describe('TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)', () => {
-  let testBed;
-  let stopSpy;
-  let initialAdvanceTurnSpy;
+describeTurnManagerSuite(
+  'TurnManager: advanceTurn() - Turn Advancement (Queue Not Empty)',
+  (getBed) => {
+    let testBed;
+    let stopSpy;
+    let initialAdvanceTurnSpy;
 
-  beforeEach(async () => {
-    // Made beforeEach async
-    jest.clearAllMocks();
-    testBed = new TurnManagerTestBed();
+    beforeEach(async () => {
+      // Made beforeEach async
+      jest.clearAllMocks();
+      testBed = getBed();
 
-    // Reset mock state
-    testBed.mocks.turnOrderService.isEmpty.mockReset().mockResolvedValue(false); // Default: Queue NOT empty
-    testBed.mocks.turnOrderService.getNextEntity.mockReset().mockResolvedValue(null); // Default reset
-    testBed.mocks.turnOrderService.clearCurrentRound.mockReset().mockResolvedValue();
-    testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
-    testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
+      // Reset mock state
+      testBed.mocks.turnOrderService.isEmpty
+        .mockReset()
+        .mockResolvedValue(false); // Default: Queue NOT empty
+      testBed.mocks.turnOrderService.getNextEntity
+        .mockReset()
+        .mockResolvedValue(null); // Default reset
+      testBed.mocks.turnOrderService.clearCurrentRound
+        .mockReset()
+        .mockResolvedValue();
+      testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
+      testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
 
-    testBed.mocks.turnHandlerResolver.resolveHandler
-      .mockClear()
-      .mockResolvedValue({
+      testBed.mocks.turnHandlerResolver.resolveHandler
+        .mockClear()
+        .mockResolvedValue({
+          startTurn: jest.fn().mockResolvedValue(undefined),
+          destroy: jest.fn().mockResolvedValue(undefined),
+        });
+
+      // Spy on stop to verify calls and simulate unsubscribe
+      stopSpy = jest
+        .spyOn(testBed.turnManager, 'stop')
+        .mockImplementation(async () => {
+          testBed.mocks.logger.debug('Mocked instance.stop() called.');
+        });
+
+      // --- Set instance to running state (simulating start()) ---
+      initialAdvanceTurnSpy = jest
+        .spyOn(testBed.turnManager, 'advanceTurn')
+        .mockImplementationOnce(async () => {
+          // Prevent advanceTurn logic during start()
+          testBed.mocks.logger.debug(
+            'advanceTurn call during start() suppressed by mock.'
+          );
+        });
+      await testBed.turnManager.start(); // Sets #isRunning = true and subscribes
+      initialAdvanceTurnSpy.mockRestore(); // Restore advanceTurn for actual testing
+
+      // Clear mocks called during start() phase
+      testBed.mocks.logger.info.mockClear(); // Clear "Turn Manager started." log
+      testBed.mocks.logger.debug.mockClear(); // Clear suppressed advanceTurn log
+      testBed.mocks.dispatcher.dispatch.mockClear();
+      testBed.mocks.dispatcher.subscribe.mockClear(); // Clear the subscribe call from start()
+      testBed.mocks.turnOrderService.isEmpty.mockClear(); // Clear mocks before actual test calls
+      testBed.mocks.turnOrderService.getNextEntity.mockClear();
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
+
+      // Re-apply default isEmpty mock for the actual tests focusing on queue NOT empty
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+    });
+
+    // --- Test Cases ---
+
+    test('Successfully getting next entity: updates current actor, resolves and calls handler startTurn', async () => {
+      // Arrange
+      const nextActor = createMockEntity('actor-next', {
+        isActor: true,
+        isPlayer: false,
+      }); // AI actor
+      const entityType = 'ai';
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(nextActor);
+
+      const mockHandler = {
         startTurn: jest.fn().mockResolvedValue(undefined),
         destroy: jest.fn().mockResolvedValue(undefined),
-      });
+      };
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      );
 
-    // Spy on stop to verify calls and simulate unsubscribe
-    stopSpy = jest.spyOn(testBed.turnManager, 'stop').mockImplementation(async () => {
-      testBed.mocks.logger.debug('Mocked instance.stop() called.');
+      // Act
+      await testBed.turnManager.advanceTurn(); // Call directly, instance is running
+
+      // Assert
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+
+      // Verify state update and logging
+      expect(testBed.turnManager.getCurrentActor()).toBe(nextActor);
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'TurnManager.advanceTurn() initiating...'
+      );
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'Queue not empty, retrieving next entity.'
+      );
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        `Resolving turn handler for entity ${nextActor.id}...`
+      );
+
+      // Check core:turn_started dispatch
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        'core:turn_started',
+        {
+          entityId: nextActor.id,
+          entityType: entityType,
+        }
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        TURN_PROCESSING_STARTED,
+        { entityId: nextActor.id, actorType: entityType }
+      );
+
+      // Verify resolver call
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(nextActor);
+
+      // Verify handler startTurn call
+      expect(mockHandler.startTurn).toHaveBeenCalledTimes(1);
+      expect(mockHandler.startTurn).toHaveBeenCalledWith(nextActor);
+
+      // Verify waiting state log
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `TurnManager now WAITING for 'core:turn_ended' event.`
+        )
+      );
+
+      // Verify no stop was called
+      expect(stopSpy).not.toHaveBeenCalled();
     });
 
-    // --- Set instance to running state (simulating start()) ---
-    initialAdvanceTurnSpy = jest
-      .spyOn(testBed.turnManager, 'advanceTurn')
-      .mockImplementationOnce(async () => {
-        // Prevent advanceTurn logic during start()
-        testBed.mocks.logger.debug('advanceTurn call during start() suppressed by mock.');
-      });
-    await testBed.turnManager.start(); // Sets #isRunning = true and subscribes
-    initialAdvanceTurnSpy.mockRestore(); // Restore advanceTurn for actual testing
+    test('getNextEntity returns null: logs error, stops manager', async () => {
+      // Arrange
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
 
-    // Clear mocks called during start() phase
-    testBed.mocks.logger.info.mockClear(); // Clear "Turn Manager started." log
-    testBed.mocks.logger.debug.mockClear(); // Clear suppressed advanceTurn log
-    testBed.mocks.dispatcher.dispatch.mockClear();
-    testBed.mocks.dispatcher.subscribe.mockClear(); // Clear the subscribe call from start()
-    testBed.mocks.turnOrderService.isEmpty.mockClear(); // Clear mocks before actual test calls
-    testBed.mocks.turnOrderService.getNextEntity.mockClear();
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
+      // Act
+      await testBed.turnManager.advanceTurn();
 
-    // Re-apply default isEmpty mock for the actual tests focusing on queue NOT empty
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-  });
+      // Assert
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
 
-  afterEach(async () => {
-    await testBed.cleanup();
-    jest.restoreAllMocks();
-  });
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.'
+      );
 
-  // --- Test Cases ---
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          message:
+            'Internal Error: Turn order inconsistency detected. Stopping game.',
+          details: {
+            raw: 'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.',
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
 
-  test('Successfully getting next entity: updates current actor, resolves and calls handler startTurn', async () => {
-    // Arrange
-    const nextActor = createMockEntity('actor-next', { isActor: true, isPlayer: false }); // AI actor
-    const entityType = 'ai';
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(nextActor);
-    
-    const mockHandler = {
-      startTurn: jest.fn().mockResolvedValue(undefined),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler);
-
-    // Act
-    await testBed.turnManager.advanceTurn(); // Call directly, instance is running
-
-    // Assert
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-
-    // Verify state update and logging
-    expect(testBed.turnManager.getCurrentActor()).toBe(nextActor);
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'TurnManager.advanceTurn() initiating...'
-    );
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'Queue not empty, retrieving next entity.'
-    );
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      `Resolving turn handler for entity ${nextActor.id}...`
-    );
-
-    // Check core:turn_started dispatch
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith('core:turn_started', {
-      entityId: nextActor.id,
-      entityType: entityType,
+      expect(stopSpy).toHaveBeenCalledTimes(1);
     });
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      TURN_PROCESSING_STARTED,
-      { entityId: nextActor.id, actorType: entityType }
-    );
 
-    // Verify resolver call
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(
-      nextActor
-    );
+    test('getNextEntity throws error: logs error, stops manager', async () => {
+      // Arrange
+      const getNextError = new Error('Turn order service failure');
+      testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(
+        getNextError
+      );
 
-    // Verify handler startTurn call
-    expect(mockHandler.startTurn).toHaveBeenCalledTimes(1);
-    expect(mockHandler.startTurn).toHaveBeenCalledWith(nextActor);
+      // Act
+      await testBed.turnManager.advanceTurn();
 
-    // Verify waiting state log
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `TurnManager now WAITING for 'core:turn_ended' event.`
-      )
-    );
+      // Assert
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
 
-    // Verify no stop was called
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Turn order service failure',
+        getNextError
+      );
 
-  test('getNextEntity returns null: logs error, stops manager', async () => {
-    // Arrange
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: getNextError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
 
-    // Act
-    await testBed.turnManager.advanceTurn();
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
 
-    // Assert
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
+    test('Handler resolver throws: logs error, stops manager', async () => {
+      // Arrange
+      const resolveError = new Error('Handler resolution failed');
+      const mockActor = createMockEntity('actor1', { isActor: true });
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
+        resolveError
+      ); // Then throw error
 
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.'
-    );
+      // Act
+      await testBed.turnManager.advanceTurn();
 
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        message: 'Internal Error: Turn order inconsistency detected. Stopping game.',
-        details: {
-          raw: 'Turn order inconsistency: getNextEntity() returned null/undefined when queue was not empty.',
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
+        resolveError
+      );
 
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: resolveError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
 
-  test('getNextEntity throws error: logs error, stops manager', async () => {
-    // Arrange
-    const getNextError = new Error('Turn order service failure');
-    testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(getNextError);
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
 
-    // Act
-    await testBed.turnManager.advanceTurn();
+    test('Handler startTurn throws: logs error, stops manager', async () => {
+      // Arrange
+      const startError = new Error('Handler start failed');
+      const mockActor = createMockEntity('actor1', { isActor: true });
+      const mockHandler = {
+        startTurn: jest.fn().mockRejectedValue(startError),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      ); // Return valid handler
+      // startTurn will throw error when called
 
-    // Assert
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
+      // Act
+      await testBed.turnManager.advanceTurn();
 
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Turn order service failure',
-      getNextError
-    );
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'Error during handler.startTurn() initiation for entity actor1 (Object): Handler start failed',
+        startError
+      );
 
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: getNextError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
+      // The implementation doesn't stop the manager for startTurn failures
+      // expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
 
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+    test('Dispatcher dispatch throws: logs error, stops manager', async () => {
+      // Arrange
+      const dispatchError = new Error('Dispatcher failure');
+      const mockActor = createMockEntity('actor1', { isActor: true });
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
+      testBed.mocks.dispatcher.dispatch.mockRejectedValue(dispatchError); // Then throw error
 
-  test('Handler resolver throws: logs error, stops manager', async () => {
-    // Arrange
-    const resolveError = new Error('Handler resolution failed');
-    const mockActor = createMockEntity('actor1', { isActor: true });
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(resolveError); // Then throw error
+      // Act
+      await testBed.turnManager.advanceTurn();
 
-    // Act
-    await testBed.turnManager.advanceTurn();
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'Failed to dispatch core:turn_started for actor1: Dispatcher failure',
+        dispatchError
+      );
 
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
-      resolveError
-    );
+      // The implementation doesn't dispatch system errors for dispatcher failures
+      // expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+      //   SYSTEM_ERROR_OCCURRED_ID,
+      //   expect.objectContaining({
+      //     details: {
+      //       raw: dispatchError.message,
+      //       stack: expect.any(String),
+      //       timestamp: expect.any(String),
+      //     },
+      //   })
+      // );
 
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: resolveError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
+      // expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
 
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+    test('Called when not running: logs debug and returns early', async () => {
+      // Arrange
+      // Create a fresh test bed that doesn't start the manager
+      const freshTestBed = new TurnManagerTestBed();
 
-  test('Handler startTurn throws: logs error, stops manager', async () => {
-    // Arrange
-    const startError = new Error('Handler start failed');
-    const mockActor = createMockEntity('actor1', { isActor: true });
-    const mockHandler = {
-      startTurn: jest.fn().mockRejectedValue(startError),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler); // Return valid handler
-    // startTurn will throw error when called
+      // Don't start the manager - it will not be running by default
+      // The manager starts with _isRunning = false
 
-    // Act
-    await testBed.turnManager.advanceTurn();
+      // Act
+      await freshTestBed.turnManager.advanceTurn();
 
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'Error during handler.startTurn() initiation for entity actor1 (Object): Handler start failed',
-      startError
-    );
+      // Assert
+      expect(freshTestBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'TurnManager.advanceTurn() called while manager is not running. Returning.'
+      );
 
-    // The implementation doesn't stop the manager for startTurn failures
-    // expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+      expect(
+        freshTestBed.mocks.turnOrderService.isEmpty
+      ).not.toHaveBeenCalled();
+      expect(
+        freshTestBed.mocks.turnOrderService.getNextEntity
+      ).not.toHaveBeenCalled();
+      expect(
+        freshTestBed.mocks.turnHandlerResolver.resolveHandler
+      ).not.toHaveBeenCalled();
+      expect(freshTestBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
 
-  test('Dispatcher dispatch throws: logs error, stops manager', async () => {
-    // Arrange
-    const dispatchError = new Error('Dispatcher failure');
-    const mockActor = createMockEntity('actor1', { isActor: true });
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
-    testBed.mocks.dispatcher.dispatch.mockRejectedValue(dispatchError); // Then throw error
-
-    // Act
-    await testBed.turnManager.advanceTurn();
-
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'Failed to dispatch core:turn_started for actor1: Dispatcher failure',
-      dispatchError
-    );
-
-    // The implementation doesn't dispatch system errors for dispatcher failures
-    // expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-    //   SYSTEM_ERROR_OCCURRED_ID,
-    //   expect.objectContaining({
-    //     details: {
-    //       raw: dispatchError.message,
-    //       stack: expect.any(String),
-    //       timestamp: expect.any(String),
-    //     },
-    //   })
-    // );
-
-    // expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('Called when not running: logs debug and returns early', async () => {
-    // Arrange
-    // Create a fresh test bed that doesn't start the manager
-    const freshTestBed = new TurnManagerTestBed();
-    
-    // Don't start the manager - it will not be running by default
-    // The manager starts with _isRunning = false
-
-    // Act
-    await freshTestBed.turnManager.advanceTurn();
-
-    // Assert
-    expect(freshTestBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'TurnManager.advanceTurn() called while manager is not running. Returning.'
-    );
-
-    expect(freshTestBed.mocks.turnOrderService.isEmpty).not.toHaveBeenCalled();
-    expect(freshTestBed.mocks.turnOrderService.getNextEntity).not.toHaveBeenCalled();
-    expect(freshTestBed.mocks.turnHandlerResolver.resolveHandler).not.toHaveBeenCalled();
-    expect(freshTestBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
-    
-    // Clean up the fresh test bed
-    await freshTestBed.cleanup();
-  });
-});
+      // Clean up the fresh test bed
+      await freshTestBed.cleanup();
+    });
+  }
+);
 // --- FILE END ---

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -1,15 +1,8 @@
 // src/tests/turns/turnManager.advanceTurn.roundStart.test.js
 // --- FILE START (Entire file content with corrected assertions) ---
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from '@jest/globals';
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { ACTOR_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import {
   SYSTEM_ERROR_OCCURRED_ID,
@@ -17,263 +10,308 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { createMockEntity } from '../../common/mockFactories.js';
 
-describe('TurnManager: advanceTurn() - Round Start (Queue Empty)', () => {
-  let testBed;
-  let stopSpy;
-  let advanceTurnSpy; // General spy for advanceTurn
+describeTurnManagerSuite(
+  'TurnManager: advanceTurn() - Round Start (Queue Empty)',
+  (getBed) => {
+    let testBed;
+    let stopSpy;
+    let advanceTurnSpy; // General spy for advanceTurn
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    testBed = new TurnManagerTestBed();
+    beforeEach(() => {
+      jest.clearAllMocks();
+      testBed = getBed();
 
-    // Reset mock state
-    testBed.mocks.turnOrderService.isEmpty.mockReset();
-    testBed.mocks.turnOrderService.startNewRound.mockReset().mockResolvedValue(undefined);
-    testBed.mocks.turnOrderService.clearCurrentRound
-      .mockReset()
-      .mockResolvedValue(undefined);
-    testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
-    testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockReset().mockResolvedValue(null);
+      // Reset mock state
+      testBed.mocks.turnOrderService.isEmpty.mockReset();
+      testBed.mocks.turnOrderService.startNewRound
+        .mockReset()
+        .mockResolvedValue(undefined);
+      testBed.mocks.turnOrderService.clearCurrentRound
+        .mockReset()
+        .mockResolvedValue(undefined);
+      testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
+      testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
+      testBed.mocks.turnHandlerResolver.resolveHandler
+        .mockReset()
+        .mockResolvedValue(null);
 
-    // Define the spy here for the actual advanceTurn method
-    advanceTurnSpy = jest.spyOn(testBed.turnManager, 'advanceTurn');
+      // Define the spy here for the actual advanceTurn method
+      advanceTurnSpy = jest.spyOn(testBed.turnManager, 'advanceTurn');
 
-    // Spy on stop - Keep the condition to ensure start was called.
-    stopSpy = jest.spyOn(testBed.turnManager, 'stop').mockImplementation(async () => {
-      testBed.mocks.logger.debug('Mocked instance.stop() called.');
+      // Spy on stop - Keep the condition to ensure start was called.
+      stopSpy = jest
+        .spyOn(testBed.turnManager, 'stop')
+        .mockImplementation(async () => {
+          testBed.mocks.logger.debug('Mocked instance.stop() called.');
+        });
+
+      // Clear constructor/setup logs AFTER instantiation and spy setup
+      testBed.mocks.logger.info.mockClear();
+      testBed.mocks.logger.debug.mockClear();
+      testBed.mocks.logger.warn.mockClear();
+      testBed.mocks.logger.error.mockClear();
     });
 
-    // Clear constructor/setup logs AFTER instantiation and spy setup
-    testBed.mocks.logger.info.mockClear();
-    testBed.mocks.logger.debug.mockClear();
-    testBed.mocks.logger.warn.mockClear();
-    testBed.mocks.logger.error.mockClear();
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
-    jest.restoreAllMocks();
-  });
-
-  // --- Test Cases ---
-
-  test('advanceTurn() does nothing with a debug log if not running', async () => {
-    // Arrange: #isRunning is false by default after construction before start()
-    // Act: Call advanceTurn directly
-    await testBed.turnManager.advanceTurn();
-
-    // Assert
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'TurnManager.advanceTurn() called while manager is not running. Returning.'
-    );
-    expect(testBed.mocks.turnOrderService.isEmpty).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
-    expect(testBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
-    expect(testBed.mocks.dispatcher.subscribe).not.toHaveBeenCalled(); // subscribe happens in start()
-  });
-
-  test('No active actors found: logs error, dispatches message, and stops', async () => {
-    // Arrange
-    const nonActorEntity = createMockEntity('nonActor1', { isActor: false, isPlayer: false });
-    testBed.setActiveEntities(nonActorEntity);
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty for the check inside advanceTurn
-    const expectedErrorMsg =
-      'Cannot start a new round: No active entities with an Actor component found.';
-
-    // Act: Start the manager, which will call advanceTurn once.
-    await testBed.turnManager.start(); // This calls advanceTurn.
-
-    // Assert (on the results of the advanceTurn call triggered by start)
-    expect(testBed.mocks.dispatcher.subscribe).toHaveBeenCalledTimes(1); // Ensure subscription happened in start()
-    expect(advanceTurnSpy).toHaveBeenCalledTimes(1); // The call from start()
-
-    // Check logs from the advanceTurn call triggered by start()
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'TurnManager.advanceTurn() initiating...'
-    );
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1); // Called once, no recursive call when no actors
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg); // Error logged
-
-    // Check dispatch and stop from the advanceTurn call
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      {
-        message:
-          'System Error: No active actors found to start a round. Stopping game.',
-        details: {
-          raw: expectedErrorMsg,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      }
-    );
-
-    expect(stopSpy).toHaveBeenCalledTimes(1); // stop() called by the advanceTurn call
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'Mocked instance.stop() called.'
-    );
-  });
-
-  test('No active actors found (empty map): logs error, dispatches message, and stops', async () => {
-    // Arrange
-    testBed.setActiveEntities(); // Explicitly empty map
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
-    const expectedErrorMsg =
-      'Cannot start a new round: No active entities with an Actor component found.';
-
-    // Act: Start the manager, which will immediately call advanceTurn and fail
-    await testBed.turnManager.start();
-
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      {
-        message:
-          'System Error: No active actors found to start a round. Stopping game.',
-        details: {
-          raw: expectedErrorMsg,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      }
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('Active actors found: starts new round and recursively calls advanceTurn', async () => {
-    // Arrange
-    const actor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-    const actor2 = createMockEntity('actor2', { isActor: true, isPlayer: false });
-    testBed.setActiveEntities(actor1, actor2);
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(actor1); // First actor in new round
-
-    const mockHandler = {
-      startTurn: jest.fn().mockResolvedValue(undefined),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    };
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockHandler);
-
-    // Act: Start the manager, which will call advanceTurn and start a new round
-    await testBed.turnManager.start();
-
-    // Assert
-    expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(2); // Called once initially, then again in recursive advanceTurn
-    expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
-      expect.arrayContaining([actor1, actor2]),
-      'round-robin'
-    );
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'New round started, recursively calling advanceTurn() to process the first turn.'
-    );
-
-    // Verify the recursive advanceTurn call
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(actor1);
-    expect(mockHandler.startTurn).toHaveBeenCalledWith(actor1);
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith('core:turn_started', {
-      entityId: actor1.id,
-      entityType: 'ai',
+    afterEach(async () => {
+      jest.restoreAllMocks();
     });
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      TURN_PROCESSING_STARTED,
-      { entityId: actor1.id, actorType: 'ai' }
-    );
-  });
 
-  test('startNewRound throws error: logs error, dispatches message, and stops', async () => {
-    // Arrange
-    const actor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-    testBed.setActiveEntities(actor1);
+    // --- Test Cases ---
 
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
-    const roundError = new Error('Round start failed');
-    testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(roundError);
+    test('advanceTurn() does nothing with a debug log if not running', async () => {
+      // Arrange: #isRunning is false by default after construction before start()
+      // Act: Call advanceTurn directly
+      await testBed.turnManager.advanceTurn();
 
-    // Act: Start the manager, which will call advanceTurn and fail to start a new round
-    await testBed.turnManager.start();
+      // Assert
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledTimes(1);
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'TurnManager.advanceTurn() called while manager is not running. Returning.'
+      );
+      expect(testBed.mocks.turnOrderService.isEmpty).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
+      expect(testBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
+      expect(testBed.mocks.dispatcher.subscribe).not.toHaveBeenCalled(); // subscribe happens in start()
+    });
 
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Round start failed',
-      roundError
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: roundError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+    test('No active actors found: logs error, dispatches message, and stops', async () => {
+      // Arrange
+      const nonActorEntity = createMockEntity('nonActor1', {
+        isActor: false,
+        isPlayer: false,
+      });
+      testBed.setActiveEntities(nonActorEntity);
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty for the check inside advanceTurn
+      const expectedErrorMsg =
+        'Cannot start a new round: No active entities with an Actor component found.';
 
-  test('getNextEntity throws error after new round: logs error, dispatches message, and stops', async () => {
-    // Arrange
-    const actor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-    testBed.setActiveEntities(actor1);
+      // Act: Start the manager, which will call advanceTurn once.
+      await testBed.turnManager.start(); // This calls advanceTurn.
 
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
-    testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(new Error('Get next entity failed'));
+      // Assert (on the results of the advanceTurn call triggered by start)
+      expect(testBed.mocks.dispatcher.subscribe).toHaveBeenCalledTimes(1); // Ensure subscription happened in start()
+      expect(advanceTurnSpy).toHaveBeenCalledTimes(1); // The call from start()
 
-    // Act: Start the manager, which will call advanceTurn, start a new round, then fail
-    await testBed.turnManager.start();
+      // Check logs from the advanceTurn call triggered by start()
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'TurnManager.advanceTurn() initiating...'
+      );
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1); // Called once, no recursive call when no actors
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg); // Error logged
 
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Get next entity failed',
-      expect.any(Error)
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: 'Get next entity failed',
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
+      // Check dispatch and stop from the advanceTurn call
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledTimes(1);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            'System Error: No active actors found to start a round. Stopping game.',
+          details: {
+            raw: expectedErrorMsg,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        }
+      );
 
-  test('Handler resolution fails after new round: logs error, dispatches message, and stops', async () => {
-    // Arrange
-    const actor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-    testBed.setActiveEntities(actor1);
+      expect(stopSpy).toHaveBeenCalledTimes(1); // stop() called by the advanceTurn call
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'Mocked instance.stop() called.'
+      );
+    });
 
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(actor1);
-    const resolveError = new Error('Handler resolution failed');
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(resolveError);
+    test('No active actors found (empty map): logs error, dispatches message, and stops', async () => {
+      // Arrange
+      testBed.setActiveEntities(); // Explicitly empty map
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+      const expectedErrorMsg =
+        'Cannot start a new round: No active entities with an Actor component found.';
 
-    // Act: Start the manager, which will call advanceTurn, start a new round, then fail
-    await testBed.turnManager.start();
+      // Act: Start the manager, which will immediately call advanceTurn and fail
+      await testBed.turnManager.start();
 
-    // Assert
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
-      resolveError
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: resolveError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-});
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            'System Error: No active actors found to start a round. Stopping game.',
+          details: {
+            raw: expectedErrorMsg,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        }
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Active actors found: starts new round and recursively calls advanceTurn', async () => {
+      // Arrange
+      const actor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      const actor2 = createMockEntity('actor2', {
+        isActor: true,
+        isPlayer: false,
+      });
+      testBed.setActiveEntities(actor1, actor2);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
+        actor1
+      ); // First actor in new round
+
+      const mockHandler = {
+        startTurn: jest.fn().mockResolvedValue(undefined),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockHandler
+      );
+
+      // Act: Start the manager, which will call advanceTurn and start a new round
+      await testBed.turnManager.start();
+
+      // Assert
+      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(2); // Called once initially, then again in recursive advanceTurn
+      expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
+        expect.arrayContaining([actor1, actor2]),
+        'round-robin'
+      );
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'New round started, recursively calling advanceTurn() to process the first turn.'
+      );
+
+      // Verify the recursive advanceTurn call
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(actor1);
+      expect(mockHandler.startTurn).toHaveBeenCalledWith(actor1);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        'core:turn_started',
+        {
+          entityId: actor1.id,
+          entityType: 'ai',
+        }
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        TURN_PROCESSING_STARTED,
+        { entityId: actor1.id, actorType: 'ai' }
+      );
+    });
+
+    test('startNewRound throws error: logs error, dispatches message, and stops', async () => {
+      // Arrange
+      const actor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      testBed.setActiveEntities(actor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+      const roundError = new Error('Round start failed');
+      testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(
+        roundError
+      );
+
+      // Act: Start the manager, which will call advanceTurn and fail to start a new round
+      await testBed.turnManager.start();
+
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Round start failed',
+        roundError
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: roundError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('getNextEntity throws error after new round: logs error, dispatches message, and stops', async () => {
+      // Arrange
+      const actor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      testBed.setActiveEntities(actor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+      testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(
+        new Error('Get next entity failed')
+      );
+
+      // Act: Start the manager, which will call advanceTurn, start a new round, then fail
+      await testBed.turnManager.start();
+
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Get next entity failed',
+        expect.any(Error)
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: 'Get next entity failed',
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Handler resolution fails after new round: logs error, dispatches message, and stops', async () => {
+      // Arrange
+      const actor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      testBed.setActiveEntities(actor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
+        actor1
+      );
+      const resolveError = new Error('Handler resolution failed');
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
+        resolveError
+      );
+
+      // Act: Start the manager, which will call advanceTurn, start a new round, then fail
+      await testBed.turnManager.start();
+
+      // Assert
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Handler resolution failed',
+        resolveError
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: resolveError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+  }
+);
 // --- FILE END ---

--- a/tests/unit/turns/turnManager.constructor.test.js
+++ b/tests/unit/turns/turnManager.constructor.test.js
@@ -1,197 +1,199 @@
 // src/tests/turns/turnManager.constructor.test.js
 // --- FILE START ---
 
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import TurnManager from '../../../src/turns/turnManager.js';
-import { beforeEach, describe, expect, it, jest, afterEach } from '@jest/globals'; // Use 'it' alias for test cases
+import { beforeEach, expect, it, jest, afterEach } from '@jest/globals'; // Use 'it' alias for test cases
 
 // --- Test Suite ---
 
-describe('TurnManager - Constructor Dependency Validation', () => {
-  let testBed;
-  let validOptions; // To hold the full set of valid options
+describeTurnManagerSuite(
+  'TurnManager - Constructor Dependency Validation',
+  (getBed) => {
+    let testBed;
+    let validOptions; // To hold the full set of valid options
 
-  beforeEach(() => {
-    testBed = new TurnManagerTestBed();
+    beforeEach(() => {
+      testBed = getBed();
 
-    // Prepare valid options object
-    validOptions = {
-      turnOrderService: testBed.mocks.turnOrderService,
-      entityManager: testBed.mocks.entityManager,
-      logger: testBed.mocks.logger,
-      dispatcher: testBed.mocks.dispatcher,
-      turnHandlerResolver: testBed.mocks.turnHandlerResolver,
-    };
+      // Prepare valid options object
+      validOptions = {
+        turnOrderService: testBed.mocks.turnOrderService,
+        entityManager: testBed.mocks.entityManager,
+        logger: testBed.mocks.logger,
+        dispatcher: testBed.mocks.dispatcher,
+        turnHandlerResolver: testBed.mocks.turnHandlerResolver,
+      };
 
-    // Spy on console.error for tests checking logger fallback
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
+      // Spy on console.error for tests checking logger fallback
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
 
-  afterEach(() => {
-    // Restore console.error spy
-    jest.restoreAllMocks();
-    testBed.cleanup();
-  });
+    afterEach(() => {
+      // Restore console.error spy
+      jest.restoreAllMocks();
+    });
 
-  // --- Success Case ---
+    // --- Success Case ---
 
-  it('should instantiate successfully with all valid dependencies', () => {
-    let turnManager;
-    expect(() => {
-      turnManager = new TurnManager(validOptions);
-    }).not.toThrow();
+    it('should instantiate successfully with all valid dependencies', () => {
+      let turnManager;
+      expect(() => {
+        turnManager = new TurnManager(validOptions);
+      }).not.toThrow();
 
-    expect(turnManager).toBeInstanceOf(TurnManager);
-    expect(testBed.mocks.logger.info).toHaveBeenCalledTimes(0); // Called only once
-    expect(turnManager.getCurrentActor()).toBeNull(); // Check initial state
-    // isRunning is private, cannot check directly without hacks
-  });
+      expect(turnManager).toBeInstanceOf(TurnManager);
+      expect(testBed.mocks.logger.info).toHaveBeenCalledTimes(0); // Called only once
+      expect(turnManager.getCurrentActor()).toBeNull(); // Check initial state
+      // isRunning is private, cannot check directly without hacks
+    });
 
-  // --- Dependency Validation Failure Cases ---
+    // --- Dependency Validation Failure Cases ---
 
-  // TurnOrderService
-  it('should throw if turnOrderService is null or undefined', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnOrderService instance.';
-    const options = { ...validOptions, turnOrderService: null };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    // Constructor uses console.error for initial checks before logger is assigned
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    // TurnOrderService
+    it('should throw if turnOrderService is null or undefined', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnOrderService instance.';
+      const options = { ...validOptions, turnOrderService: null };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      // Constructor uses console.error for initial checks before logger is assigned
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if turnOrderService is invalid (missing required methods like clearCurrentRound)', () => {
-    const invalidService = {
-      ...testBed.mocks.turnOrderService,
-      clearCurrentRound: undefined,
-    };
-    const options = { ...validOptions, turnOrderService: invalidService };
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnOrderService instance.';
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should throw if turnOrderService is invalid (missing required methods like clearCurrentRound)', () => {
+      const invalidService = {
+        ...testBed.mocks.turnOrderService,
+        clearCurrentRound: undefined,
+      };
+      const options = { ...validOptions, turnOrderService: invalidService };
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnOrderService instance.';
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  // EntityManager
-  it('should throw if entityManager is null or undefined', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid EntityManager instance.';
-    const options = { ...validOptions, entityManager: null };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    // EntityManager
+    it('should throw if entityManager is null or undefined', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid EntityManager instance.';
+      const options = { ...validOptions, entityManager: null };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if entityManager is invalid (missing getEntityInstance)', () => {
-    const invalidManager = {
-      ...testBed.mocks.entityManager,
-      getEntityInstance: undefined,
-    };
-    const options = { ...validOptions, entityManager: invalidManager };
-    const expectedErrorMsg =
-      'TurnManager requires a valid EntityManager instance.';
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should throw if entityManager is invalid (missing getEntityInstance)', () => {
+      const invalidManager = {
+        ...testBed.mocks.entityManager,
+        getEntityInstance: undefined,
+      };
+      const options = { ...validOptions, entityManager: invalidManager };
+      const expectedErrorMsg =
+        'TurnManager requires a valid EntityManager instance.';
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  // Logger
-  it('should throw if logger is null or undefined', () => {
-    const expectedErrorMsg = 'TurnManager requires a valid ILogger instance.';
-    const options = { ...validOptions, logger: null };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    // Check console was used as fallback
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    // Logger
+    it('should throw if logger is null or undefined', () => {
+      const expectedErrorMsg = 'TurnManager requires a valid ILogger instance.';
+      const options = { ...validOptions, logger: null };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      // Check console was used as fallback
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if logger is invalid (missing methods like info, warn, error, debug)', () => {
-    const expectedErrorMsg = 'TurnManager requires a valid ILogger instance.';
-    const invalidLogger = { error: jest.fn() }; // Missing info, warn, debug
-    const options = { ...validOptions, logger: invalidLogger };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    it('should throw if logger is invalid (missing methods like info, warn, error, debug)', () => {
+      const expectedErrorMsg = 'TurnManager requires a valid ILogger instance.';
+      const invalidLogger = { error: jest.fn() }; // Missing info, warn, debug
+      const options = { ...validOptions, logger: invalidLogger };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
 
-    // Test missing a different method
-    const invalidLogger2 = {
-      info: jest.fn(),
-      warn: jest.fn(),
-      debug: jest.fn(),
-    }; // Missing error
-    const options2 = { ...validOptions, logger: invalidLogger2 };
-    expect(() => new TurnManager(options2)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg); // Still uses console.error for initial check
-  });
+      // Test missing a different method
+      const invalidLogger2 = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+      }; // Missing error
+      const options2 = { ...validOptions, logger: invalidLogger2 };
+      expect(() => new TurnManager(options2)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg); // Still uses console.error for initial check
+    });
 
-  // Dispatcher
-  it('should throw if dispatcher is null or undefined', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
-    const options = { ...validOptions, dispatcher: null };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    // Logger is valid here, so check logger.error
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    // Verify console.error was NOT called for this specific check (since logger was valid)
-    expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    // Dispatcher
+    it('should throw if dispatcher is null or undefined', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
+      const options = { ...validOptions, dispatcher: null };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      // Logger is valid here, so check logger.error
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      // Verify console.error was NOT called for this specific check (since logger was valid)
+      expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if dispatcher is invalid (missing dispatch)', () => {
-    const invalidDispatcher = { subscribe: jest.fn(() => jest.fn()) }; // Missing dispatch
-    const options = { ...validOptions, dispatcher: invalidDispatcher };
-    const expectedErrorMsg =
-      'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should throw if dispatcher is invalid (missing dispatch)', () => {
+      const invalidDispatcher = { subscribe: jest.fn(() => jest.fn()) }; // Missing dispatch
+      const options = { ...validOptions, dispatcher: invalidDispatcher };
+      const expectedErrorMsg =
+        'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if dispatcher is invalid (missing subscribe)', () => {
-    const invalidDispatcher = { dispatch: jest.fn() }; // Missing subscribe
-    const options = { ...validOptions, dispatcher: invalidDispatcher };
-    const expectedErrorMsg =
-      'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should throw if dispatcher is invalid (missing subscribe)', () => {
+      const invalidDispatcher = { dispatch: jest.fn() }; // Missing subscribe
+      const options = { ...validOptions, dispatcher: invalidDispatcher };
+      const expectedErrorMsg =
+        'TurnManager requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).';
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  // TurnHandlerResolver
-  it('should throw if turnHandlerResolver is null or undefined', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnHandlerResolver instance (with resolveHandler method).';
-    const options = { ...validOptions, turnHandlerResolver: null };
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    // TurnHandlerResolver
+    it('should throw if turnHandlerResolver is null or undefined', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnHandlerResolver instance (with resolveHandler method).';
+      const options = { ...validOptions, turnHandlerResolver: null };
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should throw if turnHandlerResolver is invalid (missing resolveHandler)', () => {
-    const invalidResolver = {}; // Missing resolveHandler
-    const options = { ...validOptions, turnHandlerResolver: invalidResolver };
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnHandlerResolver instance (with resolveHandler method).';
-    expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
-    expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should throw if turnHandlerResolver is invalid (missing resolveHandler)', () => {
+      const invalidResolver = {}; // Missing resolveHandler
+      const options = { ...validOptions, turnHandlerResolver: invalidResolver };
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnHandlerResolver instance (with resolveHandler method).';
+      expect(() => new TurnManager(options)).toThrow(expectedErrorMsg);
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(expectedErrorMsg);
+      expect(console.error).not.toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  // --- Edge Cases ---
+    // --- Edge Cases ---
 
-  it('should handle empty options object gracefully', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnOrderService instance.';
-    expect(() => new TurnManager({})).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should handle empty options object gracefully', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnOrderService instance.';
+      expect(() => new TurnManager({})).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should handle undefined options gracefully', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnOrderService instance.';
-    expect(() => new TurnManager(undefined)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
+    it('should handle undefined options gracefully', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnOrderService instance.';
+      expect(() => new TurnManager(undefined)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
 
-  it('should handle null options gracefully', () => {
-    const expectedErrorMsg =
-      'TurnManager requires a valid ITurnOrderService instance.';
-    expect(() => new TurnManager(null)).toThrow(expectedErrorMsg);
-    expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
-  });
-});
+    it('should handle null options gracefully', () => {
+      const expectedErrorMsg =
+        'TurnManager requires a valid ITurnOrderService instance.';
+      expect(() => new TurnManager(null)).toThrow(expectedErrorMsg);
+      expect(console.error).toHaveBeenCalledWith(expectedErrorMsg);
+    });
+  }
+);
 // --- FILE END ---

--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -1,7 +1,10 @@
 // src/tests/turns/turnManager.errorHandling.test.js
 // --- FILE START ---
 
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import {
+  describeTurnManagerSuite,
+  flushPromisesAndTimers,
+} from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
@@ -11,15 +14,7 @@ import {
   TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import {
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-  afterEach,
-} from '@jest/globals';
-import { flushPromisesAndTimers } from '../../common/turns/turnManagerTestBed.js';
+import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
 import { createMockEntity } from '../../common/mockFactories.js';
 
 // --- Mock Implementations ---
@@ -55,7 +50,7 @@ class MockTurnHandler {
 }
 
 // --- Test Suite ---
-describe('TurnManager - Error Handling', () => {
+describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
   // Set a reasonable timeout, but hopefully the fixes prevent hitting it.
   jest.setTimeout(15000); // Slightly increased timeout just in case, but OOM is the main concern.
 
@@ -67,7 +62,7 @@ describe('TurnManager - Error Handling', () => {
     jest.useFakeTimers({ legacyFakeTimers: false });
     mockHandlerInstances.clear();
 
-    testBed = new TurnManagerTestBed();
+    testBed = getBed();
 
     // Setup actors and add to the specific entityManager instance used by TurnManager
     mockActor1 = new MockEntity('actor1', [ACTOR_COMPONENT_ID]);
@@ -80,7 +75,6 @@ describe('TurnManager - Error Handling', () => {
   });
 
   afterEach(async () => {
-    await testBed.cleanup();
     mockHandlerInstances.clear();
     // Clears mock usage data (calls, instances) between tests
     jest.clearAllMocks();
@@ -126,7 +120,9 @@ describe('TurnManager - Error Handling', () => {
     );
 
     // Verify turn manager stopped advancing
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
+    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(
+      1
+    );
   });
 
   test('should handle handler startTurn failure gracefully', async () => {
@@ -174,7 +170,9 @@ describe('TurnManager - Error Handling', () => {
     expect(failingHandler.destroy).toHaveBeenCalled();
 
     // Verify turn manager stopped advancing
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(2); // Called twice due to retry logic
+    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(
+      2
+    ); // Called twice due to retry logic
   });
 
   test('should handle turn order service errors', async () => {

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -1,20 +1,16 @@
 // src/tests/turns/turnManager.getCurrentActor.test.js
 // --- FILE START (Entire file content, Corrected) ---
 
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import {
+  TurnManagerTestBed,
+  describeTurnManagerSuite,
+} from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
 import { TURN_PROCESSING_STARTED } from '../../../src/constants/eventIds.js';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 import { createMockEntity } from '../../common/mockFactories.js';
 
 // Mock Turn Handlers - ADD startTurn and destroy
@@ -29,19 +25,28 @@ const mockAiHandler = {
   destroy: jest.fn().mockResolvedValue(),
 };
 
-describe('TurnManager', () => {
+describeTurnManagerSuite('TurnManager', (getBed) => {
   let testBed;
   let mockPlayerEntity;
   let mockAiEntity1;
   let mockAiEntity2;
 
   beforeEach(() => {
-    testBed = new TurnManagerTestBed();
+    testBed = getBed();
 
     // Create fresh mock entities
-    mockPlayerEntity = createMockEntity('player-1', { isActor: true, isPlayer: true });
-    mockAiEntity1 = createMockEntity('ai-1', { isActor: true, isPlayer: false });
-    mockAiEntity2 = createMockEntity('ai-2', { isActor: true, isPlayer: false });
+    mockPlayerEntity = createMockEntity('player-1', {
+      isActor: true,
+      isPlayer: true,
+    });
+    mockAiEntity1 = createMockEntity('ai-1', {
+      isActor: true,
+      isPlayer: false,
+    });
+    mockAiEntity2 = createMockEntity('ai-2', {
+      isActor: true,
+      isPlayer: false,
+    });
 
     // Configure default mock behaviors
     testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
@@ -58,10 +63,6 @@ describe('TurnManager', () => {
     mockAiHandler.startTurn.mockClear().mockResolvedValue();
     mockPlayerHandler.destroy.mockClear().mockResolvedValue();
     mockAiHandler.destroy.mockClear().mockResolvedValue();
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
   });
 
   // --- Basic Setup Tests ---
@@ -81,9 +82,9 @@ describe('TurnManager', () => {
   test('EntityManager mock allows setting active entities', () => {
     const entities = [mockPlayerEntity, mockAiEntity1];
     testBed.setActiveEntities(...entities);
-    expect(Array.from(testBed.mocks.entityManager.activeEntities.values())).toEqual(
-      entities
-    );
+    expect(
+      Array.from(testBed.mocks.entityManager.activeEntities.values())
+    ).toEqual(entities);
     expect(testBed.mocks.entityManager.activeEntities.get('player-1')).toBe(
       mockPlayerEntity
     );
@@ -96,21 +97,28 @@ describe('TurnManager', () => {
     });
 
     test('should return the assigned actor after start and advanceTurn assigns one', async () => {
-      const mockActor = createMockEntity('actor-test', { isActor: true, isPlayer: false });
+      const mockActor = createMockEntity('actor-test', {
+        isActor: true,
+        isPlayer: false,
+      });
       const entityType = 'ai'; // Define expected type
 
       // --- Setup mocks for start() -> advanceTurn() path ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false); // Queue not empty
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return our actor
       // Configure resolver to return the AI handler WHEN called with this specific actor
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockAiHandler);
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockAiHandler
+      );
 
       // --- Execute ---
       await testBed.turnManager.start(); // Calls advanceTurn internally
 
       // --- Assert ---
       expect(testBed.turnManager.getCurrentActor()).toBe(mockActor);
-      expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(mockActor);
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(mockActor);
       expect(mockAiHandler.startTurn).toHaveBeenCalledWith(mockActor);
       expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
         TURN_PROCESSING_STARTED,
@@ -119,12 +127,17 @@ describe('TurnManager', () => {
     });
 
     test('should return null after stop() clears the current actor', async () => {
-      const mockActor = createMockEntity('actor-test', { isActor: true, isPlayer: false });
+      const mockActor = createMockEntity('actor-test', {
+        isActor: true,
+        isPlayer: false,
+      });
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor);
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockAiHandler);
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockAiHandler
+      );
 
       // --- Execute ---
       await testBed.turnManager.start();
@@ -138,8 +151,14 @@ describe('TurnManager', () => {
     });
 
     test('should return the correct actor when multiple actors are in the queue', async () => {
-      const mockActor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-      const mockActor2 = createMockEntity('actor2', { isActor: true, isPlayer: false });
+      const mockActor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      const mockActor2 = createMockEntity('actor2', {
+        isActor: true,
+        isPlayer: false,
+      });
 
       // --- Setup mocks for sequential actors ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -155,21 +174,29 @@ describe('TurnManager', () => {
       expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
 
       // Simulate turn ending and advancing to next actor
-      testBed.trigger('core:turn_ended', { entityId: mockActor1.id, success: true });
-      await new Promise(resolve => setTimeout(resolve, 10)); // Allow async operations
-      await new Promise(resolve => setTimeout(resolve, 10)); // Additional wait for advanceTurn
+      testBed.trigger('core:turn_ended', {
+        entityId: mockActor1.id,
+        success: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Allow async operations
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Additional wait for advanceTurn
 
       // --- Assert ---
       expect(testBed.turnManager.getCurrentActor()).toBe(mockActor2);
     });
 
     test('should return null when queue becomes empty', async () => {
-      const mockActor = createMockEntity('actor-test', { isActor: true, isPlayer: false });
+      const mockActor = createMockEntity('actor-test', {
+        isActor: true,
+        isPlayer: false,
+      });
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor);
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockAiHandler);
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockAiHandler
+      );
 
       // --- Execute ---
       await testBed.turnManager.start();
@@ -180,22 +207,35 @@ describe('TurnManager', () => {
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
 
       // Simulate turn ending
-      testBed.trigger('core:turn_ended', { entityId: mockActor.id, success: true });
-      await new Promise(resolve => setTimeout(resolve, 10)); // Allow async operations
-      await new Promise(resolve => setTimeout(resolve, 10)); // Additional wait for advanceTurn
+      testBed.trigger('core:turn_ended', {
+        entityId: mockActor.id,
+        success: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Allow async operations
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Additional wait for advanceTurn
 
       // --- Assert ---
       expect(testBed.turnManager.getCurrentActor()).toBeNull();
     });
 
     test('should handle player vs AI actor types correctly', async () => {
-      const mockPlayerActor = createMockEntity('player-actor', { isActor: true, isPlayer: true });
-      const mockAiActor = createMockEntity('ai-actor', { isActor: true, isPlayer: false });
+      const mockPlayerActor = createMockEntity('player-actor', {
+        isActor: true,
+        isPlayer: true,
+      });
+      const mockAiActor = createMockEntity('ai-actor', {
+        isActor: true,
+        isPlayer: false,
+      });
 
       // Test player actor
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockPlayerActor);
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockPlayerHandler);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        mockPlayerActor
+      );
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockPlayerHandler
+      );
 
       await testBed.turnManager.start();
       expect(testBed.turnManager.getCurrentActor()).toBe(mockPlayerActor);
@@ -207,8 +247,12 @@ describe('TurnManager', () => {
       await testBed.turnManager.stop();
 
       // Test AI actor
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockAiActor);
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(mockAiHandler);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        mockAiActor
+      );
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        mockAiHandler
+      );
 
       await testBed.turnManager.start();
       expect(testBed.turnManager.getCurrentActor()).toBe(mockAiActor);
@@ -219,11 +263,16 @@ describe('TurnManager', () => {
     });
 
     test('should return null when no valid actor is found', async () => {
-      const mockNonActor = createMockEntity('non-actor', { isActor: false, isPlayer: false });
+      const mockNonActor = createMockEntity('non-actor', {
+        isActor: false,
+        isPlayer: false,
+      });
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockNonActor);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        mockNonActor
+      );
 
       // --- Execute ---
       await testBed.turnManager.start();
@@ -236,7 +285,10 @@ describe('TurnManager', () => {
     });
 
     test('should handle entity manager errors gracefully', async () => {
-      const mockActor = createMockEntity('actor-test', { isActor: true, isPlayer: false });
+      const mockActor = createMockEntity('actor-test', {
+        isActor: true,
+        isPlayer: false,
+      });
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -1,7 +1,7 @@
 // src/tests/turns/turnManager.roundLifecycle.test.js
 // --- FILE START ---
 
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
@@ -11,14 +11,7 @@ import {
   TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import {
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-  afterEach,
-} from '@jest/globals';
+import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
 import { createMockEntity } from '../../common/mockFactories.js';
 
 // --- Mock Implementations (Reusing from previous files) ---
@@ -47,231 +40,275 @@ class MockTurnHandler {
 
 // --- Test Suite ---
 
-describe('TurnManager - Round Lifecycle and Turn Advancement', () => {
-  let testBed;
-  let stopSpy;
+describeTurnManagerSuite(
+  'TurnManager - Round Lifecycle and Turn Advancement',
+  (getBed) => {
+    let testBed;
+    let stopSpy;
 
-  let mockActor1, mockActor2, mockPlayerActor;
+    let mockActor1, mockActor2, mockPlayerActor;
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-    testBed = new TurnManagerTestBed();
+    beforeEach(() => {
+      jest.useFakeTimers();
+      testBed = getBed();
 
-    mockActor1 = createMockEntity('actor1', { isActor: true, isPlayer: false });
-    mockActor2 = createMockEntity('actor2', { isActor: true, isPlayer: false });
-    mockPlayerActor = createMockEntity('player1', { isActor: true, isPlayer: true });
+      mockActor1 = createMockEntity('actor1', {
+        isActor: true,
+        isPlayer: false,
+      });
+      mockActor2 = createMockEntity('actor2', {
+        isActor: true,
+        isPlayer: false,
+      });
+      mockPlayerActor = createMockEntity('player1', {
+        isActor: true,
+        isPlayer: true,
+      });
 
-    // Configure handler resolver to return MockTurnHandler instances
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
-      async (actor) => new MockTurnHandler(actor)
-    );
+      // Configure handler resolver to return MockTurnHandler instances
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
+        async (actor) => new MockTurnHandler(actor)
+      );
 
-    stopSpy = jest.spyOn(testBed.turnManager, 'stop');
+      stopSpy = jest.spyOn(testBed.turnManager, 'stop');
 
-    testBed.mocks.logger.info.mockClear();
-    testBed.mocks.logger.debug.mockClear();
-    testBed.mocks.logger.warn.mockClear();
-    testBed.mocks.logger.error.mockClear();
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
-    jest.clearAllMocks();
-    jest.clearAllTimers();
-  });
-
-  test('Starts a new round when queue is empty and active actors exist', async () => {
-    testBed.setActiveEntities(mockActor1, mockPlayerActor);
-
-    testBed.mocks.turnOrderService.isEmpty
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(mockPlayerActor);
-
-    await testBed.turnManager.start();
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.mocks.entityManager.activeEntities.size).toBe(2);
-    expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
-      expect.arrayContaining([mockActor1, mockPlayerActor]),
-      'round-robin'
-    );
-    expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-      'New round started, recursively calling advanceTurn() to process the first turn.'
-    );
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(1);
-    expect(testBed.mocks.turnHandlerResolver.resolveHandler).toHaveBeenCalledWith(
-      mockPlayerActor
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(TURN_STARTED_ID, {
-      entityId: mockPlayerActor.id,
-      entityType: 'player',
-    });
-  });
-
-  test('Fails to start a new round and stops if no active actors are found', async () => {
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
-
-    await testBed.turnManager.start();
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'Cannot start a new round: No active entities with an Actor component found.'
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
-      message:
-        'System Error: No active actors found to start a round. Stopping game.',
-      details: {
-        raw: 'Cannot start a new round: No active entities with an Actor component found.',
-        stack: expect.any(String),
-        timestamp: expect.any(String),
-      },
-    });
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('Advances to next actor when current turn ends successfully', async () => {
-    // Use real timers for this test since turn advancement uses setTimeout
-    jest.useRealTimers();
-    
-    testBed.setActiveEntities(mockActor1, mockActor2);
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    testBed.mocks.turnOrderService.getNextEntity
-      .mockResolvedValueOnce(mockActor1)
-      .mockResolvedValueOnce(mockActor2);
-
-    await testBed.turnManager.start();
-    await new Promise(resolve => setTimeout(resolve, 10)); // Wait for initial turn advancement
-
-    expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
-
-    // Simulate turn ending
-    testBed.trigger(TURN_ENDED_ID, { entityId: mockActor1.id, success: true });
-    await new Promise(resolve => setTimeout(resolve, 10)); // Wait for async turn advancement
-    await new Promise(resolve => setTimeout(resolve, 10)); // Additional wait
-
-    expect(testBed.turnManager.getCurrentActor()).toBe(mockActor2);
-    expect(testBed.mocks.turnOrderService.getNextEntity).toHaveBeenCalledTimes(2);
-  });
-
-  test('Starts new round when queue becomes empty after turn ends', async () => {
-    testBed.setActiveEntities(mockActor1, mockActor2);
-
-    testBed.mocks.turnOrderService.isEmpty
-      .mockResolvedValueOnce(false) // Initial queue not empty
-      .mockResolvedValueOnce(true); // Queue becomes empty after first turn
-    testBed.mocks.turnOrderService.getNextEntity
-      .mockResolvedValueOnce(mockActor1) // First actor
-      .mockResolvedValueOnce(null); // No more actors
-
-    await testBed.turnManager.start();
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
-
-    // Simulate turn ending
-    testBed.trigger(TURN_ENDED_ID, { entityId: mockActor1.id, success: true });
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
-      expect.arrayContaining([mockActor1, mockActor2]),
-      'round-robin'
-    );
-  });
-
-  test('Handles turn advancement errors gracefully', async () => {
-    testBed.setActiveEntities(mockActor1);
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor1);
-    const advanceError = new Error('Turn advancement failed');
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(advanceError);
-
-    await testBed.turnManager.start();
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Turn advancement failed',
-      advanceError
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: advanceError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('Handles round start errors gracefully', async () => {
-    testBed.setActiveEntities(mockActor1);
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
-    const roundError = new Error('Round start failed');
-    testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(roundError);
-
-    await testBed.turnManager.start();
-    jest.runAllTimers();
-    await Promise.resolve();
-
-    expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-      'CRITICAL Error during turn advancement logic (before handler initiation): Round start failed',
-      roundError
-    );
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        details: {
-          raw: roundError.message,
-          stack: expect.any(String),
-          timestamp: expect.any(String),
-        },
-      })
-    );
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('Correctly identifies actor types for event dispatching', async () => {
-    // Use real timers for this test since turn advancement uses setTimeout
-    jest.useRealTimers();
-    
-    testBed.setActiveEntities(mockPlayerActor, mockActor1);
-
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    testBed.mocks.turnOrderService.getNextEntity
-      .mockResolvedValueOnce(mockPlayerActor)
-      .mockResolvedValueOnce(mockActor1);
-
-    await testBed.turnManager.start();
-    await new Promise(resolve => setTimeout(resolve, 10)); // Wait for initial turn advancement
-
-    // Check player actor event
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(TURN_STARTED_ID, {
-      entityId: mockPlayerActor.id,
-      entityType: 'player',
+      testBed.mocks.logger.info.mockClear();
+      testBed.mocks.logger.debug.mockClear();
+      testBed.mocks.logger.warn.mockClear();
+      testBed.mocks.logger.error.mockClear();
     });
 
-    // Simulate turn ending and advancing to AI actor
-    testBed.trigger(TURN_ENDED_ID, { entityId: mockPlayerActor.id, success: true });
-    await new Promise(resolve => setTimeout(resolve, 10)); // Wait for async turn advancement
-    await new Promise(resolve => setTimeout(resolve, 10)); // Additional wait
-
-    // Check AI actor event
-    expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(TURN_STARTED_ID, {
-      entityId: mockActor1.id,
-      entityType: 'ai',
+    afterEach(async () => {
+      jest.clearAllMocks();
+      jest.clearAllTimers();
     });
-  });
-});
+
+    test('Starts a new round when queue is empty and active actors exist', async () => {
+      testBed.setActiveEntities(mockActor1, mockPlayerActor);
+
+      testBed.mocks.turnOrderService.isEmpty
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
+        mockPlayerActor
+      );
+
+      await testBed.turnManager.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.mocks.entityManager.activeEntities.size).toBe(2);
+      expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
+        expect.arrayContaining([mockActor1, mockPlayerActor]),
+        'round-robin'
+      );
+      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+        'New round started, recursively calling advanceTurn() to process the first turn.'
+      );
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        testBed.mocks.turnHandlerResolver.resolveHandler
+      ).toHaveBeenCalledWith(mockPlayerActor);
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        TURN_STARTED_ID,
+        {
+          entityId: mockPlayerActor.id,
+          entityType: 'player',
+        }
+      );
+    });
+
+    test('Fails to start a new round and stops if no active actors are found', async () => {
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
+
+      await testBed.turnManager.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'Cannot start a new round: No active entities with an Actor component found.'
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        {
+          message:
+            'System Error: No active actors found to start a round. Stopping game.',
+          details: {
+            raw: 'Cannot start a new round: No active entities with an Actor component found.',
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        }
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Advances to next actor when current turn ends successfully', async () => {
+      // Use real timers for this test since turn advancement uses setTimeout
+      jest.useRealTimers();
+
+      testBed.setActiveEntities(mockActor1, mockActor2);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.turnOrderService.getNextEntity
+        .mockResolvedValueOnce(mockActor1)
+        .mockResolvedValueOnce(mockActor2);
+
+      await testBed.turnManager.start();
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for initial turn advancement
+
+      expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
+
+      // Simulate turn ending
+      testBed.trigger(TURN_ENDED_ID, {
+        entityId: mockActor1.id,
+        success: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for async turn advancement
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Additional wait
+
+      expect(testBed.turnManager.getCurrentActor()).toBe(mockActor2);
+      expect(
+        testBed.mocks.turnOrderService.getNextEntity
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    test('Starts new round when queue becomes empty after turn ends', async () => {
+      testBed.setActiveEntities(mockActor1, mockActor2);
+
+      testBed.mocks.turnOrderService.isEmpty
+        .mockResolvedValueOnce(false) // Initial queue not empty
+        .mockResolvedValueOnce(true); // Queue becomes empty after first turn
+      testBed.mocks.turnOrderService.getNextEntity
+        .mockResolvedValueOnce(mockActor1) // First actor
+        .mockResolvedValueOnce(null); // No more actors
+
+      await testBed.turnManager.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
+
+      // Simulate turn ending
+      testBed.trigger(TURN_ENDED_ID, {
+        entityId: mockActor1.id,
+        success: true,
+      });
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
+        expect.arrayContaining([mockActor1, mockActor2]),
+        'round-robin'
+      );
+    });
+
+    test('Handles turn advancement errors gracefully', async () => {
+      testBed.setActiveEntities(mockActor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
+        mockActor1
+      );
+      const advanceError = new Error('Turn advancement failed');
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
+        advanceError
+      );
+
+      await testBed.turnManager.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Turn advancement failed',
+        advanceError
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: advanceError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Handles round start errors gracefully', async () => {
+      testBed.setActiveEntities(mockActor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
+      const roundError = new Error('Round start failed');
+      testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(
+        roundError
+      );
+
+      await testBed.turnManager.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+        'CRITICAL Error during turn advancement logic (before handler initiation): Round start failed',
+        roundError
+      );
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          details: {
+            raw: roundError.message,
+            stack: expect.any(String),
+            timestamp: expect.any(String),
+          },
+        })
+      );
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Correctly identifies actor types for event dispatching', async () => {
+      // Use real timers for this test since turn advancement uses setTimeout
+      jest.useRealTimers();
+
+      testBed.setActiveEntities(mockPlayerActor, mockActor1);
+
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.turnOrderService.getNextEntity
+        .mockResolvedValueOnce(mockPlayerActor)
+        .mockResolvedValueOnce(mockActor1);
+
+      await testBed.turnManager.start();
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for initial turn advancement
+
+      // Check player actor event
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        TURN_STARTED_ID,
+        {
+          entityId: mockPlayerActor.id,
+          entityType: 'player',
+        }
+      );
+
+      // Simulate turn ending and advancing to AI actor
+      testBed.trigger(TURN_ENDED_ID, {
+        entityId: mockPlayerActor.id,
+        success: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for async turn advancement
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Additional wait
+
+      // Check AI actor event
+      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+        TURN_STARTED_ID,
+        {
+          entityId: mockActor1.id,
+          entityType: 'ai',
+        }
+      );
+    });
+  }
+);
 
 // --- FILE END ---


### PR DESCRIPTION
Summary: Added `describeTurnManagerSuite` in `tests/common/turns/turnManagerTestBed.js` to standardize TurnManager test setup and cleanup. Updated all TurnManager unit tests to use this helper and removed repetitive boilerplate. The constructor now accepts optional overrides for custom mocks.

Testing Done:
- [x] Code formatted `npx prettier -w`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855db3064f0833183043b12b7a8a71e