### PR TITLE
[Agent] simplify prompt pipeline mocks

### DIFF
--- a/tests/integration/aiDecisionMetadata.test.js
+++ b/tests/integration/aiDecisionMetadata.test.js
@@ -41,8 +41,7 @@ describe('LLMChooser.choose – metadata propagation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    promptPipeline = createMockAIPromptPipeline();
-    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
+    promptPipeline = createMockAIPromptPipeline('PROMPT');
     llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{"ok":1}') };
     responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({

--- a/tests/unit/turns/adapters/llmChooser.test.js
+++ b/tests/unit/turns/adapters/llmChooser.test.js
@@ -9,8 +9,7 @@ const dummyLogger = createMockLogger();
 
 describe('LLMChooser', () => {
   test('forwards AbortSignal to llmAdapter', async () => {
-    const promptPipeline = createMockAIPromptPipeline();
-    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
+    const promptPipeline = createMockAIPromptPipeline('PROMPT');
     const llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{}') };
     const responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({
@@ -40,8 +39,7 @@ describe('LLMChooser', () => {
   });
 
   test('returns {index, speech} shape', async () => {
-    const promptPipeline = createMockAIPromptPipeline();
-    promptPipeline.generatePrompt.mockResolvedValue('PROMPT');
+    const promptPipeline = createMockAIPromptPipeline('PROMPT');
     const llmAdapter = { getAIDecision: jest.fn().mockResolvedValue('{}') };
     const responseProcessor = {
       processResponse: jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- remove redundant `generatePrompt` mocks from ai tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68571d5386b8833198aca71666c8b3f2