### PR TITLE
[Agent] simplify engine test setup

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -142,4 +142,39 @@ export function describeGameEngineSuite(title, suiteFn, overrides = {}) {
   );
 }
 
+/**
+ * Defines an engine-focused test suite providing `bed` and `engine` variables
+ * automatically via `beforeEach`.
+ *
+ * @param {string} title - Suite title passed to `describe`.
+ * @param {(context: { bed: GameEngineTestBed, engine: import('../../../src/engine/gameEngine.js').default }) => void} suiteFn -
+ *   Callback containing the tests.
+ * @param {{[token: string]: any}} [overrides] - Optional DI overrides.
+ * @returns {void}
+ */
+export function describeEngineSuite(title, suiteFn, overrides = {}) {
+  describeGameEngineSuite(
+    title,
+    (getBed) => {
+      /** @type {GameEngineTestBed} */
+      let bed;
+      /** @type {import('../../../src/engine/gameEngine.js').default} */
+      let engine;
+      beforeEach(() => {
+        bed = getBed();
+        engine = bed.engine;
+      });
+      suiteFn({
+        get bed() {
+          return bed;
+        },
+        get engine() {
+          return engine;
+        },
+      });
+    },
+    overrides
+  );
+}
+
 export default GameEngineTestBed;

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -3,13 +3,13 @@
 import { describe, expect, it } from '@jest/globals';
 import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
+import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   describe('Constructor', () => {
     it('should instantiate and resolve all core services successfully', () => {
-      const testBed = getBed();
+      const testBed = ctx.bed;
       new GameEngine({
         container: testBed.env.mockContainer,
       }); // Instantiation for this test
@@ -34,7 +34,7 @@ describeGameEngineSuite('GameEngine', (getBed) => {
     });
 
     it('should throw an error if ILogger cannot be resolved', () => {
-      const testBed = getBed();
+      const testBed = ctx.bed;
       testBed.withTokenOverride(tokens.ILogger, () => {
         throw new Error('Logger failed to resolve');
       });
@@ -55,7 +55,7 @@ describeGameEngineSuite('GameEngine', (getBed) => {
       ['PlaytimeTracker', tokens.PlaytimeTracker],
       ['ISafeEventDispatcher', tokens.ISafeEventDispatcher],
     ])('should throw an error if %s cannot be resolved', (_, failingToken) => {
-      const testBed = getBed();
+      const testBed = ctx.bed;
       const resolutionError = new Error(`${String(failingToken)} failed`);
       testBed.withTokenOverride(failingToken, () => {
         throw resolutionError;

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
-  describeGameEngineSuite,
+  describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
   describe('loadGame', () => {
@@ -23,8 +23,8 @@ describeGameEngineSuite('GameEngine', (getBed) => {
     let prepareSpy, executeSpy, finalizeSpy, handleFailureSpy;
 
     beforeEach(() => {
-      testBed = getBed();
-      gameEngine = testBed.engine; // Ensure gameEngine is fresh
+      testBed = ctx.bed;
+      gameEngine = ctx.engine; // Ensure gameEngine is fresh
       // Spies are on the gameEngine instance created here
       prepareSpy = jest
         .spyOn(gameEngine, '_prepareForLoadGameSession')

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -3,21 +3,21 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
-  describeGameEngineSuite,
+  describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   beforeEach(() => {
-    testBed = getBed();
+    testBed = ctx.bed;
   });
   describe('showLoadGameUI', () => {
     beforeEach(() => {
-      gameEngine = testBed.engine;
+      gameEngine = ctx.engine;
       testBed.resetMocks();
     });
 

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
-  describeGameEngineSuite,
+  describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import {
@@ -11,18 +11,18 @@ import {
   CANNOT_SAVE_GAME_INFO,
 } from '../../../src/constants/eventIds.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = getBed();
+    testBed = ctx.bed;
   });
   describe('showSaveGameUI', () => {
     beforeEach(async () => {
-      gameEngine = testBed.engine;
+      gameEngine = ctx.engine;
       // Start the game to ensure this.#isEngineInitialized is true for isSavingAllowed check
       await testBed.init(MOCK_WORLD_NAME);
       testBed.resetMocks();

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -1,7 +1,7 @@
 // tests/engine/startNewGame.test.js
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { describeGameEngineSuite } from '../../common/engine/gameEngineTestBed.js';
+import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 
 import {
@@ -11,19 +11,19 @@ import {
   ENGINE_STOPPED_UI,
 } from '../../../src/constants/eventIds.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = getBed();
+    testBed = ctx.bed;
   });
 
   describe('startNewGame', () => {
     beforeEach(() => {
-      gameEngine = testBed.engine; // Standard instance for these tests
+      gameEngine = ctx.engine; // Standard instance for these tests
       testBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: true,

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -3,24 +3,24 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
-  describeGameEngineSuite,
+  describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   const MOCK_WORLD_NAME = 'TestWorld';
 
   beforeEach(() => {
-    testBed = getBed();
+    testBed = ctx.bed;
   });
   describe('stop', () => {
     beforeEach(() => {
       // Ensure gameEngine is fresh for each 'stop' test
-      gameEngine = testBed.engine;
+      gameEngine = ctx.engine;
     });
 
     it('should successfully stop a running game, with correct logging, events, and state changes', async () => {

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   createGameEngineTestBed,
-  describeGameEngineSuite,
+  describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import {
@@ -12,12 +12,12 @@ import {
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
 } from '../../common/engine/dispatchTestUtils.js';
 
-describeGameEngineSuite('GameEngine', (getBed) => {
+describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
   let gameEngine; // Instance of GameEngine
 
   beforeEach(() => {
-    testBed = getBed();
+    testBed = ctx.bed;
   });
   describe('triggerManualSave', () => {
     const SAVE_NAME = 'MySaveFile';
@@ -45,7 +45,7 @@ describeGameEngineSuite('GameEngine', (getBed) => {
     describe('when engine is initialized', () => {
       beforeEach(async () => {
         await testBed.init(MOCK_ACTIVE_WORLD_FOR_SAVE);
-        gameEngine = testBed.engine;
+        gameEngine = ctx.engine;
         testBed.resetMocks();
       });
 


### PR DESCRIPTION
Summary: Introduced `describeEngineSuite` wrapper to automatically create a `GameEngineTestBed` and expose `{bed, engine}` for tests. Updated all engine-related tests to use this helper.

Changes Made:
- Added `describeEngineSuite` in `gameEngineTestBed.js`.
- Refactored engine test files to consume the new helper.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - fails due to existing repository issues)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy tests pass (`cd llm-proxy-server && npm run test`) *(proxy not modified)*
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_6856614779c88331893b1875fe98a516