### PR TITLE
[Agent] update lifecycle test setup

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -10,6 +10,7 @@ import {
   createMockLogger,
   createMockEntityManager,
   createMockValidatedEventBus,
+  createMockTurnHandler,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
 import { describeSuite } from '../describeSuite.js';
@@ -101,6 +102,17 @@ export class TurnManagerTestBed extends BaseTestBed {
     for (const e of entities) {
       map.set(e.id, e);
     }
+  }
+
+  /**
+   * Configures the mock turnHandlerResolver to return a standard mock handler.
+   *
+   * @returns {void}
+   */
+  setupMockHandlerResolver() {
+    this.turnHandlerResolver.resolveHandler.mockImplementation(async (actor) =>
+      createMockTurnHandler({ actor, includeSignalTermination: true })
+    );
   }
 
   /**

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -2,16 +2,12 @@
 // --- FILE START ---
 
 import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
-import {
-  ACTOR_COMPONENT_ID,
-  PLAYER_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
+import { ACTOR_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import {
   TURN_ENDED_ID,
-  TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
+import { beforeEach, expect, jest, afterEach } from '@jest/globals';
 import { createMockTurnHandler } from '../../common/mockFactories.js';
 import { createAiActor } from '../../common/turns/testActors.js';
 
@@ -27,11 +23,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     testBed = getBed();
 
-    // Configure handler resolver to return mock turn handlers
-    testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
-      async (actor) =>
-        createMockTurnHandler({ actor, includeSignalTermination: true })
-    );
+    testBed.setupMockHandlerResolver();
 
     // Default: Mock advanceTurn to isolate start/stop logic
     advanceTurnSpy = jest
@@ -143,6 +135,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
         expect(stopSpy).toHaveBeenCalledTimes(1);
       } catch (error) {
         // If the error is thrown, that's also acceptable behavior
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(error.message).toBe('Turn advancement failed');
       }
 


### PR DESCRIPTION
Summary: Replaced manual resolver setup with `testBed.setupMockHandlerResolver()` and implemented the helper in `TurnManagerTestBed` to return a standard mocked handler. Adjusted imports and added an ESLint directive for conditional expectation. All tests pass in both main and proxy projects.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 516 errors in unrelated files)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_685665a614508331b4f9c43e1599faa3