### PR TITLE
[Test] Helper for loadGame spies

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -3,7 +3,7 @@
  * @see tests/common/engine/gameEngineHelpers.js
  */
 
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import {
   createGameEngineTestBed,
   GameEngineTestBed,
@@ -64,4 +64,23 @@ export function runUnavailableServiceTest(cases, invokeFn) {
       });
     },
   ]);
+}
+
+/**
+ * Attaches spies to GameEngine load helpers.
+ *
+ * @param {import('../../../src/engine/gameEngine.js').default} engine - Engine instance.
+ * @returns {{
+ *   prepareSpy: ReturnType<typeof jest.spyOn>,
+ *   executeSpy: ReturnType<typeof jest.spyOn>,
+ *   finalizeSpy: ReturnType<typeof jest.spyOn>,
+ *   handleFailureSpy: ReturnType<typeof jest.spyOn>,
+ * }} Object containing the created spies.
+ */
+export function setupLoadGameSpies(engine) {
+  const prepareSpy = jest.spyOn(engine, '_prepareForLoadGameSession');
+  const executeSpy = jest.spyOn(engine, '_executeLoadAndRestore');
+  const finalizeSpy = jest.spyOn(engine, '_finalizeLoadSuccess');
+  const handleFailureSpy = jest.spyOn(engine, '_handleLoadFailure');
+  return { prepareSpy, executeSpy, finalizeSpy, handleFailureSpy };
 }

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -1,8 +1,11 @@
 // tests/engine/loadGame.test.js
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
+import {
+  runUnavailableServiceTest,
+  setupLoadGameSpies,
+} from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
@@ -17,33 +20,25 @@ describeEngineSuite('GameEngine', (ctx) => {
     let prepareSpy, executeSpy, finalizeSpy, handleFailureSpy;
 
     beforeEach(() => {
-      // Spies are on the engine instance created here
-      prepareSpy = jest
-        .spyOn(ctx.engine, '_prepareForLoadGameSession')
-        .mockResolvedValue(undefined);
-      executeSpy = jest
-        .spyOn(ctx.engine, '_executeLoadAndRestore')
-        .mockResolvedValue({
-          success: true,
-          data: typedMockSaveData,
-        });
-      finalizeSpy = jest
-        .spyOn(ctx.engine, '_finalizeLoadSuccess')
-        .mockResolvedValue({
-          success: true,
-          data: typedMockSaveData,
-        });
-      handleFailureSpy = jest
-        .spyOn(ctx.engine, '_handleLoadFailure')
-        .mockImplementation(async (error) => {
-          const errorMsg =
-            error instanceof Error ? error.message : String(error);
-          return {
-            success: false,
-            error: `Processed: ${errorMsg}`,
-            data: null,
-          };
-        });
+      ({ prepareSpy, executeSpy, finalizeSpy, handleFailureSpy } =
+        setupLoadGameSpies(ctx.engine));
+      prepareSpy.mockResolvedValue(undefined);
+      executeSpy.mockResolvedValue({
+        success: true,
+        data: typedMockSaveData,
+      });
+      finalizeSpy.mockResolvedValue({
+        success: true,
+        data: typedMockSaveData,
+      });
+      handleFailureSpy.mockImplementation(async (error) => {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          error: `Processed: ${errorMsg}`,
+          data: null,
+        };
+      });
       ctx.bed.resetMocks();
     });
 


### PR DESCRIPTION
Summary: Adds a helper for setting up load game spies to simplify tests.

Changes Made:
- Added `setupLoadGameSpies` in `gameEngineHelpers.js` for attaching spies to key engine methods.
- Updated `loadGame.test.js` to use the helper during setup.

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes on modified files (`npx eslint tests/common/engine/gameEngineHelpers.js tests/unit/engine/loadGame.test.js`)
- [ ] Lint passes (`npm run lint`) *(fails: 2820 problems)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6856ff7108308331b61d5224368b9369