### PR TITLE
[Agent] create reusable DI test environment

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -14,9 +14,8 @@ import {
   createMockPlaytimeTracker,
   createMockSafeEventDispatcher,
   createMockInitializationService,
-  createMockContainer,
 } from '../mockFactories.js';
-import { createMockEnvironment } from '../mockEnvironment.js';
+import { buildTestEnvironment } from '../mockEnvironment.js';
 
 /**
  * Creates a set of mocks and a container for GameEngine.
@@ -38,7 +37,7 @@ import { createMockEnvironment } from '../mockEnvironment.js';
  *   replacement values used instead of defaults.
  */
 export function createTestEnvironment(overrides = {}) {
-  const { mocks, cleanup } = createMockEnvironment({
+  const factoryMap = {
     logger: createMockLogger,
     entityManager: createMockEntityManager,
     turnManager: createMockTurnManager,
@@ -46,19 +45,23 @@ export function createTestEnvironment(overrides = {}) {
     playtimeTracker: createMockPlaytimeTracker,
     safeEventDispatcher: createMockSafeEventDispatcher,
     initializationService: createMockInitializationService,
-  });
-
-  const mapping = {
-    [tokens.ILogger]: mocks.logger,
-    [tokens.IEntityManager]: mocks.entityManager,
-    [tokens.ITurnManager]: mocks.turnManager,
-    [tokens.GamePersistenceService]: mocks.gamePersistenceService,
-    [tokens.PlaytimeTracker]: mocks.playtimeTracker,
-    [tokens.ISafeEventDispatcher]: mocks.safeEventDispatcher,
-    [tokens.IInitializationService]: mocks.initializationService,
   };
 
-  const mockContainer = createMockContainer(mapping, overrides);
+  const tokenMap = {
+    [tokens.ILogger]: 'logger',
+    [tokens.IEntityManager]: 'entityManager',
+    [tokens.ITurnManager]: 'turnManager',
+    [tokens.GamePersistenceService]: 'gamePersistenceService',
+    [tokens.PlaytimeTracker]: 'playtimeTracker',
+    [tokens.ISafeEventDispatcher]: 'safeEventDispatcher',
+    [tokens.IInitializationService]: 'initializationService',
+  };
+
+  const { mocks, mockContainer, cleanup } = buildTestEnvironment(
+    factoryMap,
+    tokenMap,
+    overrides
+  );
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -20,7 +20,7 @@ import {
   createMockWorldLoader, // ← NEW import
 } from '../mockFactories.js';
 import { createLoaderMocks } from './modsLoader.test-utils.js';
-import { createMockEnvironment } from '../mockEnvironment.js';
+import { buildTestEnvironment } from '../mockEnvironment.js';
 
 /**
  * List of loader types used when generating mock loaders.
@@ -44,7 +44,7 @@ const loaderTypes = [
  * @returns {object} Test environment utilities and mocks.
  */
 export function createTestEnvironment() {
-  const { mocks, cleanup } = createMockEnvironment({
+  const factoryMap = {
     mockRegistry: createStatefulMockDataRegistry,
     mockLogger: createMockLogger,
     mockSchemaLoader: createMockSchemaLoader,
@@ -57,7 +57,9 @@ export function createTestEnvironment() {
     mockModVersionValidator: createMockModVersionValidator,
     mockModLoadOrderResolver: createMockModLoadOrderResolver,
     mockWorldLoader: createMockWorldLoader,
-  });
+  };
+
+  const { mocks, cleanup } = buildTestEnvironment(factoryMap, {});
 
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -3,6 +3,7 @@
  */
 
 import { jest } from '@jest/globals';
+import { createMockContainer } from './mockFactories.js';
 
 /**
  * Creates mocks using the provided factory functions.
@@ -28,4 +29,38 @@ export function createMockEnvironment(factories) {
   };
 
   return { mocks, cleanup };
+}
+
+/**
+ * Builds a full test environment including a mock DI container.
+ *
+ * @description Creates mocks from the provided factory map and sets up a mock
+ *   DI container resolving tokens to those mocks. Overrides allow per-test
+ *   replacements similar to {@link createMockContainer}.
+ * @param {Record<string, () => any>} factoryMap - Map of mock factory
+ *   functions to create.
+ * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
+ *   Map of DI tokens to mock keys, provider callbacks, or constant values.
+ * @param {Record<string | symbol, any>} [overrides] - Optional per-test token
+ *   overrides for the container.
+ * @returns {{ mocks: Record<string, any>, mockContainer: { resolve: jest.Mock }, cleanup: () => void }}
+ *   Mocks, container and cleanup helper.
+ */
+export function buildTestEnvironment(factoryMap, tokenMap, overrides = {}) {
+  const { mocks, cleanup } = createMockEnvironment(factoryMap);
+
+  const mapping = {};
+  for (const [token, ref] of Object.entries(tokenMap)) {
+    if (typeof ref === 'string') {
+      mapping[token] = mocks[ref];
+    } else if (typeof ref === 'function') {
+      mapping[token] = ref(mocks);
+    } else {
+      mapping[token] = ref;
+    }
+  }
+
+  const mockContainer = createMockContainer(mapping, overrides);
+
+  return { mocks, mockContainer, cleanup };
 }


### PR DESCRIPTION
## Summary
- add `buildTestEnvironment` helper for DI container-based tests
- refactor `createTestEnvironment` for `GameEngine` to use helper
- refactor mods loader test setup to use helper

## Testing Done
- `npm run format`
- `npx eslint tests/common/mockEnvironment.js tests/common/engine/gameEngine.test-environment.js tests/common/loaders/modsLoader.test-setup.js`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68564b808984833190a103da63660bc2