### PR TITLE
[Agent] Refactor loader mocks using factory helper

### DIFF
--- a/tests/common/mockFactories/coreServices.js
+++ b/tests/common/mockFactories/coreServices.js
@@ -30,7 +30,7 @@ export function createSimpleMock(methodNames, defaults = {}) {
  *  Mapping of factory names to method arrays or spec objects.
  * @returns {Record<string, () => object>} Generated factory functions.
  */
-function generateFactories(specMap) {
+export function generateFactories(specMap) {
   const factories = {};
   for (const [name, spec] of Object.entries(specMap)) {
     const { methods, defaults = {} } = Array.isArray(spec)

--- a/tests/common/mockFactories/loaders.js
+++ b/tests/common/mockFactories/loaders.js
@@ -4,63 +4,93 @@
  */
 
 import { jest } from '@jest/globals';
+import { generateFactories } from './coreServices.js';
+
+const baseFactories = generateFactories({
+  createMockContentLoader: ['loadItemsForMod'],
+  createMockSchemaLoader: ['loadAndCompileAllSchemas'],
+  createMockGameConfigLoader: ['loadConfig'],
+  createMockModManifestLoader: ['loadRequestedManifests'],
+  createMockWorldLoader: ['loadWorlds'],
+  createMockModDependencyValidator: ['validate'],
+  createMockModLoadOrderResolver: ['resolve', 'resolveOrder'],
+});
 
 /**
- * Generic content-loader mock (ActionLoader, ComponentLoader, …).
+ * Creates a generic content loader mock.
  *
- * @param {object} [defaultLoadResult]
  * @returns {{ loadItemsForMod: jest.Mock }} Loader mock
  */
-export const createMockContentLoader = (
-  defaultLoadResult = { count: 0, overrides: 0, errors: 0 }
-) => ({
-  loadItemsForMod: jest.fn().mockResolvedValue(defaultLoadResult),
-});
+export function createMockContentLoader() {
+  const mock = baseFactories.createMockContentLoader();
+  mock.loadItemsForMod.mockResolvedValue({ count: 0, overrides: 0, errors: 0 });
+  return mock;
+}
 
 /**
  * Creates a mock SchemaLoader.
  *
  * @returns {{ loadAndCompileAllSchemas: jest.Mock }} Loader mock
  */
-export const createMockSchemaLoader = () => ({
-  loadAndCompileAllSchemas: jest.fn().mockResolvedValue(undefined),
-});
+export function createMockSchemaLoader() {
+  const mock = baseFactories.createMockSchemaLoader();
+  mock.loadAndCompileAllSchemas.mockResolvedValue(undefined);
+  return mock;
+}
 
 /**
  * Creates a mock GameConfigLoader.
  *
  * @returns {{ loadConfig: jest.Mock }} Loader mock
  */
-export const createMockGameConfigLoader = () => ({
-  loadConfig: jest.fn().mockResolvedValue([]),
-});
+export function createMockGameConfigLoader() {
+  const mock = baseFactories.createMockGameConfigLoader();
+  mock.loadConfig.mockResolvedValue([]);
+  return mock;
+}
 
 /**
  * Creates a mock ModManifestLoader.
  *
  * @returns {{ loadRequestedManifests: jest.Mock }} Loader mock
  */
-export const createMockModManifestLoader = () => ({
-  loadRequestedManifests: jest.fn().mockResolvedValue(new Map()),
-});
+export function createMockModManifestLoader() {
+  const mock = baseFactories.createMockModManifestLoader();
+  mock.loadRequestedManifests.mockResolvedValue(new Map());
+  return mock;
+}
 
 /**
  * Creates a mock WorldLoader.
  *
  * @returns {{ loadWorlds: jest.Mock }} Loader mock
  */
-export const createMockWorldLoader = () => ({
-  loadWorlds: jest.fn().mockResolvedValue(undefined),
-});
+export function createMockWorldLoader() {
+  const mock = baseFactories.createMockWorldLoader();
+  mock.loadWorlds.mockResolvedValue(undefined);
+  return mock;
+}
 
 /**
  * Creates a mock ModDependencyValidator.
  *
  * @returns {{ validate: jest.Mock }} Validator mock
  */
-export const createMockModDependencyValidator = () => ({
-  validate: jest.fn(),
-});
+export function createMockModDependencyValidator() {
+  return baseFactories.createMockModDependencyValidator();
+}
+
+/**
+ * Creates a mock ModLoadOrderResolver.
+ *
+ * @returns {{ resolve: jest.Mock, resolveOrder: jest.Mock }} Resolver mock
+ */
+export function createMockModLoadOrderResolver() {
+  const mock = baseFactories.createMockModLoadOrderResolver();
+  mock.resolve.mockImplementation((reqIds) => reqIds);
+  mock.resolveOrder.mockImplementation((reqIds) => reqIds);
+  return mock;
+}
 
 /**
  * Creates a mock for the mod version validator that can be used as a function
@@ -72,17 +102,4 @@ export const createMockModVersionValidator = () => {
   const fn = jest.fn();
   fn.validate = fn;
   return fn;
-};
-
-/**
- * Creates a mock for the mod load order resolver.
- *
- * @returns {{ resolve: jest.Mock, resolveOrder: jest.Mock }} Resolver mock
- */
-export const createMockModLoadOrderResolver = () => {
-  const resolveFn = jest.fn((reqIds) => reqIds);
-  return {
-    resolve: resolveFn,
-    resolveOrder: resolveFn,
-  };
 };


### PR DESCRIPTION
Summary: Exposed the internal `generateFactories` helper and refactored loader mock factories to use it. Loader mocks now construct their jest functions via a shared base factory with per-instance default implementations.

Changes Made:
- Exported `generateFactories` from `coreServices.js`.
- Reimplemented loader mock factories in `loaders.js` using `generateFactories` and `createSimpleMock`.
- Preserved custom `createMockModVersionValidator`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685674e1fa008331a8b3aed2328a4b97