### PR TITLE
[Agent] centralize engine test typedefs

### DIFF
--- a/tests/common/engine/engineTestTypedefs.js
+++ b/tests/common/engine/engineTestTypedefs.js
@@ -1,0 +1,26 @@
+/**
+ * @file Shared JSDoc typedefs for GameEngine related unit tests.
+ * Importing this file provides type information only.
+ * @see tests/common/engine/engineTestTypedefs.js
+ */
+
+ 
+/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
+ 
+/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
+ 
+/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+ 
+/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
+ 
+/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
+ 
+/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
+ 
+/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+ 
+/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
+ 
+/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
+
+export {};

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -1,42 +1,16 @@
 // tests/engine/gameEngine.test.js
 
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import {
-  expectDispatchSequence,
-  buildSaveDispatches,
-  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
-  expectEngineStatus,
-} from '../../common/engine/dispatchTestUtils.js';
-import {
-  // --- Import new UI Event IDs ---
-  ENGINE_INITIALIZING_UI,
-  ENGINE_READY_UI,
-  ENGINE_OPERATION_FAILED_UI,
-  ENGINE_STOPPED_UI,
-  REQUEST_SHOW_SAVE_GAME_UI,
-  REQUEST_SHOW_LOAD_GAME_UI,
-  CANNOT_SAVE_GAME_INFO,
-} from '../../../src/constants/eventIds.js';
-
-// --- JSDoc Type Imports for Mocks ---
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
+import '../../common/engine/engineTestTypedefs.js';
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   describe('Constructor', () => {
     it('should instantiate and resolve all core services successfully', () => {
       const testBed = getBed();
-      const gameEngine = new GameEngine({
+      new GameEngine({
         container: testBed.env.mockContainer,
       }); // Instantiation for this test
       expect(testBed.env.mockContainer.resolve).toHaveBeenCalledWith(

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -5,18 +5,9 @@ import {
   createGameEngineTestBed,
   describeGameEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import '../../common/engine/engineTestTypedefs.js';
 import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -1,21 +1,12 @@
 // tests/engine/showLoadGameUI.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
   describeGameEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import '../../common/engine/engineTestTypedefs.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -1,24 +1,15 @@
 // tests/engine/showSaveGameUI.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
   describeGameEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import '../../common/engine/engineTestTypedefs.js';
 import {
   REQUEST_SHOW_SAVE_GAME_UI,
   CANNOT_SAVE_GAME_INFO,
 } from '../../../src/constants/eventIds.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -1,27 +1,15 @@
 // tests/engine/startNewGame.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import {
-  expectDispatchSequence,
-  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
-} from '../../common/engine/dispatchTestUtils.js';
+import '../../common/engine/engineTestTypedefs.js';
+
 import {
   ENGINE_INITIALIZING_UI,
   ENGINE_READY_UI,
   ENGINE_OPERATION_FAILED_UI,
   ENGINE_STOPPED_UI,
 } from '../../../src/constants/eventIds.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -1,21 +1,12 @@
 // tests/engine/stop.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
   describeGameEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -1,25 +1,16 @@
 // tests/engine/triggerManualSave.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
   describeGameEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import '../../common/engine/engineTestTypedefs.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
 } from '../../common/engine/dispatchTestUtils.js';
-
-/** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../src/dependencyInjection/appContainer.js').default} AppContainer */
-/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
-/** @typedef {import('../../../src/turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager */
-/** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
-/** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../../src/interfaces/IInitializationService.js').IInitializationService} IInitializationService */
-/** @typedef {import('../../../src/interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 describeGameEngineSuite('GameEngine', (getBed) => {
   let testBed;


### PR DESCRIPTION
## Summary
- consolidate shared typedefs into `engineTestTypedefs.js`
- include helper in each engine unit test
- clean up unused imports in affected tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2720 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68565ba5d2cc8331933fd6b1b64fc4f9