### PR TITLE
[Agent] refactor clone utils

### DIFF
--- a/src/data/providers/actorStateProvider.js
+++ b/src/data/providers/actorStateProvider.js
@@ -19,7 +19,7 @@ import {
   DEFAULT_FALLBACK_CHARACTER_NAME,
   DEFAULT_FALLBACK_DESCRIPTION_RAW,
 } from '../../constants/textDefaults.js';
-import { deepClone } from '../../utils/objectUtils.js';
+import { deepClone } from '../../utils/cloneUtils.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */

--- a/src/engine/engineVersion.js
+++ b/src/engine/engineVersion.js
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 
 import semver from 'semver';
-import { freeze } from '../utils/objectUtils.js';
+import { freeze } from '../utils/cloneUtils.js';
 
 // NOTE: Keep this string in sync with package.json "version".
 const versionFromPackage = '0.0.1';

--- a/src/entities/entityDefinition.js
+++ b/src/entities/entityDefinition.js
@@ -1,4 +1,4 @@
-import { deepFreeze } from '../utils/objectUtils.js'; // Import directly to avoid circular dependency
+import { deepFreeze } from '../utils/cloneUtils.js'; // Import directly to avoid circular dependency
 
 /**
  * Represents the immutable template/definition of an entity.

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -14,7 +14,7 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
 import ComponentOperationHandler from './componentOperationHandler.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
-import { deepClone } from '../../utils/objectUtils.js';
+import { deepClone } from '../../utils/cloneUtils.js';
 
 /**
  * @typedef {object} EntityRefObject

--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -1,6 +1,6 @@
 // src/persistence/componentCleaningService.js
 
-import { safeDeepClone } from '../utils/objectUtils.js';
+import { safeDeepClone } from '../utils/cloneUtils.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 /** @typedef {import('../interfaces/IComponentCleaningService.js').IComponentCleaningService} IComponentCleaningService */
 import {

--- a/src/turns/constants/turnDirectives.js
+++ b/src/turns/constants/turnDirectives.js
@@ -4,7 +4,7 @@
  * @file Defines constants for turn directives used by CommandOutcomeInterpreter.
  */
 
-import { freeze } from '../../utils/objectUtils.js';
+import { freeze } from '../../utils/cloneUtils.js';
 
 /**
  * @enum {string}

--- a/src/turns/dtos/actionComposite.js
+++ b/src/turns/dtos/actionComposite.js
@@ -4,7 +4,7 @@
  */
 
 import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../constants/core.js';
-import { freeze } from '../../utils/objectUtils.js';
+import { freeze } from '../../utils/cloneUtils.js';
 
 /**
  * @typedef {object} ActionComposite

--- a/src/turns/factories/turnActionFactory.js
+++ b/src/turns/factories/turnActionFactory.js
@@ -2,7 +2,7 @@
  * @module turnActionFactory
  */
 
-import { freeze } from '../../utils/objectUtils.js';
+import { freeze } from '../../utils/cloneUtils.js';
 import { ITurnActionFactory } from '../ports/ITurnActionFactory.js';
 
 /**

--- a/src/turns/order/turnOrderService.js
+++ b/src/turns/order/turnOrderService.js
@@ -9,7 +9,7 @@ import { ITurnOrderService } from '../interfaces/ITurnOrderService.js';
 import { ITurnOrderQueue } from '../interfaces/ITurnOrderQueue.js';
 import { SimpleRoundRobinQueue } from './queues/simpleRoundRobinQueue.js'; // Added import
 import { InitiativePriorityQueue } from './queues/initiativePriorityQueue.js';
-import { freeze } from '../../utils/objectUtils.js'; // Added import
+import { freeze } from '../../utils/cloneUtils.js'; // Added import
 
 // --- Type Imports ---
 /** @typedef {import('../interfaces/ITurnOrderQueue.js').Entity} Entity */

--- a/src/utils/cloneUtils.js
+++ b/src/utils/cloneUtils.js
@@ -1,0 +1,105 @@
+// src/utils/cloneUtils.js
+
+import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
+import { ensureValidLogger } from './loggerUtils.js';
+
+/**
+ * @file Utility functions for cloning and freezing objects.
+ * @description Re-exported from {@link src/utils/index.js}. Import from there
+ * for convenience.
+ */
+
+/**
+ * Freezes an object to make it immutable.
+ *
+ * @description
+ * Immutability ensures that value objects cannot be modified after creation,
+ * which helps prevent unintended side-effects and makes state management
+ * more predictable.
+ * @template T
+ * @param {T} o - The object to freeze.
+ * @returns {Readonly<T>} The frozen object.
+ */
+export function freeze(o) {
+  return Object.freeze(o);
+}
+
+/**
+ * Creates a deep clone of a plain object or array using JSON
+ * serialization.
+ *
+ * @description
+ * Suitable for cloning simple data structures that do not contain
+ * functions or circular references. Non-serializable values will be
+ * dropped during cloning.
+ * @template T
+ * @param {T} value - The value to clone.
+ * @returns {T} The cloned value or the original primitive.
+ * @throws {Error} If the value cannot be stringified (e.g. circular structure).
+ */
+export function deepClone(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Safely deep clones an object and logs errors on failure.
+ *
+ * @description Wraps {@link deepClone} and returns a
+ * {@link import('../persistence/persistenceErrors.js').PersistenceError} when
+ * cloning fails.
+ * @template T
+ * @param {T} value - Value to clone.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger used
+ *   for error reporting.
+ * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<T>}
+ *   Clone result object.
+ */
+export function safeDeepClone(value, logger) {
+  const log = ensureValidLogger(logger, 'CloneUtils');
+  try {
+    /** @type {T} */
+    const cloned = deepClone(value);
+    return createPersistenceSuccess(cloned);
+  } catch (error) {
+    if (logger && typeof logger.error === 'function') {
+      logger.error('DeepClone failed:', error);
+    }
+    return createPersistenceFailure(
+      PersistenceErrorCodes.DEEP_CLONE_FAILED,
+      'Failed to deep clone object.'
+    );
+  }
+}
+
+/**
+ * Deeply freezes an object and all its nested properties that are objects.
+ * This makes the object and its content immutable.
+ *
+ * @template T
+ * @param {T} object - The object to deep freeze.
+ * @returns {Readonly<T>} The deeply frozen object.
+ */
+export function deepFreeze(object) {
+  if (object && typeof object === 'object') {
+    // Freeze properties before freezing self
+    Object.keys(object).forEach((key) => {
+      const value = object[key];
+      // Recurse for nested objects
+      if (value && typeof value === 'object') {
+        deepFreeze(value);
+      }
+    });
+    Object.freeze(object);
+  }
+  return object;
+}
+
+// Add other clone-related utilities here in the future if needed.

--- a/src/utils/decisionResultUtils.js
+++ b/src/utils/decisionResultUtils.js
@@ -2,7 +2,7 @@
  * @module decisionResult
  */
 
-import { freeze } from './objectUtils.js';
+import { freeze } from './cloneUtils.js';
 
 /**
  * @typedef {object} DecisionResult

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,3 +10,4 @@ export { fetchWithRetry } from './httpUtils.js';
 export * from './loggerUtils.js';
 export * from './logHelpers.js';
 export * from './objectUtils.js';
+export * from './cloneUtils.js';

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -1,10 +1,5 @@
 // src/utils/objectUtils.js
 
-import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
-import {
-  createPersistenceFailure,
-  createPersistenceSuccess,
-} from './persistenceResultUtils.js';
 import { ensureValidLogger } from './loggerUtils.js';
 
 /**
@@ -86,95 +81,6 @@ export function safeResolvePath(obj, propertyPath, logger, contextInfo = '') {
     log.error(`Error resolving path "${propertyPath}"${info}`, error);
     return undefined;
   }
-}
-
-/**
- * Freezes an object to make it immutable.
- *
- * @description
- * Immutability ensures that value objects cannot be modified after creation,
- * which helps prevent unintended side-effects and makes state management
- * more predictable.
- * @template T
- * @param {T} o - The object to freeze.
- * @returns {Readonly<T>} The frozen object.
- */
-export function freeze(o) {
-  return Object.freeze(o);
-}
-
-/**
- * Creates a deep clone of a plain object or array using JSON
- * serialization.
- *
- * @description
- * Suitable for cloning simple data structures that do not contain
- * functions or circular references. Non-serializable values will be
- * dropped during cloning.
- * @template T
- * @param {T} value - The value to clone.
- * @returns {T} The cloned value or the original primitive.
- * @throws {Error} If the value cannot be stringified (e.g. circular structure).
- */
-export function deepClone(value) {
-  if (value === null || typeof value !== 'object') {
-    return value;
-  }
-
-  return JSON.parse(JSON.stringify(value));
-}
-
-/**
- * Safely deep clones an object and logs errors on failure.
- *
- * @description Wraps {@link deepClone} and returns a
- * {@link import('../persistence/persistenceErrors.js').PersistenceError} when
- * cloning fails.
- * @template T
- * @param {T} value - Value to clone.
- * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger used
- *   for error reporting.
- * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<T>}
- *   Clone result object.
- */
-export function safeDeepClone(value, logger) {
-  const log = ensureValidLogger(logger, 'ObjectUtils');
-  try {
-    /** @type {T} */
-    const cloned = deepClone(value);
-    return createPersistenceSuccess(cloned);
-  } catch (error) {
-    if (logger && typeof logger.error === 'function') {
-      logger.error('DeepClone failed:', error);
-    }
-    return createPersistenceFailure(
-      PersistenceErrorCodes.DEEP_CLONE_FAILED,
-      'Failed to deep clone object.'
-    );
-  }
-}
-
-/**
- * Deeply freezes an object and all its nested properties that are objects.
- * This makes the object and its content immutable.
- *
- * @template T
- * @param {T} object - The object to deep freeze.
- * @returns {Readonly<T>} The deeply frozen object.
- */
-export function deepFreeze(object) {
-  if (object && typeof object === 'object') {
-    // Freeze properties before freezing self
-    Object.keys(object).forEach((key) => {
-      const value = object[key];
-      // Recurse for nested objects
-      if (value && typeof value === 'object') {
-        deepFreeze(value);
-      }
-    });
-    Object.freeze(object);
-  }
-  return object;
 }
 
 // Add other generic object utilities here in the future if needed.

--- a/src/utils/saveStateUtils.js
+++ b/src/utils/saveStateUtils.js
@@ -1,6 +1,6 @@
 // src/utils/saveStateUtils.js
 
-import { safeDeepClone } from './objectUtils.js';
+import { safeDeepClone } from './cloneUtils.js';
 import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
 import {
   createPersistenceFailure,

--- a/tests/unit/entities/EntityDefinition.test.js
+++ b/tests/unit/entities/EntityDefinition.test.js
@@ -1,5 +1,5 @@
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
-import { deepFreeze } from '../../../src/utils/objectUtils.js'; // Used by the class, not directly tested here unless necessary
+import { deepFreeze } from '../../../src/utils/cloneUtils.js'; // Used by the class, not directly tested here unless necessary
 
 describe('EntityDefinition', () => {
   const validDefinitionData = {

--- a/tests/unit/turns/turnOrder/turnOrderService.constructor.test.js
+++ b/tests/unit/turns/turnOrder/turnOrderService.constructor.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { TurnOrderService } from '../../../../src/turns/order/turnOrderService.js';
-import { freeze } from '../../../../src/utils/objectUtils'; // Adjust path as needed
+import { freeze } from '../../../../src/utils/cloneUtils'; // Adjust path as needed
 // Assuming ILogger interface definition (or use a simplified mock structure)
 // For testing, we don't need the actual interface, just an object matching the expected structure.
 

--- a/tests/unit/utils/deepClone.test.js
+++ b/tests/unit/utils/deepClone.test.js
@@ -1,4 +1,4 @@
-import { deepClone } from '../../../src/utils/objectUtils.js';
+import { deepClone } from '../../../src/utils/cloneUtils.js';
 import { describe, it, expect } from '@jest/globals';
 
 describe('deepClone', () => {

--- a/tests/unit/utils/expandActionArray.test.js
+++ b/tests/unit/utils/expandActionArray.test.js
@@ -2,7 +2,7 @@ import {
   expandActionArray,
   expandMacros,
 } from '../../../src/utils/macroUtils.js';
-import { freeze } from '../../../src/utils/objectUtils.js';
+import { freeze } from '../../../src/utils/cloneUtils.js';
 import { describe, it, expect, jest } from '@jest/globals';
 
 const createRegistry = (macros) => ({

--- a/tests/unit/utils/macroUtils.test.js
+++ b/tests/unit/utils/macroUtils.test.js
@@ -1,5 +1,5 @@
 import { expandMacros } from '../../../src/utils/macroUtils.js';
-import { freeze } from '../../../src/utils/objectUtils.js';
+import { freeze } from '../../../src/utils/cloneUtils.js';
 import { describe, it, expect, jest } from '@jest/globals';
 
 const createRegistry = (macros) => ({

--- a/tests/unit/utils/resolvePath.test.js
+++ b/tests/unit/utils/resolvePath.test.js
@@ -3,7 +3,8 @@
  * ------------------------------------------------------------------ */
 
 import { describe, it, expect } from '@jest/globals';
-import { resolvePath, freeze } from '../../../src/utils/objectUtils.js';
+import { resolvePath } from '../../../src/utils/objectUtils.js';
+import { freeze } from '../../../src/utils/cloneUtils.js';
 
 describe('utils/resolvePath', () => {
   /* -------------------------------------------------

--- a/tests/unit/utils/saveStateUtils.test.js
+++ b/tests/unit/utils/saveStateUtils.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import * as saveStateUtils from '../../../src/utils/saveStateUtils.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
-import * as objectUtils from '../../../src/utils/objectUtils.js';
+import * as cloneUtils from '../../../src/utils/cloneUtils.js';
 
-jest.mock('../../../src/utils/objectUtils.js', () => ({
+jest.mock('../../../src/utils/cloneUtils.js', () => ({
   safeDeepClone: jest.fn(),
 }));
 
@@ -19,11 +19,11 @@ describe('saveStateUtils', () => {
 
   it('returns success when clone is valid with gameState', () => {
     const obj = { gameState: { foo: 'bar' } };
-    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+    cloneUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
 
     const result = cloneValidatedState(obj, logger);
 
-    expect(objectUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
+    expect(cloneUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
     expect(result).toEqual({ success: true, data: obj });
     expect(logger.error).not.toHaveBeenCalled();
   });
@@ -31,7 +31,7 @@ describe('saveStateUtils', () => {
   it('propagates failure from safeDeepClone', () => {
     const obj = { any: 'value' };
     const err = { code: 'ERR', message: 'bad' };
-    objectUtils.safeDeepClone.mockReturnValue({ success: false, error: err });
+    cloneUtils.safeDeepClone.mockReturnValue({ success: false, error: err });
 
     const result = cloneValidatedState(obj, logger);
 
@@ -42,7 +42,7 @@ describe('saveStateUtils', () => {
 
   it('fails when cloned object lacks gameState', () => {
     const obj = { notGameState: true };
-    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+    cloneUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
 
     const result = cloneValidatedState(obj, logger);
 
@@ -53,11 +53,11 @@ describe('saveStateUtils', () => {
 
   it('cloneAndValidateSaveState returns same result as cloneValidatedState', () => {
     const obj = { gameState: {} };
-    objectUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
+    cloneUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
 
     const viaWrapper = cloneAndValidateSaveState(obj, logger);
 
     expect(viaWrapper).toEqual({ success: true, data: obj });
-    expect(objectUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
+    expect(cloneUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
   });
 });


### PR DESCRIPTION
## Summary
- split cloning helpers into `cloneUtils`
- update imports to use the new utility module
- re-export clone helpers in utilities index
- adjust tests to import from `cloneUtils`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 543 errors, 2238 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856ea4d03908331864f20d253cc02a5