### PR TITLE
[Agent] Improve world loader test coverage

### DIFF
--- a/tests/unit/loaders/worldLoader.test.js
+++ b/tests/unit/loaders/worldLoader.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import WorldLoader from '../../../src/loaders/worldLoader.js';
+
+const createMockConfiguration = () => ({
+  getContentTypeSchemaId: jest.fn(() => 'worldSchema'),
+});
+
+const createMockPathResolver = () => ({
+  resolveModContentPath: jest.fn(
+    (modId, dir, filename) => `/mods/${modId}/${dir}/${filename}`
+  ),
+});
+
+const createMockDataFetcher = () => ({
+  fetch: jest.fn().mockResolvedValue({ instances: [] }),
+});
+
+const createMockSchemaValidator = () => ({
+  isSchemaLoaded: jest.fn().mockReturnValue(true),
+  validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
+});
+
+const createMockDataRegistry = () => ({
+  store: jest.fn(),
+});
+
+const createMockLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('WorldLoader.loadWorlds', () => {
+  let config;
+  let resolver;
+  let fetcher;
+  let validator;
+  let registry;
+  let logger;
+  let loader;
+
+  beforeEach(() => {
+    config = createMockConfiguration();
+    resolver = createMockPathResolver();
+    fetcher = createMockDataFetcher();
+    validator = createMockSchemaValidator();
+    registry = createMockDataRegistry();
+    logger = createMockLogger();
+    loader = new WorldLoader(
+      config,
+      resolver,
+      fetcher,
+      validator,
+      registry,
+      logger
+    );
+    jest.clearAllMocks();
+  });
+
+  it('logs error and returns early when schema id missing', async () => {
+    config.getContentTypeSchemaId.mockReturnValue(null);
+    const counts = {};
+    await loader.loadWorlds(['modA'], new Map(), counts);
+    expect(logger.error).toHaveBeenCalledWith(
+      "WorldLoader: Schema ID for content type 'world' not found in configuration. Cannot process world files."
+    );
+    expect(registry.store).not.toHaveBeenCalled();
+    expect(counts.worlds).toBeUndefined();
+  });
+
+  it('warns when manifest missing', async () => {
+    const counts = {};
+    await loader.loadWorlds(['modA'], new Map(), counts);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'WorldLoader [modA]: Manifest not found. Skipping world file search.'
+    );
+    expect(registry.store).toHaveBeenCalledWith('worlds', 'main', []);
+    expect(counts.worlds).toEqual({
+      count: 0,
+      overrides: 0,
+      errors: 0,
+      instances: 0,
+    });
+  });
+
+  it('skips when manifest has no world files', async () => {
+    const manifests = new Map([['moda', { content: { worlds: [] } }]]);
+    const counts = {};
+    await loader.loadWorlds(['modA'], manifests, counts);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'WorldLoader [modA]: No world files listed in manifest. Skipping.'
+    );
+    expect(registry.store).toHaveBeenCalledWith('worlds', 'main', []);
+    expect(counts.worlds).toEqual({
+      count: 0,
+      overrides: 0,
+      errors: 0,
+      instances: 0,
+    });
+  });
+
+  it('aggregates instances from world files', async () => {
+    const manifests = new Map([
+      ['moda', { content: { worlds: ['world1.json'] } }],
+    ]);
+    fetcher.fetch.mockResolvedValue({ instances: [{ id: 1 }, { id: 2 }] });
+    const counts = {};
+    await loader.loadWorlds(['modA'], manifests, counts);
+    expect(resolver.resolveModContentPath).toHaveBeenCalledWith(
+      'modA',
+      'worlds',
+      'world1.json'
+    );
+    expect(fetcher.fetch).toHaveBeenCalledWith('/mods/modA/worlds/world1.json');
+    expect(registry.store).toHaveBeenCalledWith('worlds', 'main', [
+      { id: 1 },
+      { id: 2 },
+    ]);
+    expect(counts.worlds).toEqual({
+      count: 1,
+      overrides: 0,
+      errors: 0,
+      instances: 2,
+    });
+  });
+
+  it('records failures when fetch throws', async () => {
+    const manifests = new Map([
+      ['moda', { content: { worlds: ['bad.json'] } }],
+    ]);
+    resolver.resolveModContentPath.mockReturnValue(
+      '/mods/modA/worlds/bad.json'
+    );
+    fetcher.fetch.mockRejectedValue(new Error('fail'));
+    const counts = {};
+    await loader.loadWorlds(['modA'], manifests, counts);
+    expect(logger.error).toHaveBeenCalledWith(
+      "WorldLoader [modA]: Failed to process world file 'bad.json'. Path: '/mods/modA/worlds/bad.json'",
+      expect.objectContaining({ error: 'fail' })
+    );
+    expect(registry.store).toHaveBeenCalledWith('worlds', 'main', []);
+    expect(counts.worlds).toEqual({
+      count: 0,
+      overrides: 0,
+      errors: 1,
+      instances: 0,
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added a comprehensive test suite for `WorldLoader` covering normal execution, missing schema IDs, absent manifests, missing world files, and fetch failures.

Changes Made:
- Created `tests/unit/loaders/worldLoader.test.js` with five detailed tests ensuring branches in `src/loaders/worldLoader.js` are exercised.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_6856531e20ac83318fcbb9457fec3f2f