### PR TITLE
[Agent] add runUnavailableServiceTest helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -3,6 +3,7 @@
  * @see tests/common/engine/gameEngineHelpers.js
  */
 
+import { expect } from '@jest/globals';
 import {
   createGameEngineTestBed,
   GameEngineTestBed,
@@ -25,4 +26,36 @@ export async function withGameEngineBed(overrides = {}, testFn) {
   } finally {
     await bed.cleanup();
   }
+}
+
+/**
+ * Builds test functions for scenarios where required services are unavailable.
+ *
+ * @description Generates `[token, testFn]` tuples for use with `it.each`. Each
+ * test initializes a temporary {@link GameEngineTestBed} with the specified
+ * token overridden to `null`, optionally starts the engine, executes the
+ * provided callback, and asserts that the returned logger mock was called with
+ * the expected message while the dispatch mock was not.
+ * @param {Array<[string, string, { preInit?: boolean }]>} cases - Array of
+ *   `[token, message, options]` tuples.
+ * @param {(bed: GameEngineTestBed,
+ *   engine: import('../../../src/engine/gameEngine.js').default) =>
+ *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
+ *   Callback performing the invocation and returning logger/dispatch mocks.
+ * @returns {Array<[string, () => Promise<void>]>} Generated test cases.
+ */
+export function runUnavailableServiceTest(cases, invokeFn) {
+  return cases.map(([token, expectedMessage, opts = {}]) => [
+    token,
+    async () => {
+      await withGameEngineBed({ [token]: null }, async (bed, engine) => {
+        if (opts.preInit) {
+          await bed.startAndReset('TestWorld');
+        }
+        const [loggerMock, dispatchMock] = invokeFn(bed, engine);
+        expect(loggerMock).toHaveBeenCalledWith(expectedMessage);
+        expect(dispatchMock).not.toHaveBeenCalled();
+      });
+    },
+  ]);
 }

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
-import { withGameEngineBed } from '../../../common/engine/gameEngineHelpers.js';
+import {
+  withGameEngineBed,
+  runUnavailableServiceTest,
+} from '../../../common/engine/gameEngineHelpers.js';
+import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import * as bedModule from '../../../common/engine/gameEngineTestBed.js';
 
 describe('withGameEngineBed', () => {
@@ -43,5 +47,26 @@ describe('withGameEngineBed', () => {
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
     bedModule.createGameEngineTestBed.mockRestore();
+  });
+});
+
+describe('runUnavailableServiceTest', () => {
+  it('generates executable test functions', async () => {
+    const cases = [
+      [
+        tokens.GamePersistenceService,
+        'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.',
+      ],
+    ];
+
+    const testCases = runUnavailableServiceTest(cases, (bed, engine) => {
+      engine.showLoadGameUI();
+      return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+    });
+
+    expect(Array.isArray(testCases)).toBe(true);
+    const [token, fn] = testCases[0];
+    expect(token).toBe(tokens.GamePersistenceService);
+    await fn();
   });
 });


### PR DESCRIPTION
## Summary
- add `runUnavailableServiceTest` to generate tests for unavailable services
- cover helper in unit tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685697a91e548331af450cd5e28bb2ec