### PR TITLE
[Agent] introduce FactoryTestBed and refactor test beds

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -6,8 +6,7 @@
 /* global beforeEach, afterEach, describe */
 
 import { createTestEnvironment } from './gameEngine.test-environment.js';
-import ContainerTestBed from '../containerTestBed.js';
-import BaseTestBed from '../baseTestBed.js';
+import FactoryTestBed from '../factoryTestBed.js';
 import { suppressConsoleError } from '../jestHelpers.js';
 import { describeSuiteWithHooks } from '../describeSuite.js';
 
@@ -16,11 +15,17 @@ import { describeSuiteWithHooks } from '../describeSuite.js';
  * environment and exposes helpers for common test operations.
  * @class
  */
-export class GameEngineTestBed extends ContainerTestBed {
+export class GameEngineTestBed extends FactoryTestBed {
   /** @type {ReturnType<typeof createTestEnvironment>} */
   env;
   /** @type {import('../../../src/engine/gameEngine.js').default} */
   engine;
+  /** @type {{ resolve: import('jest').Mock }} */
+  container;
+  /** @type {Map<any, any>} */
+  #tokenOverrides = new Map();
+  /** @type {Function} */
+  #originalResolve;
   /**
    * @type {{
    *   logger: ReturnType<import('../mockFactories').createMockLogger>,
@@ -39,8 +44,7 @@ export class GameEngineTestBed extends ContainerTestBed {
    */
   constructor(overrides = {}) {
     const env = createTestEnvironment(overrides);
-    super(env.mockContainer);
-    this.initializeFromFactories({
+    super({
       logger: () => env.logger,
       entityManager: () => env.entityManager,
       turnManager: () => env.turnManager,
@@ -49,9 +53,31 @@ export class GameEngineTestBed extends ContainerTestBed {
       safeEventDispatcher: () => env.safeEventDispatcher,
       initializationService: () => env.initializationService,
     });
+    this.container = env.mockContainer;
+    this.#originalResolve =
+      this.container.resolve.getMockImplementation?.() ??
+      this.container.resolve;
     const engine = env.createGameEngine();
     this.env = env;
     this.engine = engine;
+  }
+
+  /**
+   * Temporarily overrides container token resolution.
+   *
+   * @param {any} token - Token to override.
+   * @param {any | (() => any)} value - Replacement value or function.
+   * @returns {void}
+   */
+  withTokenOverride(token, value) {
+    this.#tokenOverrides.set(token, value);
+    this.container.resolve.mockImplementation((tok) => {
+      if (this.#tokenOverrides.has(tok)) {
+        const override = this.#tokenOverrides.get(tok);
+        return typeof override === 'function' ? override() : override;
+      }
+      return this.#originalResolve(tok);
+    });
   }
 
   /**
@@ -125,6 +151,8 @@ export class GameEngineTestBed extends ContainerTestBed {
   async _afterCleanup() {
     await this.stop();
     this.env.cleanup();
+    this.container.resolve.mockImplementation(this.#originalResolve);
+    this.#tokenOverrides.clear();
     await super._afterCleanup();
   }
 }

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -21,7 +21,7 @@ import {
   createMockSafeEventDispatcher,
   createSimpleMockDataRegistry,
 } from '../mockFactories';
-import BaseTestBed from '../baseTestBed.js';
+import FactoryTestBed from '../factoryTestBed.js';
 import { describeSuite } from '../describeSuite.js';
 
 // --- Centralized Mocks (REMOVED) ---
@@ -113,7 +113,7 @@ export const TestData = {
  * Creates mocks, instantiates the manager, and provides helper methods
  * to streamline test writing.
  */
-export class TestBed extends BaseTestBed {
+export class TestBed extends FactoryTestBed {
   /**
    * Collection of all mocks for easy access in tests.
    *
@@ -134,13 +134,12 @@ export class TestBed extends BaseTestBed {
    * @param {Function} [entityManagerOptions.idGenerator] - A mock ID generator function.
    */
   constructor(entityManagerOptions = {}) {
-    const { mocks } = BaseTestBed.fromFactories({
+    super({
       registry: createSimpleMockDataRegistry,
       validator: createMockSchemaValidator,
       logger: createMockLogger,
       eventDispatcher: createMockSafeEventDispatcher,
     });
-    super(mocks);
 
     this.entityManager = new EntityManager({
       registry: this.mocks.registry,

--- a/tests/common/factoryTestBed.js
+++ b/tests/common/factoryTestBed.js
@@ -1,0 +1,22 @@
+/**
+ * @file Provides a simple base class for creating mocks from factory functions.
+ */
+
+import BaseTestBed from './baseTestBed.js';
+
+/**
+ * @description Base class that automatically creates mocks from a factory map.
+ * @class
+ */
+export class FactoryTestBed extends BaseTestBed {
+  /**
+   * @description Constructs the test bed using the provided factory map.
+   * @param {Record<string, () => any>} factoryMap - Map of mock factory functions.
+   */
+  constructor(factoryMap = {}) {
+    const { mocks } = BaseTestBed.fromFactories(factoryMap);
+    super(mocks);
+  }
+}
+
+export default FactoryTestBed;

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -14,14 +14,14 @@ import {
   createMockPromptBuilder,
   createMockEntity,
 } from '../mockFactories';
-import BaseTestBed from '../baseTestBed.js';
+import FactoryTestBed from '../factoryTestBed.js';
 import { describeSuiteWithHooks } from '../describeSuite.js';
 
 /**
  * @description Utility class for unit tests that need an AIPromptPipeline with common mocks.
  * @class
  */
-export class AIPromptPipelineTestBed extends BaseTestBed {
+export class AIPromptPipelineTestBed extends FactoryTestBed {
   /** @type {import('../../src/entities/entity.js').default} */
   defaultActor;
   /** @type {import('../../src/turns/interfaces/ITurnContext.js').ITurnContext} */
@@ -30,8 +30,7 @@ export class AIPromptPipelineTestBed extends BaseTestBed {
   defaultActions;
 
   constructor() {
-    super();
-    this.initializeFromFactories({
+    super({
       llmAdapter: createMockLLMAdapter,
       gameStateProvider: createMockAIGameStateProvider,
       promptContentProvider: createMockAIPromptContentProvider,

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -12,7 +12,7 @@ import {
   createMockValidatedEventBus,
   createMockTurnHandler,
 } from '../mockFactories';
-import BaseTestBed from '../baseTestBed.js';
+import FactoryTestBed from '../factoryTestBed.js';
 import { describeSuiteWithHooks } from '../describeSuite.js';
 import { flushPromisesAndTimers } from '../jestHelpers.js';
 
@@ -21,13 +21,12 @@ import { flushPromisesAndTimers } from '../jestHelpers.js';
  * dependencies and exposes helpers for common test operations.
  * @class
  */
-export class TurnManagerTestBed extends BaseTestBed {
+export class TurnManagerTestBed extends FactoryTestBed {
   /** @type {TurnManager} */
   turnManager;
 
   constructor(overrides = {}) {
-    super();
-    this.initializeFromFactories({
+    super({
       logger: () => overrides.logger ?? createMockLogger(),
       entityManager: () => {
         const em = overrides.entityManager ?? createMockEntityManager();
@@ -106,7 +105,10 @@ export class TurnManagerTestBed extends BaseTestBed {
       map.set(e.id, e);
     }
     // Debug: print the map after adding entities
-    console.log('setActiveEntities: activeEntities =', Array.from(map.values()).map(ent => ({ id: ent.id })));
+    console.log(
+      'setActiveEntities: activeEntities =',
+      Array.from(map.values()).map((ent) => ({ id: ent.id }))
+    );
   }
 
   /**


### PR DESCRIPTION
Summary:
- add FactoryTestBed for simplified mock creation
- refactor AIPromptPipelineTestBed, TurnManagerTestBed, GameEngineTestBed and entity TestBed to extend FactoryTestBed

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 915 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68568e32c55c8331913f10da5ac5ef6a