### PR TITLE
[Agent] Add constructor validation helper

### DIFF
--- a/tests/common/constructorValidationHelpers.js
+++ b/tests/common/constructorValidationHelpers.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+/* global describe, test, expect */
 /**
  * @file Utilities for generating constructor validation test cases.
  *
@@ -51,6 +53,30 @@ export function buildMissingDependencyCases(factoryFn, spec) {
   return cases;
 }
 
+/**
+ * Defines a describe block verifying constructor dependency checks.
+ *
+ * @description Generates cases via {@link buildMissingDependencyCases} and
+ * asserts that constructing {@code Class} throws when required dependencies are
+ * missing.
+ * @param {Function} Class - Constructor under test.
+ * @param {() => Record<string, any>} createDeps - Factory for valid dependencies.
+ * @param {Record<string, {error: RegExp, methods: string[]}>} spec - Dependency
+ *   specification.
+ * @returns {void}
+ */
+export function describeConstructorValidation(Class, createDeps, spec) {
+  describe('constructor validation', () => {
+    const cases = buildMissingDependencyCases(createDeps, spec);
+    test.each(cases)('throws when %s', (_d, mutate, regex) => {
+      const deps = createDeps();
+      mutate(deps);
+      expect(() => new Class(deps)).toThrow(regex);
+    });
+  });
+}
+
 export default {
   buildMissingDependencyCases,
+  describeConstructorValidation,
 };

--- a/tests/unit/common/constructorValidationHelpers.test.js
+++ b/tests/unit/common/constructorValidationHelpers.test.js
@@ -3,7 +3,10 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
-import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
+import {
+  buildMissingDependencyCases,
+  describeConstructorValidation,
+} from '../../common/constructorValidationHelpers.js';
 
 /**
  *
@@ -50,5 +53,24 @@ describe('buildMissingDependencyCases', () => {
     for (const [, , regex] of cases) {
       expect(regex).toBeInstanceOf(RegExp);
     }
+  });
+});
+
+describe('describeConstructorValidation', () => {
+  class DummyClass {
+    constructor(deps) {
+      if (!deps.logger?.info || !deps.logger?.error) {
+        throw new Error('logger');
+      }
+      if (!deps.service?.start) {
+        throw new Error('service');
+      }
+    }
+  }
+
+  describeConstructorValidation(DummyClass, createDeps, spec);
+
+  it('allows construction when all dependencies are present', () => {
+    expect(() => new DummyClass(createDeps())).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add `describeConstructorValidation` helper for testing constructor deps
- test new helper in constructor validation helper test suite

## Testing Done
- `npm run lint` *(fails: 559 errors, 2258 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857040090fc8331b71d357a7714545c