### PR TITLE
[Agent] add generateDefault test helper

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -73,6 +73,19 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
   }
 
   /**
+   * @description Convenience wrapper over {@link generate} using the default
+   * actor, context and actions provided by the test bed.
+   * @returns {Promise<string>} The generated prompt string.
+   */
+  async generateDefault() {
+    return this.generate(
+      this.defaultActor,
+      this.defaultContext,
+      this.defaultActions
+    );
+  }
+
+  /**
    * Returns the dependency object used to construct the pipeline.
    *
    * @returns {{

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -144,13 +144,7 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
     },
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
     mutate();
-    await expect(
-      testBed.generate(
-        testBed.defaultActor,
-        testBed.defaultContext,
-        testBed.defaultActions
-      )
-    ).rejects.toThrow(error);
+    await expect(testBed.generateDefault()).rejects.toThrow(error);
   });
 
   test('availableActions are attached to DTO sent to getPromptData', async () => {


### PR DESCRIPTION
Summary: Provide a helper in `AIPromptPipelineTestBed` for generating prompts with default actor/context/actions and use it in tests.

Changes Made:
- Added `generateDefault` method with JSDoc.
- Updated tests to call new helper when defaults are used.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` - existing repo warnings remain)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68566342b500833189722a2241ce29dc