### PR TITLE
[Agent] Introduce test environment builder

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -15,12 +15,38 @@ import {
   createMockSafeEventDispatcher,
   createMockInitializationService,
 } from '../mockFactories';
-import { buildEnvironment } from '../mockEnvironment.js';
+import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+const factoryMap = {
+  logger: createMockLogger,
+  entityManager: createMockEntityManager,
+  turnManager: createMockTurnManager,
+  gamePersistenceService: createMockGamePersistenceService,
+  playtimeTracker: createMockPlaytimeTracker,
+  safeEventDispatcher: createMockSafeEventDispatcher,
+  initializationService: createMockInitializationService,
+};
+
+const tokenMap = {
+  [tokens.ILogger]: 'logger',
+  [tokens.IEntityManager]: 'entityManager',
+  [tokens.ITurnManager]: 'turnManager',
+  [tokens.GamePersistenceService]: 'gamePersistenceService',
+  [tokens.PlaytimeTracker]: 'playtimeTracker',
+  [tokens.ISafeEventDispatcher]: 'safeEventDispatcher',
+  [tokens.IInitializationService]: 'initializationService',
+};
+
+const buildGameEngineEnv = createTestEnvironmentBuilder(
+  factoryMap,
+  tokenMap,
+  (container) => new GameEngine({ container })
+);
 
 /**
  * Creates a set of mocks and a container for GameEngine.
  *
  * @description Creates a fully mocked environment for GameEngine tests.
+ * @param {{[token: string]: any}} [overrides] - Optional DI token overrides.
  * @returns {{
  *   mockContainer: { resolve: jest.Mock },
  *   logger: ReturnType<typeof createMockLogger>,
@@ -32,49 +58,19 @@ import { buildEnvironment } from '../mockEnvironment.js';
  *   initializationService: ReturnType<typeof createMockInitializationService>,
  *   createGameEngine: () => GameEngine,
  *   cleanup: () => void,
- * }} Test environment utilities and mocks.
- * @param {{[token: string]: any}} [overrides] - Optional map of DI tokens to
- *   replacement values used instead of defaults.
+ * }}
+ *   Test environment utilities and mocks.
  */
 export function createTestEnvironment(overrides = {}) {
-  const factoryMap = {
-    logger: createMockLogger,
-    entityManager: createMockEntityManager,
-    turnManager: createMockTurnManager,
-    gamePersistenceService: createMockGamePersistenceService,
-    playtimeTracker: createMockPlaytimeTracker,
-    safeEventDispatcher: createMockSafeEventDispatcher,
-    initializationService: createMockInitializationService,
-  };
-
-  const tokenMap = {
-    [tokens.ILogger]: 'logger',
-    [tokens.IEntityManager]: 'entityManager',
-    [tokens.ITurnManager]: 'turnManager',
-    [tokens.GamePersistenceService]: 'gamePersistenceService',
-    [tokens.PlaytimeTracker]: 'playtimeTracker',
-    [tokens.ISafeEventDispatcher]: 'safeEventDispatcher',
-    [tokens.IInitializationService]: 'initializationService',
-  };
-
-  const {
-    mocks,
-    mockContainer,
-    instance: gameEngine,
-    cleanup,
-  } = buildEnvironment(
-    factoryMap,
-    tokenMap,
-    overrides,
-    (container) => new GameEngine({ container })
-  );
+  const { mocks, mockContainer, instance, cleanup } =
+    buildGameEngineEnv(overrides);
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 
   return {
     mockContainer,
     ...mocks,
-    gameEngine,
+    gameEngine: instance,
     createGameEngine,
     cleanup,
   };

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -20,7 +20,7 @@ import {
   createMockWorldLoader, // ← NEW import
 } from '../mockFactories';
 import { createLoaderMocks } from './modsLoader.test-utils.js';
-import { buildEnvironment } from '../mockEnvironment.js';
+import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
 
 /**
  * List of loader types used when generating mock loaders.
@@ -62,52 +62,54 @@ export function createTestEnvironment() {
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);
 
-  const {
-    mocks,
-    instance: modsLoader,
-    cleanup,
-  } = buildEnvironment(factoryMap, {}, {}, (mockContainer, m) => {
-    m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
-      [
-        'schema:game',
-        'schema:components',
-        'schema:mod-manifest',
-        'schema:entityDefinitions',
-        'schema:actions',
-        'schema:events',
-        'schema:rules',
-        'schema:conditions',
-        'schema:entityInstances',
-        'schema:goals',
-      ].includes(id)
-    );
-    m.mockModDependencyValidator.validate.mockImplementation(() => {});
-    m.mockModVersionValidator.mockImplementation(() => {});
-    m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
+  const buildEnv = createTestEnvironmentBuilder(
+    factoryMap,
+    {},
+    (mockContainer, m) => {
+      m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
+        [
+          'schema:game',
+          'schema:components',
+          'schema:mod-manifest',
+          'schema:entityDefinitions',
+          'schema:actions',
+          'schema:events',
+          'schema:rules',
+          'schema:conditions',
+          'schema:entityInstances',
+          'schema:goals',
+        ].includes(id)
+      );
+      m.mockModDependencyValidator.validate.mockImplementation(() => {});
+      m.mockModVersionValidator.mockImplementation(() => {});
+      m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
 
-    return new ModsLoader({
-      registry: m.mockRegistry,
-      logger: m.mockLogger,
-      schemaLoader: m.mockSchemaLoader,
-      componentLoader: loaders.mockComponentLoader,
-      conditionLoader: loaders.mockConditionLoader,
-      ruleLoader: loaders.mockRuleLoader,
-      actionLoader: loaders.mockActionLoader,
-      eventLoader: loaders.mockEventLoader,
-      entityLoader: loaders.mockEntityLoader,
-      validator: m.mockValidator,
-      configuration: m.mockConfiguration,
-      gameConfigLoader: m.mockGameConfigLoader,
-      promptTextLoader: { loadPromptText: jest.fn() },
-      modManifestLoader: m.mockModManifestLoader,
-      validatedEventDispatcher: m.mockValidatedEventDispatcher,
-      modDependencyValidator: m.mockModDependencyValidator,
-      modVersionValidator: m.mockModVersionValidator,
-      modLoadOrderResolver: m.mockModLoadOrderResolver,
-      worldLoader: m.mockWorldLoader,
-      contentLoadersConfig: null,
-    });
-  });
+      return new ModsLoader({
+        registry: m.mockRegistry,
+        logger: m.mockLogger,
+        schemaLoader: m.mockSchemaLoader,
+        componentLoader: loaders.mockComponentLoader,
+        conditionLoader: loaders.mockConditionLoader,
+        ruleLoader: loaders.mockRuleLoader,
+        actionLoader: loaders.mockActionLoader,
+        eventLoader: loaders.mockEventLoader,
+        entityLoader: loaders.mockEntityLoader,
+        validator: m.mockValidator,
+        configuration: m.mockConfiguration,
+        gameConfigLoader: m.mockGameConfigLoader,
+        promptTextLoader: { loadPromptText: jest.fn() },
+        modManifestLoader: m.mockModManifestLoader,
+        validatedEventDispatcher: m.mockValidatedEventDispatcher,
+        modDependencyValidator: m.mockModDependencyValidator,
+        modVersionValidator: m.mockModVersionValidator,
+        modLoadOrderResolver: m.mockModLoadOrderResolver,
+        worldLoader: m.mockWorldLoader,
+        contentLoadersConfig: null,
+      });
+    }
+  );
+
+  const { mocks, instance: modsLoader, cleanup } = buildEnv();
 
   /* ── Return the assembled environment ──────────────────────────────── */
   return {

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -102,3 +102,29 @@ export function buildEnvironment(
   const instance = createFn ? createFn(mockContainer, mocks) : undefined;
   return { mocks, mockContainer, instance, cleanup };
 }
+
+/**
+ * Creates a reusable test environment factory.
+ *
+ * @description Partially applies {@link buildEnvironment} with the provided
+ *   factory and token maps plus an optional creation function. The returned
+ *   function accepts overrides passed through to {@link buildEnvironment}.
+ * @param {Record<string, () => any>} factoryMap - Map of mock factory
+ *   functions to create.
+ * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
+ *   Map of DI tokens to mock keys, provider callbacks or constant values.
+ * @param {(container: any, mocks: Record<string, any>) => any} [createFn]
+ *   Function returning the system under test when provided the mock container
+ *   and generated mocks.
+ * @returns {(overrides?: Record<string | symbol, any>) => {
+ *   mocks: Record<string, any>,
+ *   mockContainer: { resolve: jest.Mock },
+ *   instance: any,
+ *   cleanup: () => void,
+ * }} Function that builds the environment.
+ */
+export function createTestEnvironmentBuilder(factoryMap, tokenMap, createFn) {
+  return function build(overrides = {}) {
+    return buildEnvironment(factoryMap, tokenMap, overrides, createFn);
+  };
+}


### PR DESCRIPTION
Summary: Added `createTestEnvironmentBuilder` in test helpers to streamline environment creation. Refactored game engine and mods loader test setups to use the new builder while preserving their return shapes.

Testing Done:
- [x] Code formatted (`npx prettier --write tests/common/mockEnvironment.js tests/common/engine/gameEngine.test-environment.js tests/common/loaders/modsLoader.test-setup.js`)
- [x] Lint passes on modified files (`npx eslint tests/common/mockEnvironment.js tests/common/engine/gameEngine.test-environment.js tests/common/loaders/modsLoader.test-setup.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6857072970f08331a45a83269bfc24dd