### PR TITLE
[Test] Share AI prompt pipeline spec

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -18,6 +18,38 @@ import BaseTestBed from '../baseTestBed.js';
 import { describeSuiteWithHooks } from '../describeSuite.js';
 
 /**
+ * @typedef {object} DependencySpecEntry
+ * @property {RegExp} error - Expected error when dependency is missing.
+ * @property {string[]} methods - Methods required on the dependency.
+ */
+
+/**
+ * @description Defines how {@link AIPromptPipeline} constructor dependencies
+ * should be validated within tests. Each property specifies the expected error
+ * regex and required method names for that dependency.
+ * @type {Object<string, DependencySpecEntry>}
+ */
+export const AIPromptPipelineDependencySpec = {
+  llmAdapter: {
+    error: /ILLMAdapter/,
+    methods: ['getAIDecision', 'getCurrentActiveLlmId'],
+  },
+  gameStateProvider: {
+    error: /IAIGameStateProvider/,
+    methods: ['buildGameState'],
+  },
+  promptContentProvider: {
+    error: /IAIPromptContentProvider/,
+    methods: ['getPromptData'],
+  },
+  promptBuilder: {
+    error: /IPromptBuilder/,
+    methods: ['build'],
+  },
+  logger: { error: /ILogger/, methods: ['info'] },
+};
+
+/**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
  * @class
  */

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -4,6 +4,7 @@ import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
   describeAIPromptPipelineSuite,
   AIPromptPipelineTestBed,
+  AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';
 import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
 
@@ -16,28 +17,9 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   });
 
   describe('constructor validation', () => {
-    const spec = {
-      llmAdapter: {
-        error: /ILLMAdapter/,
-        methods: ['getAIDecision', 'getCurrentActiveLlmId'],
-      },
-      gameStateProvider: {
-        error: /IAIGameStateProvider/,
-        methods: ['buildGameState'],
-      },
-      promptContentProvider: {
-        error: /IAIPromptContentProvider/,
-        methods: ['getPromptData'],
-      },
-      promptBuilder: {
-        error: /IPromptBuilder/,
-        methods: ['build'],
-      },
-      logger: { error: /ILogger/, methods: ['info'] },
-    };
     const cases = buildMissingDependencyCases(
       () => testBed.getDependencies(),
-      spec
+      AIPromptPipelineDependencySpec
     );
     test.each(cases)('throws when %s', (_desc, mutate, regex) => {
       const deps = testBed.getDependencies();


### PR DESCRIPTION
Summary: Exported a reusable dependency specification for `AIPromptPipeline` tests. Updated the test bed to expose `AIPromptPipelineDependencySpec` and used it in the pipeline unit tests for constructor validation.

Changes Made:
- Added `AIPromptPipelineDependencySpec` definition with JSDoc in test bed.
- Imported and applied the spec in `AIPromptPipeline.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68568fe7b2e08331adf4f95fb27ecb84