### PR TITLE
[Feat] Add withGameEngineBed helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -1,0 +1,28 @@
+/**
+ * @file Helper functions for ad-hoc GameEngine test beds.
+ * @see tests/common/engine/gameEngineHelpers.js
+ */
+
+import {
+  createGameEngineTestBed,
+  GameEngineTestBed,
+} from './gameEngineTestBed.js';
+
+/**
+ * Executes a callback with a temporary {@link GameEngineTestBed} instance.
+ *
+ * @param {Record<string, any>} [overrides] - Optional dependency overrides.
+ * @param {(bed: import('./gameEngineTestBed.js').GameEngineTestBed,
+ *   engine: import('../../../src/engine/gameEngine.js').default) =>
+ *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
+ * @returns {Promise<void>} Resolves when the callback completes.
+ */
+export async function withGameEngineBed(overrides = {}, testFn) {
+  const bed = createGameEngineTestBed(overrides);
+  try {
+    bed.resetMocks();
+    await testFn(bed, bed.engine);
+  } finally {
+    await bed.cleanup();
+  }
+}

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -1,0 +1,47 @@
+/**
+ * @file Test suite for gameEngineHelpers.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { withGameEngineBed } from '../../../common/engine/gameEngineHelpers.js';
+import * as bedModule from '../../../common/engine/gameEngineTestBed.js';
+
+describe('withGameEngineBed', () => {
+  it('creates bed, resets mocks, runs callback and cleans up', async () => {
+    const bed = {
+      engine: 'engine',
+      resetMocks: jest.fn(),
+      cleanup: jest.fn(),
+    };
+    const createSpy = jest
+      .spyOn(bedModule, 'createGameEngineTestBed')
+      .mockReturnValue(bed);
+    const testFn = jest.fn();
+
+    await withGameEngineBed({ a: 1 }, testFn);
+
+    expect(createSpy).toHaveBeenCalledWith({ a: 1 });
+    expect(bed.resetMocks).toHaveBeenCalledTimes(1);
+    expect(testFn).toHaveBeenCalledWith(bed, bed.engine);
+    expect(bed.cleanup).toHaveBeenCalledTimes(1);
+
+    createSpy.mockRestore();
+  });
+
+  it('cleans up even when callback throws', async () => {
+    const bed = {
+      engine: 'engine',
+      resetMocks: jest.fn(),
+      cleanup: jest.fn(),
+    };
+    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+
+    const error = new Error('fail');
+    const testFn = jest.fn().mockRejectedValue(error);
+
+    await expect(withGameEngineBed(undefined, testFn)).rejects.toThrow('fail');
+    expect(bed.cleanup).toHaveBeenCalledTimes(1);
+
+    bedModule.createGameEngineTestBed.mockRestore();
+  });
+});


### PR DESCRIPTION
Summary: Provide a helper to easily create and clean up GameEngine test beds in parameterized tests.

Changes Made:
- Added `withGameEngineBed` in `tests/common/engine/gameEngineHelpers.js` to manage bed lifecycle.
- Created accompanying unit tests for the helper.

Testing Done:
- [x] Code formatted (`npx prettier` on new files)
- [x] Lint passes on changed files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68568f2c252883318fe6c330b455e30c