### PR TITLE
[Test] Add useTestBed helper

### DIFF
--- a/tests/common/useTestBed.js
+++ b/tests/common/useTestBed.js
@@ -1,0 +1,24 @@
+/**
+ * @file Helper to access the active TestBed within a suite.
+ */
+/* eslint-env jest */
+/* global beforeEach */
+
+/**
+ * Creates a getter for the active TestBed using beforeEach.
+ *
+ * @description Stores the TestBed returned by {@code getBed} in a local
+ * variable before each test and returns a function providing that instance.
+ * @param {() => any} getBed - Function returning the TestBed from the suite.
+ * @returns {() => any} Function that returns the current TestBed.
+ */
+export function useTestBed(getBed) {
+  /** @type {any} */
+  let bed;
+  beforeEach(() => {
+    bed = getBed();
+  });
+  return () => bed;
+}
+
+export default useTestBed;

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -6,25 +6,24 @@ import {
   AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';
 import { buildMissingDependencyCases } from '../../common/constructorValidationHelpers.js';
+import { useTestBed } from '../../common/useTestBed.js';
 
 describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
-  let bed;
-  beforeEach(() => {
-    bed = getBed();
-  });
+  const get = useTestBed(getBed);
   describe('constructor validation', () => {
     const cases = buildMissingDependencyCases(
-      () => bed.getDependencies(),
+      () => get().getDependencies(),
       AIPromptPipelineDependencySpec
     );
     test.each(cases)('throws when %s', (_desc, mutate, regex) => {
-      const deps = bed.getDependencies();
+      const deps = get().getDependencies();
       mutate(deps);
       expect(() => new AIPromptPipeline(deps)).toThrow(regex);
     });
   });
 
   test('generatePrompt orchestrates dependencies and returns prompt', async () => {
+    const bed = get();
     const actor = bed.defaultActor;
     const context = bed.defaultContext;
     const actions = [...bed.defaultActions, { id: 'a1' }];
@@ -54,6 +53,7 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
       error: 'PromptBuilder returned an empty or invalid prompt.',
     },
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
+    const bed = get();
     await bed.expectGenerationFailure(mutate, error);
   });
 });


### PR DESCRIPTION
Summary: Provide a reusable helper for accessing the active TestBed instance within test suites and update AIPromptPipeline tests to use it.

Changes Made:
- Added `useTestBed` helper to simplify bed retrieval in test suites.
- Updated `AIPromptPipeline.test.js` to use the new helper.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on changed files (`npx eslint tests/common/useTestBed.js tests/unit/prompting/AIPromptPipeline.test.js`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68570c9d00a083319b69ea70492e3aba