### PR TITLE
[Agent] convert utils to named exports

### DIFF
--- a/src/adapters/InMemoryEntityRepository.js
+++ b/src/adapters/InMemoryEntityRepository.js
@@ -1,4 +1,4 @@
-import MapManager from '../utils/mapManagerUtils.js';
+import { MapManager } from '../utils/mapManagerUtils.js';
 import { IEntityRepository } from '../ports/IEntityRepository.js';
 
 /**

--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -22,7 +22,7 @@ import LodashCloner from '../adapters/LodashCloner.js';
 import DefaultComponentPolicy from '../adapters/DefaultComponentPolicy.js';
 import Entity from './entity.js';
 import EntityInstanceData from './entityInstanceData.js';
-import MapManager from '../utils/mapManagerUtils.js';
+import { MapManager } from '../utils/mapManagerUtils.js';
 import EntityFactory from './factories/entityFactory.js';
 import EntityQuery from '../query/EntityQuery.js';
 import {
@@ -396,7 +396,7 @@ class EntityManager extends IEntityManager {
         wasReconstructed: false,
       });
       return entity;
-    } catch (err) {      
+    } catch (err) {
       if (err instanceof Error && err.message.startsWith('Entity with ID')) {
         this.#logger.error(err.message);
         // Extract the entity ID from the error message and throw DuplicateEntityError

--- a/src/entities/factories/entityFactory.js
+++ b/src/entities/factories/entityFactory.js
@@ -19,7 +19,7 @@
 import { cloneDeep } from 'lodash';
 import Entity from '../entity.js';
 import EntityInstanceData from '../entityInstanceData.js';
-import MapManager from '../../utils/mapManagerUtils.js';
+import { MapManager } from '../../utils/mapManagerUtils.js';
 import {
   assertValidId,
   assertNonBlankString,

--- a/src/entities/spatialIndexManager.js
+++ b/src/entities/spatialIndexManager.js
@@ -2,7 +2,7 @@
 
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 import { ISpatialIndexManager } from '../interfaces/ISpatialIndexManager.js';
-import MapManager from '../utils/mapManagerUtils.js';
+import { MapManager } from '../utils/mapManagerUtils.js';
 import { assertValidId } from '../utils/parameterGuards.js';
 
 /**

--- a/src/utils/actorLocationUtils.js
+++ b/src/utils/actorLocationUtils.js
@@ -36,5 +36,3 @@ export function getActorLocation(entityId, entityManager) {
   }
   return null;
 }
-
-export default getActorLocation;

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -138,5 +138,3 @@ export function tryWriteContextVariable(
     logger
   );
 }
-
-export default writeContextVariable;

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -35,5 +35,3 @@ export function resolveSafeDispatcher(execCtx, dispatcher, logger) {
 
   return null;
 }
-
-export default resolveSafeDispatcher;

--- a/src/utils/entityAssertionsUtils.js
+++ b/src/utils/entityAssertionsUtils.js
@@ -63,5 +63,3 @@ export function assertValidActor(
 ) {
   assertValidEntity(actor, logger, contextName, safeEventDispatcher);
 }
-
-export default assertValidEntity;

--- a/src/utils/handlerUtils/indexUtils.js
+++ b/src/utils/handlerUtils/indexUtils.js
@@ -7,9 +7,4 @@ import {
 
 export { assertParamsObject, initHandlerLogger, validateDeps, getExecLogger };
 
-export default {
-  assertParamsObject,
-  initHandlerLogger,
-  validateDeps,
-  getExecLogger,
-};
+// deprecated default export removed in favor of named exports only

--- a/src/utils/handlerUtils/paramsUtils.js
+++ b/src/utils/handlerUtils/paramsUtils.js
@@ -29,4 +29,4 @@ export function assertParamsObject(params, logger, opName) {
   return false;
 }
 
-export default { assertParamsObject };
+// deprecated default export removed in favor of named exports only

--- a/src/utils/jsonLogicUtils.js
+++ b/src/utils/jsonLogicUtils.js
@@ -49,5 +49,3 @@ export function warnOnBracketPaths(rule, logger) {
     Object.values(rule).forEach((v) => warnOnBracketPaths(v, logger));
   }
 }
-
-export default isEmptyCondition;

--- a/src/utils/mapManagerUtils.js
+++ b/src/utils/mapManagerUtils.js
@@ -9,7 +9,7 @@
  */
 import { isNonBlankString } from './textUtils.js';
 
