### PR TITLE
[Agent] centralize flushPromisesAndTimers

### DIFF
--- a/tests/common/jestHelpers.js
+++ b/tests/common/jestHelpers.js
@@ -24,3 +24,12 @@ export function clearMockFunctions(...targets) {
 export function suppressConsoleError() {
   return jest.spyOn(console, 'error').mockImplementation(() => {});
 }
+
+/**
+ * Flushes pending promises and advances all Jest timers.
+ *
+ * @returns {Promise<void>} Resolves once all timers have run.
+ */
+export async function flushPromisesAndTimers() {
+  await jest.runAllTimersAsync();
+}

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -14,6 +14,7 @@ import {
 } from '../mockFactories';
 import BaseTestBed from '../baseTestBed.js';
 import { describeSuiteWithHooks } from '../describeSuite.js';
+import { flushPromisesAndTimers } from '../jestHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -203,16 +204,6 @@ export function createTurnManagerTestBed(overrides = {}) {
 }
 
 /**
- * Flushes pending promises and advances all Jest timers.
- *
- * @description Flushes pending promises and advances all Jest timers.
- * @returns {Promise<void>} Resolves after timers have run.
- */
-export const flushPromisesAndTimers = async () => {
-  await jest.runAllTimersAsync();
-};
-
-/**
  * Defines a test suite with automatic {@link TurnManagerTestBed} setup.
  *
  * @param {string} title - Suite title passed to `describe`.
@@ -229,3 +220,4 @@ export function describeTurnManagerSuite(title, suiteFn, overrides = {}) {
 }
 
 export default TurnManagerTestBed;
+export { flushPromisesAndTimers };


### PR DESCRIPTION
Summary:
- add `flushPromisesAndTimers` helper in `tests/common/jestHelpers.js`
- remove old helper from `turnManagerTestBed.js` and re-export new one

Testing Done:
- `npm run format`
- `npm run lint` *(fails: existing repo lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856714a410883318cc59d14719796ce