### PR TITLE
[Agent] simplify DI registration tests

### DIFF
--- a/tests/common/containerAssertions.js
+++ b/tests/common/containerAssertions.js
@@ -1,0 +1,19 @@
+/**
+ * @file Assertion helpers for DI container-related tests.
+ */
+
+/**
+ * Asserts that resolving `token` from the container yields a singleton instance
+ * of the provided class.
+ *
+ * @param {{ resolve: Function }} container - DI container instance.
+ * @param {any} token - Token used to resolve the instance.
+ * @param {Function} Class - Expected constructor.
+ * @returns {void}
+ */
+export function expectSingleton(container, token, Class) {
+  expect(() => container.resolve(token)).not.toThrow();
+  const first = container.resolve(token);
+  expect(first).toBeInstanceOf(Class);
+  expect(container.resolve(token)).toBe(first);
+}

--- a/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
@@ -42,6 +42,7 @@ import { LLMResponseProcessor } from '../../../../src/turns/services/LLMResponse
 import { AIFallbackActionFactory } from '../../../../src/turns/services/AIFallbackActionFactory.js';
 import { AIPromptPipeline } from '../../../../src/prompting/AIPromptPipeline.js';
 import { createMockLogger } from '../../../common/mockFactories/index.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 // --- Mocks ---
 const logger = createMockLogger();
