### PR TITLE
[Agent] remove diagnostic log

### DIFF
--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -44,14 +44,6 @@ export function validateDependency(
   if (requiredMethods && requiredMethods.length > 0) {
     for (const method of requiredMethods) {
       const actualMethod = dependency[method]; // Get the method itself
-      // --- REFINED DIAGNOSTIC LOG ---
-      console.log(
-        `DIAGNOSTIC (validationUtils.js): Validating ${dependencyName}.${method}. ` +
-          `Retrieved method: ${String(actualMethod)}. ` +
-          `typeof retrieved method: ${typeof actualMethod}. ` +
-          `Dependency object keys: ${Object.keys(dependency)}`
-      );
-      // --- END REFINED DIAGNOSTIC LOG ---
       if (typeof actualMethod !== 'function') {
         const errorMsg = `Invalid or missing method '${method}' on dependency '${dependencyName}'.`;
         effectiveLogger.error(errorMsg);


### PR DESCRIPTION
Summary: Removed leftover console.log from validationUtils.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6856de1a78888331a07277793c76d8f5