### PR TITLE
[Agent] Extend invalid definition IDs in TestData

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -103,6 +103,7 @@ export const TestData = {
       [123, {}],
     ],
     invalidIds: [null, undefined, '', 123, {}, []],
+    invalidDefinitionIds: [null, undefined, '', 123, {}, []],
     serializedEntityShapes: [null, 'invalid', 42, [], { foo: 'bar' }],
     serializedInstanceIds: [null, undefined, '', 42],
   },


### PR DESCRIPTION
Summary: Added `invalidDefinitionIds` array to the centralized TestData helper used in EntityManager tests, enabling easier negative test cases for invalid definition identifiers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint checked `npx eslint tests/common/entities/testBed.js --fix`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685699a20db48331b28a0d842d700ab9