### PR TITLE
[Test] add AI prompt pipeline mock factory

### DIFF
--- a/tests/common/mockFactories/coreServices.js
+++ b/tests/common/mockFactories/coreServices.js
@@ -75,6 +75,7 @@ const simpleFactories = {
   createMockAIGameStateProvider: ['buildGameState'],
   createMockAIPromptContentProvider: ['getPromptData'],
   createMockPromptBuilder: ['build'],
+  createMockAIPromptPipeline: ['generatePrompt'],
   createMockSafeEventDispatcher: ['dispatch'],
   createMockValidatedEventDispatcher: {
     methods: ['dispatch'],
@@ -94,6 +95,7 @@ export const {
   createMockAIGameStateProvider,
   createMockAIPromptContentProvider,
   createMockPromptBuilder,
+  createMockAIPromptPipeline,
   createMockSafeEventDispatcher,
   createMockValidatedEventDispatcher,
 } = generateFactories(simpleFactories);
@@ -226,8 +228,7 @@ export const createMockPathResolver = () => ({
   resolvePath: jest.fn((path) => path),
   resolveModPath: jest.fn((modId) => `mods/${modId}`),
   resolveModContentPath: jest.fn(
-    (modId, diskFolder, filename) =>
-      `mods/${modId}/${diskFolder}/${filename}`
+    (modId, diskFolder, filename) => `mods/${modId}/${diskFolder}/${filename}`
   ),
   resolveModManifestPath: jest.fn((modId) => `mods/${modId}/mod.manifest.json`),
   getModDirectory: jest.fn((modId) => `mods/${modId}`),

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -7,4 +7,5 @@ export * from './container.js';
 export {
   createMockPathResolver,
   createMockDataFetcher,
+  createMockAIPromptPipeline,
 } from './coreServices.js';

--- a/tests/integration/aiDecisionMetadata.test.js
+++ b/tests/integration/aiDecisionMetadata.test.js
@@ -15,6 +15,10 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 // --- System Under Test imports ---------------------------------------------
 // ⚠️ PATH‑TO – please fix to real locations in your project
 import { LLMChooser } from '../../src/turns/adapters/llmChooser.js';
+import {
+  createMockLogger,
+  createMockAIPromptPipeline,
+} from '../common/mockFactories.js';
 
 // ---------------------------------------------------------------------------
 // Lightweight helpers (no behaviour)
@@ -37,7 +41,8 @@ describe('LLMChooser.choose – metadata propagation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    promptPipeline = { generatePrompt: jest.fn().mockResolvedValue('PROMPT') };
+    promptPipeline = createMockAIPromptPipeline();
+    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
     llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{"ok":1}') };
     responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({
@@ -46,12 +51,7 @@ describe('LLMChooser.choose – metadata propagation', () => {
         extractedData: { thoughts: 'thinking', notes: ['n1', 'n2'] },
       }),
     };
-    logger = {
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
+    logger = createMockLogger();
 
     chooser = new LLMChooser({
       promptPipeline,

--- a/tests/integration/turnHandlerResolution.integration.test.js
+++ b/tests/integration/turnHandlerResolution.integration.test.js
@@ -18,6 +18,10 @@ import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../src/constants/componentIds.js';
+import {
+  createMockLogger,
+  createMockAIPromptPipeline,
+} from '../common/mockFactories.js';
 
 // --- Test-Scoped Mocks & Stubs ----------------------------------------------
 class SimpleEntity {
@@ -58,14 +62,9 @@ describe('T-08: ActorTurnHandler Resolution and Startup', () => {
   let aiActor;
 
   beforeEach(() => {
-    logger = {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      debug: jest.fn(),
-    };
+    logger = createMockLogger();
     aiActor = new SimpleEntity(AI_ACTOR_ID, [ACTOR_COMPONENT_ID]);
-    mockAiPromptPipeline = { generatePrompt: jest.fn() };
+    mockAiPromptPipeline = createMockAIPromptPipeline();
 
     mockTurnState = {
       startTurn: jest.fn(),

--- a/tests/unit/turns/adapters/llmChooser.test.js
+++ b/tests/unit/turns/adapters/llmChooser.test.js
@@ -1,18 +1,16 @@
 import { jest, describe, test, expect } from '@jest/globals';
 import { LLMChooser } from '../../../../src/turns/adapters/llmChooser.js';
+import {
+  createMockLogger,
+  createMockAIPromptPipeline,
+} from '../../../common/mockFactories.js';
 
-const dummyLogger = {
-  debug: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-};
+const dummyLogger = createMockLogger();
 
 describe('LLMChooser', () => {
   test('forwards AbortSignal to llmAdapter', async () => {
-    const promptPipeline = {
-      generatePrompt: jest.fn().mockResolvedValue('PROMPT'),
-    };
+    const promptPipeline = createMockAIPromptPipeline();
+    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
     const llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{}') };
     const responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({
@@ -42,9 +40,8 @@ describe('LLMChooser', () => {
   });
 
   test('returns {index, speech} shape', async () => {
-    const promptPipeline = {
-      generatePrompt: jest.fn().mockResolvedValue('PROMPT'),
-    };
+    const promptPipeline = createMockAIPromptPipeline();
+    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
     const llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{}') };
     const responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({


### PR DESCRIPTION
Summary: Added `createMockAIPromptPipeline` mock factory and updated integration/unit tests to use standardized helpers.

Changes Made:
- Extended `coreServices.js` and re-exported new `createMockAIPromptPipeline` factory.
- Updated tests to use `createMockLogger` and `createMockAIPromptPipeline` instead of manual stubs.
- Formatted updated files.

Testing Done:
- [x] Code formatted (`npx prettier --write` on modified files)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6856f11163c48331a7c6cefa7d34db62