### PR TITLE
[Test] centralize timer reset in test bed

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -73,6 +73,8 @@ export class BaseTestBed {
    * @returns {Promise<void>} Promise resolving when cleanup is complete.
    */
   async cleanup() {
+    jest.useRealTimers();
+    jest.clearAllTimers();
     jest.clearAllMocks();
     this.resetMocks();
     await this._afterCleanup();

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -53,7 +53,7 @@ describeTurnManagerSuite(
         stopSpy.mockRestore();
       }
       turnEndCapture.unsubscribe.mockClear();
-      jest.useRealTimers();
+      // Timer cleanup handled by BaseTestBed
     });
 
     test.each([
@@ -110,7 +110,7 @@ describeTurnManagerSuite(
         await flushPromisesAndTimers();
         expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 
-        jest.useRealTimers();
+        // Timer cleanup handled by BaseTestBed
       }
     );
 
@@ -138,7 +138,6 @@ describeTurnManagerSuite(
     });
 
     test('Entity manager error: logs error, stops manager', async () => {
-      const entityError = new Error('Entity not found');
 
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);

--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -34,8 +34,7 @@ describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
   afterEach(async () => {
     // Clears mock usage data between tests
     jest.clearAllMocks();
-    // Restore real timers after each test
-    jest.useRealTimers();
+    // Timer cleanup handled by BaseTestBed
   });
 
   test('should stop advancing if handlerResolver fails', async () => {

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -55,8 +55,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    // Timer cleanup handled by BaseTestBed
   });
 
   // --- Basic Setup Tests ---

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -2,16 +2,12 @@
 // --- FILE START ---
 
 import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
-import {
-  ACTOR_COMPONENT_ID,
-  PLAYER_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
+import { ACTOR_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import {
   TURN_ENDED_ID,
-  TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
+import { beforeEach, expect, jest, afterEach } from '@jest/globals';
 import { createMockTurnHandler } from '../../common/mockFactories';
 import { createAiActor } from '../../common/turns/testActors.js';
 
@@ -23,7 +19,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
   let advanceTurnSpy;
 
   beforeEach(() => {
-    jest.useRealTimers();
+    // Timers reset via BaseTestBed cleanup
 
     testBed = getBed();
 
@@ -126,21 +122,9 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
       advanceTurnSpy.mockRejectedValue(advanceError);
       const stopSpy = jest.spyOn(testBed.turnManager, 'stop');
 
-      // The current implementation might not handle advanceTurn failures gracefully
-      // Skip this test for now or expect the error to be thrown
-      try {
-        await testBed.turnManager.start();
-        // If we reach here, the error was handled gracefully
-        expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-          'CRITICAL Error during turn advancement logic (before handler initiation): Turn advancement failed',
-          advanceError
-        );
-        expect(stopSpy).toHaveBeenCalledTimes(1);
-      } catch (error) {
-        // If the error is thrown, that's also acceptable behavior
-        expect(error.message).toBe('Turn advancement failed');
-      }
-
+      await expect(testBed.turnManager.start()).rejects.toThrow(
+        'Turn advancement failed'
+      );
       stopSpy.mockRestore();
     });
   });

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -3,7 +3,7 @@
 
 import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
-import { ACTOR_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+// import removed constant; not needed
 import {
   TURN_ENDED_ID,
   TURN_STARTED_ID,
@@ -14,10 +14,7 @@ import {
   createDefaultActors,
   createAiActor,
 } from '../../common/turns/testActors.js';
-import {
-  createMockEntity,
-  createMockTurnHandler,
-} from '../../common/mockFactories.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
 
 // --- Test Suite ---
 
@@ -43,7 +40,7 @@ describeTurnManagerSuite(
       testBed.mocks.turnHandlerResolver.resolveHandler.mockImplementation(
         async (actor) => {
           const handler = createMockTurnHandler({ actor });
-          handler.startTurn = (_currentActor) => Promise.resolve();
+          handler.startTurn = () => Promise.resolve();
 
           return handler;
         }
@@ -59,17 +56,13 @@ describeTurnManagerSuite(
 
     afterEach(async () => {
       jest.clearAllMocks();
-      jest.clearAllTimers();
-      jest.useRealTimers();
+      // Timer cleanup handled by BaseTestBed
     });
 
     test('Starts a new round when queue is empty and active actors exist', async () => {
       testBed.setActiveEntities(ai1, player);
 
-      // Debug: verify actors
-      const entities = Array.from(testBed.entityManager.entities);
-
-      // Entities have ACTOR_COMPONENT_ID component or not; not logged
+      // Debug: verify actor references
 
       // Mock isEmpty to return true (queue is empty) before the first turn
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);


### PR DESCRIPTION
Summary: BaseTestBed.cleanup now resets Jest timers, so individual TurnManager suites no longer call `jest.useRealTimers` or `jest.clearAllTimers`. This keeps timer handling consistent across tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint tests/common/baseTestBed.js tests/unit/turns/turnManager.*.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68570674ab70833198da208c4c12a82a