### PR TITLE
[Agent] remove baseService shim

### DIFF
--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -1,7 +1,7 @@
 // src/logic/jsonLogicEvaluationService.js
 import jsonLogic from 'json-logic-js';
 import { validateServiceDeps } from '../utils/serviceInitializerUtils.js';
-import { BaseService } from '../utils/baseService.js';
+import { BaseService } from '../utils/serviceBase.js';
 import { warnOnBracketPaths } from '../utils/jsonLogicUtils.js';
 
 // --- JSDoc Imports for Type Hinting ---

--- a/src/logic/operationInterpreter.js
+++ b/src/logic/operationInterpreter.js
@@ -4,7 +4,7 @@
 // -----------------------------------------------------------------------------
 
 import { resolvePlaceholders } from '../utils/contextUtils.js';
-import { BaseService } from '../utils/baseService.js';
+import { BaseService } from '../utils/serviceBase.js';
 import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 /** @typedef {import('../../data/schemas/operation.schema.json').Operation} Operation */

--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -4,7 +4,7 @@
 
 /** @typedef {import('./defs.js').OperationHandler} OperationHandler */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-import { BaseService } from '../utils/baseService.js';
+import { BaseService } from '../utils/serviceBase.js';
 import { getNormalizedOperationType } from '../utils/operationTypeUtils.js';
 
 class OperationRegistry extends BaseService {

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -8,7 +8,7 @@ import { createNestedExecutionContext } from './contextAssembler.js';
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { REQUIRED_ENTITY_MANAGER_METHODS } from '../constants/entityManager.js';
 import { evaluateConditionWithLogging } from './jsonLogicEvaluationService.js';
-import { BaseService } from '../utils/baseService.js';
+import { BaseService } from '../utils/serviceBase.js';
 import { executeActionSequence } from './actionSequence.js';
 import { buildRuleCache } from '../utils/ruleCacheUtils.js';
 import { isEmptyCondition } from '../utils/jsonLogicUtils.js';

--- a/src/utils/baseService.js
+++ b/src/utils/baseService.js
@@ -1,1 +1,0 @@
-export { BaseService } from './serviceBase.js';


### PR DESCRIPTION
Summary: Removed obsolete `src/utils/baseService.js` and updated all imports to reference `serviceBase.js` directly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6856ddf93e308331969a2e2c1733b6c0