### PR TITLE
[Agent] refactor mock registry helpers

### DIFF
--- a/tests/common/mockFactories/entities.js
+++ b/tests/common/mockFactories/entities.js
@@ -10,16 +10,30 @@ import {
 } from '../../../src/constants/componentIds.js';
 
 /**
+ * Builds a base registry object with stubbed methods.
+ *
+ * @description Provides minimal jest.fn implementations for registry APIs used
+ *   in tests.
+ * @returns {{get: jest.Mock, getAll: jest.Mock, store: jest.Mock, clear: jest.Mock}}
+ *   Base registry stub.
+ */
+function buildRegistryBase() {
+  return {
+    get: jest.fn(),
+    getAll: jest.fn(() => []),
+    store: jest.fn(),
+    clear: jest.fn(),
+  };
+}
+
+/**
  * Creates a simple mock data registry with jest.fn methods.
  *
  * @returns {{get: jest.Mock, store: jest.Mock, clear: jest.Mock}} Registry mock
  */
 export const createSimpleMockDataRegistry = () => ({
+  ...buildRegistryBase(),
   getEntityDefinition: jest.fn(),
-  get: jest.fn(),
-  getAll: jest.fn(() => []),
-  store: jest.fn(),
-  clear: jest.fn(),
 });
 
 /**
@@ -38,6 +52,7 @@ export const createStatefulMockDataRegistry = () => {
 
   const registry = {
     _internalStore: internalStore,
+    ...buildRegistryBase(),
     store: jest.fn((type, id, data) => {
       if (!internalStore[type]) internalStore[type] = {};
       internalStore[type][id] = data;


### PR DESCRIPTION
## Summary
- add private `buildRegistryBase` helper for registry mocks
- compose `createSimpleMockDataRegistry` from base helper
- reuse base helper in `createStatefulMockDataRegistry`

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68571ea5940483319164e2d1b16916ec