### PR TITLE
[Agent] Add tests for entity name fallback utility

### DIFF
--- a/tests/unit/utils/entityNameFallbackUtils.test.js
+++ b/tests/unit/utils/entityNameFallbackUtils.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { resolveEntityNameFallback } from '../../../src/utils/entityNameFallbackUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
+
+jest.mock('../../../src/utils/entityUtils.js', () => ({
+  getEntityDisplayName: jest.fn(),
+}));
+
+const logger = { debug: jest.fn() };
+
+describe('resolveEntityNameFallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when resolutionRoot is missing', () => {
+    expect(resolveEntityNameFallback('actor.name', null)).toBeUndefined();
+    expect(resolveEntityNameFallback('actor.name', undefined)).toBeUndefined();
+    expect(getEntityDisplayName).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for unknown placeholder path', () => {
+    const root = {};
+    expect(resolveEntityNameFallback('foo.name', root)).toBeUndefined();
+    expect(getEntityDisplayName).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when referenced entity is missing', () => {
+    const root = { actor: null };
+    expect(resolveEntityNameFallback('actor.name', root)).toBeUndefined();
+    expect(getEntityDisplayName).not.toHaveBeenCalled();
+  });
+
+  it('passes entity through when it already has getComponentData', () => {
+    const entity = { id: 'id1', getComponentData: jest.fn() };
+    getEntityDisplayName.mockReturnValue('Hero');
+    const result = resolveEntityNameFallback(
+      'target.name',
+      { target: entity },
+      logger
+    );
+    expect(result).toBe('Hero');
+    expect(getEntityDisplayName).toHaveBeenCalledWith(
+      entity,
+      undefined,
+      logger
+    );
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('adapts entity lacking getComponentData', () => {
+    const entity = { id: 'id2', components: { foo: { bar: 'baz' } } };
+    getEntityDisplayName.mockReturnValue('Adapted');
+    const result = resolveEntityNameFallback(
+      'actor.name',
+      { actor: entity },
+      logger
+    );
+    expect(result).toBe('Adapted');
+    expect(getEntityDisplayName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'id2',
+        components: entity.components,
+        getComponentData: expect.any(Function),
+      }),
+      undefined,
+      logger
+    );
+    // ensure adapter not using same reference when missing method
+    expect(getEntityDisplayName.mock.calls[0][0]).not.toBe(entity);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('returns undefined when name cannot be resolved', () => {
+    const entity = { id: 'id3', getComponentData: jest.fn() };
+    getEntityDisplayName.mockReturnValue(undefined);
+    const result = resolveEntityNameFallback(
+      'actor.name',
+      { actor: entity },
+      logger
+    );
+    expect(result).toBeUndefined();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Add dedicated tests for `resolveEntityNameFallback` to ensure placeholder name resolution works as expected.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685659d33a4c8331befecfeafe4ef634