### PR TITLE
[Agent] use mock data registry factory in integration tests

### DIFF
--- a/tests/common/mockFactories.js
+++ b/tests/common/mockFactories.js
@@ -1,0 +1,1 @@
+export * from './mockFactories/index.js';

--- a/tests/integration/coreHandlers.integration.test.js
+++ b/tests/integration/coreHandlers.integration.test.js
@@ -26,6 +26,7 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
+import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
 
 // -----------------------------------------------------------------------------
 //  Minimal in‑memory EntityManager stub – just enough for the handlers we use.
@@ -63,20 +64,6 @@ class SimpleEntityManager {
   // Not used but keeps the public surface familiar
   getEntityInstance(id) {
     return { id };
-  }
-}
-
-// -----------------------------------------------------------------------------
-//  Minimal IDataRegistry stub – only the method the interpreter needs.
-// -----------------------------------------------------------------------------
-class StubDataRegistry {
-  /** @param {import('../../data/schemas/rule.schema.json').SystemRule[]} rules */
-  constructor(rules) {
-    this._rules = rules;
-  }
-
-  getAllSystemRules() {
-    return this._rules;
   }
 }
 
@@ -194,7 +181,10 @@ describe('T‑07: enemy_damaged ➜ enemy_dead chained rules', () => {
       ],
     };
 
-    const dataRegistry = new StubDataRegistry([ruleA, ruleB]);
+    const rules = [ruleA, ruleB];
+    const dataRegistry = createSimpleMockDataRegistry();
+    dataRegistry.getAllSystemRules = jest.fn();
+    dataRegistry.getAllSystemRules.mockReturnValue(rules);
 
     // ---- System‑logic interpreter ------------------------------------------
     interpreter = new SystemLogicInterpreter({

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -32,6 +32,7 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
+import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -76,18 +77,6 @@ class SimpleEntityManager {
     return { id: entityId };
   }
 }
-
-/** Stub IDataRegistry exposing only the method used by SystemLogicInterpreter. */
-class StubDataRegistry {
-  constructor(rules) {
-    this._rules = rules;
-  }
-
-  getAllSystemRules() {
-    return this._rules;
-  }
-}
-
 /** Jest‑friendly logger stub capturing calls for optional debugging. */
 const createMockLogger = () => ({
   info: jest.fn(),
@@ -208,7 +197,10 @@ describe('Sequential Action Execution – Success Path', () => {
         },
       ],
     };
-    const dataRegistry = new StubDataRegistry([testRule]);
+    const rules = [testRule];
+    const dataRegistry = createSimpleMockDataRegistry();
+    dataRegistry.getAllSystemRules = jest.fn();
+    dataRegistry.getAllSystemRules.mockReturnValue(rules);
 
     sysInterpreter = new SystemLogicInterpreter({
       logger,

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -22,6 +22,7 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
+import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -53,16 +54,6 @@ class SimpleEntityManager {
 
   getEntityInstance(id) {
     return { id };
-  }
-}
-
-class StubDataRegistry {
-  constructor(rules) {
-    this._rules = rules;
-  }
-
-  getAllSystemRules() {
-    return this._rules;
   }
 }
 
@@ -156,7 +147,10 @@ describe('Sequential Action Execution – Error Path', () => {
         },
       ],
     };
-    const dataRegistry = new StubDataRegistry([testRule]);
+    const rules = [testRule];
+    const dataRegistry = createSimpleMockDataRegistry();
+    dataRegistry.getAllSystemRules = jest.fn();
+    dataRegistry.getAllSystemRules.mockReturnValue(rules);
 
     /* Interpreter */
     sysInterpreter = new SystemLogicInterpreter({


### PR DESCRIPTION
## Summary
- reuse shared mock data registry in integration tests
- re-export mock factories for easier imports

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint`
- `npm run lint --prefix llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_68567016f35c8331bdae52b4c6ceeec8