### PR TITLE
[Agent] add expectSingleDispatch util

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -88,11 +88,24 @@ export function expectEngineStatus(engine, expectedStatus) {
   expect(engine.getEngineStatus()).toEqual(expectedStatus);
 }
 
+/**
+ * Asserts a single dispatch call with the given id and payload.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {string} eventId - Expected dispatched event id.
+ * @param {any} payload - Expected dispatched payload.
+ * @returns {void}
+ */
+export function expectSingleDispatch(mock, eventId, payload) {
+  expectDispatchSequence(mock, [[eventId, payload]]);
+}
+
 export { expectDispatchSequence as expectDispatchCalls };
 
 export default {
   expectDispatchSequence,
   buildSaveDispatches,
   expectEngineStatus,
+  expectSingleDispatch,
   expectDispatchCalls: expectDispatchSequence,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
   expectDispatchSequence,
+  expectSingleDispatch,
   buildSaveDispatches,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   expectEngineStatus,
@@ -39,6 +40,22 @@ describe('dispatchTestUtils', () => {
       expect(() =>
         expectDispatchSequence(mock, ['eventA', { a: 2 }])
       ).toThrow();
+    });
+  });
+
+  describe('expectSingleDispatch', () => {
+    it('succeeds when single call matches', () => {
+      const mock = jest.fn();
+      mock('eventA', { a: 1 });
+      expect(() =>
+        expectSingleDispatch(mock, 'eventA', { a: 1 })
+      ).not.toThrow();
+    });
+
+    it('throws when call differs', () => {
+      const mock = jest.fn();
+      mock('eventA', { a: 2 });
+      expect(() => expectSingleDispatch(mock, 'eventA', { a: 1 })).toThrow();
     });
   });
 

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -18,7 +18,10 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import {
+  expectDispatchSequence,
+  expectSingleDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -83,17 +86,16 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NEW_COMPONENT_ID,
-              componentData: NEW_COMPONENT_DATA,
-              oldComponentData: undefined,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_ADDED_ID,
+          {
+            entity: entity,
+            componentTypeId: NEW_COMPONENT_ID,
+            componentData: NEW_COMPONENT_DATA,
+            oldComponentData: undefined,
+          }
+        );
       });
 
       it('should update an existing component', () => {
@@ -145,17 +147,16 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              componentData: UPDATED_NAME_DATA,
-              oldComponentData: originalNameData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_ADDED_ID,
+          {
+            entity: entity,
+            componentTypeId: NAME_COMPONENT_ID,
+            componentData: UPDATED_NAME_DATA,
+            oldComponentData: originalNameData,
+          }
+        );
       });
 
       it('should throw EntityNotFoundError for a non-existent entity', () => {
@@ -329,16 +330,15 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_REMOVED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              oldComponentData: overrideData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_REMOVED_ID,
+          {
+            entity: entity,
+            componentTypeId: NAME_COMPONENT_ID,
+            oldComponentData: overrideData,
+          }
+        );
       });
 
       it('should throw an error if component is not an override on the instance', () => {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -23,11 +23,13 @@ import {
   ENTITY_CREATED_ID,
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import {
+  expectDispatchSequence,
+  expectSingleDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 import { MapManager } from '../../../src/utils/mapManagerUtils.js';
 import { buildSerializedEntity } from '../../common/entities/serializationUtils.js';
-
 
 describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
   describe('constructor', () => {
@@ -127,15 +129,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createEntity('basic');
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: false,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: false,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definitionId does not exist', () => {
@@ -256,15 +253,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = entityManager.reconstructEntity(serializedEntity);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: true,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: true,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definition is not found', () => {
@@ -382,14 +374,9 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_REMOVED_ID,
-          {
-            entity,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_REMOVED_ID, {
+        entity,
+      });
     });
 
     it('should throw an EntityNotFoundError when trying to remove a non-existent entity', () => {


### PR DESCRIPTION
Summary:
- implement expectSingleDispatch helper
- test expectSingleDispatch behavior
- use expectSingleDispatch in entity manager tests

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856e696eca88331a29e31b848ca97a9