### PR TITLE
[Agent] centralize exec context helper

### DIFF
--- a/tests/common/entities/execContext.js
+++ b/tests/common/entities/execContext.js
@@ -1,0 +1,22 @@
+/**
+ * @file Helper for constructing ExecutionContext objects in tests.
+ * @see tests/common/entities/execContext.js
+ */
+
+/**
+ * Builds an {@link import('../../src/logic/defs.js').ExecutionContext} object from
+ * the raw evaluation context supplied by OperationInterpreter and the core
+ * services used by operation handlers.
+ *
+ * @param {object} params - Options object.
+ * @param {import('../../src/logic/defs.js').JsonLogicEvaluationContext} params.evaluationContext
+ *   - Raw evaluation context passed into the handler.
+ * @param {import('../../src/entities/entityManager.js').default} params.entityManager
+ *   - EntityManager instance used by operations.
+ * @param {import('../../src/interfaces/coreServices.js').ILogger} params.logger
+ *   - Logger instance for operation handlers.
+ * @returns {import('../../src/logic/defs.js').ExecutionContext} Constructed execution context.
+ */
+export function buildExecContext({ evaluationContext, entityManager, logger }) {
+  return { evaluationContext, entityManager, logger };
+}

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -36,6 +36,7 @@ import {
   createSimpleMockDataRegistry,
   createMockLogger,
 } from '../common/mockFactories.js';
+import { buildExecContext } from '../common/entities/execContext.js';
 import {
   afterEach,
   beforeEach,
@@ -81,23 +82,6 @@ class SimpleEntityManager {
   }
 }
 /** Jest‑friendly logger stub capturing calls for optional debugging. */
-
-/**
- * Build the ExecutionContext object expected by real operation handlers from
- * the *raw* evaluationContext that OperationInterpreter currently passes in.
- *
- * @param root0
- * @param root0.evaluationContext
- * @param root0.entityManager
- * @param root0.logger
- */
-function buildExecContext({ evaluationContext, entityManager, logger }) {
-  return {
-    evaluationContext,
-    entityManager,
-    logger,
-  };
-}
 
 describe('Sequential Action Execution – Success Path', () => {
   /** @type {*} */

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -26,6 +26,7 @@ import {
   createSimpleMockDataRegistry,
   createMockLogger,
 } from '../common/mockFactories.js';
+import { buildExecContext } from '../common/entities/execContext.js';
 import {
   afterEach,
   beforeEach,
@@ -58,17 +59,6 @@ class SimpleEntityManager {
   getEntityInstance(id) {
     return { id };
   }
-}
-
-/**
- *
- * @param root0
- * @param root0.evaluationContext
- * @param root0.entityManager
- * @param root0.logger
- */
-function buildExecCtx({ evaluationContext, entityManager, logger }) {
-  return { evaluationContext, entityManager, logger };
 }
 
 /* ------------------------ The Test --------------------------------------- */
@@ -119,7 +109,7 @@ describe('Sequential Action Execution – Error Path', () => {
     skippedModifyHandlerMock = jest.fn((p, ctx) =>
       realMod.execute(
         p,
-        buildExecCtx({ evaluationContext: ctx, entityManager, logger })
+        buildExecContext({ evaluationContext: ctx, entityManager, logger })
       )
     );
     opRegistry.register('MODIFY_COMPONENT', skippedModifyHandlerMock);


### PR DESCRIPTION
## Summary
- create `execContext.js` helper under common entities
- use `buildExecContext` in sequential action integration tests

## Testing
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856ff07bd3c8331a26b3493dcc15026