### PR TITLE
[Agent] add event handler capture helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -117,6 +117,31 @@ export class TurnManagerTestBed extends BaseTestBed {
   }
 
   /**
+   * Sets up the dispatcher to capture subscriptions for the specified event.
+   *
+   * @param {string} eventId - Event identifier to capture.
+   * @returns {{ unsubscribe: jest.Mock, handler: (() => void)|null }} Captured
+   *   unsubscribe mock and subscribed handler once registration occurs.
+   */
+  captureSubscription(eventId) {
+    let captured = null;
+    const unsubscribe = jest.fn();
+    this.dispatcher.subscribe.mockImplementation((id, handler) => {
+      if (id === eventId) {
+        captured = handler;
+      }
+      return unsubscribe;
+    });
+
+    return {
+      get handler() {
+        return captured;
+      },
+      unsubscribe,
+    };
+  }
+
+  /**
    * Triggers an event on the internal dispatcher.
    *
    * @param {string} eventType - Event name.

--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -91,6 +91,14 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
     expect(testBed.captureHandler('evt')).toBe(cb);
   });
 
+  it('captureSubscription captures handler and returns unsubscribe', () => {
+    const capture = testBed.captureSubscription('evt');
+    const cb = jest.fn();
+    const result = testBed.dispatcher.subscribe('evt', cb);
+    expect(capture.handler).toBe(cb);
+    expect(result).toBe(capture.unsubscribe);
+  });
+
   it('advanceAndFlush runs timers after advancing', async () => {
     jest.useFakeTimers({ legacyFakeTimers: false });
     const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });


### PR DESCRIPTION
## Summary
- add `captureSubscription` helper to `TurnManagerTestBed`
- ensure new helper works with a unit test
- simplify actor identification tests using the new helper

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68565ce3ff7c83319360e4bd95353baa