### PR TITLE
[Agent] Add mock handler resolver helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -10,6 +10,7 @@ import {
   createMockLogger,
   createMockEntityManager,
   createMockValidatedEventBus,
+  createMockTurnHandler,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
 import { describeSuite } from '../describeSuite.js';
@@ -101,6 +102,21 @@ export class TurnManagerTestBed extends BaseTestBed {
     for (const e of entities) {
       map.set(e.id, e);
     }
+  }
+
+  /**
+   * Configures the resolver to return a fresh mock handler for any actor.
+   *
+   * @param {boolean} [includeSignal] - Whether handlers include signalNormalApparentTermination.
+   * @returns {void}
+   */
+  setupMockHandlerResolver(includeSignal = true) {
+    this.turnHandlerResolver.resolveHandler.mockImplementation(async (actor) =>
+      createMockTurnHandler({
+        actor,
+        includeSignalTermination: includeSignal,
+      })
+    );
   }
 
   /**

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -28,10 +28,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
     testBed = getBed();
 
     // Configure handler resolver to return mock turn handlers
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
-      async (actor) =>
-        createMockTurnHandler({ actor, includeSignalTermination: true })
-    );
+    testBed.setupMockHandlerResolver();
 
     // Default: Mock advanceTurn to isolate start/stop logic
     advanceTurnSpy = jest

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -12,7 +12,6 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import { createMockTurnHandler } from '../../common/mockFactories.js';
 import {
   createAiActor,
   createPlayerActor,
@@ -37,10 +36,7 @@ describeTurnManagerSuite(
       mockPlayerActor = createPlayerActor('player1');
 
       // Configure handler resolver to return mock turn handlers
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
-        async (actor) =>
-          createMockTurnHandler({ actor, includeSignalTermination: true })
-      );
+      testBed.setupMockHandlerResolver();
 
       stopSpy = jest.spyOn(testBed.turnManager, 'stop');
 


### PR DESCRIPTION
## Summary
- add `setupMockHandlerResolver` in test bed
- use helper in turn manager lifecycle tests

## Testing
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68566310dbf88331968b68a540398746