### PR TITLE
Refactor loader registrations to replace ModVersionValidator with val…

### DIFF
--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -59,7 +59,7 @@ import WorldLoader from '../../loaders/worldLoader.js';
 
 // --- Modding Service Imports ---
 import ModDependencyValidator from '../../modding/modDependencyValidator.js';
-import ModVersionValidator from '../../modding/modVersionValidator.js';
+import validateModEngineVersions from '../../modding/modVersionValidator.js';
 import ModLoadOrderResolver from '../../modding/modLoadOrderResolver.js';
 
 // --- DI & Helper Imports ---
@@ -351,7 +351,7 @@ export function registerLoaders(container) {
       modManifestLoader: c.resolve(tokens.ModManifestLoader),
       validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
       modDependencyValidator: new ModDependencyValidator(loggerDep),
-      modVersionValidator: new ModVersionValidator(loggerDep),
+      modVersionValidator: validateModEngineVersions,
       modLoadOrderResolver: new ModLoadOrderResolver(loggerDep),
       worldLoader: c.resolve(tokens.WorldLoader),
     });

--- a/src/loaders/ModManifestProcessor.js
+++ b/src/loaders/ModManifestProcessor.js
@@ -103,10 +103,9 @@ export class ModManifestProcessor {
       throw e;
     }
 
-    const finalOrder = this.#modLoadOrderResolver.resolveOrder(
+    const finalOrder = this.#modLoadOrderResolver.resolve(
       requestedIds,
-      manifestsForValidation,
-      this.#logger
+      manifestsForValidation
     );
     this.#logger.debug(
       `ModsLoader: Final mod order resolved: [${finalOrder.join(', ')}]`

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -83,7 +83,7 @@ export function createTestEnvironment() {
     );
     m.mockModDependencyValidator.validate.mockImplementation(() => {});
     m.mockModVersionValidator.mockImplementation(() => {});
-    m.mockModLoadOrderResolver.resolveOrder.mockImplementation((ids) => ids);
+    m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
 
     return new ModsLoader({
       registry: m.mockRegistry,
@@ -118,7 +118,7 @@ export function createTestEnvironment() {
     // Handy aliases for deeply nested jest fns
     mockedModDependencyValidator: mocks.mockModDependencyValidator.validate,
     mockedValidateModEngineVersions: mocks.mockModVersionValidator,
-    mockedResolveOrder: mocks.mockModLoadOrderResolver.resolveOrder,
+    mockedResolveOrder: mocks.mockModLoadOrderResolver.resolve,
     cleanup,
   };
 }

--- a/tests/unit/loaders/modManifestProcessor.test.js
+++ b/tests/unit/loaders/modManifestProcessor.test.js
@@ -43,7 +43,7 @@ describe('ModManifestProcessor.processManifests', () => {
     dispatcher = { dispatch: jest.fn() };
     modDependencyValidator = { validate: jest.fn() };
     modVersionValidator = jest.fn();
-    modLoadOrderResolver = { resolveOrder: jest.fn(() => ['modA', 'modB']) };
+    modLoadOrderResolver = { resolve: jest.fn(() => ['modA', 'modB']) };
     processor = new ModManifestProcessor({
       modManifestLoader: manifestLoader,
       logger,
@@ -72,10 +72,9 @@ describe('ModManifestProcessor.processManifests', () => {
       logger,
       dispatcher
     );
-    expect(modLoadOrderResolver.resolveOrder).toHaveBeenCalledWith(
+    expect(modLoadOrderResolver.resolve).toHaveBeenCalledWith(
       ['modA', 'modB'],
-      expect.any(Map),
-      logger
+      expect.any(Map)
     );
     expect(registry.store).toHaveBeenCalledWith(
       'mod_manifests',
@@ -112,7 +111,7 @@ describe('ModManifestProcessor.processManifests', () => {
       expect.stringContaining('Encountered 1 engine version incompatibilities'),
       error
     );
-    expect(modLoadOrderResolver.resolveOrder).not.toHaveBeenCalled();
+    expect(modLoadOrderResolver.resolve).not.toHaveBeenCalled();
     expect(registry.store).not.toHaveBeenCalledWith(
       'meta',
       'final_mod_order',

--- a/tests/unit/loaders/modsLoader.preLoopErrors.test.js
+++ b/tests/unit/loaders/modsLoader.preLoopErrors.test.js
@@ -151,8 +151,7 @@ describe('ModsLoader Integration Test Suite - Pre-Loop Error Handling (Refactore
 
     expect(env.mockedResolveOrder).toHaveBeenCalledWith(
       requestedIds,
-      cycleManifestMap,
-      env.mockLogger
+      cycleManifestMap
     );
   });
 });

--- a/tests/unit/modding/modLoadOrderResolver.integration.test.js
+++ b/tests/unit/modding/modLoadOrderResolver.integration.test.js
@@ -1,0 +1,31 @@
+import ModLoadOrderResolver from '../../../src/modding/modLoadOrderResolver.js';
+import ModDependencyError from '../../../src/errors/modDependencyError.js';
+
+describe('ModLoadOrderResolver integration', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  it('can be instantiated and resolves simple order', () => {
+    const resolver = new ModLoadOrderResolver(mockLogger);
+    const manifests = new Map([
+      ['a', { id: 'a', dependencies: [{ id: 'b', required: true }] }],
+      ['b', { id: 'b' }],
+    ]);
+    const order = resolver.resolve(['a', 'b'], manifests);
+    // b must come before a
+    expect(order.indexOf('b')).toBeLessThan(order.indexOf('a'));
+  });
+
+  it('throws on dependency cycle', () => {
+    const resolver = new ModLoadOrderResolver(mockLogger);
+    const manifests = new Map([
+      ['a', { id: 'a', dependencies: [{ id: 'b', required: true }] }],
+      ['b', { id: 'b', dependencies: [{ id: 'a', required: true }] }],
+    ]);
+    expect(() => resolver.resolve(['a', 'b'], manifests)).toThrow(ModDependencyError);
+  });
+}); 


### PR DESCRIPTION
…idateModEngineVersions. Update ModLoadOrderResolver method from resolveOrder to resolve for consistency across the codebase. Adjust related tests to reflect these changes.