### PR TITLE
[Agent] update AIPromptPipeline mock factory

### DIFF
--- a/tests/common/mockFactories/coreServices.js
+++ b/tests/common/mockFactories/coreServices.js
@@ -84,6 +84,8 @@ const simpleFactories = {
   },
 };
 
+const generatedFactories = generateFactories(simpleFactories);
+
 export const {
   createMockLogger,
   createMockTurnManager,
@@ -96,10 +98,20 @@ export const {
   createMockAIGameStateProvider,
   createMockAIPromptContentProvider,
   createMockPromptBuilder,
-  createMockAIPromptPipeline,
   createMockSafeEventDispatcher,
   createMockValidatedEventDispatcher,
-} = generateFactories(simpleFactories);
+} = generatedFactories;
+
+const baseCreateMockAIPromptPipeline =
+  generatedFactories.createMockAIPromptPipeline;
+
+export const createMockAIPromptPipeline = (defaultPrompt) => {
+  const pipeline = baseCreateMockAIPromptPipeline();
+  if (typeof defaultPrompt === 'string') {
+    pipeline.generatePrompt = jest.fn().mockResolvedValue(defaultPrompt);
+  }
+  return pipeline;
+};
 
 /**
  * Creates a mock turn handler.


### PR DESCRIPTION
## Summary
- update AIPromptPipeline mock factory to optionally resolve a default prompt

## Testing
- `npm run lint` *(fails: 564 errors, 2250 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685718c30e1c8331b1e53d667381ca15