### PR TITLE
[Agent] inject dispatcher class dependency

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -38,7 +38,7 @@ export function formatActionCommand(
   displayNameFn = getEntityDisplayName
 ) {
   const { debug = false, logger = console, safeEventDispatcher } = options;
-  const dispatcher = resolveSafeDispatcher(null, safeEventDispatcher, logger);
+  const dispatcher = safeEventDispatcher || resolveSafeDispatcher(null, logger);
   if (!dispatcher) {
     logger.warn(
       'formatActionCommand: safeEventDispatcher resolution failed; error events may not be dispatched.'

--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -32,11 +32,8 @@ class CommandProcessor extends ICommandProcessor {
 
     this.#logger = logger;
 
-    this.#safeEventDispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      this.#logger
-    );
+    this.#safeEventDispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#safeEventDispatcher) {
       console.warn(
         'CommandProcessor: safeEventDispatcher resolution failed; some events may not be dispatched.'

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -75,11 +75,8 @@ class WorldContext extends IWorldContext {
         'WorldContext requires a valid ILogger instance with info, error, debug and warn methods.'
       );
     }
-    this.#safeEventDispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      logger
-    );
+    this.#safeEventDispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, logger);
     if (!this.#safeEventDispatcher) {
       logger.warn(
         'WorldContext: safeEventDispatcher resolution failed; some errors may not be dispatched.'

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -99,11 +99,8 @@ export class LocationRenderer extends BoundDomRendererBase {
       },
     };
 
-    const resolvedDispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      logger
-    );
+    const resolvedDispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, logger);
     if (!resolvedDispatcher) {
       console.warn(
         '[LocationRenderer] safeEventDispatcher resolution failed; UI errors may not be reported.'

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -80,11 +80,8 @@ class PlaytimeTracker extends IPlaytimeTracker {
       this.#logger = logger;
     }
 
-    this.#safeEventDispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      this.#logger
-    );
+    this.#safeEventDispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#safeEventDispatcher) {
       console.warn(
         'PlaytimeTracker: safeEventDispatcher resolution failed; playtime events may not be emitted.'

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -48,11 +48,8 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
     super();
 
     this.#logger = initLogger('ClientApiKeyProvider', logger);
-    this.#dispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      this.#logger
-    );
+    this.#dispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#dispatcher) {
       console.warn(
         'ClientApiKeyProvider: safeEventDispatcher resolution failed; errors may not be reported.'

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -139,11 +139,8 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   }) {
     super();
     this.#logger = initLogger('ServerApiKeyProvider', logger);
-    this.#dispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      this.#logger
-    );
+    this.#dispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#dispatcher) {
       console.warn(
         'ServerApiKeyProvider: safeEventDispatcher resolution failed; key errors may not be reported.'

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -26,11 +26,8 @@ export class BrowserStorageProvider extends IStorageProvider {
       throw new Error(errorMsg);
     }
     this.#logger = logger;
-    this.#safeEventDispatcher = resolveSafeDispatcher(
-      null,
-      safeEventDispatcher,
-      this.#logger
-    );
+    this.#safeEventDispatcher =
+      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#safeEventDispatcher) {
       console.warn(
         'BrowserStorageProvider: safeEventDispatcher resolution failed; some errors may go unreported.'

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -59,7 +59,7 @@ export function writeContextVariable(
   logger
 ) {
   const log = getModuleLogger('contextVariableUtils', logger);
-  const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
+  const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
   const { valid, error, name } = _validateContextAndName(variableName, execCtx);
 
   if (!valid) {
@@ -109,7 +109,7 @@ export function tryWriteContextVariable(
   const log = getModuleLogger('contextVariableUtils', logger);
   const validation = _validateContextAndName(variableName, execCtx);
   if (!validation.valid) {
-    const safeDispatcher = resolveSafeDispatcher(execCtx, dispatcher, log);
+    const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
     if (safeDispatcher) {
       safeDispatchError(safeDispatcher, validation.error.message, {
         variableName,

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -6,25 +6,24 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  * Resolves a usable ISafeEventDispatcher instance.
  *
  * @description
- * Returns the provided dispatcher when available. Otherwise, if the execution
- * context contains a validatedEventDispatcher, a new SafeEventDispatcher is
- * constructed using the supplied logger. Construction failures result in
- * `null`.
+ * Instantiates and returns a dispatcher when the execution context contains a
+ * validatedEventDispatcher. A custom dispatcher class can be provided for
+ * testing. Construction failures result in `null`.
  * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
- * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] -
- *   Optional pre-existing dispatcher.
- * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the SafeEventDispatcher.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the dispatcher.
+ * @param {typeof SafeEventDispatcher} [DispatcherClass] -
+ *   Class used to instantiate the dispatcher when needed.
  * @returns {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher | null}
  *   The resolved dispatcher or `null` when unavailable.
  */
-export function resolveSafeDispatcher(execCtx, dispatcher, logger) {
-  if (dispatcher) {
-    return dispatcher;
-  }
-
+export function resolveSafeDispatcher(
+  execCtx,
+  logger,
+  DispatcherClass = SafeEventDispatcher
+) {
   if (execCtx?.validatedEventDispatcher) {
     try {
-      return new SafeEventDispatcher({
+      return new DispatcherClass({
         validatedEventDispatcher: execCtx.validatedEventDispatcher,
         logger,
       });

--- a/tests/unit/utils/dispatcherUtils.test.js
+++ b/tests/unit/utils/dispatcherUtils.test.js
@@ -3,11 +3,6 @@ import { resolveSafeDispatcher } from '../../../src/utils/dispatcherUtils.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
 
 describe('resolveSafeDispatcher', () => {
-  test('returns provided dispatcher', () => {
-    const dispatcher = { dispatch: jest.fn() };
-    expect(resolveSafeDispatcher({}, dispatcher)).toBe(dispatcher);
-  });
-
   test('creates SafeEventDispatcher from execCtx', () => {
     const validated = {
       dispatch: jest.fn(),
@@ -21,7 +16,7 @@ describe('resolveSafeDispatcher', () => {
       info: jest.fn(),
       debug: jest.fn(),
     };
-    const result = resolveSafeDispatcher(execCtx, undefined, logger);
+    const result = resolveSafeDispatcher(execCtx, logger);
     expect(result).toBeInstanceOf(SafeEventDispatcher);
   });
 
@@ -33,7 +28,35 @@ describe('resolveSafeDispatcher', () => {
       info: jest.fn(),
       debug: jest.fn(),
     };
-    const result = resolveSafeDispatcher(execCtx, undefined, logger);
+    const result = resolveSafeDispatcher(execCtx, logger);
     expect(result).toBeNull();
+  });
+
+  test('uses injected DispatcherClass', () => {
+    const validated = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    const execCtx = { validatedEventDispatcher: validated };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const spy = jest.fn();
+    class DummyDispatcher {
+      constructor({ validatedEventDispatcher, logger }) {
+        spy(validatedEventDispatcher, logger);
+        this.validatedEventDispatcher = validatedEventDispatcher;
+        this.logger = logger;
+      }
+    }
+
+    const result = resolveSafeDispatcher(execCtx, logger, DummyDispatcher);
+
+    expect(result).toBeInstanceOf(DummyDispatcher);
+    expect(spy).toHaveBeenCalledWith(validated, logger);
   });
 });


### PR DESCRIPTION
Summary:
- allow injecting dispatcher class with default SafeEventDispatcher
- update all resolveSafeDispatcher call sites
- test custom dispatcher injection

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: many pre-existing errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68571d9e59b483319fd4b3d08c66c8a3