### PR TITLE
[Agent] remove redundant context assignments

### DIFF
--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -10,8 +10,6 @@ import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
   describe('loadGame', () => {
     const SAVE_ID = 'savegame-001.sav';
     const mockSaveData = {
@@ -23,26 +21,24 @@ describeEngineSuite('GameEngine', (ctx) => {
     let prepareSpy, executeSpy, finalizeSpy, handleFailureSpy;
 
     beforeEach(() => {
-      testBed = ctx.bed;
-      gameEngine = ctx.engine; // Ensure gameEngine is fresh
-      // Spies are on the gameEngine instance created here
+      // Spies are on the engine instance created here
       prepareSpy = jest
-        .spyOn(gameEngine, '_prepareForLoadGameSession')
+        .spyOn(ctx.engine, '_prepareForLoadGameSession')
         .mockResolvedValue(undefined);
       executeSpy = jest
-        .spyOn(gameEngine, '_executeLoadAndRestore')
+        .spyOn(ctx.engine, '_executeLoadAndRestore')
         .mockResolvedValue({
           success: true,
           data: typedMockSaveData,
         });
       finalizeSpy = jest
-        .spyOn(gameEngine, '_finalizeLoadSuccess')
+        .spyOn(ctx.engine, '_finalizeLoadSuccess')
         .mockResolvedValue({
           success: true,
           data: typedMockSaveData,
         });
       handleFailureSpy = jest
-        .spyOn(gameEngine, '_handleLoadFailure')
+        .spyOn(ctx.engine, '_handleLoadFailure')
         .mockImplementation(async (error) => {
           const errorMsg =
             error instanceof Error ? error.message : String(error);
@@ -52,13 +48,13 @@ describeEngineSuite('GameEngine', (ctx) => {
             data: null,
           };
         });
-      testBed.resetMocks();
+      ctx.bed.resetMocks();
     });
 
     it('should successfully orchestrate loading a game and call helpers in order', async () => {
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
         `GameEngine: loadGame called for identifier: ${SAVE_ID}`
       );
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
@@ -80,11 +76,11 @@ describeEngineSuite('GameEngine', (ctx) => {
         return { success: false, error: String(error), data: null };
       });
 
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
       expect(executeSpy).toHaveBeenCalledWith(SAVE_ID);
-      expect(testBed.mocks.logger.warn).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         `GameEngine: Load/restore operation reported failure for "${SAVE_ID}".`
       );
       expect(finalizeSpy).not.toHaveBeenCalled();
@@ -105,11 +101,11 @@ describeEngineSuite('GameEngine', (ctx) => {
         return { success: false, error: String(error), data: null };
       });
 
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
       expect(executeSpy).toHaveBeenCalledWith(SAVE_ID);
-      expect(testBed.mocks.logger.warn).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         `GameEngine: Load/restore operation reported failure for "${SAVE_ID}".`
       );
       expect(finalizeSpy).not.toHaveBeenCalled();
@@ -153,10 +149,10 @@ describeEngineSuite('GameEngine', (ctx) => {
       const prepareError = new Error('Prepare failed');
       prepareSpy.mockRejectedValue(prepareError);
 
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
-      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.error).toHaveBeenCalledWith(
         `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${prepareError.message || String(prepareError)}`,
         prepareError
       );
@@ -174,11 +170,11 @@ describeEngineSuite('GameEngine', (ctx) => {
       const executeError = new Error('Execute failed');
       executeSpy.mockRejectedValue(executeError);
 
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
       expect(executeSpy).toHaveBeenCalledWith(SAVE_ID);
-      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.error).toHaveBeenCalledWith(
         `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${executeError.message || String(executeError)}`,
         executeError
       );
@@ -196,12 +192,12 @@ describeEngineSuite('GameEngine', (ctx) => {
       finalizeSpy.mockRejectedValue(finalizeError); // _executeLoadAndRestore is fine
       executeSpy.mockResolvedValue({ success: true, data: typedMockSaveData });
 
-      const result = await gameEngine.loadGame(SAVE_ID);
+      const result = await ctx.engine.loadGame(SAVE_ID);
 
       expect(prepareSpy).toHaveBeenCalledWith(SAVE_ID);
       expect(executeSpy).toHaveBeenCalledWith(SAVE_ID);
       expect(finalizeSpy).toHaveBeenCalledWith(typedMockSaveData, SAVE_ID);
-      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.error).toHaveBeenCalledWith(
         `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${finalizeError.message || String(finalizeError)}`,
         finalizeError
       );

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -9,29 +9,22 @@ import '../../common/engine/engineTestTypedefs.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
-  beforeEach(() => {
-    testBed = ctx.bed;
-  });
   describe('showLoadGameUI', () => {
     beforeEach(() => {
-      gameEngine = ctx.engine;
-      testBed.resetMocks();
+      ctx.bed.resetMocks();
     });
 
     it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
-      gameEngine.showLoadGameUI(); // Method is now sync
+      ctx.engine.showLoadGameUI(); // Method is now sync
 
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
       );
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         REQUEST_SHOW_LOAD_GAME_UI,
         {}
       );
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
         1
       );
     });

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -12,58 +12,51 @@ import {
 } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
   const MOCK_WORLD_NAME = 'TestWorld';
 
-  beforeEach(() => {
-    testBed = ctx.bed;
-  });
   describe('showSaveGameUI', () => {
     beforeEach(async () => {
-      gameEngine = ctx.engine;
       // Start the game to ensure this.#isEngineInitialized is true for isSavingAllowed check
-      await testBed.initAndReset(MOCK_WORLD_NAME);
+      await ctx.bed.initAndReset(MOCK_WORLD_NAME);
     });
 
     it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', () => {
-      testBed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
+      ctx.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
         true
       );
-      gameEngine.showSaveGameUI(); // Method is now sync
+      ctx.engine.showSaveGameUI(); // Method is now sync
 
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
         'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
       );
       expect(
-        testBed.mocks.gamePersistenceService.isSavingAllowed
+        ctx.bed.mocks.gamePersistenceService.isSavingAllowed
       ).toHaveBeenCalledWith(true); // engine is initialized
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         REQUEST_SHOW_SAVE_GAME_UI,
         {}
       );
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
         1
       );
     });
 
     it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', () => {
-      testBed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
+      ctx.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
         false
       );
