### PR TITLE
[Agent] refactor logger mocks in integration tests

### DIFF
--- a/tests/integration/loaderRegistry.integration.test.js
+++ b/tests/integration/loaderRegistry.integration.test.js
@@ -1,6 +1,7 @@
 // Filename: src/tests/integration/loaderRegistry.integration.test.js
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { createMockLogger } from '../common/mockFactories.js';
 import ActionLoader from '../../src/loaders/actionLoader.js'; // Adjust path if needed
 import ComponentLoader from '../../src/loaders/componentLoader.js'; // Adjust path if needed
 import InMemoryDataRegistry from '../../src/data/inMemoryDataRegistry.js'; // Use the real registry
@@ -169,22 +170,6 @@ const createMockSchemaValidator = (overrides = {}) => {
   };
   return mockValidator;
 };
-
-/**
- * Creates a mock ILogger service.
- *
- * @param {object} [overrides] - Optional overrides for mock methods.
- * @returns {import('../../../../interfaces/coreServices.js').ILogger} Mocked logger service.
- */
-const createMockLogger = (overrides = {}) => ({
-  // Set default mocks using jest.fn()
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-  // Allow overriding specific methods or adding new ones
-  ...overrides,
-});
 
 // --- Test Suite ---
 

--- a/tests/integration/modLoadDependencyFail.test.js
+++ b/tests/integration/modLoadDependencyFail.test.js
@@ -7,6 +7,7 @@ import ModsLoader from '../../src/loaders/modsLoader.js';
 import ModManifestLoader from '../../src/modding/modManifestLoader.js';
 import AjvSchemaValidator from '../../src/validation/ajvSchemaValidator.js';
 import ModDependencyError from '../../src/errors/modDependencyError.js';
+import { createMockLogger } from '../common/mockFactories.js';
 
 /* -------------------------------------------------------------------------- */
 /* Helper factories – duplicated from modManifestLoader.harness.test.js        */
@@ -141,13 +142,6 @@ const createMockRegistry = () => {
     getManifest: jest.fn(),
   };
 };
-
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /* -------------------------------------------------------------------------- */
 /* Integration test                                                           */

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -32,7 +32,10 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
-import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -77,13 +80,6 @@ class SimpleEntityManager {
     return { id: entityId };
   }
 }
-/** Jest‑friendly logger stub capturing calls for optional debugging. */
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /**
  * Build the ExecutionContext object expected by real operation handlers from

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -22,7 +22,10 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
-import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -56,13 +59,6 @@ class SimpleEntityManager {
     return { id };
   }
 }
-
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /**
  *


### PR DESCRIPTION
## Summary
- reuse `createMockLogger` across integration tests
- remove local logger factories

## Testing Done
- `npm run lint` *(fails: many errors/warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685674f9da5483318a05dfb5869ee142