### PR TITLE
[Agent] introduce AutoMockingTestBed

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -4,6 +4,7 @@
 
 import { jest } from '@jest/globals';
 import { clearMockFunctions } from './jestHelpers.js';
+import { createMockEnvironment } from './mockEnvironment.js';
 
 /**
  * @description Base class that stores mocks and exposes a reset helper.
@@ -28,6 +29,18 @@ export class BaseTestBed {
     Object.entries(mocks).forEach(([key, value]) => {
       this[key] = value;
     });
+  }
+
+  /**
+   * Creates mocks from factory functions and returns them with a cleanup helper.
+   *
+   * @param {Record<string, () => any>} factoryMap - Map of mock factory functions.
+   * @param {object} [extraProps] - Additional data merged into the result.
+   * @returns {{ mocks: Record<string, any>, cleanup: () => void } & object}
+   *   Generated mocks and cleanup function.
+   */
+  static fromFactories(factoryMap, extraProps = {}) {
+    return { ...createMockEnvironment(factoryMap), ...extraProps };
   }
 
   /**

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -2,9 +2,12 @@
  * @file Provides a minimal test bed for GameEngine unit tests.
  * @see tests/common/engine/gameEngineTestBed.js
  */
+/* eslint-env jest */
+/* global beforeEach, afterEach, describe */
 
 import { createTestEnvironment } from './gameEngine.test-environment.js';
 import ContainerTestBed from '../containerTestBed.js';
+import BaseTestBed from '../baseTestBed.js';
 import { suppressConsoleError } from '../jestHelpers.js';
 import { describeSuite } from '../describeSuite.js';
 
