### PR TITLE
[Agent] Add describeSuiteWithHooks helper and refactor suites

### DIFF
--- a/tests/common/describeSuite.js
+++ b/tests/common/describeSuite.js
@@ -2,6 +2,8 @@
  * @file Provides a generic helper for defining test suites with automatic
  * TestBed setup and teardown.
  */
+/* eslint-env jest */
+/* global beforeEach, afterEach, describe */
 
 /**
  * @description Defines a test suite using the given TestBed constructor.
@@ -26,5 +28,43 @@ export function describeSuite(title, TestBedCtor, suiteFn, ...args) {
       await testBed.cleanup();
     });
     suiteFn(() => testBed);
+  });
+}
+
+/**
+ * @description Defines a test suite with optional hooks executed after
+ * TestBed creation and before cleanup.
+ * @param {string} title - Suite title for the describe block.
+ * @param {new (...args: any[]) => {cleanup: () => Promise<void>}} TestBedCtor -
+ *   Constructor for the test bed.
+ * @param {(getBed: () => any) => void} suiteFn - Function containing the tests.
+ *   Receives a getter returning the current test bed.
+ * @param {object} [options] - Optional hook configuration.
+ * @param {(bed: any) => void} [options.beforeEachHook] - Hook executed after the
+ *   bed is instantiated but before each test.
+ * @param {(bed: any) => void} [options.afterEachHook] - Hook executed after the
+ *   bed cleanup runs.
+ * @param {any[]} [options.args] - Arguments forwarded to the TestBed
+ *   constructor.
+ * @returns {void}
+ */
+export function describeSuiteWithHooks(
+  title,
+  TestBedCtor,
+  suiteFn,
+  { beforeEachHook, afterEachHook, args = [] } = {}
+) {
+  describe(title, () => {
+    /** @type {any} */
+    let bed;
+    beforeEach(() => {
+      bed = new TestBedCtor(...args);
+      if (beforeEachHook) beforeEachHook(bed);
+    });
+    afterEach(async () => {
+      await bed.cleanup();
+      if (afterEachHook) afterEachHook(bed);
+    });
+    suiteFn(() => bed);
   });
 }

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -9,7 +9,7 @@ import { createTestEnvironment } from './gameEngine.test-environment.js';
 import ContainerTestBed from '../containerTestBed.js';
 import BaseTestBed from '../baseTestBed.js';
 import { suppressConsoleError } from '../jestHelpers.js';
-import { describeSuite } from '../describeSuite.js';
+import { describeSuiteWithHooks } from '../describeSuite.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -125,21 +125,16 @@ export function createGameEngineTestBed(overrides = {}) {
  * @returns {void}
  */
 export function describeGameEngineSuite(title, suiteFn, overrides = {}) {
-  describeSuite(
-    title,
-    GameEngineTestBed,
-    (getBed) => {
-      let consoleSpy;
-      beforeEach(() => {
-        consoleSpy = suppressConsoleError();
-      });
-      afterEach(() => {
-        consoleSpy.mockRestore();
-      });
-      suiteFn(getBed);
+  let consoleSpy;
+  describeSuiteWithHooks(title, GameEngineTestBed, suiteFn, {
+    args: [overrides],
+    beforeEachHook() {
+      consoleSpy = suppressConsoleError();
     },
-    overrides
-  );
+    afterEachHook() {
+      consoleSpy.mockRestore();
+    },
+  });
 }
 
 /**

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -15,7 +15,7 @@ import {
   createMockEntity,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
-import { describeSuite } from '../describeSuite.js';
+import { describeSuiteWithHooks } from '../describeSuite.js';
 
 /**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
@@ -139,11 +139,10 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
  * @returns {void}
  */
 function describeAIPromptPipelineSuite(title, suiteFn) {
-  describeSuite(title, AIPromptPipelineTestBed, (getBed) => {
-    beforeEach(() => {
-      getBed().setupMockSuccess();
-    });
-    suiteFn(getBed);
+  describeSuiteWithHooks(title, AIPromptPipelineTestBed, suiteFn, {
+    beforeEachHook(bed) {
+      bed.setupMockSuccess();
+    },
   });
 }
 

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -12,7 +12,7 @@ import {
   createMockValidatedEventBus,
 } from '../mockFactories.js';
 import BaseTestBed from '../baseTestBed.js';
-import { describeSuite } from '../describeSuite.js';
+import { describeSuiteWithHooks } from '../describeSuite.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -207,7 +207,9 @@ export const flushPromisesAndTimers = async () => {
  * @returns {void}
  */
 export function describeTurnManagerSuite(title, suiteFn, overrides = {}) {
-  describeSuite(title, TurnManagerTestBed, suiteFn, overrides);
+  describeSuiteWithHooks(title, TurnManagerTestBed, suiteFn, {
+    args: [overrides],
+  });
 }
 
 export default TurnManagerTestBed;


### PR DESCRIPTION
## Summary
- support before/after hooks when describing suites
- refactor GameEngineTestBed, TurnManagerTestBed, and AIPromptPipelineTestBed to use new helper

## Testing Done
- `npm run lint` *(fails: 517 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685665b4ebbc8331b23a9169ad8bb097