### PR TITLE
[Agent] Add setup overrides to expectSuccessfulGeneration

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -148,6 +148,10 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
    * @param {import('../../../src/turns/interfaces/ITurnContext.js').ITurnContext} params.context - Turn context.
    * @param {import('../../../src/turns/dtos/actionComposite.js').ActionComposite[]} params.actions - Available actions.
    * @param {string} params.expectedPrompt - Expected final prompt string.
+   * @param {string} [params.llmId] - Optional LLM ID override.
+   * @param {object} [params.gameState] - Optional game state override.
+   * @param {object} [params.promptData] - Optional prompt data override.
+   * @param {string} [params.finalPrompt] - Optional final prompt override.
    * @returns {Promise<void>} Resolves when assertions pass.
    */
   async expectSuccessfulGeneration({
@@ -155,11 +159,20 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
     context,
     actions,
     expectedPrompt,
+    llmId,
+    gameState,
+    promptData,
+    finalPrompt,
   }) {
+    this.setupMockSuccess({ llmId, gameState, promptData, finalPrompt });
     const prompt = await this.generate(actor, context, actions);
     expect(prompt).toBe(expectedPrompt);
 
-    const { llmId, gameState, promptData } = this._successOptions;
+    const {
+      llmId: _llmId,
+      gameState: _gameState,
+      promptData: _promptData,
+    } = this._successOptions;
     expect(this.llmAdapter.getCurrentActiveLlmId).toHaveBeenCalledTimes(1);
     expect(this.gameStateProvider.buildGameState).toHaveBeenCalledWith(
       actor,
@@ -167,10 +180,10 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
       this.logger
     );
     expect(this.promptContentProvider.getPromptData).toHaveBeenCalledWith(
-      expect.objectContaining({ ...gameState, availableActions: actions }),
+      expect.objectContaining({ ..._gameState, availableActions: actions }),
       this.logger
     );
-    expect(this.promptBuilder.build).toHaveBeenCalledWith(llmId, promptData);
+    expect(this.promptBuilder.build).toHaveBeenCalledWith(_llmId, _promptData);
   }
 }
 

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -51,18 +51,15 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
     const context = testBed.defaultContext;
     const actions = [...testBed.defaultActions, { id: 'a1' }];
 
-    testBed.setupMockSuccess({
-      llmId: 'llm1',
-      gameState: { state: true },
-      promptData: { pd: true },
-      finalPrompt: 'FINAL',
-    });
-
     await testBed.expectSuccessfulGeneration({
       actor,
       context,
       actions,
       expectedPrompt: 'FINAL',
+      llmId: 'llm1',
+      gameState: { state: true },
+      promptData: { pd: true },
+      finalPrompt: 'FINAL',
     });
   });
 


### PR DESCRIPTION
Summary: Allow expectSuccessfulGeneration to internally handle mock setup options, simplifying tests.

Changes Made:
- Updated promptPipelineTestBed to accept and apply overrides when asserting successful prompt generation.
- Modified AIPromptPipeline tests to use new override feature.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` - fails due to existing repo issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_68567042ee508331b39a7f079fd810b0