### PR TITLE
[Agent] remove redundant afterEach in turnManager tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -1,7 +1,7 @@
 // src/tests/turns/turnManager.advanceTurn.queueNotEmpty.test.js
 // --- FILE START (Entire file content as requested, with corrections) ---
 
-import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 import {
   describeTurnManagerSuite,
   TurnManagerTestBed,
@@ -22,7 +22,6 @@ describeTurnManagerSuite(
 
     beforeEach(async () => {
       // Made beforeEach async
-      jest.clearAllMocks();
       testBed = getBed();
 
       // Reset mock state
@@ -57,10 +56,6 @@ describeTurnManagerSuite(
 
       // Re-apply default isEmpty mock after resetting call history
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-    });
-
-    afterEach(async () => {
-      jest.restoreAllMocks();
     });
 
     // --- Test Cases ---

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -1,9 +1,8 @@
 // src/tests/turns/turnManager.advanceTurn.roundStart.test.js
 // --- FILE START (Entire file content with corrected assertions) ---
 
-import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
-import { ACTOR_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import {
   SYSTEM_ERROR_OCCURRED_ID,
   TURN_PROCESSING_STARTED,
@@ -18,7 +17,6 @@ describeTurnManagerSuite(
     let advanceTurnSpy; // General spy for advanceTurn
 
     beforeEach(() => {
-      jest.clearAllMocks();
       testBed = getBed();
 
       // Reset mock state
@@ -50,10 +48,6 @@ describeTurnManagerSuite(
       testBed.mocks.logger.debug.mockClear();
       testBed.mocks.logger.warn.mockClear();
       testBed.mocks.logger.error.mockClear();
-    });
-
-    afterEach(async () => {
-      jest.restoreAllMocks();
     });
 
     // --- Test Cases ---


### PR DESCRIPTION
Summary: Removed unnecessary afterEach blocks and jest.clearAllMocks() calls in two turnManager advanceTurn tests. Updated imports accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (files changed) `npx eslint tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js tests/unit/turns/turnManager.advanceTurn.roundStart.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6856705bcf948331b2d02d9e6ca7ef0f