### PR TITLE
[Agent] unify test environment builder

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -15,7 +15,7 @@ import {
   createMockSafeEventDispatcher,
   createMockInitializationService,
 } from '../mockFactories.js';
-import { buildTestEnvironment } from '../mockEnvironment.js';
+import { buildEnvironment } from '../mockEnvironment.js';
 
 /**
  * Creates a set of mocks and a container for GameEngine.
@@ -57,10 +57,16 @@ export function createTestEnvironment(overrides = {}) {
     [tokens.IInitializationService]: 'initializationService',
   };
 
-  const { mocks, mockContainer, cleanup } = buildTestEnvironment(
+  const {
+    mocks,
+    mockContainer,
+    instance: gameEngine,
+    cleanup,
+  } = buildEnvironment(
     factoryMap,
     tokenMap,
-    overrides
+    overrides,
+    (container) => new GameEngine({ container })
   );
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
@@ -68,6 +74,7 @@ export function createTestEnvironment(overrides = {}) {
   return {
     mockContainer,
     ...mocks,
+    gameEngine,
     createGameEngine,
     cleanup,
   };

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -20,7 +20,7 @@ import {
   createMockWorldLoader, // ← NEW import
 } from '../mockFactories.js';
 import { createLoaderMocks } from './modsLoader.test-utils.js';
-import { buildTestEnvironment } from '../mockEnvironment.js';
+import { buildEnvironment } from '../mockEnvironment.js';
 
 /**
  * List of loader types used when generating mock loaders.
@@ -59,52 +59,54 @@ export function createTestEnvironment() {
     mockWorldLoader: createMockWorldLoader,
   };
 
-  const { mocks, cleanup } = buildTestEnvironment(factoryMap, {});
-
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);
 
-  /* ── Default success behaviour overrides ───────────────────────────── */
-  mocks.mockValidator.isSchemaLoaded.mockImplementation((id) =>
-    [
-      'schema:game',
-      'schema:components',
-      'schema:mod-manifest',
-      'schema:entityDefinitions',
-      'schema:actions',
-      'schema:events',
-      'schema:rules',
-      'schema:conditions',
-      'schema:entityInstances',
-      'schema:goals',
-    ].includes(id)
-  );
-  mocks.mockModDependencyValidator.validate.mockImplementation(() => {});
-  mocks.mockModVersionValidator.mockImplementation(() => {});
-  mocks.mockModLoadOrderResolver.resolveOrder.mockImplementation((ids) => ids);
+  const {
+    mocks,
+    instance: modsLoader,
+    cleanup,
+  } = buildEnvironment(factoryMap, {}, {}, (mockContainer, m) => {
+    m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
+      [
+        'schema:game',
+        'schema:components',
+        'schema:mod-manifest',
+        'schema:entityDefinitions',
+        'schema:actions',
+        'schema:events',
+        'schema:rules',
+        'schema:conditions',
+        'schema:entityInstances',
+        'schema:goals',
+      ].includes(id)
+    );
+    m.mockModDependencyValidator.validate.mockImplementation(() => {});
+    m.mockModVersionValidator.mockImplementation(() => {});
+    m.mockModLoadOrderResolver.resolveOrder.mockImplementation((ids) => ids);
 
-  /* ── Instantiate system-under-test ──────────────────────────────────── */
-  const modsLoader = new ModsLoader({
-    registry: mocks.mockRegistry,
-    logger: mocks.mockLogger,
-    schemaLoader: mocks.mockSchemaLoader,
-    componentLoader: loaders.mockComponentLoader,
-    conditionLoader: loaders.mockConditionLoader,
-    ruleLoader: loaders.mockRuleLoader,
-    actionLoader: loaders.mockActionLoader,
-    eventLoader: loaders.mockEventLoader,
-    entityLoader: loaders.mockEntityLoader,
-    validator: mocks.mockValidator,
-    configuration: mocks.mockConfiguration,
-    gameConfigLoader: mocks.mockGameConfigLoader,
-    promptTextLoader: { loadPromptText: jest.fn() },
-    modManifestLoader: mocks.mockModManifestLoader,
-    validatedEventDispatcher: mocks.mockValidatedEventDispatcher,
-    modDependencyValidator: mocks.mockModDependencyValidator,
-    modVersionValidator: mocks.mockModVersionValidator,
-    modLoadOrderResolver: mocks.mockModLoadOrderResolver,
-    worldLoader: mocks.mockWorldLoader, // ← injected here
-    contentLoadersConfig: null,
+    return new ModsLoader({
+      registry: m.mockRegistry,
+      logger: m.mockLogger,
+      schemaLoader: m.mockSchemaLoader,
+      componentLoader: loaders.mockComponentLoader,
+      conditionLoader: loaders.mockConditionLoader,
+      ruleLoader: loaders.mockRuleLoader,
+      actionLoader: loaders.mockActionLoader,
+      eventLoader: loaders.mockEventLoader,
+      entityLoader: loaders.mockEntityLoader,
+      validator: m.mockValidator,
+      configuration: m.mockConfiguration,
+      gameConfigLoader: m.mockGameConfigLoader,
+      promptTextLoader: { loadPromptText: jest.fn() },
+      modManifestLoader: m.mockModManifestLoader,
+      validatedEventDispatcher: m.mockValidatedEventDispatcher,
+      modDependencyValidator: m.mockModDependencyValidator,
+      modVersionValidator: m.mockModVersionValidator,
+      modLoadOrderResolver: m.mockModLoadOrderResolver,
+      worldLoader: m.mockWorldLoader,
+      contentLoadersConfig: null,
+    });
   });
 
   /* ── Return the assembled environment ──────────────────────────────── */

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -64,3 +64,41 @@ export function buildTestEnvironment(factoryMap, tokenMap, overrides = {}) {
 
   return { mocks, mockContainer, cleanup };
 }
+
+/**
+ * Builds and optionally instantiates a test environment.
+ *
+ * @description Wrapper around {@link buildTestEnvironment} that also
+ *   constructs an instance of the system under test using the provided
+ *   creation callback.
+ * @param {Record<string, () => any>} factoryMap - Map of mock factory
+ *   functions to create.
+ * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
+ *   Map of DI tokens to mock keys, provider callbacks, or constant values.
+ * @param {Record<string | symbol, any>} [overrides] - Optional per-test token
+ *   overrides for the container.
+ * @param {(container: any, mocks: Record<string, any>) => any} [createFn]
+ *   Function that returns the system under test when provided the mock
+ *   container and generated mocks.
+ * @returns {{
+ *   mocks: Record<string, any>,
+ *   mockContainer: { resolve: jest.Mock },
+ *   instance: any,
+ *   cleanup: () => void,
+ * }}
+ *   Mocks, container, optionally created instance and cleanup helper.
+ */
+export function buildEnvironment(
+  factoryMap,
+  tokenMap,
+  overrides = {},
+  createFn
+) {
+  const { mocks, mockContainer, cleanup } = buildTestEnvironment(
+    factoryMap,
+    tokenMap,
+    overrides
+  );
+  const instance = createFn ? createFn(mockContainer, mocks) : undefined;
+  return { mocks, mockContainer, instance, cleanup };
+}


### PR DESCRIPTION
## Summary
- support creating a test instance via `buildEnvironment`
- use `buildEnvironment` for GameEngine and ModsLoader test helpers

## Testing
- `npm run format`
- `npm run lint` *(fails: 517 errors, 2204 warnings)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68566949246483319fb46de7e61e67b6