### PR TITLE
[Agent] enhance TurnManagerTestBed

### DIFF
--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -12,6 +12,16 @@ jest.mock('../../../../src/turns/turnManager.js');
 describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
   let testBed;
 
+  class FakeManager {
+    constructor() {
+      this.start = jest.fn(async () => {
+        await this.advanceTurn();
+      });
+      this.stop = jest.fn();
+      this.advanceTurn = jest.fn();
+    }
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     testBed = new TurnManagerTestBed();
@@ -54,5 +64,43 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
     expect(testBed.logger.debug).toHaveBeenCalledTimes(0);
+  });
+
+  it('startWithEntities starts manager and clears logs', async () => {
+    const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
+    const e1 = { id: 'a' };
+    bed.logger.info('pre');
+    await bed.startWithEntities(e1);
+    expect(bed.turnManager.start).toHaveBeenCalledTimes(1);
+    expect(bed.entityManager.activeEntities.get('a')).toBe(e1);
+    expect(bed.logger.info).toHaveBeenCalledTimes(0);
+    await bed.cleanup();
+  });
+
+  it('startRunning sets running without advancing', async () => {
+    const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
+    await bed.startRunning();
+    expect(bed.turnManager.start).toHaveBeenCalledTimes(1);
+    expect(bed.turnManager.advanceTurn).not.toHaveBeenCalled();
+    await bed.cleanup();
+  });
+
+  it('captureHandler retrieves subscribed callback', () => {
+    const cb = jest.fn();
+    testBed.dispatcher.subscribe('evt', cb);
+    expect(testBed.captureHandler('evt')).toBe(cb);
+  });
+
+  it('advanceAndFlush runs timers after advancing', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false });
+    const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
+    bed.turnManager.advanceTurn.mockResolvedValue();
+    const fn = jest.fn();
+    setTimeout(fn, 50);
+    await bed.advanceAndFlush();
+    expect(bed.turnManager.advanceTurn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalled();
+    jest.useRealTimers();
+    await bed.cleanup();
   });
 });

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -7,10 +7,6 @@ import {
   TurnManagerTestBed,
 } from '../../common/turns/turnManagerTestBed.js';
 import {
-  ACTOR_COMPONENT_ID,
-  PLAYER_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
-import {
   SYSTEM_ERROR_OCCURRED_ID,
   TURN_PROCESSING_STARTED,
 } from '../../../src/constants/eventIds.js';
@@ -23,7 +19,6 @@ describeTurnManagerSuite(
   (getBed) => {
     let testBed;
     let stopSpy;
-    let initialAdvanceTurnSpy;
 
     beforeEach(async () => {
       // Made beforeEach async
@@ -57,28 +52,10 @@ describeTurnManagerSuite(
           testBed.mocks.logger.debug('Mocked instance.stop() called.');
         });
 
-      // --- Set instance to running state (simulating start()) ---
-      initialAdvanceTurnSpy = jest
-        .spyOn(testBed.turnManager, 'advanceTurn')
-        .mockImplementationOnce(async () => {
-          // Prevent advanceTurn logic during start()
-          testBed.mocks.logger.debug(
-            'advanceTurn call during start() suppressed by mock.'
-          );
-        });
-      await testBed.turnManager.start(); // Sets #isRunning = true and subscribes
-      initialAdvanceTurnSpy.mockRestore(); // Restore advanceTurn for actual testing
+      // Start manager without running advanceTurn
+      await testBed.startRunning();
 
-      // Clear mocks called during start() phase
-      testBed.mocks.logger.info.mockClear(); // Clear "Turn Manager started." log
-      testBed.mocks.logger.debug.mockClear(); // Clear suppressed advanceTurn log
-      testBed.mocks.dispatcher.dispatch.mockClear();
-      testBed.mocks.dispatcher.subscribe.mockClear(); // Clear the subscribe call from start()
-      testBed.mocks.turnOrderService.isEmpty.mockClear(); // Clear mocks before actual test calls
-      testBed.mocks.turnOrderService.getNextEntity.mockClear();
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
-
-      // Re-apply default isEmpty mock for the actual tests focusing on queue NOT empty
+      // Re-apply default isEmpty mock after resetting call history
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
     });
 


### PR DESCRIPTION
Summary: Added utility helpers to TurnManagerTestBed including `startWithEntities`, `startRunning`, `captureHandler`, and `advanceAndFlush`. Updated queue-not-empty tests to use the new `startRunning` helper and expanded the TurnManagerTestBed unit suite with coverage for the new helpers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856546edee88331a160ffd0db5dffee