### PR TITLE
[Agent] Validate variable names with isNonBlankString

### DIFF
--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -3,6 +3,7 @@
 import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from './dispatcherUtils.js';
+import { isNonBlankString } from './textUtils.js';
 
 /**
  * Validate that the context exists and the variable name is valid.
@@ -13,15 +14,10 @@ import { resolveSafeDispatcher } from './dispatcherUtils.js';
  * @private
  */
 function _validateContextAndName(variableName, execCtx) {
-  const trimmedName =
-    typeof variableName === 'string' ? variableName.trim() : '';
-
-  if (!trimmedName) {
+  if (!isNonBlankString(variableName)) {
     return {
       valid: false,
-      error: new Error(
-        'writeContextVariable: variableName must be a non-empty string.'
-      ),
+      error: new Error(`Invalid variableName: "${variableName}"`),
     };
   }
 
@@ -39,7 +35,7 @@ function _validateContextAndName(variableName, execCtx) {
     };
   }
 
-  return { valid: true, name: trimmedName };
+  return { valid: true, name: variableName };
 }
 
 /**
@@ -92,8 +88,8 @@ export function writeContextVariable(
 }
 
 /**
- * Wrapper around {@link writeContextVariable} that trims the variable name and validates
- * it before storage.
+ * Wrapper around {@link writeContextVariable} that validates the variable name
+ * before storage.
  *
  * @param {string|null|undefined} variableName - Target context variable name.
  * @param {*} value - Value to store.
@@ -110,10 +106,8 @@ export function tryWriteContextVariable(
   dispatcher,
   logger
 ) {
-  const trimmedName =
-    typeof variableName === 'string' ? variableName.trim() : '';
   const log = getModuleLogger('contextVariableUtils', logger);
-  const validation = _validateContextAndName(trimmedName, execCtx);
+  const validation = _validateContextAndName(variableName, execCtx);
   if (!validation.valid) {
     const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
     if (safeDispatcher) {

--- a/tests/unit/logic/operationHandlers/queryComponentHandler.test.js
+++ b/tests/unit/logic/operationHandlers/queryComponentHandler.test.js
@@ -592,9 +592,9 @@ describe('QueryComponentHandler', () => {
       mockActorId,
       trimmedCompType
     ); // Check EM call with trimmed type
-    expect(context.evaluationContext.context[trimmedResultVar]).toEqual(
+    expect(context.evaluationContext.context['  paddedVar  ']).toEqual(
       mockResult
-    ); // Check context storage with trimmed variable name
+    ); // Check context storage with untrimmed variable name
     expect(context.logger.error).not.toHaveBeenCalled(); // Check context logger for errors
 
     // --- FIX: Correct the log message checks ---

--- a/tests/unit/utils/contextVariableUtils.test.js
+++ b/tests/unit/utils/contextVariableUtils.test.js
@@ -76,4 +76,27 @@ describe('tryWriteContextVariable', () => {
       expect.objectContaining({ message: expect.any(String) })
     );
   });
+
+  test('rejects blank or whitespace-only variable names', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    const blank = tryWriteContextVariable('', 1, ctx);
+    const spaces = tryWriteContextVariable('   ', 1, ctx);
+
+    expect(blank.success).toBe(false);
+    expect(blank.error).toBeInstanceOf(Error);
+    expect(blank.error.message).toMatch(/^Invalid variableName/);
+
+    expect(spaces.success).toBe(false);
+    expect(spaces.error).toBeInstanceOf(Error);
+    expect(spaces.error.message).toMatch(/^Invalid variableName/);
+  });
+
+  test('keeps variable name untrimmed on success', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    const name = ' foo ';
+    const result = tryWriteContextVariable(name, 42, ctx);
+
+    expect(result).toEqual({ success: true });
+    expect(ctx.evaluationContext.context).toHaveProperty(name, 42);
+  });
 });


### PR DESCRIPTION
Summary: Centralized validation for context variable names by using `isNonBlankString` and updated affected tests. Names are now stored without trimming and whitespace-only names are rejected.

Changes Made:
- Imported `isNonBlankString` in `contextVariableUtils.js` and removed manual trim checks.
- Updated `_validateContextAndName` and `tryWriteContextVariable` accordingly.
- Adjusted query component handler test for new behavior.
- Added new tests covering blank, whitespace-only, and untrimmed variable names.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` on modified files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6857133466dc8331b60ee9453c7b534c