### PR TITLE
[Agent] add dispatch test helpers

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -8,6 +8,10 @@ import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
   ENGINE_READY_UI,
   GAME_SAVED_ID,
+  ENTITY_CREATED_ID,
+  ENTITY_REMOVED_ID,
+  COMPONENT_ADDED_ID,
+  COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
 
 /**
@@ -100,6 +104,79 @@ export function expectSingleDispatch(mock, eventId, payload) {
   expectDispatchSequence(mock, [[eventId, payload]]);
 }
 
+/**
+ * Asserts that an ENTITY_CREATED dispatch with the correct payload occurred.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {import('../../../src/entities/entity.js').default} entity - Entity instance.
+ * @param {boolean} wasReconstructed - Flag indicating reconstruction.
+ * @returns {void}
+ */
+export function expectEntityCreatedDispatch(mock, entity, wasReconstructed) {
+  expectSingleDispatch(mock, ENTITY_CREATED_ID, {
+    entity,
+    wasReconstructed,
+  });
+}
+
+/**
+ * Asserts that an ENTITY_REMOVED dispatch with the correct payload occurred.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {import('../../../src/entities/entity.js').default} entity - Entity instance.
+ * @returns {void}
+ */
+export function expectEntityRemovedDispatch(mock, entity) {
+  expectSingleDispatch(mock, ENTITY_REMOVED_ID, { entity });
+}
+
+/**
+ * Asserts that a COMPONENT_ADDED dispatch with the expected payload occurred.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {import('../../../src/entities/entity.js').default} entity - Entity instance.
+ * @param {string} componentTypeId - Component type identifier.
+ * @param {object|null} newData - New component data.
+ * @param {object|null|undefined} oldData - Previous component data.
+ * @returns {void}
+ */
+export function expectComponentAddedDispatch(
+  mock,
+  entity,
+  componentTypeId,
+  newData,
+  oldData
+) {
+  expectSingleDispatch(mock, COMPONENT_ADDED_ID, {
+    entity,
+    componentTypeId,
+    componentData: newData,
+    oldComponentData: oldData,
+  });
+}
+
+/**
+ * Asserts that a COMPONENT_REMOVED dispatch with the expected payload occurred.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @param {import('../../../src/entities/entity.js').default} entity - Entity instance.
+ * @param {string} componentTypeId - Component type identifier.
+ * @param {object|null|undefined} oldData - Previous component data.
+ * @returns {void}
+ */
+export function expectComponentRemovedDispatch(
+  mock,
+  entity,
+  componentTypeId,
+  oldData
+) {
+  expectSingleDispatch(mock, COMPONENT_REMOVED_ID, {
+    entity,
+    componentTypeId,
+    oldComponentData: oldData,
+  });
+}
+
 export { expectDispatchSequence as expectDispatchCalls };
 
 export default {
@@ -107,5 +184,9 @@ export default {
   buildSaveDispatches,
   expectEngineStatus,
   expectSingleDispatch,
+  expectEntityCreatedDispatch,
+  expectEntityRemovedDispatch,
+  expectComponentAddedDispatch,
+  expectComponentRemovedDispatch,
   expectDispatchCalls: expectDispatchSequence,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -5,11 +5,19 @@ import {
   buildSaveDispatches,
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   expectEngineStatus,
+  expectEntityCreatedDispatch,
+  expectEntityRemovedDispatch,
+  expectComponentAddedDispatch,
+  expectComponentRemovedDispatch,
 } from './dispatchTestUtils.js';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
   ENGINE_READY_UI,
   GAME_SAVED_ID,
+  ENTITY_CREATED_ID,
+  ENTITY_REMOVED_ID,
+  COMPONENT_ADDED_ID,
+  COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
 
 describe('dispatchTestUtils', () => {
@@ -114,6 +122,65 @@ describe('dispatchTestUtils', () => {
     it('throws when statuses differ', () => {
       const engine = { getEngineStatus: () => ({ ready: false }) };
       expect(() => expectEngineStatus(engine, { ready: true })).toThrow();
+    });
+  });
+
+  describe('entity and component dispatch helpers', () => {
+    it('validates ENTITY_CREATED helper', () => {
+      const mock = jest.fn();
+      const entity = { id: 'e1' };
+      mock(ENTITY_CREATED_ID, { entity, wasReconstructed: false });
+
+      expect(() =>
+        expectEntityCreatedDispatch(mock, entity, false)
+      ).not.toThrow();
+    });
+
+    it('throws on mismatched ENTITY_CREATED payload', () => {
+      const mock = jest.fn();
+      const entity = { id: 'e1' };
+      mock(ENTITY_CREATED_ID, { entity, wasReconstructed: false });
+
+      expect(() => expectEntityCreatedDispatch(mock, entity, true)).toThrow();
+    });
+
+    it('validates ENTITY_REMOVED helper', () => {
+      const mock = jest.fn();
+      const entity = { id: 'e1' };
+      mock(ENTITY_REMOVED_ID, { entity });
+
+      expect(() => expectEntityRemovedDispatch(mock, entity)).not.toThrow();
+    });
+
+    it('validates COMPONENT_ADDED helper', () => {
+      const mock = jest.fn();
+      const entity = { id: 'e1' };
+      const newData = { a: 1 };
+      mock(COMPONENT_ADDED_ID, {
+        entity,
+        componentTypeId: 'typeA',
+        componentData: newData,
+        oldComponentData: undefined,
+      });
+
+      expect(() =>
+        expectComponentAddedDispatch(mock, entity, 'typeA', newData, undefined)
+      ).not.toThrow();
+    });
+
+    it('validates COMPONENT_REMOVED helper', () => {
+      const mock = jest.fn();
+      const entity = { id: 'e1' };
+      const oldData = { a: 1 };
+      mock(COMPONENT_REMOVED_ID, {
+        entity,
+        componentTypeId: 'typeA',
+        oldComponentData: oldData,
+      });
+
+      expect(() =>
+        expectComponentRemovedDispatch(mock, entity, 'typeA', oldData)
+      ).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend `dispatchTestUtils` with entity/component helpers
- export helpers and write unit tests

## Testing
- `npx eslint tests/common/engine/dispatchTestUtils.js tests/common/engine/dispatchTestUtils.test.js`
- `npm run test`
- `npm run test:single tests/common/engine/dispatchTestUtils.test.js`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68571ffd5008833199bd06e4cb2c5280