### PR TITLE
[Agent] add serialized entity builder utils and tests

### DIFF
--- a/tests/common/entities/serializationUtils.js
+++ b/tests/common/entities/serializationUtils.js
@@ -1,0 +1,22 @@
+/**
+ * @file Helper utilities for serialized entity structures used in tests.
+ * @see tests/common/entities/serializationUtils.js
+ */
+
+/**
+ * Creates a minimal serialized entity structure.
+ *
+ * @description Convenience helper for unit tests that need to construct
+ * serialized entity objects. Provides defaults and ensures consistent shape.
+ * @param {string} instanceId - Unique ID of the entity instance.
+ * @param {string} definitionId - Definition ID that the entity conforms to.
+ * @param {object} [components] - Component data keyed by component ID.
+ * @returns {{instanceId: string, definitionId: string, components: object}} Serialized entity object.
+ */
+export function buildSerializedEntity(
+  instanceId,
+  definitionId,
+  components = {}
+) {
+  return { instanceId, definitionId, components };
+}

--- a/tests/common/entities/serializationUtils.test.js
+++ b/tests/common/entities/serializationUtils.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildSerializedEntity } from './serializationUtils.js';
+
+describe('buildSerializedEntity', () => {
+  it('returns object with provided parameters', () => {
+    const result = buildSerializedEntity('id1', 'def1', { c: 1 });
+    expect(result).toEqual({
+      instanceId: 'id1',
+      definitionId: 'def1',
+      components: { c: 1 },
+    });
+  });
+
+  it('defaults components to empty object', () => {
+    const result = buildSerializedEntity('id2', 'def2');
+    expect(result).toEqual({
+      instanceId: 'id2',
+      definitionId: 'def2',
+      components: {},
+    });
+  });
+});

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -25,6 +25,7 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
 import MapManager from '../../../src/utils/mapManagerUtils.js';
+import { buildSerializedEntity } from '../../common/entities/serializationUtils.js';
 
 describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
   describe('constructor', () => {
@@ -44,13 +45,14 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
         const { registry, validator, logger, eventDispatcher } = getBed().mocks;
         const EntityManager = getBed().entityManager.constructor;
 
-        expect(() =>
-          new EntityManager({
-            registry: depName === 'registry' ? value : registry,
-            validator: depName === 'validator' ? value : validator,
-            logger,
-            dispatcher: eventDispatcher,
-          })
+        expect(
+          () =>
+            new EntityManager({
+              registry: depName === 'registry' ? value : registry,
+              validator: depName === 'validator' ? value : validator,
+              logger,
+              dispatcher: eventDispatcher,
+            })
         ).toThrow(
           depName === 'registry'
             ? 'Missing required dependency: IDataRegistry.'
@@ -225,11 +227,9 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
       getBed().setupDefinitions(TestData.Definitions.basic);
 
-      const serializedEntity = {
-        instanceId: PRIMARY,
-        definitionId: BASIC,
-        components: { 'core:name': { name: 'Reconstructed' } },
-      };
+      const serializedEntity = buildSerializedEntity(PRIMARY, BASIC, {
+        'core:name': { name: 'Reconstructed' },
+      });
 
       // Act
       const entity = entityManager.reconstructEntity(serializedEntity);
@@ -248,11 +248,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
       getBed().setupDefinitions(TestData.Definitions.basic);
 
-      const serializedEntity = {
-        instanceId: PRIMARY,
-        definitionId: BASIC,
-        components: {},
-      };
+      const serializedEntity = buildSerializedEntity(PRIMARY, BASIC, {});
 
       // Act
       const entity = entityManager.reconstructEntity(serializedEntity);
@@ -275,11 +271,11 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const NON_EXISTENT_DEF_ID = 'non:existent';
       getBed().setupDefinitions(); // No definitions available
 
-      const serializedEntity = {
-        instanceId: 'test-instance',
-        definitionId: NON_EXISTENT_DEF_ID,
-        components: {},
-      };
+      const serializedEntity = buildSerializedEntity(
+        'test-instance',
+        NON_EXISTENT_DEF_ID,
+        {}
+      );
 
       // Act & Assert
       expect(() => entityManager.reconstructEntity(serializedEntity)).toThrow(
@@ -297,11 +293,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       // Create the first entity
       getBed().createEntity('basic', { instanceId: PRIMARY });
 
-      const serializedEntity = {
-        instanceId: PRIMARY,
-        definitionId: BASIC,
-        components: {},
-      };
+      const serializedEntity = buildSerializedEntity(PRIMARY, BASIC, {});
 
       // Act & Assert
       expect(() => entityManager.reconstructEntity(serializedEntity)).toThrow(
@@ -321,11 +313,9 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
         errors: validationErrors,
       });
 
-      const serializedEntity = {
-        instanceId: PRIMARY,
-        definitionId: BASIC,
-        components: { 'core:name': { name: 'invalid' } },
-      };
+      const serializedEntity = buildSerializedEntity(PRIMARY, BASIC, {
+        'core:name': { name: 'invalid' },
+      });
 
       // Act & Assert
       expect(() => entityManager.reconstructEntity(serializedEntity)).toThrow(
@@ -351,11 +341,11 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
         )
       )('should throw an error if instanceId is %p', (invalidId) => {
         const { entityManager } = getBed();
-        const serializedEntity = {
-          instanceId: invalidId,
-          definitionId: TestData.DefinitionIDs.BASIC,
-          components: {},
-        };
+        const serializedEntity = buildSerializedEntity(
+          invalidId,
+          TestData.DefinitionIDs.BASIC,
+          {}
+        );
         expect(() => entityManager.reconstructEntity(serializedEntity)).toThrow(
           'EntityManager.reconstructEntity: instanceId is missing or invalid in serialized data.'
         );


### PR DESCRIPTION
## Summary
- add `buildSerializedEntity` helper for tests
- add tests for the serialization util
- replace object literal creation in entityManager lifecycle tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2758 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856e075174c8331bae280ec8c345412