### PR TITLE
[Agent] Refactor AIPromptPipeline test suite helper

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,39 +1,31 @@
 /* eslint-env node */
-import { beforeEach, test, expect } from '@jest/globals';
+import { test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
   describeAIPromptPipelineSuite,
-  AIPromptPipelineTestBed,
   AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';
 import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
 
-describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
-  /** @type {AIPromptPipelineTestBed} */
-  let testBed;
-
-  beforeEach(() => {
-    testBed = getBed();
-  });
-
+describeAIPromptPipelineSuite('AIPromptPipeline', (bed) => {
   describe('constructor validation', () => {
     const cases = buildMissingDependencyCases(
-      () => testBed.getDependencies(),
+      () => bed.getDependencies(),
       AIPromptPipelineDependencySpec
     );
     test.each(cases)('throws when %s', (_desc, mutate, regex) => {
-      const deps = testBed.getDependencies();
+      const deps = bed.getDependencies();
       mutate(deps);
       expect(() => new AIPromptPipeline(deps)).toThrow(regex);
     });
   });
 
   test('generatePrompt orchestrates dependencies and returns prompt', async () => {
-    const actor = testBed.defaultActor;
-    const context = testBed.defaultContext;
-    const actions = [...testBed.defaultActions, { id: 'a1' }];
+    const actor = bed.defaultActor;
+    const context = bed.defaultContext;
+    const actions = [...bed.defaultActions, { id: 'a1' }];
 
-    await testBed.expectSuccessfulGeneration({
+    await bed.expectSuccessfulGeneration({
       actor,
       context,
       actions,
@@ -58,25 +50,25 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
       error: 'PromptBuilder returned an empty or invalid prompt.',
     },
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
-    await testBed.expectGenerationFailure(mutate, error);
+    await bed.expectGenerationFailure(mutate, error);
   });
 
   test('availableActions are attached to DTO sent to getPromptData', async () => {
-    const actor = testBed.defaultActor;
-    const context = testBed.defaultContext;
-    const actions = [...testBed.defaultActions, { id: 'act' }];
+    const actor = bed.defaultActor;
+    const context = bed.defaultContext;
+    const actions = [...bed.defaultActions, { id: 'act' }];
 
-    testBed.setupMockSuccess({
+    bed.setupMockSuccess({
       gameState: {},
       promptData: {},
       finalPrompt: 'prompt',
     });
 
-    await testBed.generate(actor, context, actions);
+    await bed.generate(actor, context, actions);
 
-    expect(testBed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
+    expect(bed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
       expect.objectContaining({ availableActions: actions }),
-      testBed.logger
+      bed.logger
     );
   });
 });


### PR DESCRIPTION
## Summary
- adjust `describeAIPromptPipelineSuite` to pass the test bed directly
- update tests accordingly

## Testing Done
- `npm run lint` *(fails: 3166 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68569e2aec888331bd327ee03ef4f2c6