### PR TITLE
[Agent] Add prompt pipeline success helper

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -58,21 +58,11 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
       finalPrompt: 'FINAL',
     });
 
-    const prompt = await testBed.generate(actor, context, actions);
-
-    expect(prompt).toBe('FINAL');
-    expect(testBed.llmAdapter.getCurrentActiveLlmId).toHaveBeenCalledTimes(1);
-    expect(testBed.gameStateProvider.buildGameState).toHaveBeenCalledWith(
+    await testBed.expectSuccessfulGeneration({
       actor,
       context,
-      testBed.logger
-    );
-    expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
-      expect.objectContaining({ state: true, availableActions: actions }),
-      testBed.logger
-    );
-    expect(testBed.promptBuilder.build).toHaveBeenCalledWith('llm1', {
-      pd: true,
+      actions,
+      expectedPrompt: 'FINAL',
     });
   });
 


### PR DESCRIPTION
Summary: 
- extend promptPipelineTestBed with expectSuccessfulGeneration helper
- use helper in AIPromptPipeline test

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (fails: known repo issues) `npm run lint`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68566bff266883318871307d5608719d