### PR TITLE
[Agent] add turnManager testbed spies

### DIFF
--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -152,6 +152,7 @@ describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
   test('should handle turn order service errors', async () => {
     // Arrange
     const orderError = new Error('Turn order service failure');
+    testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
     testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(orderError);
 
     // Act


### PR DESCRIPTION
## Summary
- enhance TurnManagerTestBed with startAndFlush and spy helpers
- auto-restore spies during cleanup
- apply default hooks to describeTurnManagerSuite
- test new helpers
- fix error-handling test to account for fake timers

## Testing Done
- `npx prettier --write tests/common/turns/turnManagerTestBed.js tests/unit/common/turns/turnManagerTestBed.test.js tests/unit/turns/turnManager.errorHandling.test.js`
- `npx eslint tests/common/turns/turnManagerTestBed.js tests/unit/common/turns/turnManagerTestBed.test.js tests/unit/turns/turnManager.errorHandling.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685712f909948331b2bf21353a5fa9b9