### PR TITLE
[Agent] refactor mock logger usage in integration tests

### DIFF
--- a/tests/integration/loaders/loaderRegistry.integration.test.js
+++ b/tests/integration/loaders/loaderRegistry.integration.test.js
@@ -1,6 +1,7 @@
 // Filename: src/tests/integration/loaderRegistry.integration.test.js
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { createMockLogger } from '../../common/mockFactories.js';
 import ActionLoader from '../../../src/loaders/actionLoader.js';
 import ComponentLoader from '../../../src/loaders/componentLoader.js';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
@@ -81,13 +82,6 @@ const createMockSchemaValidator = (overrides = {}) => {
   return mockValidator;
 };
 
-const createMockLogger = (overrides = {}) => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-  ...overrides,
-});
 
 // --- Test Suite ---
 describe('Integration: Loaders, Registry State, and Overrides (REFACTOR-8.6)', () => {

--- a/tests/integration/loaders/modLoadDependencyFail.test.js
+++ b/tests/integration/loaders/modLoadDependencyFail.test.js
@@ -1,6 +1,7 @@
 // Filename: src/tests/integration/loaders/modLoadDependencyFail.test.js
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { createMockLogger } from '../../common/mockFactories.js';
 
 // Core services under test
 import ModsLoader from '../../../src/loaders/modsLoader.js';
@@ -141,12 +142,6 @@ const createMockRegistry = () => {
   };
 };
 
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /* -------------------------------------------------------------------------- */
 /* Integration test                                                           */

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -32,7 +32,10 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
-import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -78,12 +81,6 @@ class SimpleEntityManager {
   }
 }
 /** Jest‑friendly logger stub capturing calls for optional debugging. */
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /**
  * Build the ExecutionContext object expected by real operation handlers from

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -22,7 +22,10 @@ import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
-import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../common/mockFactories.js';
 import {
   afterEach,
   beforeEach,
@@ -57,12 +60,6 @@ class SimpleEntityManager {
   }
 }
 
-const createMockLogger = () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-});
 
 /**
  *


### PR DESCRIPTION
## Summary
- use shared `createMockLogger` across integration tests

## Testing Done
- `npm run lint` *(fails: 3159 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685683bc148c83318ebb5339d779dd78