### PR TITLE
[Agent] use runUnavailableServiceTest for manual save

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -39,9 +39,12 @@ export async function withGameEngineBed(overrides = {}, testFn) {
  * @param {Array<[string, string, { preInit?: boolean }]>} cases - Array of
  *   `[token, message, options]` tuples.
  * @param {(bed: GameEngineTestBed,
- *   engine: import('../../../src/engine/gameEngine.js').default) =>
+ *   engine: import('../../../src/engine/gameEngine.js').default,
+ *   expectedMessage: string) =>
  *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
- *   Callback performing the invocation and returning logger/dispatch mocks.
+ *   Callback performing the invocation and returning logger/dispatch mocks. The
+ *   `expectedMessage` parameter allows additional assertions using the case's
+ *   message.
  * @returns {Array<[string, () => Promise<void>]>} Generated test cases.
  */
 export function runUnavailableServiceTest(cases, invokeFn) {
@@ -52,7 +55,11 @@ export function runUnavailableServiceTest(cases, invokeFn) {
         if (opts.preInit) {
           await bed.startAndReset('TestWorld');
         }
-        const [loggerMock, dispatchMock] = invokeFn(bed, engine);
+        const [loggerMock, dispatchMock] = await invokeFn(
+          bed,
+          engine,
+          expectedMessage
+        );
         expect(loggerMock).toHaveBeenCalledWith(expectedMessage);
         expect(dispatchMock).not.toHaveBeenCalled();
       });


### PR DESCRIPTION
## Summary
- add expected message passthrough to `runUnavailableServiceTest`
- convert manual-save service-unavailable tests to use helper

## Testing Done
- `npm run lint`
- `npm run test`
- `npm test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_6856aa871ed48331a30068b1aeb8178a