### PR TITLE
[Agent] streamline AIPromptPipeline constructor tests

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -5,6 +5,7 @@ import {
   describeAIPromptPipelineSuite,
   AIPromptPipelineTestBed,
 } from '../../common/prompting/promptPipelineTestBed.js';
+import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
 
 describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   /** @type {AIPromptPipelineTestBed} */
@@ -15,85 +16,30 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   });
 
   describe('constructor validation', () => {
-    test.each([
-      [
-        'llmAdapter missing',
-        (d) => {
-          delete d.llmAdapter;
-        },
-        /ILLMAdapter/,
-      ],
-      [
-        'llmAdapter.getAIDecision missing',
-        (d) => {
-          delete d.llmAdapter.getAIDecision;
-        },
-        /ILLMAdapter/,
-      ],
-      [
-        'llmAdapter.getCurrentActiveLlmId missing',
-        (d) => {
-          delete d.llmAdapter.getCurrentActiveLlmId;
-        },
-        /ILLMAdapter/,
-      ],
-      [
-        'gameStateProvider missing',
-        (d) => {
-          delete d.gameStateProvider;
-        },
-        /IAIGameStateProvider/,
-      ],
-      [
-        'gameStateProvider.buildGameState missing',
-        (d) => {
-          delete d.gameStateProvider.buildGameState;
-        },
-        /IAIGameStateProvider/,
-      ],
-      [
-        'promptContentProvider missing',
-        (d) => {
-          delete d.promptContentProvider;
-        },
-        /IAIPromptContentProvider/,
-      ],
-      [
-        'promptContentProvider.getPromptData missing',
-        (d) => {
-          delete d.promptContentProvider.getPromptData;
-        },
-        /IAIPromptContentProvider/,
-      ],
-      [
-        'promptBuilder missing',
-        (d) => {
-          delete d.promptBuilder;
-        },
-        /IPromptBuilder/,
-      ],
-      [
-        'promptBuilder.build missing',
-        (d) => {
-          delete d.promptBuilder.build;
-        },
-        /IPromptBuilder/,
-      ],
-      [
-        'logger missing',
-        (d) => {
-          delete d.logger;
-        },
-        /ILogger/,
-      ],
-      [
-        'logger.info missing',
-        (d) => {
-          delete d.logger.info;
-        },
-        /ILogger/,
-      ],
-    ])('throws when %s', (_desc, mutate, regex) => {
+    const spec = {
+      llmAdapter: {
+        error: /ILLMAdapter/,
+        methods: ['getAIDecision', 'getCurrentActiveLlmId'],
+      },
+      gameStateProvider: {
+        error: /IAIGameStateProvider/,
+        methods: ['buildGameState'],
+      },
+      promptContentProvider: {
+        error: /IAIPromptContentProvider/,
+        methods: ['getPromptData'],
+      },
+      promptBuilder: {
+        error: /IPromptBuilder/,
+        methods: ['build'],
+      },
+      logger: { error: /ILogger/, methods: ['info'] },
+    };
+    const cases = buildMissingDependencyCases(
+      () => testBed.getDependencies(),
+      spec
+    );
+    test.each(cases)('throws when %s', (_desc, mutate, regex) => {
       const deps = testBed.getDependencies();
       mutate(deps);
       expect(() => new AIPromptPipeline(deps)).toThrow(regex);


### PR DESCRIPTION
## Summary
- use `buildMissingDependencyCases` in `AIPromptPipeline` tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` *(fails: 517 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856692d33908331b5cd2c1a43e99ae7