### PR TITLE
[Agent] centralize default test world

### DIFF
--- a/tests/common/constants.js
+++ b/tests/common/constants.js
@@ -1,0 +1,6 @@
+/**
+ * Default world name used across test suites.
+ *
+ * @type {string}
+ */
+export const DEFAULT_TEST_WORLD = 'TestWorld';

--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -8,6 +8,7 @@ import {
   createGameEngineTestBed,
   GameEngineTestBed,
 } from './gameEngineTestBed.js';
+import { DEFAULT_TEST_WORLD } from '../constants.js';
 
 /**
  * Executes a callback with a temporary {@link GameEngineTestBed} instance.
@@ -46,14 +47,14 @@ export async function withInitializedGameEngineBed(overrides, world, testFn) {
   if (typeof overrides === 'function') {
     testFn = overrides;
     overrides = {};
-    world = 'TestWorld';
+    world = DEFAULT_TEST_WORLD;
   } else if (typeof world === 'function') {
     testFn = world;
-    world = 'TestWorld';
+    world = DEFAULT_TEST_WORLD;
     overrides = overrides || {};
   } else {
     overrides = overrides || {};
-    world = world || 'TestWorld';
+    world = world || DEFAULT_TEST_WORLD;
   }
   const bed = createGameEngineTestBed(overrides);
   try {
@@ -88,7 +89,7 @@ export function runUnavailableServiceTest(cases, invokeFn) {
     async () => {
       await withGameEngineBed({ [token]: null }, async (bed, engine) => {
         if (opts.preInit) {
-          await bed.startAndReset('TestWorld');
+          await bed.startAndReset(DEFAULT_TEST_WORLD);
         }
         const [loggerMock, dispatchMock] = await invokeFn(
           bed,

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -14,6 +14,7 @@ import {
   createDescribeTestBedSuite,
   describeSuiteWithHooks,
 } from '../describeSuite.js';
+import { DEFAULT_TEST_WORLD } from '../constants.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -70,7 +71,7 @@ export class GameEngineTestBed extends StoppableMixin(
    * @param {string} [world] - World name to initialize.
    * @returns {Promise<void>} Promise resolving when the engine has started.
    */
-  async init(world = 'TestWorld') {
+  async init(world = DEFAULT_TEST_WORLD) {
     this.env.initializationService.runInitializationSequence.mockResolvedValue({
       success: true,
     });
@@ -83,7 +84,7 @@ export class GameEngineTestBed extends StoppableMixin(
    * @param {string} [world] - World name to initialize.
    * @returns {Promise<void>} Resolves once initialization completes.
    */
-  async initAndReset(world = 'TestWorld') {
+  async initAndReset(world = DEFAULT_TEST_WORLD) {
     await this.init(world);
     this.resetMocks();
   }
@@ -222,9 +223,9 @@ export function describeInitializedEngineSuite(
 ) {
   if (typeof world === 'object' && world !== null) {
     overrides = world;
-    world = 'TestWorld';
+    world = DEFAULT_TEST_WORLD;
   }
-  world = world || 'TestWorld';
+  world = world || DEFAULT_TEST_WORLD;
   describeEngineSuite(
     title,
     (ctx) => {


### PR DESCRIPTION
Summary: Added `DEFAULT_TEST_WORLD` constant for reuse across engine test helpers and updated their imports and usages.

Testing Done:
- [ ] `npm run format` *(failed: lint issues remain)*
- [ ] `npm run lint`
- [x] `npm test`
- [x] `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857164e06cc8331975fdf56a72dd262