### PR TITLE
[Agent] refactor TurnManager actor helpers in tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -9,6 +9,10 @@ import {
 
 import { TURN_ENDED_ID } from '../../../src/constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+import {
+  createAiActor,
+  createPlayerActor,
+} from '../../common/turns/testActors.js';
 import { createMockEntity } from '../../common/mockFactories';
 
 // --- Test Suite ---
@@ -25,10 +29,7 @@ describeTurnManagerSuite(
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
-        createMockEntity('initial-actor-for-start', {
-          isActor: true,
-          isPlayer: false,
-        })
+        createAiActor('initial-actor-for-start')
       );
 
       testBed.mocks.dispatcher.dispatch.mockClear().mockResolvedValue(true);
@@ -62,11 +63,8 @@ describeTurnManagerSuite(
     });
 
     test.each([
-      [
-        'player',
-        createMockEntity('player-1', { isActor: true, isPlayer: true }),
-      ],
-      ['ai', createMockEntity('ai-goblin', { isActor: true, isPlayer: false })],
+      ['player', createPlayerActor('player-1')],
+      ['ai', createAiActor('ai-goblin')],
     ])(
       'actor identified (%s) -> handler invoked and event dispatched',
       async (_, actor) => {

--- a/tests/unit/turns/turnManager.base.test.js
+++ b/tests/unit/turns/turnManager.base.test.js
@@ -6,8 +6,15 @@ import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
-import { beforeEach, describe, expect, jest, test, afterEach } from '@jest/globals';
-import { createMockEntity } from '../../common/mockFactories.js';
+import {
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+  afterEach,
+} from '@jest/globals';
+import { createDefaultActors } from '../../common/turns/testActors.js';
 
 describe('TurnManager', () => {
   let testBed;
@@ -18,10 +25,12 @@ describe('TurnManager', () => {
   beforeEach(() => {
     testBed = new TurnManagerTestBed();
 
-    // Create fresh mock entities
-    mockPlayerEntity = createMockEntity('player-1', { isActor: true, isPlayer: true });
-    mockAiEntity1 = createMockEntity('ai-1', { isActor: true, isPlayer: false });
-    mockAiEntity2 = createMockEntity('ai-2', { isActor: true, isPlayer: false });
+    // Create fresh mock entities using helpers
+    ({
+      player: mockPlayerEntity,
+      ai1: mockAiEntity1,
+      ai2: mockAiEntity2,
+    } = createDefaultActors());
   });
 
   afterEach(() => testBed.cleanup());
@@ -39,7 +48,7 @@ describe('TurnManager', () => {
 
   test('mock entities should behave as configured', () => {
     // This tests the helper, doesn't directly involve TurnManager instance much
-    expect(mockPlayerEntity.id).toBe('player-1');
+    expect(mockPlayerEntity.id).toBe('player1');
     expect(mockPlayerEntity.hasComponent(ACTOR_COMPONENT_ID)).toBe(true);
     expect(mockPlayerEntity.hasComponent(PLAYER_COMPONENT_ID)).toBe(true);
     expect(mockAiEntity1.hasComponent(PLAYER_COMPONENT_ID)).toBe(false);
@@ -49,9 +58,7 @@ describe('TurnManager', () => {
     // This tests the mock helper, doesn't directly involve TurnManager instance much
     const entities = [mockPlayerEntity, mockAiEntity1];
     testBed.setActiveEntities(...entities);
-    expect(Array.from(testBed.mocks.entityManager.entities)).toEqual(
-      entities
-    );
+    expect(Array.from(testBed.mocks.entityManager.entities)).toEqual(entities);
   });
 
   // Add more tests for start, stop, advanceTurn, etc. later

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -11,6 +11,11 @@ import {
 } from '../../../src/constants/componentIds.js';
 import { TURN_PROCESSING_STARTED } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test } from '@jest/globals';
+import {
+  createDefaultActors,
+  createAiActor,
+  createPlayerActor,
+} from '../../common/turns/testActors.js';
 import { createMockEntity } from '../../common/mockFactories';
 
 // Mock Turn Handlers - ADD startTurn and destroy
@@ -34,19 +39,12 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   beforeEach(() => {
     testBed = getBed();
 
-    // Create fresh mock entities
-    mockPlayerEntity = createMockEntity('player-1', {
-      isActor: true,
-      isPlayer: true,
-    });
-    mockAiEntity1 = createMockEntity('ai-1', {
-      isActor: true,
-      isPlayer: false,
-    });
-    mockAiEntity2 = createMockEntity('ai-2', {
-      isActor: true,
-      isPlayer: false,
-    });
+    // Create fresh mock entities using helpers
+    ({
+      player: mockPlayerEntity,
+      ai1: mockAiEntity1,
+      ai2: mockAiEntity2,
+    } = createDefaultActors());
 
     // Configure default mock behaviors
     testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
@@ -73,7 +71,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   });
 
   test('mock entities should behave as configured', () => {
-    expect(mockPlayerEntity.id).toBe('player-1');
+    expect(mockPlayerEntity.id).toBe('player1');
     expect(mockPlayerEntity.hasComponent(ACTOR_COMPONENT_ID)).toBe(true);
     expect(mockPlayerEntity.hasComponent(PLAYER_COMPONENT_ID)).toBe(true);
     expect(mockAiEntity1.hasComponent(PLAYER_COMPONENT_ID)).toBe(false);
@@ -82,12 +80,12 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   test('EntityManager mock allows setting active entities', () => {
     const entities = [mockPlayerEntity, mockAiEntity1];
     testBed.setActiveEntities(...entities);
-    expect(Array.from(testBed.mocks.entityManager.entities)).toEqual(
-      entities
-    );
-    expect(Array.from(testBed.mocks.entityManager.entities).find(e => e.id === 'player-1')).toBe(
-      mockPlayerEntity
-    );
+    expect(Array.from(testBed.mocks.entityManager.entities)).toEqual(entities);
+    expect(
+      Array.from(testBed.mocks.entityManager.entities).find(
+        (e) => e.id === 'player1'
+      )
+    ).toBe(mockPlayerEntity);
   });
 
   // --- Tests for getCurrentActor() ---
@@ -97,10 +95,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should return the assigned actor after start and advanceTurn assigns one', async () => {
-      const mockActor = createMockEntity('actor-test', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockActor = createAiActor('actor-test');
       const entityType = 'ai'; // Define expected type
 
       // --- Setup mocks for start() -> advanceTurn() path ---
@@ -127,10 +122,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should return null after stop() clears the current actor', async () => {
-      const mockActor = createMockEntity('actor-test', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockActor = createAiActor('actor-test');
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -151,14 +143,8 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should return the correct actor when multiple actors are in the queue', async () => {
-      const mockActor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
-      const mockActor2 = createMockEntity('actor2', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockActor1 = createAiActor('actor1');
+      const mockActor2 = createAiActor('actor2');
 
       // --- Setup mocks for sequential actors ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -186,10 +172,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should return null when queue becomes empty', async () => {
-      const mockActor = createMockEntity('actor-test', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockActor = createAiActor('actor-test');
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -219,14 +202,8 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should handle player vs AI actor types correctly', async () => {
-      const mockPlayerActor = createMockEntity('player-actor', {
-        isActor: true,
-        isPlayer: true,
-      });
-      const mockAiActor = createMockEntity('ai-actor', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockPlayerActor = createPlayerActor('player-actor');
+      const mockAiActor = createAiActor('ai-actor');
 
       // Test player actor
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
@@ -285,10 +262,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should handle entity manager errors gracefully', async () => {
-      const mockActor = createMockEntity('actor-test', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const mockActor = createAiActor('actor-test');
 
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -13,10 +13,8 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
 import { createDefaultActors } from '../../common/turns/testActors.js';
-import {
-  createMockEntity,
-  createMockTurnHandler,
-} from '../../common/mockFactories.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
+import { createAiActor } from '../../common/turns/testActors.js';
 
 // --- Test Suite ---
 
@@ -249,8 +247,8 @@ describeTurnManagerSuite(
       testBed.mocks.turnOrderService.clearCurrentRound.mockImplementation(
         () => {
           // Create fresh mock actors for the new round
-          const newActor1 = createMockEntity('actor1', { isActor: true });
-          const newActor2 = createMockEntity('actor2', { isActor: true });
+          const newActor1 = createAiActor('actor1');
+          const newActor2 = createAiActor('actor2');
           testBed.setActiveEntities(newActor1, newActor2);
           return Promise.resolve();
         }


### PR DESCRIPTION
Summary: Replaced manual actor construction in several TurnManager test suites with shared helpers from `tests/common/turns/testActors.js` for consistency.

Changes Made:
- Updated imports to use `createDefaultActors`, `createAiActor`, and `createPlayerActor`.
- Modified `beforeEach` blocks to instantiate actors via helpers.
- Adjusted expectations to match helper-generated IDs.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` - errors remain in untouched files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6856aa5055a08331b389dd760037be61