### PR TITLE
[Agent] introduce generic describeSuite test helper

### DIFF
--- a/tests/common/describeSuite.js
+++ b/tests/common/describeSuite.js
@@ -1,0 +1,30 @@
+/**
+ * @file Provides a generic helper for defining test suites with automatic
+ * TestBed setup and teardown.
+ */
+
+/**
+ * @description Defines a test suite using the given TestBed constructor.
+ * Instantiates the TestBed before each test and cleans it up after each test.
+ * A getter for the active TestBed is passed to the supplied suite function.
+ * @param {string} title - Title of the describe block.
+ * @param {new (...args: any[]) => {cleanup: () => Promise<void>}} TestBedCtor -
+ *   Constructor for the test bed.
+ * @param {(getBed: () => any) => void} suiteFn - Function containing the tests.
+ *   Receives a getter returning the current test bed.
+ * @param {...any} args - Arguments forwarded to the TestBed constructor.
+ * @returns {void}
+ */
+export function describeSuite(title, TestBedCtor, suiteFn, ...args) {
+  describe(title, () => {
+    /** @type {any} */
+    let testBed;
+    beforeEach(() => {
+      testBed = new TestBedCtor(...args);
+    });
+    afterEach(async () => {
+      await testBed.cleanup();
+    });
+    suiteFn(() => testBed);
+  });
+}

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -6,6 +6,7 @@
 import { createTestEnvironment } from './gameEngine.test-environment.js';
 import ContainerTestBed from '../containerTestBed.js';
 import { suppressConsoleError } from '../jestHelpers.js';
+import { describeSuite } from '../describeSuite.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -120,19 +121,21 @@ export function createGameEngineTestBed(overrides = {}) {
  * @returns {void}
  */
 export function describeGameEngineSuite(title, suiteFn, overrides = {}) {
-  describe(title, () => {
-    let testBed;
-    let consoleSpy;
-    beforeEach(() => {
-      consoleSpy = suppressConsoleError();
-      testBed = new GameEngineTestBed(overrides);
-    });
-    afterEach(async () => {
-      await testBed.cleanup();
-      consoleSpy.mockRestore();
-    });
-    suiteFn(() => testBed);
-  });
+  describeSuite(
+    title,
+    GameEngineTestBed,
+    (getBed) => {
+      let consoleSpy;
+      beforeEach(() => {
+        consoleSpy = suppressConsoleError();
+      });
+      afterEach(() => {
+        consoleSpy.mockRestore();
+      });
+      suiteFn(getBed);
+    },
+    overrides
+  );
 }
 
 export default GameEngineTestBed;

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -23,6 +23,7 @@ import {
   createSimpleMockDataRegistry,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
+import { describeSuite } from '../describeSuite.js';
 
 // --- Centralized Mocks (REMOVED) ---
 // Mock creation functions are now imported.
@@ -226,16 +227,7 @@ export class TestBed extends BaseTestBed {
  * @returns {void}
  */
 export function describeEntityManagerSuite(title, suiteFn) {
-  describe(title, () => {
-    let tb;
-    beforeEach(() => {
-      tb = new TestBed();
-    });
-    afterEach(async () => {
-      await tb.cleanup();
-    });
-    suiteFn(() => tb);
-  });
+  describeSuite(title, TestBed, suiteFn);
 }
 
 export default TestBed;

--- a/tests/unit/common/describeSuite.test.js
+++ b/tests/unit/common/describeSuite.test.js
@@ -1,0 +1,50 @@
+/**
+ * @file Test suite for the generic describeSuite helper.
+ */
+
+import { describe, it, expect, jest, afterAll } from '@jest/globals';
+import { describeSuite } from '../../common/describeSuite.js';
+
+class DummyBed {
+  constructor(value) {
+    this.value = value;
+  }
+
+  async cleanup() {}
+}
+
+describe('describeSuite', () => {
+  let cleanupCalls = 0;
+  const originalCleanup = DummyBed.prototype.cleanup;
+  const cleanupSpy = jest
+    .spyOn(DummyBed.prototype, 'cleanup')
+    .mockImplementation(async function (...args) {
+      cleanupCalls++;
+      return originalCleanup.apply(this, args);
+    });
+
+  describeSuite(
+    'inner',
+    DummyBed,
+    (getBed) => {
+      it('instantiates the test bed with arguments', () => {
+        const bed = getBed();
+        expect(bed).toBeInstanceOf(DummyBed);
+        expect(bed.value).toBe('foo');
+      });
+
+      it('provides the same instance to each test', () => {
+        expect(getBed()).toBe(getBed());
+      });
+    },
+    'foo'
+  );
+
+  afterAll(() => {
+    cleanupSpy.mockRestore();
+  });
+
+  it('calls cleanup after each test', () => {
+    expect(cleanupCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
Summary: Added a reusable `describeSuite` helper for test setup/cleanup. Entity and game engine suite helpers now delegate to it. New tests cover the helper.

Changes Made:
- created `tests/common/describeSuite.js` with generic logic
- refactored existing test beds to use the helper
- added `tests/unit/common/describeSuite.test.js`

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` – fails due to existing repo issues)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`) *(not run: no changes)*
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6855dcdf3664833189546d101318acfd