### PR TITLE
[Agent] add reset helpers to GameEngineTestBed

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -68,6 +68,17 @@ export class GameEngineTestBed extends ContainerTestBed {
   }
 
   /**
+   * Initializes the engine then clears mock call history.
+   *
+   * @param {string} [world] - World name to initialize.
+   * @returns {Promise<void>} Resolves once initialization completes.
+   */
+  async initAndReset(world = 'TestWorld') {
+    await this.init(world);
+    this.resetMocks();
+  }
+
+  /**
    * Presets initialization results and starts a new game.
    *
    * @param {string} worldName - Name of the world to initialize.
@@ -79,6 +90,19 @@ export class GameEngineTestBed extends ContainerTestBed {
       initResult
     );
     await this.engine.startNewGame(worldName);
+  }
+
+  /**
+   * Starts a new game and immediately clears mock call history.
+   *
+   * @param {string} world - Name of the world to initialize.
+   * @param {import('../../src/interfaces/IInitializationService.js').InitializationResult} [result]
+   *   Initialization result returned by the service.
+   * @returns {Promise<void>} Resolves when the game has started.
+   */
+  async startAndReset(world, result = { success: true }) {
+    await this.start(world, result);
+    this.resetMocks();
   }
 
   /**

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -24,8 +24,7 @@ describeEngineSuite('GameEngine', (ctx) => {
     beforeEach(async () => {
       gameEngine = ctx.engine;
       // Start the game to ensure this.#isEngineInitialized is true for isSavingAllowed check
-      await testBed.init(MOCK_WORLD_NAME);
-      testBed.resetMocks();
+      await testBed.initAndReset(MOCK_WORLD_NAME);
     });
 
     it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', () => {

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -67,9 +67,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       testBed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }
       );
-      await gameEngine.startNewGame('InitialWorld');
-
-      testBed.resetMocks();
+      await testBed.startAndReset('InitialWorld');
 
       testBed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -29,10 +29,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           success: true,
         }
       );
-      await gameEngine.startNewGame(MOCK_WORLD_NAME); // Start the game first
-
-      // Clear mocks to ensure we only check calls from stop()
-      testBed.resetMocks();
+      await testBed.startAndReset(MOCK_WORLD_NAME); // Start the game first and clear mocks
 
       await gameEngine.stop();
 
@@ -88,13 +85,11 @@ describeEngineSuite('GameEngine', (ctx) => {
         localBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
           { success: true }
         );
-        await localEngine.startNewGame(MOCK_WORLD_NAME);
+        await localBed.startAndReset(MOCK_WORLD_NAME);
 
         const statusAfterStart = localEngine.getEngineStatus();
         expect(statusAfterStart.isInitialized).toBe(true);
         expect(statusAfterStart.isLoopRunning).toBe(true);
-
-        localBed.resetMocks();
 
         await localEngine.stop();
 

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -44,9 +44,8 @@ describeEngineSuite('GameEngine', (ctx) => {
 
     describe('when engine is initialized', () => {
       beforeEach(async () => {
-        await testBed.init(MOCK_ACTIVE_WORLD_FOR_SAVE);
+        await testBed.initAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
         gameEngine = ctx.engine;
-        testBed.resetMocks();
       });
 
       it.each([
@@ -65,9 +64,7 @@ describeEngineSuite('GameEngine', (ctx) => {
               success: true,
             }
           );
-          await localBed.engine.startNewGame(MOCK_ACTIVE_WORLD_FOR_SAVE);
-
-          localBed.resetMocks();
+          await localBed.startAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
 
           const result = await localBed.engine.triggerManualSave(SAVE_NAME);
 


### PR DESCRIPTION
Summary: Added `initAndReset` and `startAndReset` helpers to GameEngineTestBed to combine initialization/start with mock resets. Updated engine tests to use these helpers when preparing the engine. All tests pass.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 520 errors, 2198 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685665e044048331a8514c7bdccac6cd