### PR TITLE
[Agent] simplify constructor validation test

### DIFF
--- a/tests/common/constructorValidationHelpers.js
+++ b/tests/common/constructorValidationHelpers.js
@@ -1,3 +1,4 @@
+import { describe, test, expect } from '@jest/globals';
 /**
  * @file Utilities for generating constructor validation test cases.
  *
@@ -51,6 +52,28 @@ export function buildMissingDependencyCases(factoryFn, spec) {
   return cases;
 }
 
+/**
+ * Defines a `describe` block verifying that the given constructor validates its
+ * dependencies according to the provided specification.
+ *
+ * @param {Function} Ctor - Constructor to test.
+ * @param {() => Record<string, any>} getDeps - Function returning valid deps.
+ * @param {Record<string, {error: RegExp, methods: string[]}>} spec - Validation
+ *   specification for each dependency.
+ * @returns {void}
+ */
+export function describeConstructorValidation(Ctor, getDeps, spec) {
+  describe('constructor validation', () => {
+    const cases = buildMissingDependencyCases(getDeps, spec);
+    test.each(cases)('throws when %s', (_desc, mutate, regex) => {
+      const deps = getDeps();
+      mutate(deps);
+      expect(() => new Ctor(deps)).toThrow(regex);
+    });
+  });
+}
+
 export default {
   buildMissingDependencyCases,
+  describeConstructorValidation,
 };

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,28 +1,23 @@
 /* eslint-env node */
-import { test, expect } from '@jest/globals';
+/* eslint jest/expect-expect: "off" */
+import { test } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
   describeAIPromptPipelineSuite,
   AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';
-import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
+import { describeConstructorValidation } from '../../common/constructorValidationHelpers.js';
 
 describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   let bed;
   beforeEach(() => {
     bed = getBed();
   });
-  describe('constructor validation', () => {
-    const cases = buildMissingDependencyCases(
-      () => bed.getDependencies(),
-      AIPromptPipelineDependencySpec
-    );
-    test.each(cases)('throws when %s', (_desc, mutate, regex) => {
-      const deps = bed.getDependencies();
-      mutate(deps);
-      expect(() => new AIPromptPipeline(deps)).toThrow(regex);
-    });
-  });
+  describeConstructorValidation(
+    AIPromptPipeline,
+    () => bed.getDependencies(),
+    AIPromptPipelineDependencySpec
+  );
 
   test('generatePrompt orchestrates dependencies and returns prompt', async () => {
     const actor = bed.defaultActor;


### PR DESCRIPTION
## Summary
- add helper to describe constructor validation
- use helper in AIPromptPipeline tests

## Testing Done
- `npm run lint` *(fails: many existing errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68570628e5a88331b9da208727748110