### PR TITLE
[Agent] update manual save test utility usage

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -39,7 +39,9 @@ export async function withGameEngineBed(overrides = {}, testFn) {
  * @param {Array<[string, string, { preInit?: boolean }]>} cases - Array of
  *   `[token, message, options]` tuples.
  * @param {(bed: GameEngineTestBed,
- *   engine: import('../../../src/engine/gameEngine.js').default) =>
+ *   engine: import('../../../src/engine/gameEngine.js').default,
+ *   expectedMessage: string) =>
+ *   Promise<[import('@jest/globals').Mock, import('@jest/globals').Mock]> |
  *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
  *   Callback performing the invocation and returning logger/dispatch mocks.
  * @returns {Array<[string, () => Promise<void>]>} Generated test cases.
@@ -52,7 +54,11 @@ export function runUnavailableServiceTest(cases, invokeFn) {
         if (opts.preInit) {
           await bed.startAndReset('TestWorld');
         }
-        const [loggerMock, dispatchMock] = invokeFn(bed, engine);
+        const [loggerMock, dispatchMock] = await invokeFn(
+          bed,
+          engine,
+          expectedMessage
+        );
         expect(loggerMock).toHaveBeenCalledWith(expectedMessage);
         expect(dispatchMock).not.toHaveBeenCalled();
       });

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -5,6 +5,7 @@ import {
   createGameEngineTestBed,
   describeEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
+import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import {
   expectDispatchSequence,
@@ -41,37 +42,35 @@ describeEngineSuite('GameEngine', (ctx) => {
         await ctx.bed.initAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
       });
 
-      it.each([
-        [
-          'GamePersistenceService',
-          tokens.GamePersistenceService,
-          'GamePersistenceService is not available. Cannot save game.',
-        ],
-      ])(
-        'should dispatch error if %s is unavailable',
-        async (_name, token, expectedMsg) => {
-          const localBed = createGameEngineTestBed({ [token]: null });
-
-          localBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
-            {
-              success: true,
-            }
-          );
-          await localBed.startAndReset(MOCK_ACTIVE_WORLD_FOR_SAVE);
-
-          const result = await localBed.engine.triggerManualSave(SAVE_NAME);
-
-          expect(localBed.mocks.logger.error).toHaveBeenCalledWith(
-            `GameEngine.triggerManualSave: ${expectedMsg}`
-          );
-          expect(
-            localBed.mocks.safeEventDispatcher.dispatch
-          ).not.toHaveBeenCalled();
-          expect(result).toEqual({ success: false, error: expectedMsg });
-
-          await localBed.cleanup();
-        }
-      );
+      it.each(
+        runUnavailableServiceTest(
+          [
+            [
+              tokens.GamePersistenceService,
+              'GameEngine.triggerManualSave: GamePersistenceService is not available. Cannot save game.',
+              { preInit: true },
+            ],
+          ],
+          async (bed, engine) => {
+            const result = await engine.triggerManualSave(SAVE_NAME);
+            expect(
+              bed.mocks.safeEventDispatcher.dispatch
+            ).not.toHaveBeenCalled();
+            expect(result).toEqual({
+              success: false,
+              error:
+                'GamePersistenceService is not available. Cannot save game.',
+            });
+            return [
+              bed.mocks.logger.error,
+              bed.mocks.safeEventDispatcher.dispatch,
+            ];
+          }
+        )
+      )('should dispatch error if %s is unavailable', async (_token, fn) => {
+        expect.assertions(4);
+        await fn();
+      });
 
       it('should successfully save, dispatch all UI events in order, and return success result', async () => {
         const saveResultData = { success: true, filePath: 'path/to/my.sav' };


### PR DESCRIPTION
Summary: use `runUnavailableServiceTest` for `triggerManualSave` error case. Updated helper to await callbacks and allow pre-initialization.

Testing Done:
- [ ] Code formatted     `npx prettier tests/unit/engine/triggerManualSave.test.js tests/common/engine/gameEngineHelpers.js --write`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test` *(fails: Cannot find module './loaderPhase.js')*
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6856b0d48d3883319ff340c797275c7e