### PR TITLE
[Agent] centralize entity test imports

### DIFF
--- a/tests/common/engine/systemLogicTestEnv.js
+++ b/tests/common/engine/systemLogicTestEnv.js
@@ -10,7 +10,7 @@ import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
-import SimpleEntityManager from '../entities/simpleEntityManager.js';
+import { SimpleEntityManager } from '../entities/index.js';
 import { createMockLogger } from '../mockFactories/index.js';
 
 /**

--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -1,0 +1,6 @@
+export { default as SimpleEntityManager } from './simpleEntityManager.js';
+export { default as TestBed } from './testBed.js';
+export * from './testBed.js';
+export * from './serializationUtils.js';
+export * from './execContext.js';
+export * from './invalidInputHelpers.js';

--- a/tests/common/entities/invalidInputHelpers.js
+++ b/tests/common/entities/invalidInputHelpers.js
@@ -3,7 +3,7 @@
  * @see tests/common/entities/invalidInputHelpers.js
  */
 
-import { TestData } from './testBed.js';
+import { TestData } from './index.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 /**

--- a/tests/common/entities/serializationUtils.test.js
+++ b/tests/common/entities/serializationUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { buildSerializedEntity } from './serializationUtils.js';
+import { buildSerializedEntity } from './index.js';
 
 describe('buildSerializedEntity', () => {
   it('returns object with provided parameters', () => {

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -36,7 +36,7 @@ import {
   createSimpleMockDataRegistry,
   createMockLogger,
 } from '../common/mockFactories.js';
-import { buildExecContext } from '../common/entities/execContext.js';
+import { buildExecContext } from '../common/entities/index.js';
 import {
   afterEach,
   beforeEach,

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -26,7 +26,7 @@ import {
   createSimpleMockDataRegistry,
   createMockLogger,
 } from '../common/mockFactories.js';
-import { buildExecContext } from '../common/entities/execContext.js';
+import { buildExecContext } from '../common/entities/index.js';
 import {
   afterEach,
   beforeEach,

--- a/tests/unit/common/entities/testBed.test.js
+++ b/tests/unit/common/entities/testBed.test.js
@@ -5,7 +5,7 @@
 
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 // Corrected the path to be relative to the test file's location as per the logs.
-import { TestBed, TestData } from '../../../common/entities/testBed.js';
+import { TestBed, TestData } from '../../../common/entities/index.js';
 import EntityManager from '../../../../src/entities/entityManager.js';
 import EntityDefinition from '../../../../src/entities/entityDefinition.js';
 import {

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -9,8 +9,8 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestData,
-} from '../../common/entities/testBed.js';
-import { runInvalidIdPairTests } from '../../common/entities/invalidInputHelpers.js';
+} from '../../common/entities/index.js';
+import { runInvalidIdPairTests } from '../../common/entities/index.js';
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 import { ValidationError } from '../../../src/errors/validationError.js';

--- a/tests/unit/entities/entityManager.definitionMutation.test.js
+++ b/tests/unit/entities/entityManager.definitionMutation.test.js
@@ -4,7 +4,7 @@ import { test, expect } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestBed,
-} from '../../common/entities/testBed.js';
+} from '../../common/entities/index.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 
 describeEntityManagerSuite(

--- a/tests/unit/entities/entityManager.injection.test.js
+++ b/tests/unit/entities/entityManager.injection.test.js
@@ -10,7 +10,7 @@ import { describe, it, expect } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestData,
-} from '../../common/entities/testBed.js';
+} from '../../common/entities/index.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 
 describeEntityManagerSuite(

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -10,11 +10,11 @@ import {
   describeEntityManagerSuite,
   TestData,
   TestBed,
-} from '../../common/entities/testBed.js';
+} from '../../common/entities/index.js';
 import {
   runInvalidEntityIdTests,
   runInvalidDefinitionIdTests,
-} from '../../common/entities/invalidInputHelpers.js';
+} from '../../common/entities/index.js';
 import Entity from '../../../src/entities/entity.js';
 import { DefinitionNotFoundError } from '../../../src/errors/definitionNotFoundError.js';
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
@@ -26,7 +26,7 @@ import {
 import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 import { MapManager } from '../../../src/utils/mapManagerUtils.js';
-import { buildSerializedEntity } from '../../common/entities/serializationUtils.js';
+import { buildSerializedEntity } from '../../common/entities/index.js';
 
 describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
   describe('constructor', () => {

--- a/tests/unit/entities/entityManager.queries.test.js
+++ b/tests/unit/entities/entityManager.queries.test.js
@@ -9,7 +9,7 @@ import { describe, it, expect } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestData,
-} from '../../common/entities/testBed.js';
+} from '../../common/entities/index.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 describeEntityManagerSuite(

--- a/tests/unit/smoke/newCharacterMemory.test.js
+++ b/tests/unit/smoke/newCharacterMemory.test.js
@@ -17,7 +17,7 @@ import { expect, test } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestBed,
-} from '../../common/entities/testBed.js';
+} from '../../common/entities/index.js';
 
 /**
  * Uses {@link TestBed} to verify that the EntityManager injects the


### PR DESCRIPTION
## Summary
- create tests/common/entities/index.js
- update test imports to use new index

## Testing Done
- ✅ `npm run format`
- ❌ `npm run lint` (errors remain in repo)
- ✅ `npm run test`
- ✅ `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68570657c7788331952e199d6228ba39