### PR TITLE
[Agent] consolidate engine status assertions

### DIFF
--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -10,6 +10,7 @@ import {
   ENGINE_OPERATION_FAILED_UI,
   ENGINE_STOPPED_UI,
 } from '../../../src/constants/eventIds.js';
+import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   const MOCK_WORLD_NAME = 'TestWorld';
@@ -49,10 +50,11 @@ describeEngineSuite('GameEngine', (ctx) => {
       );
       expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
 
-      const status = ctx.engine.getEngineStatus();
-      expect(status.isInitialized).toBe(true);
-      expect(status.isLoopRunning).toBe(true);
-      expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
+      expectEngineStatus(ctx.engine, {
+        isInitialized: true,
+        isLoopRunning: true,
+        activeWorld: MOCK_WORLD_NAME,
+      });
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {
@@ -84,8 +86,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           message: 'Enter command...',
         }
       );
-      const status = ctx.engine.getEngineStatus();
-      expect(status.activeWorld).toBe(MOCK_WORLD_NAME);
+      expectEngineStatus(ctx.engine, {
+        isInitialized: true,
+        isLoopRunning: true,
+        activeWorld: MOCK_WORLD_NAME,
+      });
     });
 
     it('should handle InitializationService failure', async () => {
@@ -108,10 +113,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      const status = ctx.engine.getEngineStatus();
-      expect(status.isInitialized).toBe(false);
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(ctx.engine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
     });
 
     it('should handle general errors during start-up and dispatch failure event', async () => {
@@ -135,10 +141,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      const status = ctx.engine.getEngineStatus();
-      expect(status.isInitialized).toBe(false); // Should be reset by _handleNewGameFailure
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(ctx.engine, {
+        isInitialized: false, // Should be reset by _handleNewGameFailure
+        isLoopRunning: false,
+        activeWorld: null,
+      });
     });
   });
 });

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -7,6 +7,7 @@ import {
 } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
+import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   const MOCK_WORLD_NAME = 'TestWorld';
@@ -36,19 +37,22 @@ describeEngineSuite('GameEngine', (ctx) => {
         { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
       );
 
-      const status = ctx.engine.getEngineStatus();
-      expect(status.isInitialized).toBe(false);
-      expect(status.isLoopRunning).toBe(false);
-      expect(status.activeWorld).toBeNull();
+      expectEngineStatus(ctx.engine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
 
       expect(ctx.bed.mocks.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should do nothing and log if engine is already stopped', async () => {
       // ctx.engine is fresh, so not initialized
-      const initialStatus = ctx.engine.getEngineStatus();
-      expect(initialStatus.isInitialized).toBe(false);
-      expect(initialStatus.isLoopRunning).toBe(false);
+      expectEngineStatus(ctx.engine, {
+        isInitialized: false,
+        isLoopRunning: false,
+        activeWorld: null,
+      });
 
       ctx.bed.resetMocks();
 
@@ -80,9 +84,11 @@ describeEngineSuite('GameEngine', (ctx) => {
         );
         await localBed.startAndReset(MOCK_WORLD_NAME);
 
-        const statusAfterStart = localEngine.getEngineStatus();
-        expect(statusAfterStart.isInitialized).toBe(true);
-        expect(statusAfterStart.isLoopRunning).toBe(true);
+        expectEngineStatus(localEngine, {
+          isInitialized: true,
+          isLoopRunning: true,
+          activeWorld: MOCK_WORLD_NAME,
+        });
 
         await localEngine.stop();
 


### PR DESCRIPTION
## Summary
- use `expectEngineStatus` helper for engine status checks in engine start/stop tests

## Testing Done
- `npm run lint` *(fails: many existing lint issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68567499ae44833187bd46383988414a