### PR TITLE
[Agent] remove redundant cleanup overrides

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -93,15 +93,6 @@ export class GameEngineTestBed extends ContainerTestBed {
   }
 
   /**
-   * Stops the engine and cleans up the environment.
-   *
-   * @returns {Promise<void>} Promise resolving when cleanup is complete.
-   */
-  async cleanup() {
-    await super.cleanup();
-  }
-
-  /**
    * Stops the engine and cleans up the mock environment after base cleanup.
    *
    * @protected

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -163,14 +163,6 @@ export class TestBed extends BaseTestBed {
   }
 
   /**
-   * Clears all mocks and the entity manager's internal state.
-   * This should be called in an `afterEach` block to ensure test isolation.
-   */
-  async cleanup() {
-    await super.cleanup();
-  }
-
-  /**
    * Clears mock implementations and resets entity manager state after base cleanup.
    *
    * @protected

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -91,13 +91,6 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
   }
 
   /**
-   * Clears all jest mocks used by this test bed.
-   */
-  async cleanup() {
-    await super.cleanup();
-  }
-
-  /**
    * Sets up mock resolved values for a successful pipeline run.
    *
    * @param {object} [options] - Configuration options.

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -138,15 +138,6 @@ export class TurnManagerTestBed extends BaseTestBed {
   }
 
   /**
-   * Clears all mocks and stops the TurnManager.
-   *
-   * @returns {Promise<void>}
-   */
-  async cleanup() {
-    await super.cleanup();
-  }
-
-  /**
    * Stops the TurnManager after base cleanup.
    *
    * @protected


### PR DESCRIPTION
Summary: Removed unused `cleanup()` overrides from test bed classes so they now rely on inherited cleanup logic.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint tests/common/engine/gameEngineTestBed.js tests/common/entities/testBed.js tests/common/prompting/promptPipelineTestBed.js tests/common/turns/turnManagerTestBed.js --fix`
- [x] Root tests `npm run test`
- [ ] Proxy tests
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68565e2623c88331bb337636a09e3f9b