### PR TITLE
[Agent] add helper for generation failures

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -216,6 +216,23 @@ export class AIPromptPipelineTestBed extends FactoryTestBed {
     );
     expect(this.promptBuilder.build).toHaveBeenCalledWith(_llmId, _promptData);
   }
+
+  /**
+   * Applies a mutation to the test bed's mocks and expects generation to fail.
+   *
+   * @description Applies a mutation to the mocks and verifies that
+   *   {@link AIPromptPipelineTestBed#generateDefault} rejects with the given
+   *   error.
+   * @param {(bed: this) => void} mutateFn - Function that mutates the test
+   *   bed's mocks before generation.
+   * @param {string|RegExp|Error} expectedError - Error expected from the
+   *   generation call.
+   * @returns {Promise<void>} Resolves when the assertion completes.
+   */
+  async expectGenerationFailure(mutateFn, expectedError) {
+    mutateFn(this);
+    await expect(this.generateDefault()).rejects.toThrow(expectedError);
+  }
 }
 
 /**

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -48,18 +48,17 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   test.each([
     {
       desc: 'llmAdapter returns falsy',
-      mutate: () =>
-        testBed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null),
+      mutate: (bed) =>
+        bed.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(null),
       error: 'Could not determine active LLM ID.',
     },
     {
       desc: 'promptBuilder returns empty string',
-      mutate: () => testBed.promptBuilder.build.mockResolvedValue(''),
+      mutate: (bed) => bed.promptBuilder.build.mockResolvedValue(''),
       error: 'PromptBuilder returned an empty or invalid prompt.',
     },
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
-    mutate();
-    await expect(testBed.generateDefault()).rejects.toThrow(error);
+    await testBed.expectGenerationFailure(mutate, error);
   });
 
   test('availableActions are attached to DTO sent to getPromptData', async () => {


### PR DESCRIPTION
## Summary
- add `expectGenerationFailure` helper to promptPipelineTestBed
- use helper in AIPromptPipeline tests

## Testing Done
- `npm run format` *(partial: targeted files)*
- `npx eslint tests/common/prompting/promptPipelineTestBed.js tests/unit/prompting/AIPromptPipeline.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856979791a48331b95ec5730d7abfd4