-class MapManager {
+export class MapManager {
   /**
    * Initializes the internal Map storage.
    *
@@ -130,5 +130,3 @@ class MapManager {
     this.items.clear();
   }
 }
-
-export default MapManager;

--- a/src/utils/operationTypeUtils.js
+++ b/src/utils/operationTypeUtils.js
@@ -27,5 +27,3 @@ export function getNormalizedOperationType(type, logger, label) {
 
   return trimmed;
 }
-
-export default getNormalizedOperationType;

--- a/src/utils/persistenceErrorUtils.js
+++ b/src/utils/persistenceErrorUtils.js
@@ -55,5 +55,3 @@ export function wrapSyncPersistenceOperation(
     };
   }
 }
-
-export default wrapPersistenceOperation;

--- a/src/utils/persistenceResultUtils.js
+++ b/src/utils/persistenceResultUtils.js
@@ -55,5 +55,3 @@ export function normalizePersistenceFailure(result, fallbackCode, defaultMsg) {
     data: null,
   };
 }
-
-export default createPersistenceFailure;

--- a/src/utils/ruleIdUtils.js
+++ b/src/utils/ruleIdUtils.js
@@ -19,5 +19,3 @@ export function deriveBaseRuleIdFromFilename(filename) {
     '.rule.yaml',
   ]);
 }
-
-export default deriveBaseRuleIdFromFilename;

--- a/src/utils/saveMetadataUtils.js
+++ b/src/utils/saveMetadataUtils.js
@@ -41,5 +41,3 @@ export function validateSaveMetadataFields(metadata, fileName, logger) {
 
   return metadata;
 }
-
-export default validateSaveMetadataFields;

--- a/src/utils/saveStateUtils.js
+++ b/src/utils/saveStateUtils.js
@@ -51,5 +51,3 @@ export function cloneValidatedState(obj, logger) {
 export function cloneAndValidateSaveState(obj, logger) {
   return cloneValidatedState(obj, logger);
 }
-
-export default cloneAndValidateSaveState;

--- a/src/utils/serviceBase.js
+++ b/src/utils/serviceBase.js
@@ -39,5 +39,3 @@ export class BaseService {
     validateServiceDeps(serviceName, logger, deps);
   }
 }
-
-export default BaseService;

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -24,7 +24,7 @@ import {
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
 import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
-import MapManager from '../../../src/utils/mapManagerUtils.js';
+import { MapManager } from '../../../src/utils/mapManagerUtils.js';
 
 describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
   describe('constructor', () => {
@@ -44,13 +44,14 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
         const { registry, validator, logger, eventDispatcher } = getBed().mocks;
         const EntityManager = getBed().entityManager.constructor;
 
-        expect(() =>
-          new EntityManager({
-            registry: depName === 'registry' ? value : registry,
-            validator: depName === 'validator' ? value : validator,
-            logger,
-            dispatcher: eventDispatcher,
-          })
+        expect(
+          () =>
+            new EntityManager({
+              registry: depName === 'registry' ? value : registry,
+              validator: depName === 'validator' ? value : validator,
+              logger,
+              dispatcher: eventDispatcher,
+            })
         ).toThrow(
           depName === 'registry'
             ? 'Missing required dependency: IDataRegistry.'

--- a/tests/unit/utils/contextVariableUtils.test.js
+++ b/tests/unit/utils/contextVariableUtils.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import writeContextVariable, {
+import {
+  writeContextVariable,
   tryWriteContextVariable,
 } from '../../../src/utils/contextVariableUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';

--- a/tests/unit/utils/handlerUtils.indexUtils.test.js
+++ b/tests/unit/utils/handlerUtils.indexUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import indexUtils, {
+import {
   assertParamsObject,
   initHandlerLogger,
   validateDeps,
@@ -18,14 +18,5 @@ describe('handlerUtils/indexUtils exports', () => {
     expect(initHandlerLogger).toBe(serviceInit);
     expect(validateDeps).toBe(serviceValidate);
     expect(getExecLogger).toBe(serviceGetExec);
-  });
-
-  it('default export contains same references', () => {
-    expect(indexUtils).toEqual({
-      assertParamsObject: paramsAssert,
-      initHandlerLogger: serviceInit,
-      validateDeps: serviceValidate,
-      getExecLogger: serviceGetExec,
-    });
   });
 });

--- a/tests/unit/utils/mapManagerUtils.test.js
+++ b/tests/unit/utils/mapManagerUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import MapManager from '../../../src/utils/mapManagerUtils.js';
+import { MapManager } from '../../../src/utils/mapManagerUtils.js';
 
 describe('MapManager', () => {
   it('manages values with valid ids', () => {


### PR DESCRIPTION
## Summary
- use named exports for utility modules
- update imports for mapManagerUtils
- adjust associated unit tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6856de22dae8833182e723051e4706ea