### PR TITLE
[Agent] Add safeDispatch helper

### DIFF
--- a/src/utils/eventHelpers.js
+++ b/src/utils/eventHelpers.js
@@ -1,0 +1,31 @@
+// src/utils/eventHelpers.js
+
+/**
+ * @file Helper functions for dispatching events safely.
+ */
+
+/**
+ * @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher
+ */
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+/**
+ * Dispatches an event and logs if dispatch fails.
+ *
+ * @param {IValidatedEventDispatcher} bus - Dispatcher used to emit the event.
+ * @param {string} id - Event identifier.
+ * @param {object} payload - Event payload to dispatch.
+ * @param {ILogger} logger - Logger for error output.
+ * @returns {Promise<void>} Resolves when dispatch completes or failure is logged.
+ */
+export async function safeDispatch(bus, id, payload, logger) {
+  try {
+    await bus.dispatch(id, payload);
+  } catch (e) {
+    logger.error(`Dispatch ${id} failed: ${e.message}`, e);
+  }
+}
+
+// --- FILE END ---

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -301,7 +301,7 @@ describeTurnManagerSuite(
 
       // Assert
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-        'Failed to dispatch core:turn_started for actor1: Dispatcher failure',
+        'Dispatch core:turn_started failed: Dispatcher failure',
         dispatchError
       );
 

--- a/tests/unit/utils/eventHelpers.test.js
+++ b/tests/unit/utils/eventHelpers.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { safeDispatch } from '../../../src/utils/eventHelpers.js';
+
+describe('safeDispatch', () => {
+  test('logs error when dispatch rejects and does not throw', async () => {
+    const bus = { dispatch: jest.fn().mockRejectedValue(new Error('boom')) };
+    const logger = { error: jest.fn() };
+    await expect(
+      safeDispatch(bus, 'evt', { foo: 'bar' }, logger)
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `safeDispatch` helper for deduplicating try/catch event emission
- refactor `TurnManager` to use `safeDispatch`
- add unit test coverage for the helper
- update existing test expectations

## Testing Done
- `npm run format`
- `npm run lint` *(fails: hundreds of existing errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68564c46e16c8331bbba127c4ca2b84f