### PR TITLE
[Agent] Refactor AIPromptPipeline tests to use helper suite

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,21 +1,17 @@
 /* eslint-env node */
-import { describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+import { beforeEach, test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
-import { AIPromptPipelineTestBed } from '../../common/prompting/promptPipelineTestBed.js';
+import {
+  describeAIPromptPipelineSuite,
+  AIPromptPipelineTestBed,
+} from '../../common/prompting/promptPipelineTestBed.js';
 
-describe('AIPromptPipeline', () => {
+describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   /** @type {AIPromptPipelineTestBed} */
   let testBed;
 
   beforeEach(() => {
-    testBed = new AIPromptPipelineTestBed();
-
-    // Default success paths
-    testBed.setupMockSuccess();
-  });
-
-  afterEach(async () => {
-    await testBed.cleanup();
+    testBed = getBed();
   });
 
   describe('constructor validation', () => {


### PR DESCRIPTION
## Summary
- refactor `AIPromptPipeline.test.js` to use `describeAIPromptPipelineSuite`
- remove manual test bed setup and cleanup

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685661355bf48331b62dd598dbe3a324