### PR TITLE
[Agent] use expectEngineStatus helper

### DIFF
--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
+import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
 import '../../common/engine/engineTestTypedefs.js';
 
 import {
@@ -57,10 +58,11 @@ describeEngineSuite('GameEngine', (ctx) => {
       );
       expect(testBed.mocks.turnManager.start).toHaveBeenCalled();
 
-      const status = gameEngine.getEngineStatus();
-      expect(status.isInitialized).toBe(true);
-      expect(status.isLoopRunning).toBe(true);
-      expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
+      expectEngineStatus(gameEngine, {
+        isInitialized: true,
+        isLoopRunning: true,
+        activeWorld: MOCK_WORLD_NAME,
+      });
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {
@@ -92,8 +94,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           message: 'Enter command...',
         }
       );
-      const status = gameEngine.getEngineStatus();
-      expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
+      expectEngineStatus(gameEngine, {
+        isInitialized: true,
+        isLoopRunning: true,
+        activeWorld: MOCK_WORLD_NAME,
+      });
     });
 
     it('should handle InitializationService failure', async () => {
@@ -116,10 +121,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      const status = gameEngine.getEngineStatus();
-      expect(status.isInitialized).toBe(false);
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(gameEngine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
     });
 
     it('should handle general errors during start-up and dispatch failure event', async () => {
@@ -143,10 +149,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      const status = gameEngine.getEngineStatus();
-      expect(status.isInitialized).toBe(false); // Should be reset by _handleNewGameFailure
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(gameEngine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
     });
   });
 });

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -7,6 +7,7 @@ import {
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
+import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   let testBed;
@@ -43,19 +44,22 @@ describeEngineSuite('GameEngine', (ctx) => {
         { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
       );
 
-      const status = gameEngine.getEngineStatus();
-      expect(status.isInitialized).toBe(false);
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(gameEngine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
 
       expect(testBed.mocks.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should do nothing and log if engine is already stopped', async () => {
       // gameEngine is fresh, so not initialized
-      const initialStatus = gameEngine.getEngineStatus();
-      expect(initialStatus.isInitialized).toBe(false);
-      expect(initialStatus.isLoopRunning).toBe(false);
+      expectEngineStatus(gameEngine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
 
       testBed.resetMocks();
 
@@ -87,9 +91,11 @@ describeEngineSuite('GameEngine', (ctx) => {
         );
         await localBed.startAndReset(MOCK_WORLD_NAME);
 
-        const statusAfterStart = localEngine.getEngineStatus();
-        expect(statusAfterStart.isInitialized).toBe(true);
-        expect(statusAfterStart.isLoopRunning).toBe(true);
+        expectEngineStatus(localEngine, {
+          isInitialized: true,
+          isLoopRunning: true,
+          activeWorld: MOCK_WORLD_NAME,
+        });
 
         await localEngine.stop();
 


### PR DESCRIPTION
## Summary
- switch to expectEngineStatus in `startNewGame.test.js`
- switch to expectEngineStatus in `stop.test.js`

## Testing Done
- `npm run test`
- `npm run test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_68567038ff908331bc7eaf9955dc0a22