@@ -36,16 +39,16 @@ export class GameEngineTestBed extends ContainerTestBed {
    */
   constructor(overrides = {}) {
     const env = createTestEnvironment(overrides);
+    const { mocks } = BaseTestBed.fromFactories({
+      logger: () => env.logger,
+      entityManager: () => env.entityManager,
+      turnManager: () => env.turnManager,
+      gamePersistenceService: () => env.gamePersistenceService,
+      playtimeTracker: () => env.playtimeTracker,
+      safeEventDispatcher: () => env.safeEventDispatcher,
+      initializationService: () => env.initializationService,
+    });
     const engine = env.createGameEngine();
-    const mocks = {
-      logger: env.logger,
-      entityManager: env.entityManager,
-      turnManager: env.turnManager,
-      gamePersistenceService: env.gamePersistenceService,
-      playtimeTracker: env.playtimeTracker,
-      safeEventDispatcher: env.safeEventDispatcher,
-      initializationService: env.initializationService,
-    };
     super(env.mockContainer, mocks);
     this.env = env;
     this.engine = engine;

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -5,7 +5,6 @@
  * @see tests/common/entities/testBed.js
  */
 
-import { jest } from '@jest/globals';
 import EntityManager from '../../../src/entities/entityManager.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import {
@@ -135,12 +134,12 @@ export class TestBed extends BaseTestBed {
    * @param {Function} [entityManagerOptions.idGenerator] - A mock ID generator function.
    */
   constructor(entityManagerOptions = {}) {
-    const mocks = {
-      registry: createSimpleMockDataRegistry(),
-      validator: createMockSchemaValidator(),
-      logger: createMockLogger(),
-      eventDispatcher: createMockSafeEventDispatcher(),
-    };
+    const { mocks } = BaseTestBed.fromFactories({
+      registry: createSimpleMockDataRegistry,
+      validator: createMockSchemaValidator,
+      logger: createMockLogger,
+      eventDispatcher: createMockSafeEventDispatcher,
+    });
     super(mocks);
 
     this.entityManager = new EntityManager({

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -3,7 +3,6 @@
  * @see tests/common/prompting/promptPipelineTestBed.js
  */
 
-import { jest } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
   createMockLogger,
@@ -28,13 +27,13 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
   defaultActions;
 
   constructor() {
-    const mocks = {
-      llmAdapter: createMockLLMAdapter(),
-      gameStateProvider: createMockAIGameStateProvider(),
-      promptContentProvider: createMockAIPromptContentProvider(),
-      promptBuilder: createMockPromptBuilder(),
-      logger: createMockLogger(),
-    };
+    const { mocks } = BaseTestBed.fromFactories({
+      llmAdapter: createMockLLMAdapter,
+      gameStateProvider: createMockAIGameStateProvider,
+      promptContentProvider: createMockAIPromptContentProvider,
+      promptBuilder: createMockPromptBuilder,
+      logger: createMockLogger,
+    });
     super(mocks);
     this.defaultActor = createMockEntity('actor');
     this.defaultContext = {};

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -2,6 +2,8 @@
  * @file Provides a minimal test bed for TurnManager unit tests.
  * @see tests/common/turns/turnManagerTestBed.js
  */
+/* eslint-env jest */
+/* global describe, beforeEach, afterEach */
 
 import { jest } from '@jest/globals';
 import TurnManager from '../../../src/turns/turnManager.js';
@@ -22,37 +24,30 @@ export class TurnManagerTestBed extends BaseTestBed {
   turnManager;
 
   constructor(overrides = {}) {
-    const logger = overrides.logger ?? createMockLogger();
-    const entityManager = overrides.entityManager ?? createMockEntityManager();
-    // Attach active entity map used by TurnManager
-    entityManager.activeEntities = new Map();
-    entityManager.getEntityInstance = jest.fn((id) =>
-      entityManager.activeEntities.get(id)
-    );
-    entityManager.getActiveEntities.mockImplementation(() =>
-      Array.from(entityManager.activeEntities.values())
-    );
-
-    const turnOrderService = overrides.turnOrderService ?? {
-      isEmpty: jest.fn(),
-      getNextEntity: jest.fn(),
-      startNewRound: jest.fn(),
-      clearCurrentRound: jest.fn(),
-    };
-
-    const turnHandlerResolver = overrides.turnHandlerResolver ?? {
-      resolveHandler: jest.fn(),
-    };
-
-    const dispatcher = overrides.dispatcher ?? createMockValidatedEventBus();
-
-    const mocks = {
-      turnOrderService,
-      entityManager,
-      logger,
-      dispatcher,
-      turnHandlerResolver,
-    };
+    const { mocks } = BaseTestBed.fromFactories({
+      logger: () => overrides.logger ?? createMockLogger(),
+      entityManager: () => {
+        const em = overrides.entityManager ?? createMockEntityManager();
+        em.activeEntities = new Map();
+        em.getEntityInstance = jest.fn((id) => em.activeEntities.get(id));
+        em.getActiveEntities.mockImplementation(() =>
+          Array.from(em.activeEntities.values())
+        );
+        return em;
+      },
+      turnOrderService: () =>
+        overrides.turnOrderService ?? {
+          isEmpty: jest.fn(),
+          getNextEntity: jest.fn(),
+          startNewRound: jest.fn(),
+          clearCurrentRound: jest.fn(),
+        },
+      turnHandlerResolver: () =>
+        overrides.turnHandlerResolver ?? {
+          resolveHandler: jest.fn(),
+        },
+      dispatcher: () => overrides.dispatcher ?? createMockValidatedEventBus(),
+    });
     super(mocks);
 
     const TurnManagerClass = overrides.TurnManagerClass ?? TurnManager;


### PR DESCRIPTION
## Summary
- add `fromFactories` helper to BaseTestBed
- use `fromFactories` in Entity, GameEngine, PromptPipeline, and TurnManager test beds
- clean up unused imports and add jest env comments

## Testing Done
- `npm run format`
- `npx eslint tests/common/baseTestBed.js tests/common/entities/testBed.js tests/common/prompting/promptPipelineTestBed.js tests/common/turns/turnManagerTestBed.js tests/common/engine/gameEngineTestBed.js`
- `npm test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855e1a31dac83319a3279cae7e0f2f6