### PR TITLE
[Agent] add resetDispatch option

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -194,16 +194,26 @@ export class TestBed extends FactoryTestBed {
    *   definition to use.
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
+   * @param {object} [config] - Additional configuration options.
+   * @param {boolean} [config.resetDispatch=false] - If true, resets the event
+   *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createEntity(defKey, options = {}) {
+  createEntity(defKey, options = {}, { resetDispatch = false } = {}) {
     const definition = TestData.Definitions[defKey];
     if (!definition) {
       throw new Error(`Unknown test definition key: ${defKey}`);
     }
     this.setupDefinitions(definition);
-    return this.entityManager.createEntityInstance(definition.id, options);
+    const entity = this.entityManager.createEntityInstance(
+      definition.id,
+      options
+    );
+    if (resetDispatch) {
+      this.resetDispatchMock();
+    }
+    return entity;
   }
 
   /**

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -36,10 +36,13 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', {
-          instanceId: PRIMARY,
-        });
-        getBed().resetDispatchMock();
+        getBed().createEntity(
+          'basic',
+          {
+            instanceId: PRIMARY,
+          },
+          { resetDispatch: true }
+        );
 
         // Act
         entityManager.addComponent(
@@ -64,10 +67,13 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager, mocks } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        const entity = getBed().createEntity('basic', {
-          instanceId: PRIMARY,
-        });
-        getBed().resetDispatchMock();
+        const entity = getBed().createEntity(
+          'basic',
+          {
+            instanceId: PRIMARY,
+          },
+          { resetDispatch: true }
+        );
 
         // Act
         entityManager.addComponent(
@@ -121,9 +127,13 @@ describeEntityManagerSuite(
         const { PRIMARY } = TestData.InstanceIDs;
         const UPDATED_NAME_DATA = { name: 'Updated Name' };
 
-        const entity = getBed().createEntity('basic', {
-          instanceId: PRIMARY,
-        });
+        const entity = getBed().createEntity(
+          'basic',
+          {
+            instanceId: PRIMARY,
+          },
+          { resetDispatch: true }
+        );
         const originalNameData = entity.getComponentData(NAME_COMPONENT_ID);
         getBed().resetDispatchMock();
 
@@ -167,8 +177,11 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager, mocks } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
-        getBed().resetDispatchMock();
+        getBed().createEntity(
+          'basic',
+          { instanceId: PRIMARY },
+          { resetDispatch: true }
+        );
 
         const validationErrors = [{ message: 'Invalid data' }];
         mocks.validator.validate.mockReturnValue({
@@ -236,11 +249,13 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager, mocks } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        const entity = getBed().createEntity('basic', {
-          instanceId: PRIMARY,
-        });
-        // Clear dispatcher mock to ignore the ENTITY_CREATED event from setup.
-        getBed().resetDispatchMock();
+        const entity = getBed().createEntity(
+          'basic',
+          {
+            instanceId: PRIMARY,
+          },
+          { resetDispatch: true }
+        );
 
         // Mock the entity's own method to simulate an internal failure
         const addComponentSpy = jest
@@ -275,7 +290,7 @@ describeEntityManagerSuite(
         const { PRIMARY } = TestData.InstanceIDs;
 
         // Add component as an override
-        const entity = getBed().createEntity('basic', {
+        getBed().createEntity('basic', {
           instanceId: PRIMARY,
         });
         entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
@@ -300,9 +315,13 @@ describeEntityManagerSuite(
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         const overrideData = { name: 'ToBeRemoved' };
-        const entity = getBed().createEntity('basic', {
-          instanceId: PRIMARY,
-        });
+        const entity = getBed().createEntity(
+          'basic',
+          {
+            instanceId: PRIMARY,
+          },
+          { resetDispatch: true }
+        );
         entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, overrideData);
         getBed().resetDispatchMock();
 
@@ -327,9 +346,12 @@ describeEntityManagerSuite(
         const { entityManager, mocks } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createEntity(
+          'basic',
+          { instanceId: PRIMARY },
+          { resetDispatch: true }
+        );
         // NAME_COMPONENT_ID exists on definition, but not as an override
-        getBed().resetDispatchMock();
 
         // Act & Assert
         expect(() =>

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -44,13 +44,14 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
         const { registry, validator, logger, eventDispatcher } = getBed().mocks;
         const EntityManager = getBed().entityManager.constructor;
 
-        expect(() =>
-          new EntityManager({
-            registry: depName === 'registry' ? value : registry,
-            validator: depName === 'validator' ? value : validator,
-            logger,
-            dispatcher: eventDispatcher,
-          })
+        expect(
+          () =>
+            new EntityManager({
+              registry: depName === 'registry' ? value : registry,
+              validator: depName === 'validator' ? value : validator,
+              logger,
+              dispatcher: eventDispatcher,
+            })
         ).toThrow(
           depName === 'registry'
             ? 'Missing required dependency: IDataRegistry.'
@@ -380,8 +381,11 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
     it('should dispatch an ENTITY_REMOVED event upon successful removal', () => {
       // Arrange
       const { entityManager, mocks } = getBed();
-      const entity = getBed().createEntity('basic');
-      getBed().resetDispatchMock();
+      const entity = getBed().createEntity(
+        'basic',
+        {},
+        { resetDispatch: true }
+      );
 
       // Act
       entityManager.removeEntityInstance(entity.id);


### PR DESCRIPTION
Summary:
- createEntity helper can reset dispatch mock via options
- update tests to pass {resetDispatch: true}

Testing Done:
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856e064b60083319abcabb721de7441