### PR TITLE
[Agent] use default actors helper

### DIFF
--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -15,10 +15,7 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import {
-  createAiActor,
-  createPlayerActor,
-} from '../../common/turns/testActors.js';
+import { createDefaultActors } from '../../common/turns/testActors.js';
 
 // --- Test Suite ---
 
@@ -34,10 +31,11 @@ describeTurnManagerSuite(
       jest.useFakeTimers();
       testBed = getBed();
 
-      mockActor1 = createAiActor('actor1');
-      mockActor2 = createAiActor('actor2');
-      mockPlayerActor = createPlayerActor('player1');
-
+      ({
+        ai1: mockActor1,
+        ai2: mockActor2,
+        player: mockPlayerActor,
+      } = createDefaultActors());
       // Configure handler resolver to return mock turn handlers
       testBed.setupMockHandlerResolver();
 


### PR DESCRIPTION
Summary: Replaced individual actor initialization in the round lifecycle tests with the `createDefaultActors()` helper and updated imports accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: ESLint module missing)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start` *(failed: module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856693a586c833188a37f2df6be1d40