@@ -110,9 +111,7 @@ describe('registerAI', () => {
   describe('LLM Infrastructure & Adapter', () => {
     it('should register IHttpClient using ISafeEventDispatcher if available', () => {
       registerAI(container);
-      expect(() => container.resolve(tokens.IHttpClient)).not.toThrow();
-      const instance = container.resolve(tokens.IHttpClient);
-      expect(instance).toBeInstanceOf(RetryHttpClient);
+      expectSingleton(container, tokens.IHttpClient, RetryHttpClient);
     });
 
     it('should register IHttpClient using IValidatedEventDispatcher as fallback', () => {
@@ -130,18 +129,12 @@ describe('registerAI', () => {
 
       registerAI(fallbackContainer);
 
-      expect(() => fallbackContainer.resolve(tokens.IHttpClient)).not.toThrow();
-      const instance = fallbackContainer.resolve(tokens.IHttpClient);
-      expect(instance).toBeInstanceOf(RetryHttpClient);
+      expectSingleton(fallbackContainer, tokens.IHttpClient, RetryHttpClient);
     });
 
     it('should register LLMAdapter as a singleton factory', () => {
       registerAI(container);
-      expect(() => container.resolve(tokens.LLMAdapter)).not.toThrow();
-      const instance1 = container.resolve(tokens.LLMAdapter);
-      const instance2 = container.resolve(tokens.LLMAdapter);
-      expect(instance1).toBeInstanceOf(ConfigurableLLMAdapter);
-      expect(instance1).toBe(instance2);
+      expectSingleton(container, tokens.LLMAdapter, ConfigurableLLMAdapter);
     });
   });
 
@@ -182,10 +175,7 @@ describe('registerAI', () => {
       'should register $token correctly',
       ({ token, Class }) => {
         registerAI(container);
-        expect(() => container.resolve(token)).not.toThrow();
-        const instance = container.resolve(token);
-        expect(instance).toBeInstanceOf(Class);
-        expect(container.resolve(token)).toBe(instance);
+        expectSingleton(container, token, Class);
       }
     );
 
@@ -232,8 +222,7 @@ describe('registerAI', () => {
       'should register $token correctly',
       ({ token, Class }) => {
         registerAI(container);
-        expect(() => container.resolve(token)).not.toThrow();
-        expect(container.resolve(token)).toBeInstanceOf(Class);
+        expectSingleton(container, token, Class);
       }
     );
 
@@ -270,10 +259,7 @@ describe('registerAI', () => {
       'should register $token correctly',
       ({ token, Class }) => {
         registerAI(container);
-        expect(() => container.resolve(token)).not.toThrow();
-        const instance = container.resolve(token);
-        expect(instance).toBeInstanceOf(Class);
-        expect(container.resolve(token)).toBe(instance);
+        expectSingleton(container, token, Class);
       }
     );
 

--- a/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
@@ -28,6 +28,7 @@ import { PrerequisiteEvaluationService } from '../../../../src/actions/validatio
 import { DomainContextCompatibilityChecker } from '../../../../src/validation/domainContextCompatibilityChecker.js';
 import { ActionValidationService } from '../../../../src/actions/validation/actionValidationService.js';
 import CommandProcessor from '../../../../src/commands/commandProcessor.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerCommandAndAction', () => {
   /** @type {AppContainer} */
@@ -152,13 +153,7 @@ describe('registerCommandAndAction', () => {
         registerCommandAndAction(container);
 
         // --- Assert ---
-
-        // 1. Check if the service can be resolved and is of the correct concrete type
-        const instance = container.resolve(token);
-        expect(instance).toBeInstanceOf(Class);
-
-        // 2. Check for singleton behavior (all are singletons or singleton factories)
-        expect(container.resolve(token)).toBe(instance);
+        expectSingleton(container, token, Class);
 
         // 3. Find the call to container.register for the specific token using the spy
         const registrationCall = registerSpy.mock.calls.find(

--- a/tests/unit/dependencyInjection/registrations/eventBusAdapterRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/eventBusAdapterRegistrations.test.js
@@ -23,6 +23,7 @@ import { registerEventBusAdapters } from '../../../../src/dependencyInjection/re
 // --- Concrete Class Imports for `instanceof` checks ---
 import { EventBusPromptAdapter } from '../../../../src/turns/adapters/eventBusPromptAdapter.js';
 import EventBusTurnEndAdapter from '../../../../src/turns/adapters/eventBusTurnEndAdapter.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerEventBusAdapters', () => {
   /** @type {AppContainer} */
@@ -122,12 +123,11 @@ describe('registerEventBusAdapters', () => {
       registerEventBusAdapters(freshContainer);
 
       // Assert
-      // 1. Resolves without error and is correct type
-      const instance = freshContainer.resolve(tokens.IPromptOutputPort);
-      expect(instance).toBeInstanceOf(EventBusPromptAdapter);
-
-      // 2. Is a singleton
-      expect(freshContainer.resolve(tokens.IPromptOutputPort)).toBe(instance);
+      expectSingleton(
+        freshContainer,
+        tokens.IPromptOutputPort,
+        EventBusPromptAdapter
+      );
     });
 
     test('should throw during resolution if dispatcher dependency is missing', () => {
@@ -166,9 +166,11 @@ describe('registerEventBusAdapters', () => {
       registerEventBusAdapters(freshContainer);
 
       // Assert
-      const instance = freshContainer.resolve(tokens.ITurnEndPort);
-      expect(instance).toBeInstanceOf(EventBusTurnEndAdapter);
-      expect(freshContainer.resolve(tokens.ITurnEndPort)).toBe(instance);
+      expectSingleton(
+        freshContainer,
+        tokens.ITurnEndPort,
+        EventBusTurnEndAdapter
+      );
     });
 
     test('should throw during resolution if both dispatcher dependencies are missing', () => {

--- a/tests/unit/dependencyInjection/registrations/orchestrationRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/orchestrationRegistrations.test.js
@@ -18,6 +18,7 @@ import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import { registerOrchestration } from '../../../../src/dependencyInjection/registrations/orchestrationRegistrations.js';
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
 import ShutdownService from '../../../../src/shutdown/services/shutdownService.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerOrchestration', () => {
   /** @type {AppContainer} */
@@ -52,13 +53,12 @@ describe('registerOrchestration', () => {
   it('registers InitializationService and ShutdownService as singleton factories', () => {
     registerOrchestration(container);
 
-    const initInstance = container.resolve(tokens.IInitializationService);
-    expect(initInstance).toBeInstanceOf(InitializationService);
-    expect(container.resolve(tokens.IInitializationService)).toBe(initInstance);
-
-    const shutdownInstance = container.resolve(tokens.ShutdownService);
-    expect(shutdownInstance).toBeInstanceOf(ShutdownService);
-    expect(container.resolve(tokens.ShutdownService)).toBe(shutdownInstance);
+    expectSingleton(
+      container,
+      tokens.IInitializationService,
+      InitializationService
+    );
+    expectSingleton(container, tokens.ShutdownService, ShutdownService);
 
     const initCall = registerSpy.mock.calls.find(
       (c) => c[0] === tokens.IInitializationService

--- a/tests/unit/dependencyInjection/registrations/persistenceRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/persistenceRegistrations.test.js
@@ -28,6 +28,7 @@ import ActiveModsManifestBuilder from '../../../../src/persistence/activeModsMan
 import SaveLoadService from '../../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../../src/persistence/saveFileRepository.js';
 import { BrowserStorageProvider } from '../../../../src/storage/browserStorageProvider.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerPersistence', () => {
   /** @type {AppContainer} */
@@ -161,12 +162,7 @@ describe('registerPersistence', () => {
       ({ token, Class, lifecycle, deps }) => {
         registerPersistence(container);
 
-        // 1. Resolution
-        const instance = container.resolve(token);
-        expect(instance).toBeInstanceOf(Class);
-
-        // 2. Singleton behavior
-        expect(container.resolve(token)).toBe(instance);
+        expectSingleton(container, token, Class);
 
         // 3. Registration call
         const call = registerSpy.mock.calls.find((c) => c[0] === token);

--- a/tests/unit/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
@@ -23,6 +23,7 @@ import TurnHandlerResolver from '../../../../src/turns/services/turnHandlerResol
 import { ConcreteTurnStateFactory } from '../../../../src/turns/factories/concreteTurnStateFactory.js';
 import { ConcreteTurnContextFactory } from '../../../../src/turns/factories/concreteTurnContextFactory.js';
 import PromptCoordinator from '../../../../src/turns/prompting/promptCoordinator';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerTurnLifecycle', () => {
   let container;
@@ -167,18 +168,7 @@ describe('registerTurnLifecycle', () => {
     ({ token, Class, lifecycle, tags }) => {
       registerTurnLifecycle(container);
 
-      const instance = container.resolve(token);
-      expect(instance).toBeInstanceOf(Class);
-
-      const instance2 = container.resolve(token);
-      expect(instance2).toBeInstanceOf(Class);
-      if (lifecycle === 'transient') {
-        // eslint-disable-next-line jest/no-conditional-expect
-        expect(instance2).not.toBe(instance);
-      } else {
-        // eslint-disable-next-line jest/no-conditional-expect
-        expect(instance2).toBe(instance);
-      }
+      expectSingleton(container, token, Class);
 
       const call = registerSpy.mock.calls.find((c) => c[0] === token);
       expect(call).toBeDefined();

--- a/tests/unit/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/worldAndEntityRegistrations.test.js
@@ -22,6 +22,7 @@ import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import WorldContext from '../../../../src/context/worldContext.js';
 import JsonLogicEvaluationService from '../../../../src/logic/jsonLogicEvaluationService.js';
 import { EntityDisplayDataProvider } from '../../../../src/entities/entityDisplayDataProvider.js';
+import { expectSingleton } from '../../../common/containerAssertions.js';
 // EntityManager is now registered by the SUT, so we might not need to import its class here unless for instanceof checks on IEntityManager resolution.
 // import EntityManager from '../../../src/entities/entityManager.js';
 
@@ -118,11 +119,7 @@ describe('registerWorldAndEntity', () => {
     ({ token, Class, lifecycle, deps }) => {
       registerWorldAndEntity(container);
 
-      // Resolution yields correct instance
-      const instance = container.resolve(token);
-      expect(instance).toBeInstanceOf(Class);
-      // Singleton behavior
-      expect(container.resolve(token)).toBe(instance);
+      expectSingleton(container, token, Class);
 
       // Registration metadata check (verifies how it was registered by the SUT)
       const registrationCall = registerSpy.mock.calls.find(


### PR DESCRIPTION
## Summary
- add `expectSingleton` test helper
- reuse `expectSingleton` across DI registration test suites

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint found errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6856e5ee20308331bd98d17d68264c8a