### PR TITLE
[Agent] add initializeFromFactories util

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -44,6 +44,21 @@ export class BaseTestBed {
   }
 
   /**
+   * Initializes the test bed's mocks from factory functions.
+   *
+   * @param {Record<string, () => any>} factoryMap - Map of mock factory
+   *   functions.
+   * @returns {void}
+   */
+  initializeFromFactories(factoryMap) {
+    const { mocks } = BaseTestBed.fromFactories(factoryMap);
+    this.mocks = mocks;
+    Object.entries(mocks).forEach(([k, v]) => {
+      this[k] = v;
+    });
+  }
+
+  /**
    * Clears call history on all mocks stored in {@link BaseTestBed#mocks}.
    *
    * @returns {void}

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -39,7 +39,8 @@ export class GameEngineTestBed extends ContainerTestBed {
    */
   constructor(overrides = {}) {
     const env = createTestEnvironment(overrides);
-    const { mocks } = BaseTestBed.fromFactories({
+    super(env.mockContainer);
+    this.initializeFromFactories({
       logger: () => env.logger,
       entityManager: () => env.entityManager,
       turnManager: () => env.turnManager,
@@ -49,7 +50,6 @@ export class GameEngineTestBed extends ContainerTestBed {
       initializationService: () => env.initializationService,
     });
     const engine = env.createGameEngine();
-    super(env.mockContainer, mocks);
     this.env = env;
     this.engine = engine;
   }

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -30,14 +30,14 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
   defaultActions;
 
   constructor() {
-    const { mocks } = BaseTestBed.fromFactories({
+    super();
+    this.initializeFromFactories({
       llmAdapter: createMockLLMAdapter,
       gameStateProvider: createMockAIGameStateProvider,
       promptContentProvider: createMockAIPromptContentProvider,
       promptBuilder: createMockPromptBuilder,
       logger: createMockLogger,
     });
-    super(mocks);
     this.defaultActor = createMockEntity('actor');
     this.defaultContext = {};
     this.defaultActions = [];

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -24,7 +24,8 @@ export class TurnManagerTestBed extends BaseTestBed {
   turnManager;
 
   constructor(overrides = {}) {
-    const { mocks } = BaseTestBed.fromFactories({
+    super();
+    this.initializeFromFactories({
       logger: () => overrides.logger ?? createMockLogger(),
       entityManager: () => {
         const em = overrides.entityManager ?? createMockEntityManager();
@@ -48,7 +49,6 @@ export class TurnManagerTestBed extends BaseTestBed {
         },
       dispatcher: () => overrides.dispatcher ?? createMockValidatedEventBus(),
     });
-    super(mocks);
 
     const TurnManagerClass = overrides.TurnManagerClass ?? TurnManager;
     const tmOptions = overrides.turnManagerOptions ?? {};


### PR DESCRIPTION
## Summary
- extend `BaseTestBed` with `initializeFromFactories`
- refactor test beds to use new helper

## Testing Done
- [x] `npm run format`
- [x] `npx eslint tests/common/baseTestBed.js tests/common/engine/gameEngineTestBed.js tests/common/prompting/promptPipelineTestBed.js tests/common/turns/turnManagerTestBed.js --fix`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`
- [x] `PORT=8081 npm run start` *(fails: No matching export in src/modding/modLoadOrderResolver.js)*

------
https://chatgpt.com/codex/tasks/task_e_685665c5b1608331bbe4593b90657f10