### PR TITLE
[Agent] expand mock helpers

### DIFF
--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -12,31 +12,10 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import { createMockEntity } from '../../common/mockFactories.js';
-
-// --- Mock Implementations (Reusing from previous files) ---
-
-class MockEntity {
-  constructor(id, components = []) {
-    this.id = id || `entity-${Math.random().toString(36).substr(2, 9)}`;
-    this.components = new Map(components.map((c) => [c, {}]));
-    this.hasComponent = jest.fn((componentId) =>
-      this.components.has(componentId)
-    );
-    this.getComponent = jest.fn((componentId) =>
-      this.components.get(componentId)
-    );
-  }
-}
-
-class MockTurnHandler {
-  constructor(actor) {
-    this.actor = actor;
-    this.startTurn = jest.fn(async (currentActor) => {});
-    this.destroy = jest.fn(async () => {});
-    this.signalNormalApparentTermination = jest.fn();
-  }
-}
+import {
+  createMockActor,
+  createMockTurnHandler,
+} from '../../common/mockFactories.js';
 
 // --- Test Suite ---
 
@@ -52,22 +31,14 @@ describeTurnManagerSuite(
       jest.useFakeTimers();
       testBed = getBed();
 
-      mockActor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
-      mockActor2 = createMockEntity('actor2', {
-        isActor: true,
-        isPlayer: false,
-      });
-      mockPlayerActor = createMockEntity('player1', {
-        isActor: true,
-        isPlayer: true,
-      });
+      mockActor1 = createMockActor('actor1');
+      mockActor2 = createMockActor('actor2');
+      mockPlayerActor = createMockActor('player1', { isPlayer: true });
 
-      // Configure handler resolver to return MockTurnHandler instances
+      // Configure handler resolver to return mock turn handlers
       testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
-        async (actor) => new MockTurnHandler(actor)
+        async (actor) =>
+          createMockTurnHandler({ actor, includeSignalTermination: true })
       );
 
       stopSpy = jest.spyOn(testBed.turnManager, 'stop');


### PR DESCRIPTION
## Summary
- extend `createMockTurnHandler` with failure modes and optional termination signaling
- add `createMockActor` with component mapping support
- use new mocks in TurnManager tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68564f420e288331b8918b463aac53ac