### PR TITLE
[Agent] remove outdated availableActions test

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -52,23 +52,4 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (bed) => {
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
     await bed.expectGenerationFailure(mutate, error);
   });
-
-  test('availableActions are attached to DTO sent to getPromptData', async () => {
-    const actor = bed.defaultActor;
-    const context = bed.defaultContext;
-    const actions = [...bed.defaultActions, { id: 'act' }];
-
-    bed.setupMockSuccess({
-      gameState: {},
-      promptData: {},
-      finalPrompt: 'prompt',
-    });
-
-    await bed.generate(actor, context, actions);
-
-    expect(bed.promptContentProvider.getPromptData).toHaveBeenCalledWith(
-      expect.objectContaining({ availableActions: actions }),
-      bed.logger
-    );
-  });
 });


### PR DESCRIPTION
## Summary
- remove `availableActions` expectations from AIPromptPipeline tests

## Testing
- `npm run lint` *(fails: 926 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6856a6f1c1d083318dfe33d8fc3d4b70