### PR TITLE
[Agent] use actor helpers in TurnManager tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -10,6 +10,10 @@ import {
 import { TURN_ENDED_ID } from '../../../src/constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { createMockEntity } from '../../common/mockFactories';
+import {
+  createAiActor,
+  createPlayerActor,
+} from '../../common/turns/testActors.js';
 
 // --- Test Suite ---
 
@@ -25,10 +29,7 @@ describeTurnManagerSuite(
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
-        createMockEntity('initial-actor-for-start', {
-          isActor: true,
-          isPlayer: false,
-        })
+        createAiActor('initial-actor-for-start')
       );
 
       testBed.mocks.dispatcher.dispatch.mockClear().mockResolvedValue(true);
@@ -62,11 +63,8 @@ describeTurnManagerSuite(
     });
 
     test.each([
-      [
-        'player',
-        createMockEntity('player-1', { isActor: true, isPlayer: true }),
-      ],
-      ['ai', createMockEntity('ai-goblin', { isActor: true, isPlayer: false })],
+      ['player', createPlayerActor('player-1')],
+      ['ai', createAiActor('ai-goblin')],
     ])(
       'actor identified (%s) -> handler invoked and event dispatched',
       async (_, actor) => {

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -8,6 +8,7 @@ import {
   TURN_PROCESSING_STARTED,
 } from '../../../src/constants/eventIds.js';
 import { createMockEntity } from '../../common/mockFactories';
+import { createAiActor } from '../../common/turns/testActors.js';
 
 describeTurnManagerSuite(
   'TurnManager: advanceTurn() - Round Start (Queue Empty)',
@@ -146,14 +147,8 @@ describeTurnManagerSuite(
 
     test('Active actors found: starts new round and recursively calls advanceTurn', async () => {
       // Arrange
-      const actor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
-      const actor2 = createMockEntity('actor2', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const actor1 = createAiActor('actor1');
+      const actor2 = createAiActor('actor2');
       testBed.setActiveEntities(actor1, actor2);
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty for TurnCycle.nextActor()
@@ -205,10 +200,7 @@ describeTurnManagerSuite(
 
     test('startNewRound throws error: logs error, dispatches message, and stops', async () => {
       // Arrange
-      const actor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const actor1 = createAiActor('actor1');
       testBed.setActiveEntities(actor1);
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
@@ -240,10 +232,7 @@ describeTurnManagerSuite(
 
     test('getNextEntity throws error after new round: logs error, dispatches message, and stops', async () => {
       // Arrange
-      const actor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const actor1 = createAiActor('actor1');
       testBed.setActiveEntities(actor1);
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // First call by TurnCycle.nextActor()
@@ -275,10 +264,7 @@ describeTurnManagerSuite(
 
     test('Handler resolution fails after new round: logs error, dispatches message, and stops', async () => {
       // Arrange
-      const actor1 = createMockEntity('actor1', {
-        isActor: true,
-        isPlayer: false,
-      });
+      const actor1 = createAiActor('actor1');
       testBed.setActiveEntities(actor1);
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // First call by TurnCycle.nextActor()

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -12,7 +12,10 @@ import {
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
 import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
-import { createDefaultActors } from '../../common/turns/testActors.js';
+import {
+  createDefaultActors,
+  createAiActor,
+} from '../../common/turns/testActors.js';
 import {
   createMockEntity,
   createMockTurnHandler,
@@ -37,7 +40,6 @@ describeTurnManagerSuite(
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
       testBed.mocks.turnOrderService.startNewRound.mockResolvedValue();
       testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
-
 
       ({ ai1, ai2, player } = createDefaultActors());
 
@@ -71,7 +73,6 @@ describeTurnManagerSuite(
       const entities = Array.from(testBed.entityManager.entities);
 
       // Entities have ACTOR_COMPONENT_ID component or not; not logged
-
 
       // Mock isEmpty to return true (queue is empty) before the first turn
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
@@ -219,8 +220,8 @@ describeTurnManagerSuite(
       testBed.mocks.turnOrderService.clearCurrentRound.mockImplementation(
         () => {
           // Create fresh mock actors for the new round
-          const newActor1 = createMockEntity('actor1', { isActor: true });
-          const newActor2 = createMockEntity('actor2', { isActor: true });
+          const newActor1 = createAiActor('actor1');
+          const newActor2 = createAiActor('actor2');
           testBed.setActiveEntities(newActor1, newActor2);
           return Promise.resolve();
         }
@@ -241,7 +242,6 @@ describeTurnManagerSuite(
       let found = false;
       for (let i = 0; i < 50; i++) {
         if (testBed.turnManager.getCurrentActor()?.id === ai2.id) {
-
           found = true;
           break;
         }


### PR DESCRIPTION
## Summary
- swap manual actor setup with `createAiActor`/`createPlayerActor`
- adjust round start tests to use actor helpers
- inject actor helpers for round lifecycle tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856de4434788331816390cf11b5b4e8