### PR TITLE
[Agent] Simplify actor identification test setup

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -20,7 +20,6 @@ describeTurnManagerSuite(
     let turnEndCapture;
 
     beforeEach(async () => {
-      jest.clearAllMocks();
       testBed = getBed();
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -47,16 +46,7 @@ describeTurnManagerSuite(
         .spyOn(testBed.turnManager, 'stop')
         .mockImplementation(async () => {});
 
-      await testBed.turnManager.start();
-
-      testBed.mocks.logger.info.mockClear();
-      testBed.mocks.logger.debug.mockClear();
-      testBed.mocks.logger.warn.mockClear();
-      testBed.mocks.logger.error.mockClear();
-      testBed.mocks.dispatcher.dispatch.mockClear();
-      testBed.mocks.turnOrderService.isEmpty.mockClear();
-      testBed.mocks.turnOrderService.getNextEntity.mockClear();
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockClear();
+      await testBed.startRunning();
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.dispatcher.dispatch.mockResolvedValue(true);


### PR DESCRIPTION
Summary: Removed unnecessary mock resets and used `startRunning` helper in the actor identification test for cleaner setup.

Changes Made:
- Deleted redundant `jest.clearAllMocks` call.
- Replaced manual start/clear logic with `startRunning` and captured subscription before startup.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - fails due to existing repo issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (`npm run start` failed during build)



------
https://chatgpt.com/codex/tasks/task_e_68566c11da6483319d18d8b7163aafa9