### PR TITLE
[Agent] simplify constructor validation test

### DIFF
--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -5,24 +5,18 @@ import {
   describeAIPromptPipelineSuite,
   AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';
-import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
+import { describeConstructorValidation } from '../../common/constructorValidationHelpers.js';
 
 describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
   let bed;
   beforeEach(() => {
     bed = getBed();
   });
-  describe('constructor validation', () => {
-    const cases = buildMissingDependencyCases(
-      () => bed.getDependencies(),
-      AIPromptPipelineDependencySpec
-    );
-    test.each(cases)('throws when %s', (_desc, mutate, regex) => {
-      const deps = bed.getDependencies();
-      mutate(deps);
-      expect(() => new AIPromptPipeline(deps)).toThrow(regex);
-    });
-  });
+  describeConstructorValidation(
+    AIPromptPipeline,
+    () => bed.getDependencies(),
+    AIPromptPipelineDependencySpec
+  );
 
   test('generatePrompt orchestrates dependencies and returns prompt', async () => {
     const actor = bed.defaultActor;


### PR DESCRIPTION
Summary: Replace custom constructor validation logic with `describeConstructorValidation` for AIPromptPipeline tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint run `npm run lint` *(fails: 580 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685708d35a408331a52dcb21f2747ac7