### PR TITLE
[Agent] simplify entityManager test helpers

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -39,6 +39,19 @@ export function expectDispatchSequence(mock, ...events) {
 }
 
 /**
+ * Asserts that a single dispatch occurred with the given event id and payload.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {string} eventId - Expected event identifier.
+ * @param {any} payload - Expected payload for the dispatch.
+ * @returns {void}
+ */
+export function expectSingleDispatch(mock, eventId, payload) {
+  expect(mock).toHaveBeenCalledTimes(1);
+  expect(mock).toHaveBeenCalledWith(eventId, payload);
+}
+
+/**
  * Builds the dispatch sequence emitted during a manual save.
  * When `filePath` is omitted, the GAME_SAVED_ID event is excluded, mimicking
  * a failure scenario.
@@ -92,6 +105,7 @@ export { expectDispatchSequence as expectDispatchCalls };
 
 export default {
   expectDispatchSequence,
+  expectSingleDispatch,
   buildSaveDispatches,
   expectEngineStatus,
   expectDispatchCalls: expectDispatchSequence,

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -18,7 +18,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -83,17 +83,16 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NEW_COMPONENT_ID,
-              componentData: NEW_COMPONENT_DATA,
-              oldComponentData: undefined,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_ADDED_ID,
+          {
+            entity: entity,
+            componentTypeId: NEW_COMPONENT_ID,
+            componentData: NEW_COMPONENT_DATA,
+            oldComponentData: undefined,
+          }
+        );
       });
 
       it('should update an existing component', () => {
@@ -135,7 +134,6 @@ describeEntityManagerSuite(
           { resetDispatch: true }
         );
         const originalNameData = entity.getComponentData(NAME_COMPONENT_ID);
-        getBed().resetDispatchMock();
 
         // Act
         entityManager.addComponent(
@@ -145,17 +143,16 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_ADDED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              componentData: UPDATED_NAME_DATA,
-              oldComponentData: originalNameData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_ADDED_ID,
+          {
+            entity: entity,
+            componentTypeId: NAME_COMPONENT_ID,
+            componentData: UPDATED_NAME_DATA,
+            oldComponentData: originalNameData,
+          }
+        );
       });
 
       it('should throw EntityNotFoundError for a non-existent entity', () => {
@@ -329,16 +326,15 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-          [
-            COMPONENT_REMOVED_ID,
-            {
-              entity: entity,
-              componentTypeId: NAME_COMPONENT_ID,
-              oldComponentData: overrideData,
-            },
-          ],
-        ]);
+        expectSingleDispatch(
+          mocks.eventDispatcher.dispatch,
+          COMPONENT_REMOVED_ID,
+          {
+            entity: entity,
+            componentTypeId: NAME_COMPONENT_ID,
+            oldComponentData: overrideData,
+          }
+        );
       });
 
       it('should throw an error if component is not an override on the instance', () => {

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -23,11 +23,10 @@ import {
   ENTITY_CREATED_ID,
   ENTITY_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-import { expectDispatchSequence } from '../../common/engine/dispatchTestUtils.js';
+import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 import { MapManager } from '../../../src/utils/mapManagerUtils.js';
 import { buildSerializedEntity } from '../../common/entities/serializationUtils.js';
-
 
 describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
   describe('constructor', () => {
@@ -127,15 +126,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createEntity('basic');
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: false,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: false,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definitionId does not exist', () => {
@@ -256,15 +250,10 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = entityManager.reconstructEntity(serializedEntity);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_CREATED_ID,
-          {
-            entity,
-            wasReconstructed: true,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+        entity,
+        wasReconstructed: true,
+      });
     });
 
     it('should throw a DefinitionNotFoundError if the definition is not found', () => {
@@ -382,14 +371,9 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expectDispatchSequence(mocks.eventDispatcher.dispatch, [
-        [
-          ENTITY_REMOVED_ID,
-          {
-            entity,
-          },
-        ],
-      ]);
+      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_REMOVED_ID, {
+        entity,
+      });
     });
 
     it('should throw an EntityNotFoundError when trying to remove a non-existent entity', () => {


### PR DESCRIPTION
Summary: 
- added `expectSingleDispatch` helper and exported it
- replaced single-event dispatch assertions with `expectSingleDispatch`
- used `resetDispatch` option when creating entities

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails on unrelated files, see logs)*
- [x] Root tests `npm run test`
- [ ] Proxy tests
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6856e5b43d5883319bae1265a5396b91