### PR TITLE
[Agent] Add AI prompt pipeline describe suite helper

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -2,6 +2,8 @@
  * @file Provides a minimal test bed for creating AIPromptPipeline instances with mocked dependencies.
  * @see tests/common/prompting/promptPipelineTestBed.js
  */
+/* eslint-env jest */
+/* global beforeEach */
 
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
@@ -13,6 +15,7 @@ import {
   createMockEntity,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
+import { describeSuite } from '../describeSuite.js';
 
 /**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
@@ -120,5 +123,24 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
     this.mocks.promptBuilder.build.mockResolvedValue(finalPrompt);
   }
 }
+
+/**
+ * Defines a test suite with automatic {@link AIPromptPipelineTestBed} setup.
+ *
+ * @param {string} title - Suite title passed to `describe`.
+ * @param {(getBed: () => AIPromptPipelineTestBed) => void} suiteFn - Callback
+ *   containing the tests. Receives a getter for the active test bed.
+ * @returns {void}
+ */
+function describeAIPromptPipelineSuite(title, suiteFn) {
+  describeSuite(title, AIPromptPipelineTestBed, (getBed) => {
+    beforeEach(() => {
+      getBed().setupMockSuccess();
+    });
+    suiteFn(getBed);
+  });
+}
+
+export { describeAIPromptPipelineSuite };
 
 export default AIPromptPipelineTestBed;


### PR DESCRIPTION
## Summary
- create `describeAIPromptPipelineSuite` helper for AI prompt pipeline tests
- set up Jest environment comments
- export helper from `promptPipelineTestBed`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2738 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68565b96c26c8331b0630b19a0c25495