### PR TITLE
[Feat] add context details to dispatcher errors

### DIFF
--- a/src/utils/safeDispatchErrorUtils.js
+++ b/src/utils/safeDispatchErrorUtils.js
@@ -17,10 +17,10 @@ export class InvalidDispatcherError extends Error {
    * @param {string} message - The error message.
    * @param {object} [details] - Optional diagnostic details.
    */
-  constructor(message, details) {
+  constructor(message, details = {}) {
     super(message);
     this.name = 'InvalidDispatcherError';
-    if (details) this.details = details;
+    this.details = details;
   }
 }
 
@@ -42,7 +42,9 @@ export function safeDispatchError(dispatcher, message, details = {}) {
     const errorMsg =
       "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'.";
     console.error(errorMsg);
-    throw new InvalidDispatcherError(errorMsg);
+    throw new InvalidDispatcherError(errorMsg, {
+      functionName: 'safeDispatchError',
+    });
   }
 
   dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });

--- a/tests/unit/utils/safeDispatchErrorUtils.test.js
+++ b/tests/unit/utils/safeDispatchErrorUtils.test.js
@@ -16,10 +16,17 @@ describe('safeDispatchError', () => {
   });
 
   it('throws if dispatcher is invalid', () => {
-    expect(() => safeDispatchError({}, 'oops')).toThrow(
-      new InvalidDispatcherError(
-        "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
-      )
+    const call = () => safeDispatchError({}, 'oops');
+    expect(call).toThrow(InvalidDispatcherError);
+    let error;
+    try {
+      call();
+    } catch (err) {
+      error = err;
+    }
+    expect(error.message).toBe(
+      "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
     );
+    expect(error.details).toEqual({ functionName: 'safeDispatchError' });
   });
 });


### PR DESCRIPTION
Summary: Enables richer diagnostics for invalid dispatchers.

Changes Made:
- Updated `InvalidDispatcherError` to store an optional `details` object.
- Included caller info when throwing the error from `safeDispatchError`.
- Adjusted unit tests for `safeDispatchError` to verify new behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6856ff3e055c8331813e2f8a5a7c9821