### PR TITLE
[Agent] use deepClone in test helpers

### DIFF
--- a/tests/common/engine/systemLogicTestEnv.js
+++ b/tests/common/engine/systemLogicTestEnv.js
@@ -12,6 +12,7 @@ import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationSe
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import { SimpleEntityManager } from '../entities/index.js';
 import { createMockLogger } from '../mockFactories/index.js';
+import { deepClone } from '../../../src/utils/cloneUtils.js';
 
 /**
  * Creates a complete test environment for system logic rule testing.
@@ -109,10 +110,7 @@ export function createRuleTestEnvironment({
     reset: (newEntities = []) => {
       env.cleanup();
       // Deep clone entities and their components to avoid mutation issues
-      const clonedEntities = newEntities.map((e) => ({
-        id: e.id,
-        components: JSON.parse(JSON.stringify(e.components)),
-      }));
+      const clonedEntities = newEntities.map((e) => deepClone(e));
       const newEnv = initializeEnv(clonedEntities);
       env.entityManager = newEnv.entityManager;
       env.operationRegistry = newEnv.operationRegistry;

--- a/tests/common/entities/simpleEntityManager.js
+++ b/tests/common/entities/simpleEntityManager.js
@@ -9,6 +9,8 @@
  *
  * @class
  */
+import { deepClone } from '../../../src/utils/cloneUtils.js';
+
 export default class SimpleEntityManager {
   /**
    * Creates a new instance pre-populated with the provided entities.
@@ -19,10 +21,8 @@ export default class SimpleEntityManager {
     /** @type {Map<string, {id:string, components:Record<string, any>}>} */
     this.entities = new Map();
     for (const e of entities) {
-      this.entities.set(e.id, {
-        id: e.id,
-        components: { ...e.components },
-      });
+      const cloned = deepClone(e);
+      this.entities.set(cloned.id, cloned);
     }
   }
 
@@ -72,7 +72,7 @@ export default class SimpleEntityManager {
   addComponent(id, type, data) {
     const ent = this.entities.get(id);
     if (ent) {
-      ent.components[type] = JSON.parse(JSON.stringify(data));
+      ent.components[type] = deepClone(data);
     }
   }
 


### PR DESCRIPTION
Summary: Replaced manual JSON cloning with deepClone utility in test helper modules to avoid mutation issues and import consistency.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails globally but not in modified files)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685718c6bd088331a2791c8341e2cf88