-      gameEngine.showSaveGameUI(); // Method is now sync
+      ctx.engine.showSaveGameUI(); // Method is now sync
 
-      expect(testBed.mocks.logger.warn).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         'GameEngine.showSaveGameUI: Saving is not currently allowed.'
       );
       expect(
-        testBed.mocks.gamePersistenceService.isSavingAllowed
+        ctx.bed.mocks.gamePersistenceService.isSavingAllowed
       ).toHaveBeenCalledWith(true);
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         CANNOT_SAVE_GAME_INFO
       );
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
         1
       );
     });

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -12,19 +12,11 @@ import {
 } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
   const MOCK_WORLD_NAME = 'TestWorld';
-
-  beforeEach(() => {
-    testBed = ctx.bed;
-  });
 
   describe('startNewGame', () => {
     beforeEach(() => {
-      gameEngine = ctx.engine; // Standard instance for these tests
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: true,
         }
@@ -32,118 +24,118 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should successfully start a new game', async () => {
-      await gameEngine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
 
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_INITIALIZING_UI,
         { worldName: MOCK_WORLD_NAME },
         { allowSchemaNotFound: true }
       );
-      expect(testBed.mocks.entityManager.clearAll).toHaveBeenCalled();
-      expect(testBed.mocks.playtimeTracker.reset).toHaveBeenCalled();
-      expect(testBed.env.mockContainer.resolve).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.entityManager.clearAll).toHaveBeenCalled();
+      expect(ctx.bed.mocks.playtimeTracker.reset).toHaveBeenCalled();
+      expect(ctx.bed.env.mockContainer.resolve).toHaveBeenCalledWith(
         tokens.IInitializationService
       );
       expect(
-        testBed.mocks.initializationService.runInitializationSequence
+        ctx.bed.mocks.initializationService.runInitializationSequence
       ).toHaveBeenCalledWith(MOCK_WORLD_NAME);
-      expect(testBed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_READY_UI,
         {
           activeWorld: MOCK_WORLD_NAME,
           message: 'Enter command...',
         }
       );
-      expect(testBed.mocks.turnManager.start).toHaveBeenCalled();
+      expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
 
-      const status = gameEngine.getEngineStatus();
+      const status = ctx.engine.getEngineStatus();
       expect(status.isInitialized).toBe(true);
       expect(status.isLoopRunning).toBe(true);
       expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }
       );
