### PR TITLE
[Agent] normalize timer handling in TurnManager tests

### DIFF
--- a/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -11,6 +11,7 @@ import {
   expect,
   jest,
 } from '@jest/globals';
+import { flushPromisesAndTimers } from '../../../common/turns/turnManagerTestBed.js';
 
 // Use fake timers to control setTimeout/clearTimeout and advance time manually.
 jest.useFakeTimers();
@@ -229,7 +230,7 @@ describe('AwaitingExternalTurnEndState', () => {
         // Act
         await state.enterState(mockHandler, null);
         // Manually trigger timeout to check the actionId in the generated error message.
-        jest.runAllTimers();
+        await flushPromisesAndTimers();
 
         // Assert
         expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
@@ -326,25 +327,25 @@ describe('AwaitingExternalTurnEndState', () => {
       await state.enterState(mockHandler, null);
     });
 
-    test('should do nothing if timeout fires after state has been cleaned up', () => {
+    test('should do nothing if timeout fires after state has been cleaned up', async () => {
       // Arrange
       // Simulate cleanup (e.g., a turn_ended event was received first).
       mockTurnContext.isAwaitingExternalEvent.mockReturnValue(false);
 
       // Act
-      jest.runAllTimers();
+      await flushPromisesAndTimers();
 
       // Assert
       expect(mockEventDispatcher.dispatch).not.toHaveBeenCalled();
       expect(mockTurnContext.endTurn).not.toHaveBeenCalled();
     });
 
-    test('should dispatch an error and end the turn when timeout fires', () => {
+    test('should dispatch an error and end the turn when timeout fires', async () => {
       // Arrange
       expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
 
       // Act
-      jest.runAllTimers();
+      await flushPromisesAndTimers();
 
       // Assert
       // 1. A display error event is dispatched.
@@ -370,7 +371,7 @@ describe('AwaitingExternalTurnEndState', () => {
       expect(endTurnError.message).toContain('timed out after 3000 ms');
     });
 
-    test('should recover if endTurn throws an error during timeout handling', () => {
+    test('should recover if endTurn throws an error during timeout handling', async () => {
       // Arrange
       const endTurnFailure = new Error('Failed to end turn');
       mockTurnContext.endTurn.mockImplementation(() => {
@@ -378,7 +379,7 @@ describe('AwaitingExternalTurnEndState', () => {
       });
 
       // Act
-      jest.runAllTimers();
+      await flushPromisesAndTimers();
 
       // Assert
       // It still attempts to end the turn.

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -2,7 +2,10 @@
 // --- FILE START (Corrected) ---
 
 import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
-import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
+import {
+  describeTurnManagerSuite,
+  flushPromisesAndTimers,
+} from '../../common/turns/turnManagerTestBed.js';
 
 import { TURN_ENDED_ID } from '../../../src/constants/eventIds.js';
 import { createMockEntity } from '../../common/mockFactories.js';
@@ -117,7 +120,7 @@ describeTurnManagerSuite(
         payload: { entityId: playerActor.id, success: true },
       });
 
-      await jest.runAllTimersAsync();
+      await flushPromisesAndTimers();
       expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 
       jest.useRealTimers();
@@ -171,7 +174,7 @@ describeTurnManagerSuite(
         payload: { entityId: aiActor.id, success: true },
       });
 
-      await jest.runAllTimersAsync();
+      await flushPromisesAndTimers();
       expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 
       jest.useRealTimers();

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -1,7 +1,10 @@
 // src/tests/turns/turnManager.roundLifecycle.test.js
 // --- FILE START ---
 
-import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
+import {
+  describeTurnManagerSuite,
+  flushPromisesAndTimers,
+} from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
@@ -66,8 +69,7 @@ describeTurnManagerSuite(
       );
 
       await testBed.turnManager.start();
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.mocks.entityManager.activeEntities.size).toBe(2);
       expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
@@ -96,8 +98,7 @@ describeTurnManagerSuite(
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
 
       await testBed.turnManager.start();
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
         'Cannot start a new round: No active entities with an Actor component found.'
@@ -158,8 +159,7 @@ describeTurnManagerSuite(
         .mockResolvedValueOnce(null); // No more actors
 
       await testBed.turnManager.start();
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.turnManager.getCurrentActor()).toBe(mockActor1);
 
@@ -168,8 +168,7 @@ describeTurnManagerSuite(
         entityId: mockActor1.id,
         success: true,
       });
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
         expect.arrayContaining([mockActor1, mockActor2]),
@@ -190,8 +189,7 @@ describeTurnManagerSuite(
       );
 
       await testBed.turnManager.start();
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
         'CRITICAL Error during turn advancement logic (before handler initiation): Turn advancement failed',
@@ -220,8 +218,7 @@ describeTurnManagerSuite(
       );
 
       await testBed.turnManager.start();
-      jest.runAllTimers();
-      await Promise.resolve();
+      await flushPromisesAndTimers();
 
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
         'CRITICAL Error during turn advancement logic (before handler initiation): Round start failed',


### PR DESCRIPTION
## Summary
- import `flushPromisesAndTimers` helper in TurnManager-related test suites
- use `flushPromisesAndTimers` instead of manual timer flushing in `turnManager.advanceTurn.actorIdentification` tests
- normalize timer flushing in `turnManager.roundLifecycle` tests
- update `AwaitingExternalTurnEndState` comprehensive tests to use the helper

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68566186892c8331b2140d3023902f3c