### PR TITLE
[Agent] refactor turn manager test suite helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -3,7 +3,6 @@
  * @see tests/common/turns/turnManagerTestBed.js
  */
 /* eslint-env jest */
-/* global describe, beforeEach, afterEach */
 
 import { jest } from '@jest/globals';
 import TurnManager from '../../../src/turns/turnManager.js';
@@ -13,6 +12,7 @@ import {
   createMockValidatedEventBus,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
+import { describeSuite } from '../describeSuite.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -191,16 +191,7 @@ export const flushPromisesAndTimers = async () => {
  * @returns {void}
  */
 export function describeTurnManagerSuite(title, suiteFn, overrides = {}) {
-  describe(title, () => {
-    let testBed;
-    beforeEach(() => {
-      testBed = new TurnManagerTestBed(overrides);
-    });
-    afterEach(async () => {
-      await testBed.cleanup();
-    });
-    suiteFn(() => testBed);
-  });
+  describeSuite(title, TurnManagerTestBed, suiteFn, overrides);
 }
 
 export default TurnManagerTestBed;


### PR DESCRIPTION
Summary: Simplified the TurnManager test suite helper by delegating setup and teardown to `describeSuite`. This removes redundant describe/beforeEach/afterEach logic.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails on unrelated files; targeted file linted with `npx eslint`)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68565e2ae5f483319bc11ce1e66f3ff8