-      await testBed.startAndReset('InitialWorld');
+      await ctx.bed.startAndReset('InitialWorld');
 
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }
       );
-      await gameEngine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
 
-      expect(testBed.mocks.logger.warn).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         'GameEngine._prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
       );
       expect(
-        testBed.mocks.playtimeTracker.endSessionAndAccumulate
+        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
       ).toHaveBeenCalledTimes(1);
-      expect(testBed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_STOPPED_UI,
         { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
       );
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_READY_UI,
         {
           activeWorld: MOCK_WORLD_NAME,
           message: 'Enter command...',
         }
       );
-      const status = gameEngine.getEngineStatus();
+      const status = ctx.engine.getEngineStatus();
       expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
     });
 
     it('should handle InitializationService failure', async () => {
       const initError = new Error('Initialization failed via service');
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: false,
           error: initError,
         }
       );
 
-      await expect(gameEngine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
         initError
       );
 
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_OPERATION_FAILED_UI,
         {
           errorMessage: `Failed to start new game: ${initError.message}`,
           errorTitle: 'Initialization Error',
         }
       );
-      const status = gameEngine.getEngineStatus();
+      const status = ctx.engine.getEngineStatus();
       expect(status.isInitialized).toBe(false);
       expect(status.isLoopRunning).toBe(false);
       expect(status.activeWorld).toBeNull();
     });
 
     it('should handle general errors during start-up and dispatch failure event', async () => {
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: true,
         }
       );
       const startupError = new Error('TurnManager failed to start');
-      testBed.mocks.playtimeTracker.startSession.mockImplementation(() => {}); // Make sure this doesn't throw
-      testBed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
+      ctx.bed.mocks.playtimeTracker.startSession.mockImplementation(() => {}); // Make sure this doesn't throw
+      ctx.bed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
 
-      await expect(gameEngine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
         startupError
       );
 
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_OPERATION_FAILED_UI,
         {
           errorMessage: `Failed to start new game: ${startupError.message}`, // Error from TurnManager
           errorTitle: 'Initialization Error',
         }
       );
-      const status = gameEngine.getEngineStatus();
+      const status = ctx.engine.getEngineStatus();
       expect(status.isInitialized).toBe(false); // Should be reset by _handleNewGameFailure
       expect(status.isLoopRunning).toBe(false);
       expect(status.activeWorld).toBeNull();

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -9,64 +9,57 @@ import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
   const MOCK_WORLD_NAME = 'TestWorld';
 
