### PR TITLE
[Agent] Expand DefaultComponentPolicy tests

### DIFF
--- a/tests/unit/adapters/defaultComponentPolicy.errorHandling.test.js
+++ b/tests/unit/adapters/defaultComponentPolicy.errorHandling.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import DefaultComponentPolicy from '../../../src/adapters/DefaultComponentPolicy.js';
+import {
+  createMockLogger,
+  createMockSchemaValidator,
+} from '../../common/mockFactories.js';
+import EntityDefinition from '../../../src/entities/entityDefinition.js';
+import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
+import Entity from '../../../src/entities/entity.js';
+import {
+  ACTOR_COMPONENT_ID,
+  SHORT_TERM_MEMORY_COMPONENT_ID,
+  NOTES_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+
+describe('DefaultComponentPolicy error handling', () => {
+  it('logs and skips component when validation fails', () => {
+    const validator = createMockSchemaValidator();
+    validator.validate = jest
+      .fn()
+      .mockReturnValueOnce({ isValid: false, errors: [{ msg: 'bad' }] })
+      .mockReturnValue({ isValid: true });
+    const logger = createMockLogger();
+    const def = new EntityDefinition('actor', {
+      components: { [ACTOR_COMPONENT_ID]: {} },
+    });
+    const data = new EntityInstanceData('e1', def);
+    const entity = new Entity(data);
+
+    const policy = new DefaultComponentPolicy();
+    policy.apply(entity, { validator, logger });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Default STM component injection for entity e1 Errors:'
+      )
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Failed to inject default component ${SHORT_TERM_MEMORY_COMPONENT_ID} for entity e1`
+      )
+    );
+    expect(entity.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(false);
+    expect(entity.hasComponent(NOTES_COMPONENT_ID)).toBe(true);
+  });
+
+  it('logs error when validator throws', () => {
+    const validator = createMockSchemaValidator();
+    validator.validate = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const logger = createMockLogger();
+    const def = new EntityDefinition('actor', {
+      components: { [ACTOR_COMPONENT_ID]: {} },
+    });
+    const data = new EntityInstanceData('e2', def);
+    const entity = new Entity(data);
+
+    const policy = new DefaultComponentPolicy();
+    policy.apply(entity, { validator, logger });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Failed to inject default component ${SHORT_TERM_MEMORY_COMPONENT_ID} for entity e2: boom`
+      )
+    );
+    expect(entity.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary: Added new test suite covering validation failure and thrown error scenarios for DefaultComponentPolicy.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on new file `npx eslint tests/unit/adapters/defaultComponentPolicy.errorHandling.test.js --fix`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68564821d8f4833189730ddd9dec6304