### PR TITLE
[Agent] Add constructor validation helper

### DIFF
--- a/tests/common/constructorValidationHelpers.js
+++ b/tests/common/constructorValidationHelpers.js
@@ -1,0 +1,56 @@
+/**
+ * @file Utilities for generating constructor validation test cases.
+ *
+ * Usage:
+ *   const cases = buildMissingDependencyCases(createDeps, {
+ *     logger: { error: /logger/, methods: ['info'] }
+ *   });
+ *   it.each(cases)('%s', (desc, mutate, regex) => {
+ *     const deps = createDeps();
+ *     mutate(deps);
+ *     expect(() => new MyClass(deps)).toThrow(regex);
+ *   });
+ */
+
+/**
+ * Builds test cases for missing dependency scenarios.
+ *
+ * @description Accepts a factory returning valid dependency objects and a
+ * specification describing expected error patterns and required methods for
+ * each dependency. Returns an array of cases suitable for `it.each` where each
+ * case is `[description, mutateFn, expectedError]`.
+ * @param {() => Record<string, any>} factoryFn - Produces valid dependencies.
+ * @param {Record<string, {error: RegExp, methods: string[]}>} spec - Mapping of
+ *   dependency keys to validation info.
+ * @returns {Array<[string, (deps: Record<string, any>) => void, RegExp]>}
+ *   Generated test cases.
+ */
+export function buildMissingDependencyCases(factoryFn, spec) {
+  /** @type {Array<[string, (deps: Record<string, any>) => void, RegExp]>} */
+  const cases = [];
+  for (const [depKey, { error, methods }] of Object.entries(spec)) {
+    cases.push([
+      `missing ${depKey}`,
+      (deps) => {
+        delete deps[depKey];
+      },
+      error,
+    ]);
+    for (const method of methods) {
+      cases.push([
+        `missing ${depKey}.${method}`,
+        (deps) => {
+          if (deps[depKey]) {
+            delete deps[depKey][method];
+          }
+        },
+        error,
+      ]);
+    }
+  }
+  return cases;
+}
+
+export default {
+  buildMissingDependencyCases,
+};

--- a/tests/unit/common/constructorValidationHelpers.test.js
+++ b/tests/unit/common/constructorValidationHelpers.test.js
@@ -1,0 +1,54 @@
+/**
+ * @file Unit tests for constructor validation helpers.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
+
+/**
+ *
+ */
+function createDeps() {
+  return {
+    logger: { info: jest.fn(), error: jest.fn() },
+    service: { start: jest.fn(), stop: jest.fn() },
+  };
+}
+
+const spec = {
+  logger: { error: /logger/, methods: ['info', 'error'] },
+  service: { error: /service/, methods: ['start'] },
+};
+
+describe('buildMissingDependencyCases', () => {
+  const cases = buildMissingDependencyCases(createDeps, spec);
+
+  it('generates a case for each missing dependency and method', () => {
+    const descriptions = cases.map((c) => c[0]);
+    expect(descriptions).toEqual([
+      'missing logger',
+      'missing logger.info',
+      'missing logger.error',
+      'missing service',
+      'missing service.start',
+    ]);
+  });
+
+  it('mutate functions remove properties as described', () => {
+    const [, mutateLogger] = cases[0];
+    const deps1 = createDeps();
+    mutateLogger(deps1);
+    expect(deps1.logger).toBeUndefined();
+
+    const [, mutateMethod] = cases[1];
+    const deps2 = createDeps();
+    mutateMethod(deps2);
+    expect(deps2.logger.info).toBeUndefined();
+  });
+
+  it('returns the expected error regex for each case', () => {
+    for (const [, , regex] of cases) {
+      expect(regex).toBeInstanceOf(RegExp);
+    }
+  });
+});


### PR DESCRIPTION
Summary: Added new helper `buildMissingDependencyCases` for generating constructor dependency validation cases and accompanying unit tests. 

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 520 errors in existing files)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685666d9812c8331a44199854374e977