-  beforeEach(() => {
-    testBed = ctx.bed;
-  });
   describe('stop', () => {
     beforeEach(() => {
-      // Ensure gameEngine is fresh for each 'stop' test
-      gameEngine = ctx.engine;
+      // Ensure engine is fresh for each 'stop' test
     });
 
     it('should successfully stop a running game, with correct logging, events, and state changes', async () => {
-      testBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: true,
         }
       );
-      await testBed.startAndReset(MOCK_WORLD_NAME); // Start the game first and clear mocks
+      await ctx.bed.startAndReset(MOCK_WORLD_NAME); // Start the game first and clear mocks
 
-      await gameEngine.stop();
+      await ctx.engine.stop();
 
       expect(
-        testBed.mocks.playtimeTracker.endSessionAndAccumulate
+        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
       ).toHaveBeenCalledTimes(1);
-      expect(testBed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+      expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
 
-      expect(testBed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_STOPPED_UI,
         { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
       );
 
-      const status = gameEngine.getEngineStatus();
+      const status = ctx.engine.getEngineStatus();
       expect(status.isInitialized).toBe(false);
       expect(status.isLoopRunning).toBe(false);
       expect(status.activeWorld).toBeNull();
 
-      expect(testBed.mocks.logger.warn).not.toHaveBeenCalled();
+      expect(ctx.bed.mocks.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should do nothing and log if engine is already stopped', async () => {
-      // gameEngine is fresh, so not initialized
-      const initialStatus = gameEngine.getEngineStatus();
+      // ctx.engine is fresh, so not initialized
+      const initialStatus = ctx.engine.getEngineStatus();
       expect(initialStatus.isInitialized).toBe(false);
       expect(initialStatus.isLoopRunning).toBe(false);
 
-      testBed.resetMocks();
+      ctx.bed.resetMocks();
 
-      await gameEngine.stop();
+      await ctx.engine.stop();
 
       expect(
-        testBed.mocks.playtimeTracker.endSessionAndAccumulate
+        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
       ).not.toHaveBeenCalled();
-      expect(testBed.mocks.turnManager.stop).not.toHaveBeenCalled();
+      expect(ctx.bed.mocks.turnManager.stop).not.toHaveBeenCalled();
       expect(
-        testBed.mocks.safeEventDispatcher.dispatch
+        ctx.bed.mocks.safeEventDispatcher.dispatch
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
 

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -13,12 +13,6 @@ import {
 } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  let testBed;
-  let gameEngine; // Instance of GameEngine
-
-  beforeEach(() => {
-    testBed = ctx.bed;
-  });
   describe('triggerManualSave', () => {
     const SAVE_NAME = 'MySaveFile';
     const MOCK_ACTIVE_WORLD_FOR_SAVE = DEFAULT_ACTIVE_WORLD_FOR_SAVE;
@@ -44,8 +38,7 @@ describeEngineSuite('GameEngine', (ctx) => {
 
     describe('when engine is initialized', () => {
       beforeEach(async () => {
-        await testBed.initAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
-        gameEngine = ctx.engine;
+        await ctx.bed.initAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
       });
 
       it.each([
@@ -82,19 +75,19 @@ describeEngineSuite('GameEngine', (ctx) => {
 
       it('should successfully save, dispatch all UI events in order, and return success result', async () => {
         const saveResultData = { success: true, filePath: 'path/to/my.sav' };
-        testBed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
+        ctx.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
           saveResultData
         );
 
-        const result = await gameEngine.triggerManualSave(SAVE_NAME);
+        const result = await ctx.engine.triggerManualSave(SAVE_NAME);
 
         expectDispatchSequence(
-          testBed.mocks.safeEventDispatcher.dispatch,
+          ctx.bed.mocks.safeEventDispatcher.dispatch,
           ...buildSaveDispatches(SAVE_NAME, saveResultData.filePath)
         );
 
         expect(
-          testBed.mocks.gamePersistenceService.saveGame
+          ctx.bed.mocks.gamePersistenceService.saveGame
         ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
         expect(result).toEqual(saveResultData);
       });
@@ -104,38 +97,38 @@ describeEngineSuite('GameEngine', (ctx) => {
           success: false,
           error: 'Disk is critically full',
         };
-        testBed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
+        ctx.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
           saveFailureData
         );
 
-        const result = await gameEngine.triggerManualSave(SAVE_NAME);
+        const result = await ctx.engine.triggerManualSave(SAVE_NAME);
 
         expectDispatchSequence(
-          testBed.mocks.safeEventDispatcher.dispatch,
+          ctx.bed.mocks.safeEventDispatcher.dispatch,
           ...buildSaveDispatches(SAVE_NAME)
         );
 
         expect(
-          testBed.mocks.gamePersistenceService.saveGame
+          ctx.bed.mocks.gamePersistenceService.saveGame
         ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
         expect(result).toEqual(saveFailureData);
       });
 
       it('should handle unexpected error during saveGame call, dispatch UI events, and return failure result', async () => {
         const unexpectedError = new Error('Network connection failed');
-        testBed.mocks.gamePersistenceService.saveGame.mockRejectedValue(
+        ctx.bed.mocks.gamePersistenceService.saveGame.mockRejectedValue(
           unexpectedError
         );
 
-        const result = await gameEngine.triggerManualSave(SAVE_NAME);
+        const result = await ctx.engine.triggerManualSave(SAVE_NAME);
 
         expectDispatchSequence(
-          testBed.mocks.safeEventDispatcher.dispatch,
+          ctx.bed.mocks.safeEventDispatcher.dispatch,
           ...buildSaveDispatches(SAVE_NAME)
         );
 
         expect(
-          testBed.mocks.gamePersistenceService.saveGame
+          ctx.bed.mocks.gamePersistenceService.saveGame
         ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
         expect(result).toEqual({
           success: false,


### PR DESCRIPTION
Summary:
- stop assigning `testBed` and `gameEngine` in GameEngine unit tests
- rely on `ctx.bed` and `ctx.engine` getters from `describeEngineSuite`

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on edited files `npx eslint tests/unit/engine/...`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start` *(failed: No matching export in modLoadOrderResolver.js)*

------
https://chatgpt.com/codex/tasks/task_e_68566e90b8d083318d2dd0c9d5d3a4ee