### PR TITLE
[Agent] remove debug console logs in tests

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -107,11 +107,6 @@ export class TurnManagerTestBed extends FactoryTestBed {
     for (const e of entities) {
       map.set(e.id, e);
     }
-    // Debug: print the map after adding entities
-    console.log(
-      'setActiveEntities: activeEntities =',
-      Array.from(map.values()).map((ent) => ({ id: ent.id }))
-    );
   }
 
   /**

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -44,20 +44,7 @@ describeTurnManagerSuite(
       testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
         async (actor) => {
           const handler = createMockTurnHandler({ actor });
-          handler.startTurn = (_currentActor) => {
-            const promise = Promise.resolve();
-            console.log(
-              'test override: startTurn called, returns Promise:',
-              typeof promise.then === 'function'
-            );
-            return promise;
-          };
-          console.log(
-            'resolveHandler called for actor:',
-            actor?.id,
-            'returning handler:',
-            !!handler
-          );
+          handler.startTurn = (_currentActor) => Promise.resolve();
           return handler;
         }
       );
@@ -78,15 +65,9 @@ describeTurnManagerSuite(
     test('Starts a new round when queue is empty and active actors exist', async () => {
       testBed.setActiveEntities(ai1, player);
 
-      // Debug: print hasComponent for each entity
+      // Debug: verify actors
       const entities = Array.from(testBed.entityManager.entities);
-      console.log(
-        'Entities and isActor:',
-        entities.map((e) => ({
-          id: e.id,
-          isActor: e.hasComponent(ACTOR_COMPONENT_ID),
-        }))
-      );
+      // Entities have ACTOR_COMPONENT_ID component or not; not logged
 
       // Mock isEmpty to return true (queue is empty) before the first turn
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
@@ -141,22 +122,11 @@ describeTurnManagerSuite(
           testBed.mocks.turnOrderService.getNextEntity.mock.calls.length === 1
             ? ai1
             : ai2;
-        const emActor = testBed.entityManager.activeEntities.get(result.id);
-        console.log(
-          'getNextEntity called, returning:',
-          result?.id,
-          'entityManager ref === result:',
-          emActor === result
-        );
         return Promise.resolve(result);
       });
 
       await testBed.turnManager.start();
       await flushPromisesAndTimers();
-      console.log(
-        'After start, current actor:',
-        testBed.turnManager.getCurrentActor()?.id
-      );
 
       expect(testBed.turnManager.getCurrentActor()).toBe(ai1);
 
@@ -166,10 +136,6 @@ describeTurnManagerSuite(
         success: true,
       });
       await flushPromisesAndTimers();
-      console.log(
-        'After turn end, current actor:',
-        testBed.turnManager.getCurrentActor()?.id
-      );
 
       expect(testBed.turnManager.getCurrentActor()).toBe(ai2);
     });


### PR DESCRIPTION
Summary: Removed stray `console.log` calls from test utilities and turn manager tests.

Testing Done:
- [x] Code formatted `npx prettier --write tests/common/turns/turnManagerTestBed.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6856a6d1c60883319df8f21d6f2151a2