### PR TITLE
[Agent] Add TestBed describe suite generator

### DIFF
--- a/tests/common/describeSuite.js
+++ b/tests/common/describeSuite.js
@@ -68,3 +68,29 @@ export function describeSuiteWithHooks(
     suiteFn(() => bed);
   });
 }
+
+/**
+ * @description Generates a helper for defining suites that automatically
+ *   instantiate and clean up a given TestBed.
+ * @param {new (...args: any[]) => {cleanup: () => Promise<void>}} TestBedCtor -
+ *   Constructor for the TestBed.
+ * @param {object} [defaultOptions] - Default options forwarded to
+ *   {@link describeSuiteWithHooks}.
+ * @param {(bed: any) => void} [defaultOptions.beforeEachHook] - Default hook
+ *   executed after bed creation.
+ * @param {(bed: any) => void} [defaultOptions.afterEachHook] - Default hook
+ *   executed after bed cleanup.
+ * @param {any[]} [defaultOptions.args] - Default arguments for the TestBed
+ *   constructor.
+ * @returns {(title: string, suiteFn: (getBed: () => any) => void, overrides?: any) => void}
+ *   Suite function that wraps {@link describeSuiteWithHooks}.
+ */
+export function createDescribeTestBedSuite(TestBedCtor, defaultOptions = {}) {
+  return function (title, suiteFn, overrides) {
+    const options = {
+      ...defaultOptions,
+      args: overrides ? [overrides] : defaultOptions.args,
+    };
+    describeSuiteWithHooks(title, TestBedCtor, suiteFn, options);
+  };
+}

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -8,7 +8,10 @@
 import { createTestEnvironment } from './gameEngine.test-environment.js';
 import FactoryTestBed from '../factoryTestBed.js';
 import { suppressConsoleError } from '../jestHelpers.js';
-import { describeSuiteWithHooks } from '../describeSuite.js';
+import {
+  createDescribeTestBedSuite,
+  describeSuiteWithHooks,
+} from '../describeSuite.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -176,18 +179,20 @@ export function createGameEngineTestBed(overrides = {}) {
  * @param {{[token: string]: any}} [overrides] - Optional DI overrides.
  * @returns {void}
  */
-export function describeGameEngineSuite(title, suiteFn, overrides = {}) {
-  let consoleSpy;
-  describeSuiteWithHooks(title, GameEngineTestBed, suiteFn, {
-    args: [overrides],
-    beforeEachHook() {
-      consoleSpy = suppressConsoleError();
-    },
-    afterEachHook() {
-      consoleSpy.mockRestore();
-    },
-  });
-}
+export const describeGameEngineSuite = createDescribeTestBedSuite(
+  GameEngineTestBed,
+  (() => {
+    let consoleSpy;
+    return {
+      beforeEachHook() {
+        consoleSpy = suppressConsoleError();
+      },
+      afterEachHook() {
+        consoleSpy.mockRestore();
+      },
+    };
+  })()
+);
 
 /**
  * Defines an engine-focused test suite providing `bed` and `engine` variables

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -22,7 +22,7 @@ import {
   createSimpleMockDataRegistry,
 } from '../mockFactories';
 import FactoryTestBed from '../factoryTestBed.js';
-import { describeSuite } from '../describeSuite.js';
+import { createDescribeTestBedSuite } from '../describeSuite.js';
 
 // --- Centralized Mocks (REMOVED) ---
 // Mock creation functions are now imported.
@@ -225,8 +225,6 @@ export class TestBed extends FactoryTestBed {
  *   tests. It receives a callback that returns the active {@link TestBed}.
  * @returns {void}
  */
-export function describeEntityManagerSuite(title, suiteFn) {
-  describeSuite(title, TestBed, suiteFn);
-}
+export const describeEntityManagerSuite = createDescribeTestBedSuite(TestBed);
 
 export default TestBed;

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -15,7 +15,10 @@ import {
   createMockEntity,
 } from '../mockFactories';
 import FactoryTestBed from '../factoryTestBed.js';
-import { describeSuiteWithHooks } from '../describeSuite.js';
+import {
+  createDescribeTestBedSuite,
+  describeSuiteWithHooks,
+} from '../describeSuite.js';
 
 /**
  * @typedef {object} DependencySpecEntry
@@ -243,14 +246,13 @@ export class AIPromptPipelineTestBed extends FactoryTestBed {
  *   containing the tests. Receives a getter for the active test bed.
  * @returns {void}
  */
-function describeAIPromptPipelineSuite(title, suiteFn) {
-  describeSuiteWithHooks(title, AIPromptPipelineTestBed, suiteFn, {
+export const describeAIPromptPipelineSuite = createDescribeTestBedSuite(
+  AIPromptPipelineTestBed,
+  {
     beforeEachHook(bed) {
       bed.setupMockSuccess();
     },
-  });
-}
-
-export { describeAIPromptPipelineSuite };
+  }
+);
 
 export default AIPromptPipelineTestBed;

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -13,7 +13,10 @@ import {
   createMockTurnHandler,
 } from '../mockFactories';
 import FactoryTestBed from '../factoryTestBed.js';
-import { describeSuiteWithHooks } from '../describeSuite.js';
+import {
+  describeSuiteWithHooks,
+  createDescribeTestBedSuite,
+} from '../describeSuite.js';
 import { flushPromisesAndTimers } from '../jestHelpers.js';
 
 /**
@@ -219,11 +222,8 @@ export function createTurnManagerTestBed(overrides = {}) {
  *   creation.
  * @returns {void}
  */
-export function describeTurnManagerSuite(title, suiteFn, overrides = {}) {
-  describeSuiteWithHooks(title, TurnManagerTestBed, suiteFn, {
-    args: [overrides],
-  });
-}
+export const describeTurnManagerSuite =
+  createDescribeTestBedSuite(TurnManagerTestBed);
 
 export default TurnManagerTestBed;
 export { flushPromisesAndTimers };


### PR DESCRIPTION
Summary: Added `createDescribeTestBedSuite` helper to DRY up test suite helpers. Updated GameEngine, TurnManager, EntityManager and AIPromptPipeline test bed suite functions to use the new generator.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68569ab7ff0c8331951503497ca753d1