### PR TITLE
[Agent] Add load failure tests and refactor stop helper usage

### DIFF
--- a/tests/unit/engine/handleLoadFailure.test.js
+++ b/tests/unit/engine/handleLoadFailure.test.js
@@ -1,0 +1,59 @@
+// tests/engine/handleLoadFailure.test.js
+import { describe, it, expect } from '@jest/globals';
+import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
+import { tokens } from '../../../src/dependencyInjection/tokens.js';
+import {
+  withGameEngineBed,
+  runUnavailableServiceTest,
+} from '../../common/engine/gameEngineHelpers.js';
+import '../../common/engine/engineTestTypedefs.js';
+
+describe('GameEngine', () => {
+  describe('_handleLoadFailure', () => {
+    it('dispatches failure UI event and returns failure result', async () => {
+      await withGameEngineBed({}, async (bed, engine) => {
+        const err = new Error('bad');
+        const result = await engine._handleLoadFailure(err, 'save-001');
+        expect(bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+          ENGINE_OPERATION_FAILED_UI,
+          {
+            errorMessage: `Failed to load game: ${err.message}`,
+            errorTitle: 'Load Failed',
+          }
+        );
+        expect(result).toEqual({
+          success: false,
+          error: err.message,
+          data: null,
+        });
+      });
+    });
+
+    it.each(
+      runUnavailableServiceTest(
+        [
+          [
+            tokens.ISafeEventDispatcher,
+            'GameEngine._handleLoadFailure: ISafeEventDispatcher not available, cannot dispatch UI failure event.',
+          ],
+        ],
+        async (bed, engine) => {
+          const err = new Error('oops');
+          const result = await engine._handleLoadFailure(err, 'save-002');
+          expect(result).toEqual({
+            success: false,
+            error: err.message,
+            data: null,
+          });
+          return [
+            bed.mocks.logger.error,
+            bed.mocks.safeEventDispatcher.dispatch,
+          ];
+        }
+      )
+    )('logs error if %s is unavailable', async (_token, fn) => {
+      expect.assertions(3);
+      await fn();
+    });
+  });
+});

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -1,10 +1,8 @@
 // tests/engine/stop.test.js
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import {
-  createGameEngineTestBed,
-  describeEngineSuite,
-} from '../../common/engine/gameEngineTestBed.js';
+import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
+import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
@@ -67,35 +65,38 @@ describeEngineSuite('GameEngine', (ctx) => {
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
 
-    it.each([
-      [
-        'PlaytimeTracker',
-        tokens.PlaytimeTracker,
-        'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
-      ],
-    ])(
+    it.each(
+      runUnavailableServiceTest(
+        [
+          [
+            tokens.PlaytimeTracker,
+            'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
+            { preInit: true },
+          ],
+        ],
+        async (bed, engine) => {
+          expectEngineStatus(engine, {
+            isInitialized: true,
+            isLoopRunning: true,
+            activeWorld: MOCK_WORLD_NAME,
+          });
+
+          await engine.stop();
+
+          expect(bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+            ENGINE_STOPPED_UI,
+            { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
+          );
+          expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+          const dummyDispatch = jest.fn();
+          return [bed.mocks.logger.warn, dummyDispatch];
+        }
+      )
+    )(
       'should log warning for %s if it is not available during stop, after a successful start',
-      async (_name, token, expectedMsg) => {
-        const localBed = createGameEngineTestBed({ [token]: null });
-        const localEngine = localBed.engine;
-
-        localBed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
-          { success: true }
-        );
-        await localBed.startAndReset(MOCK_WORLD_NAME);
-
-        expectEngineStatus(localEngine, {
-          isInitialized: true,
-          isLoopRunning: true,
-          activeWorld: MOCK_WORLD_NAME,
-        });
-
-        await localEngine.stop();
-
-        expect(localBed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
-        expect(localBed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
-
-        await localBed.cleanup();
+      async (_token, fn) => {
+        expect.assertions(5);
+        await fn();
       }
     );
   });


### PR DESCRIPTION
Summary: Added unit tests for `GameEngine._handleLoadFailure` and updated stop tests to use `runUnavailableServiceTest` for bed setup and cleanup. Verified dispatch payloads and returned failure results.

Changes Made:
- New `handleLoadFailure.test.js` covering dispatch and result.
- Refactored stop test unavailability case to use helper and check dispatch.

Testing Done:
- [x] Code formatted (`npm run format` on modified files)
- [x] Lint passes (`npm run lint` on modified files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_6856eecaae1083319b673e607b4fd508