### PR TITLE
[Agent] add tests for buildModalElementsConfig

### DIFF
--- a/tests/unit/domUI/helpers/buildModalElementsConfig.test.js
+++ b/tests/unit/domUI/helpers/buildModalElementsConfig.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildModalElementsConfig } from '../../../../src/domUI/helpers/buildModalElementsConfig.js';
+
+describe('buildModalElementsConfig', () => {
+  it('transforms selectors map into config objects', () => {
+    const result = buildModalElementsConfig({
+      container: '#container',
+      button: ['.btn', HTMLButtonElement],
+      list: ['ul'],
+      skip: null,
+    });
+
+    expect(result).toEqual({
+      container: { selector: '#container', required: true },
+      button: {
+        selector: '.btn',
+        required: true,
+        expectedType: HTMLButtonElement,
+      },
+      list: { selector: 'ul', required: true },
+    });
+  });
+
+  it('omits entries with falsy values', () => {
+    const result = buildModalElementsConfig({ a: '#a', b: undefined, c: '' });
+    expect(result).toEqual({ a: { selector: '#a', required: true } });
+  });
+});


### PR DESCRIPTION
Summary: Added new unit tests covering domUI helper buildModalElementsConfig.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (warnings expected)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68565c5537348331b0f3d762e7727bcb