### PR TITLE
[Agent] standardize test bed cleanup

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -60,7 +60,17 @@ export class BaseTestBed {
   async cleanup() {
     jest.clearAllMocks();
     this.resetMocks();
+    await this._afterCleanup();
   }
+
+  /**
+   * Hook invoked at the end of {@link BaseTestBed#cleanup} for subclass-specific
+   * teardown logic.
+   *
+   * @protected
+   * @returns {Promise<void>} Promise resolving when subclass cleanup is complete.
+   */
+  async _afterCleanup() {}
 }
 
 export default BaseTestBed;

--- a/tests/common/containerTestBed.js
+++ b/tests/common/containerTestBed.js
@@ -56,8 +56,18 @@ export class ContainerTestBed extends BaseTestBed {
    */
   async cleanup() {
     await super.cleanup();
+  }
+
+  /**
+   * Restores the container state and clears overrides after base cleanup.
+   *
+   * @protected
+   * @returns {Promise<void>} Promise resolving when container cleanup is complete.
+   */
+  async _afterCleanup() {
     this.container.resolve.mockImplementation(this.#originalResolve);
     this.#tokenOverrides.clear();
+    await super._afterCleanup();
   }
 }
 

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -99,8 +99,18 @@ export class GameEngineTestBed extends ContainerTestBed {
    */
   async cleanup() {
     await super.cleanup();
+  }
+
+  /**
+   * Stops the engine and cleans up the mock environment after base cleanup.
+   *
+   * @protected
+   * @returns {Promise<void>} Promise resolving when engine cleanup is complete.
+   */
+  async _afterCleanup() {
     await this.stop();
     this.env.cleanup();
+    await super._afterCleanup();
   }
 }
 

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -168,7 +168,15 @@ export class TestBed extends BaseTestBed {
    */
   async cleanup() {
     await super.cleanup();
+  }
 
+  /**
+   * Clears mock implementations and resets entity manager state after base cleanup.
+   *
+   * @protected
+   * @returns {Promise<void>} Promise resolving when entity cleanup is complete.
+   */
+  async _afterCleanup() {
     // Reset specific mock implementations that tests commonly override
     this.mocks.registry.getEntityDefinition.mockReset();
     this.mocks.validator.validate.mockReset();
@@ -181,6 +189,7 @@ export class TestBed extends BaseTestBed {
     ) {
       this.entityManager.clearAll();
     }
+    await super._afterCleanup();
   }
 
   /**

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -95,9 +95,19 @@ export class TurnManagerTestBed extends BaseTestBed {
    */
   async cleanup() {
     await super.cleanup();
+  }
+
+  /**
+   * Stops the TurnManager after base cleanup.
+   *
+   * @protected
+   * @returns {Promise<void>} Promise resolving when manager cleanup is complete.
+   */
+  async _afterCleanup() {
     if (this.turnManager && typeof this.turnManager.stop === 'function') {
       await this.turnManager.stop();
     }
+    await super._afterCleanup();
   }
 }
 


### PR DESCRIPTION
## Summary
- add `_afterCleanup` hook in `BaseTestBed`
- update derived test beds to implement `_afterCleanup`
- call `super.cleanup()` for common teardown

## Testing Done
- `npm run lint` *(fails: 2740 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(fails: No matching export in modLoadOrderResolver)*


------
https://chatgpt.com/codex/tasks/task_e_68564fb1db348331af613d395cf1bcad