### PR TITLE
[Agent] Add expectSingleDispatch utility and tests

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -88,11 +88,24 @@ export function expectEngineStatus(engine, expectedStatus) {
   expect(engine.getEngineStatus()).toEqual(expectedStatus);
 }
 
+/**
+ * Asserts a single dispatch call with the given id and payload.
+ *
+ * @param {import('@jest/globals').Mock} mock
+ * @param {string} eventId
+ * @param {any} payload
+ * @returns {void}
+ */
+export function expectSingleDispatch(mock, eventId, payload) {
+  expectDispatchSequence(mock, [[eventId, payload]]);
+}
+
 export { expectDispatchSequence as expectDispatchCalls };
 
 export default {
   expectDispatchSequence,
   buildSaveDispatches,
   expectEngineStatus,
+  expectSingleDispatch,
   expectDispatchCalls: expectDispatchSequence,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -4,6 +4,7 @@ import {
   buildSaveDispatches,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   expectEngineStatus,
+  expectSingleDispatch,
 } from './dispatchTestUtils.js';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
@@ -39,6 +40,23 @@ describe('dispatchTestUtils', () => {
       expect(() =>
         expectDispatchSequence(mock, ['eventA', { a: 2 }])
       ).toThrow();
+    });
+  });
+
+  describe('expectSingleDispatch', () => {
+    it('verifies a single dispatch call', () => {
+      const mock = jest.fn();
+      const event = ['eventA', { a: 1 }];
+      mock(...event);
+      expect(() =>
+        expectSingleDispatch(mock, 'eventA', { a: 1 })
+      ).not.toThrow();
+    });
+
+    it('throws when the call does not match', () => {
+      const mock = jest.fn();
+      mock('eventA', { a: 1 });
+      expect(() => expectSingleDispatch(mock, 'eventB', { b: 2 })).toThrow();
     });
   });
 

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -18,7 +18,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -77,17 +77,12 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NEW_COMPONENT_ID,
-              componentData: NEW_COMPONENT_DATA,
-              oldComponentData: undefined,
-            },
-          ],
-        ]);
+        expectSingleDispatch(mocks.eventDispatcher.dispatch, COMPONENT_ADDED_ID, {
+          entity: entity,
+          componentTypeId: NEW_COMPONENT_ID,
+          componentData: NEW_COMPONENT_DATA,
+          oldComponentData: undefined,
+        });
       });
 
       it('should update an existing component', () => {
@@ -135,17 +130,12 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              componentData: UPDATED_NAME_DATA,
-              oldComponentData: originalNameData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(mocks.eventDispatcher.dispatch, COMPONENT_ADDED_ID, {
+          entity: entity,
+          componentTypeId: NAME_COMPONENT_ID,
+          componentData: UPDATED_NAME_DATA,
+          oldComponentData: originalNameData,
+        });
       });
 
       it('should throw EntityNotFoundError for a non-existent entity', () => {
@@ -289,6 +279,7 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
+        expect(entity).toBeDefined();
         expect(
           entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID, true)
         ).toBe(false);
@@ -310,16 +301,15 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_REMOVED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              oldComponentData: overrideData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_REMOVED_ID,
+          {
+            entity: entity,
+            componentTypeId: NAME_COMPONENT_ID,
+            oldComponentData: overrideData,
+          }
+        );
       });
 
       it('should throw an error if component is not an override on the instance', () => {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -23,7 +23,7 @@ import {
   ENTITY_CREATED_ID,
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
 import MapManager from '../../../src/utils/mapManagerUtils.js';
 import { buildSerializedEntity } from '../../common/entities/serializationUtils.js';
 
@@ -125,15 +125,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createEntity('basic');
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: false,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: false,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definitionId does not exist', () => {
@@ -254,15 +249,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = entityManager.reconstructEntity(serializedEntity);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: true,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: true,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definition is not found', () => {
@@ -377,14 +367,9 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_REMOVED_ID,
-          {
-            entity,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_REMOVED_ID, {
+        entity,
+      });
     });
 
     it('should throw an EntityNotFoundError when trying to remove a non-existent entity', () => {


### PR DESCRIPTION
## Summary
- add `expectSingleDispatch` helper to dispatchTestUtils
- test new `expectSingleDispatch` behavior
- use `expectSingleDispatch` in entity manager tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856e055691883318115bbeb774919d2