### PR TITLE
[Feat] Simplify TurnManager test mocks

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -125,6 +125,22 @@ export class TurnManagerTestBed extends FactoryTestBed {
   }
 
   /**
+   * @description Initializes common mock implementations used across many
+   *   test suites. All turn order service methods resolve successfully,
+   *   dispatcher.dispatch resolves to `true`, and a default handler resolver is
+   *   configured.
+   * @returns {void}
+   */
+  initializeDefaultMocks() {
+    this.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
+    this.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
+    this.mocks.turnOrderService.startNewRound.mockResolvedValue();
+    this.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
+    this.mocks.dispatcher.dispatch.mockResolvedValue(true);
+    this.setupMockHandlerResolver();
+  }
+
+  /**
    * Retrieves the subscribed callback for the given event id.
    *
    * @param {string} eventId - Event identifier.

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -27,22 +27,16 @@ describeTurnManagerSuite(
     beforeEach(async () => {
       testBed = getBed();
 
+      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
         createAiActor('initial-actor-for-start')
       );
-
-      testBed.mocks.dispatcher.dispatch.mockClear().mockResolvedValue(true);
       turnEndCapture = testBed.captureSubscription(TURN_ENDED_ID);
-      testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
-
-      // Set default resolution for the resolver
-      testBed.mocks.turnHandlerResolver.resolveHandler
-        .mockClear()
-        .mockResolvedValue({
-          startTurn: jest.fn().mockResolvedValue(undefined),
-          destroy: jest.fn().mockResolvedValue(undefined),
-        });
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue({
+        startTurn: jest.fn().mockResolvedValue(undefined),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      });
 
       stopSpy = jest
         .spyOn(testBed.turnManager, 'stop')

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -42,25 +42,14 @@ describeTurnManagerSuite(
       // Made beforeEach async
       testBed = getBed();
 
-      // Reset mock state
-      testBed.mocks.turnOrderService.isEmpty
-        .mockReset()
-        .mockResolvedValue(false); // Default: Queue NOT empty
-      testBed.mocks.turnOrderService.getNextEntity
-        .mockReset()
-        .mockResolvedValue(null); // Default reset
-      testBed.mocks.turnOrderService.clearCurrentRound
-        .mockReset()
-        .mockResolvedValue();
-      testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
+      testBed.initializeDefaultMocks();
+      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
-
-      testBed.mocks.turnHandlerResolver.resolveHandler
-        .mockClear()
-        .mockResolvedValue({
-          startTurn: jest.fn().mockResolvedValue(undefined),
-          destroy: jest.fn().mockResolvedValue(undefined),
-        });
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue({
+        startTurn: jest.fn().mockResolvedValue(undefined),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      });
 
       // Spy on stop to verify calls and simulate unsubscribe
       stopSpy = jest

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -20,19 +20,10 @@ describeTurnManagerSuite(
     beforeEach(() => {
       testBed = getBed();
 
-      // Reset mock state
+      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockReset();
-      testBed.mocks.turnOrderService.startNewRound
-        .mockReset()
-        .mockResolvedValue(undefined);
-      testBed.mocks.turnOrderService.clearCurrentRound
-        .mockReset()
-        .mockResolvedValue(undefined);
-      testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
-      testBed.mocks.turnHandlerResolver.resolveHandler
-        .mockReset()
-        .mockResolvedValue(null);
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(null);
 
       // Define the spy here for the actual advanceTurn method
       advanceTurnSpy = jest.spyOn(testBed.turnManager, 'advanceTurn');

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -35,21 +35,15 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   let mockPlayerEntity;
   let mockAiEntity1;
 
-
   beforeEach(() => {
     testBed = getBed();
 
     ({ player: mockPlayerEntity, ai1: mockAiEntity1 } = createDefaultActors());
 
-    // Configure default mock behaviors
-    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
-    testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
-    testBed.mocks.turnOrderService.startNewRound.mockResolvedValue();
-    testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
-    testBed.mocks.dispatcher.dispatch.mockReset().mockResolvedValue(true);
-    testBed.mocks.turnHandlerResolver.resolveHandler
-      .mockReset()
-      .mockResolvedValue(mockAiHandler);
+    testBed.initializeDefaultMocks();
+    testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+      mockAiHandler
+    );
 
     // Clear handler mocks
     mockPlayerHandler.startTurn.mockClear().mockResolvedValue();
@@ -257,7 +251,6 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
     });
 
     test('should handle entity manager errors gracefully', async () => {
-
       // --- Setup mocks ---
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       // Simulate getNextEntity returning null to trigger the error condition

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -35,11 +35,9 @@ describeTurnManagerSuite(
       jest.useFakeTimers();
       testBed = getBed();
 
-      // Set up default mocks for turn order service
+      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
-      testBed.mocks.turnOrderService.startNewRound.mockResolvedValue();
-      testBed.mocks.turnOrderService.clearCurrentRound.mockResolvedValue();
 
       ({ ai1, ai2, player } = createDefaultActors());
 


### PR DESCRIPTION
Summary: Introduced helper for common TurnManager mocks and updated suites.

Changes Made:
- Added `initializeDefaultMocks()` to `turnManagerTestBed.js` for setting safe defaults.
- Updated several TurnManager test suites to use the new helper.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_6856e5e0b7fc8331b5689bd649fa2d3b