### PR TITLE
[Agent] update basic entity test helpers

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -217,6 +217,34 @@ export class TestBed extends FactoryTestBed {
   }
 
   /**
+   * Convenience wrapper around {@link TestBed#setupDefinitions} for test
+   * definitions stored in {@link TestData}.
+   *
+   * @param {...keyof typeof TestData.Definitions} defKeys - Keys of test
+   *   definitions to register.
+   * @returns {void}
+   */
+  setupTestDefinitions(...defKeys) {
+    this.setupDefinitions(...defKeys.map((key) => TestData.Definitions[key]));
+  }
+
+  /**
+   * Convenience wrapper for creating an entity using the 'basic' test
+   * definition.
+   *
+   * @param {object} [options] - Options forwarded to
+   *   {@link EntityManager#createEntityInstance}.
+   * @param {object} [config] - Additional configuration options.
+   * @param {boolean} [config.resetDispatch] - If true, resets the event
+   *   dispatch mock after creation.
+   * @returns {import('../../../src/entities/entity.js').default} The created
+   *   entity instance.
+   */
+  createBasicEntity(options = {}, config = {}) {
+    return this.createEntity('basic', options, config);
+  }
+
+  /**
    * Resets the dispatch mock on the internal event dispatcher.
    *
    * @returns {void}

--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -102,7 +102,7 @@ describeEntityManagerSuite(
         const { PRIMARY } = TestData.InstanceIDs;
         const UPDATED_NAME_DATA = { name: 'Updated Name' };
 
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act
         entityManager.addComponent(
@@ -202,7 +202,7 @@ describeEntityManagerSuite(
         const { entityManager, mocks } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act & Assert
         expect(() =>
@@ -222,7 +222,7 @@ describeEntityManagerSuite(
           const { entityManager, mocks } = getBed();
           const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
           const { PRIMARY } = TestData.InstanceIDs;
-          getBed().createEntity('basic', { instanceId: PRIMARY });
+          getBed().createBasicEntity({ instanceId: PRIMARY });
           const receivedType = typeof value;
           const expectedError = `EntityManager.addComponent: componentData for ${NAME_COMPONENT_ID} on ${PRIMARY} must be an object. Received: ${receivedType}`;
 
@@ -287,7 +287,7 @@ describeEntityManagerSuite(
         const { PRIMARY } = TestData.InstanceIDs;
 
         // Add component as an override
-        getBed().createEntity('basic', {
+        getBed().createBasicEntity({
           instanceId: PRIMARY,
         });
         entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
@@ -386,7 +386,7 @@ describeEntityManagerSuite(
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
         const expectedData = TestData.Definitions.basic.components['core:name'];
 
         // Act
@@ -402,7 +402,7 @@ describeEntityManagerSuite(
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         const overrideData = { name: 'Override' };
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
         entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, overrideData);
 
         // Act
@@ -416,7 +416,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act
         const data = entityManager.getComponentData(PRIMARY, 'non:existent');
@@ -453,7 +453,7 @@ describeEntityManagerSuite(
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act
         const result = entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID);
@@ -466,7 +466,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act
         entityManager.addComponent(PRIMARY, 'new:component', { data: 'test' });
@@ -480,7 +480,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntity('basic', { instanceId: PRIMARY });
+        getBed().createBasicEntity({ instanceId: PRIMARY });
 
         // Act
         const result = entityManager.hasComponent(PRIMARY, 'non:existent');
@@ -511,7 +511,7 @@ describeEntityManagerSuite(
           const { entityManager } = getBed();
           const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
           const { PRIMARY } = TestData.InstanceIDs;
-          getBed().createEntity('basic', { instanceId: PRIMARY });
+          getBed().createBasicEntity({ instanceId: PRIMARY });
 
           // Act
           const result = entityManager.hasComponent(
@@ -529,7 +529,7 @@ describeEntityManagerSuite(
           const { entityManager } = getBed();
           const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
           const { PRIMARY } = TestData.InstanceIDs;
-          getBed().createEntity('basic', { instanceId: PRIMARY });
+          getBed().createBasicEntity({ instanceId: PRIMARY });
           entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
             name: 'Override',
           });
@@ -552,7 +552,7 @@ describeEntityManagerSuite(
           const { entityManager } = getBed();
           const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
           const { PRIMARY } = TestData.InstanceIDs;
-          getBed().createEntity('basic', { instanceId: PRIMARY });
+          getBed().createBasicEntity({ instanceId: PRIMARY });
 
           // Act
           const result = entityManager.hasComponentOverride(
@@ -569,7 +569,7 @@ describeEntityManagerSuite(
           const { entityManager } = getBed();
           const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
           const { PRIMARY } = TestData.InstanceIDs;
-          getBed().createEntity('basic', { instanceId: PRIMARY });
+          getBed().createBasicEntity({ instanceId: PRIMARY });
           entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
             name: 'Override',
           });

--- a/tests/unit/entities/entityManager.injection.test.js
+++ b/tests/unit/entities/entityManager.injection.test.js
@@ -122,10 +122,10 @@ describeEntityManagerSuite(
         } = TestData.ComponentIDs;
 
         // The 'basic' definition is not an actor
-        getBed().setupDefinitions(TestData.Definitions.basic);
+        getBed().setupTestDefinitions('basic');
 
         // Act
-        const entity = getBed().createEntity('basic');
+        const entity = getBed().createBasicEntity();
 
         // Assert
         expect(entity.hasComponent(GOALS_COMPONENT_ID)).toBe(false);

--- a/tests/unit/entities/entityManager.queries.test.js
+++ b/tests/unit/entities/entityManager.queries.test.js
@@ -25,7 +25,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { PRIMARY } = TestData.InstanceIDs;
-        const expectedEntity = getBed().createEntity('basic', {
+        const expectedEntity = getBed().createBasicEntity({
           instanceId: PRIMARY,
         });
 
@@ -89,7 +89,7 @@ describeEntityManagerSuite(
       it('should return an empty array if no entities have the specified component', () => {
         // Arrange
         const { entityManager } = getBed();
-        getBed().createEntity('basic', {
+        getBed().createBasicEntity({
           componentOverrides: { [COMPONENT_B]: { val: 1 } },
         });
 
@@ -103,15 +103,15 @@ describeEntityManagerSuite(
       it('should return only entities that have the specified component', () => {
         // Arrange
         const { entityManager } = getBed();
-        const entity1 = getBed().createEntity('basic', {
+        const entity1 = getBed().createBasicEntity({
           instanceId: 'instance-1',
           componentOverrides: { [COMPONENT_A]: { val: 1 } },
         });
-        const entity2 = getBed().createEntity('basic', {
+        const entity2 = getBed().createBasicEntity({
           instanceId: 'instance-2',
           componentOverrides: { [COMPONENT_B]: { val: 2 } },
         });
-        const entity3 = getBed().createEntity('basic', {
+        const entity3 = getBed().createBasicEntity({
           instanceId: 'instance-3',
           componentOverrides: {
             [COMPONENT_A]: { val: 3 },
@@ -134,12 +134,9 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
-        getBed().setupDefinitions(
-          TestData.Definitions.basic,
-          TestData.Definitions.actor
-        ); // basic has name, actor does not
+        getBed().setupTestDefinitions('basic', 'actor'); // basic has name, actor does not
 
-        const entityWithComponent = getBed().createEntity('basic');
+        const entityWithComponent = getBed().createBasicEntity();
         const entityWithoutComponent = getBed().createEntity('actor');
 
         // Act
@@ -158,7 +155,7 @@ describeEntityManagerSuite(
         (invalidId) => {
           // Arrange
           const { entityManager, mocks } = getBed();
-          getBed().createEntity('basic');
+          getBed().createBasicEntity();
 
           // Act & Assert
           expect(() =>
@@ -173,7 +170,7 @@ describeEntityManagerSuite(
       it('should return a new array, not a live reference', () => {
         // Arrange
         const { entityManager } = getBed();
-        const entity1 = getBed().createEntity('basic', {
+        const entity1 = getBed().createBasicEntity({
           componentOverrides: { [COMPONENT_A]: { val: 1 } },
         });
 
@@ -182,7 +179,7 @@ describeEntityManagerSuite(
         expect(results1).toHaveLength(1);
 
         // Modify the state by adding another entity with the component
-        const entity2 = getBed().createEntity('basic', {
+        const entity2 = getBed().createBasicEntity({
           componentOverrides: { [COMPONENT_A]: { val: 2 } },
         });
 
@@ -210,7 +207,7 @@ describeEntityManagerSuite(
 
       beforeEach(() => {
         const { entityManager } = getBed();
-        getBed().setupDefinitions(TestData.Definitions.basic);
+        getBed().setupTestDefinitions('basic');
 
         // entity1: has A
         entity1 = entityManager.createEntityInstance(


### PR DESCRIPTION
## Summary
- add `setupTestDefinitions` and `createBasicEntity` helpers for tests
- use the new helpers in `entityManager.*.test.js`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685718e0cf688331a253fb580ff63664