### PR TITLE
[Test] centralize TurnManager actor helpers

### DIFF
--- a/tests/common/turns/testActors.js
+++ b/tests/common/turns/testActors.js
@@ -1,0 +1,42 @@
+/**
+ * @file Helper functions for creating common actor test data.
+ * @see tests/common/turns/testActors.js
+ */
+
+import { createMockActor } from '../mockFactories.js';
+
+/**
+ * Creates a mock AI actor entity.
+ *
+ * @param {string} id - Actor identifier.
+ * @param {object} [options] - Additional creation options.
+ * @returns {ReturnType<typeof createMockActor>} Mock AI actor.
+ */
+export function createAiActor(id, options = {}) {
+  return createMockActor(id, { ...options, isPlayer: false });
+}
+
+/**
+ * Creates a mock player actor entity.
+ *
+ * @param {string} [id] - Player identifier.
+ * @param {object} [options] - Additional creation options.
+ * @returns {ReturnType<typeof createMockActor>} Mock player actor.
+ */
+export function createPlayerActor(id = 'player1', options = {}) {
+  return createMockActor(id, { ...options, isPlayer: true });
+}
+
+/**
+ * Returns a simple set of default actors frequently used in TurnManager tests.
+ *
+ * @returns {{ ai1: ReturnType<typeof createAiActor>, ai2: ReturnType<typeof createAiActor>, player: ReturnType<typeof createPlayerActor> }}
+ *   Object containing two AI actors and one player actor.
+ */
+export function createDefaultActors() {
+  return {
+    ai1: createAiActor('actor1'),
+    ai2: createAiActor('actor2'),
+    player: createPlayerActor('player1'),
+  };
+}

--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -15,10 +15,8 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import {
-  createMockActor,
-  createMockTurnHandler,
-} from '../../common/mockFactories.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
+import { createAiActor } from '../../common/turns/testActors.js';
 
 // --- Mock Implementations ---
 
@@ -37,9 +35,9 @@ describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
     testBed = getBed();
 
     // Setup actors and add to the specific entityManager instance used by TurnManager
-    mockActor1 = createMockActor('actor1');
-    mockActor2 = createMockActor('actor2');
-    mockActor3 = createMockActor('actor3');
+    mockActor1 = createAiActor('actor1');
+    mockActor2 = createAiActor('actor2');
+    mockActor3 = createAiActor('actor3');
     testBed.setActiveEntities(mockActor1, mockActor2, mockActor3);
 
     // Default Mocks setup - configure specifically within each test if needed

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -12,10 +12,8 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import {
-  createMockActor,
-  createMockTurnHandler,
-} from '../../common/mockFactories.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
+import { createAiActor } from '../../common/turns/testActors.js';
 
 // --- Test Setup Helpers ---
 // --- Test Suite ---
@@ -191,7 +189,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
       advanceTurnSpy.mockRestore();
 
       // Set up the turn order service to return an entity
-      const mockActor = createMockActor('actor1', {
+      const mockActor = createAiActor('actor1', {
         components: [ACTOR_COMPONENT_ID],
       });
       testBed.setActiveEntities(mockActor);

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -12,10 +12,11 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
 import {
-  createMockActor,
-  createMockTurnHandler,
-} from '../../common/mockFactories.js';
+  createAiActor,
+  createPlayerActor,
+} from '../../common/turns/testActors.js';
 
 // --- Test Suite ---
 
@@ -31,9 +32,9 @@ describeTurnManagerSuite(
       jest.useFakeTimers();
       testBed = getBed();
 
-      mockActor1 = createMockActor('actor1');
-      mockActor2 = createMockActor('actor2');
-      mockPlayerActor = createMockActor('player1', { isPlayer: true });
+      mockActor1 = createAiActor('actor1');
+      mockActor2 = createAiActor('actor2');
+      mockPlayerActor = createPlayerActor('player1');
 
       // Configure handler resolver to return mock turn handlers
       testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(


### PR DESCRIPTION
Summary: Adds reusable actor factory in tests and updates TurnManager suites to use it for reduced duplication.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint run (`npm run lint` - fails as expected)
- [x] Root tests pass (`npm run test`)
- [x] Proxy tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68565a6dcf508331b6864d491fda6d0e