### PR TITLE
[Agent] use mock turn handler factory in tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -11,6 +11,7 @@ import {
   TURN_PROCESSING_STARTED,
 } from '../../../src/constants/eventIds.js';
 import { createAiActor } from '../../common/turns/testActors.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
 import TurnManager from '../../../src/turns/turnManager.js';
 import RoundManager from '../../../src/turns/roundManager.js';
 
@@ -46,10 +47,9 @@ describeTurnManagerSuite(
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue({
-        startTurn: jest.fn().mockResolvedValue(undefined),
-        destroy: jest.fn().mockResolvedValue(undefined),
-      });
+      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+        createMockTurnHandler()
+      );
 
       // Spy on stop to verify calls and simulate unsubscribe
       stopSpy = jest
@@ -73,10 +73,7 @@ describeTurnManagerSuite(
       const entityType = 'ai';
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(nextActor);
 
-      const mockHandler = {
-        startTurn: jest.fn().mockResolvedValue(undefined),
-        destroy: jest.fn().mockResolvedValue(undefined),
-      };
+      const mockHandler = createMockTurnHandler({ actor: nextActor });
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
         mockHandler
       );
@@ -244,10 +241,8 @@ describeTurnManagerSuite(
       // Arrange
       const startError = new Error('Handler start failed');
       const mockActor = createAiActor('actor1');
-      const mockHandler = {
-        startTurn: jest.fn().mockRejectedValue(startError),
-        destroy: jest.fn().mockResolvedValue(undefined),
-      };
+      const mockHandler = createMockTurnHandler({ actor: mockActor });
+      mockHandler.startTurn.mockRejectedValue(startError);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(mockActor); // Return valid entity first
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
         mockHandler
@@ -259,7 +254,7 @@ describeTurnManagerSuite(
 
       // Assert
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
-        'Error during handler.startTurn() initiation for entity actor1 (Object): Handler start failed',
+        'Error during handler.startTurn() initiation for entity actor1 (MockTurnHandler): Handler start failed',
         startError
       );
 

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -9,6 +9,7 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { createMockEntity } from '../../common/mockFactories';
 import { createAiActor } from '../../common/turns/testActors.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
 
 describeTurnManagerSuite(
   'TurnManager: advanceTurn() - Round Start (Queue Empty)',
@@ -147,10 +148,7 @@ describeTurnManagerSuite(
         actor1
       ); // First actor in new round
 
-      const mockHandler = {
-        startTurn: jest.fn().mockResolvedValue(undefined),
-        destroy: jest.fn().mockResolvedValue(undefined),
-      };
+      const mockHandler = createMockTurnHandler({ actor: actor1 });
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
         mockHandler
       );

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -18,18 +18,11 @@ import {
   createAiActor,
   createPlayerActor,
 } from '../../common/turns/testActors.js';
+import { createMockTurnHandler } from '../../common/mockFactories.js';
 
-// Mock Turn Handlers - ADD startTurn and destroy
-const mockPlayerHandler = {
-  constructor: { name: 'MockPlayerHandler' },
-  startTurn: jest.fn().mockResolvedValue(),
-  destroy: jest.fn().mockResolvedValue(),
-};
-const mockAiHandler = {
-  constructor: { name: 'MockAiHandler' },
-  startTurn: jest.fn().mockResolvedValue(),
-  destroy: jest.fn().mockResolvedValue(),
-};
+// Mock Turn Handlers
+const mockPlayerHandler = createMockTurnHandler();
+const mockAiHandler = createMockTurnHandler();
 
 describeTurnManagerSuite('TurnManager', (getBed) => {
   let testBed;


### PR DESCRIPTION
Summary: use `createMockTurnHandler` helper in several TurnManager unit tests to remove ad-hoc handler objects and keep expectations aligned with the factory's constructor name.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68571d67e1b883318ad73cd76a828071