### PR TITLE
[Agent] verify logger warning on stop

### DIFF
--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -74,7 +74,7 @@ describeEngineSuite('GameEngine', (ctx) => {
             { preInit: true },
           ],
         ],
-        async (bed, engine) => {
+        async (bed, engine, expectedMsg) => {
           expectEngineStatus(engine, {
             isInitialized: true,
             isLoopRunning: true,
@@ -83,6 +83,7 @@ describeEngineSuite('GameEngine', (ctx) => {
 
           await engine.stop();
 
+          expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
           expect(bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
             ENGINE_STOPPED_UI,
             { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
@@ -95,7 +96,7 @@ describeEngineSuite('GameEngine', (ctx) => {
     )(
       'should log warning for %s if it is not available during stop, after a successful start',
       async (_token, fn) => {
-        expect.assertions(5);
+        expect.assertions(6);
         await fn();
       }
     );


### PR DESCRIPTION
Summary: Added explicit assertion for logger warning when PlaytimeTracker is unavailable and engine.stop is called after initialization.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6856ff6365ac83319638c98f93dbf863