### PR TITLE
[Agent] update turnManager tests for new suite hooks

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -1,7 +1,7 @@
 // tests/turns/turnManager.advanceTurn.actorIdentification.test.js
 // --- FILE START (Corrected) ---
 
-import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, expect, test } from '@jest/globals';
 import {
   describeTurnManagerSuite,
   flushPromisesAndTimers,
@@ -27,8 +27,6 @@ describeTurnManagerSuite(
 
     beforeEach(async () => {
       testBed = getBed();
-
-      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
         createAiActor('initial-actor-for-start')
@@ -38,9 +36,8 @@ describeTurnManagerSuite(
         createMockTurnHandler()
       );
 
-      stopSpy = jest
-        .spyOn(testBed.turnManager, 'stop')
-        .mockImplementation(async () => {});
+      stopSpy = testBed.spyOnStop();
+      stopSpy.mockImplementation(async () => {});
 
       await testBed.startRunning();
 
@@ -49,9 +46,6 @@ describeTurnManagerSuite(
     });
 
     afterEach(async () => {
-      if (stopSpy) {
-        stopSpy.mockRestore();
-      }
       turnEndCapture.unsubscribe.mockClear();
       // Timer cleanup handled by BaseTestBed
     });
@@ -62,8 +56,6 @@ describeTurnManagerSuite(
     ])(
       'actor identified (%s) -> handler invoked and event dispatched',
       async (_, actor) => {
-        jest.useFakeTimers();
-
         const entityType = actor.hasComponent(PLAYER_COMPONENT_ID)
           ? 'player'
           : 'ai';

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -12,24 +12,6 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { createAiActor } from '../../common/turns/testActors.js';
 import { createMockTurnHandler } from '../../common/mockFactories.js';
-import TurnManager from '../../../src/turns/turnManager.js';
-import RoundManager from '../../../src/turns/roundManager.js';
-
-// Define a mock RoundManager for this test
-class MockRoundManager {
-  constructor() {
-    this.inProgress = false;
-    this.hadSuccess = true;
-  }
-  resetFlags() {}
-  startRound() {
-    // Simulate the real RoundManager behavior - throw error when no actors found
-    throw new Error(
-      'Cannot start a new round: No active entities with an Actor component found.'
-    );
-  }
-  endTurn() {}
-}
 
 // --- Test Suite ---
 
@@ -43,7 +25,6 @@ describeTurnManagerSuite(
       // Made beforeEach async
       testBed = getBed();
 
-      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
@@ -52,11 +33,10 @@ describeTurnManagerSuite(
       );
 
       // Spy on stop to verify calls and simulate unsubscribe
-      stopSpy = jest
-        .spyOn(testBed.turnManager, 'stop')
-        .mockImplementation(async () => {
-          testBed.mocks.logger.debug('Mocked instance.stop() called.');
-        });
+      stopSpy = testBed.spyOnStop();
+      stopSpy.mockImplementation(async () => {
+        testBed.mocks.logger.debug('Mocked instance.stop() called.');
+      });
 
       // Start manager without running advanceTurn
       await testBed.startRunning();

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -20,27 +20,21 @@ describeTurnManagerSuite(
 
     beforeEach(() => {
       testBed = getBed();
-
-      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockReset();
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(null);
 
       // Define the spy here for the actual advanceTurn method
-      advanceTurnSpy = jest.spyOn(testBed.turnManager, 'advanceTurn');
+      advanceTurnSpy = testBed.spyOnAdvanceTurn();
 
       // Spy on stop - Keep the condition to ensure start was called.
-      stopSpy = jest
-        .spyOn(testBed.turnManager, 'stop')
-        .mockImplementation(async () => {
-          testBed.mocks.logger.debug('Mocked instance.stop() called.');
-        });
+      stopSpy = testBed.spyOnStop();
+      stopSpy.mockImplementation(async () => {
+        testBed.mocks.logger.debug('Mocked instance.stop() called.');
+      });
 
       // Clear constructor/setup logs AFTER instantiation and spy setup
-      testBed.mocks.logger.info.mockClear();
-      testBed.mocks.logger.debug.mockClear();
-      testBed.mocks.logger.warn.mockClear();
-      testBed.mocks.logger.error.mockClear();
+      testBed.resetMocks();
     });
 
     // --- Test Cases ---

--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -18,9 +18,6 @@ describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
   let ai1, ai2, player;
 
   beforeEach(() => {
-    // Use MODERN fake timers explicitly
-    jest.useFakeTimers({ legacyFakeTimers: false });
-
     testBed = getBed();
 
     // Setup actors and add to the specific entityManager instance used by TurnManager

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -11,7 +11,7 @@ import {
   PLAYER_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
 import { TURN_PROCESSING_STARTED } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, test } from '@jest/globals';
 import { createMockEntity } from '../../common/mockFactories';
 import {
   createDefaultActors,
@@ -30,12 +30,9 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
   let mockAiEntity1;
 
   beforeEach(() => {
-    jest.useFakeTimers();
     testBed = getBed();
 
     ({ player: mockPlayerEntity, ai1: mockAiEntity1 } = createDefaultActors());
-
-    testBed.initializeDefaultMocks();
     testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
       mockAiHandler
     );

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -25,15 +25,13 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     testBed.setupMockHandlerResolver();
 
-    advanceTurnSpy = jest
-      .spyOn(testBed.turnManager, 'advanceTurn')
-      .mockResolvedValue(undefined);
+    advanceTurnSpy = testBed.spyOnAdvanceTurn();
+    advanceTurnSpy.mockResolvedValue(undefined);
 
-    testBed.mocks.logger.info.mockClear(); // Clear constructor log
+    testBed.resetMocks();
   });
 
   afterEach(async () => {
-    advanceTurnSpy.mockRestore(); // Restore original advanceTurn
     jest.clearAllMocks(); // General cleanup
   });
 
@@ -66,7 +64,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     it('should handle subscription failure gracefully (invalid return value)', async () => {
       testBed.mocks.dispatcher.subscribe.mockReturnValue(null);
-      const stopSpy = jest.spyOn(testBed.turnManager, 'stop');
+      const stopSpy = testBed.spyOnStop();
       await testBed.turnManager.start();
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -87,7 +85,6 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
         })
       );
       expect(stopSpy).toHaveBeenCalledTimes(1);
-      stopSpy.mockRestore();
     });
 
     it('should handle subscription failure gracefully (subscribe throws)', async () => {
@@ -95,7 +92,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
       testBed.mocks.dispatcher.subscribe.mockImplementation(() => {
         throw subscribeError;
       });
-      const stopSpy = jest.spyOn(testBed.turnManager, 'stop');
+      const stopSpy = testBed.spyOnStop();
       await testBed.turnManager.start();
       expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -114,18 +111,15 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
         })
       );
       expect(stopSpy).toHaveBeenCalledTimes(1);
-      stopSpy.mockRestore();
     });
 
     it('should handle advanceTurn failure gracefully', async () => {
       const advanceError = new Error('Turn advancement failed');
       advanceTurnSpy.mockRejectedValue(advanceError);
-      const stopSpy = jest.spyOn(testBed.turnManager, 'stop');
 
       await expect(testBed.turnManager.start()).rejects.toThrow(
         'Turn advancement failed'
       );
-      stopSpy.mockRestore();
     });
   });
 

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -27,10 +27,7 @@ describeTurnManagerSuite(
     let ai1, ai2, player;
 
     beforeEach(() => {
-      jest.useFakeTimers();
       testBed = getBed();
-
-      testBed.initializeDefaultMocks();
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
 
@@ -46,12 +43,9 @@ describeTurnManagerSuite(
         }
       );
 
-      stopSpy = jest.spyOn(testBed.turnManager, 'stop');
+      stopSpy = testBed.spyOnStop();
 
-      testBed.mocks.logger.info.mockClear();
-      testBed.mocks.logger.debug.mockClear();
-      testBed.mocks.logger.warn.mockClear();
-      testBed.mocks.logger.error.mockClear();
+      testBed.resetMocks();
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## Summary
- clean up manual mocks in turnManager test suites
- rely on TurnManagerTestBed helpers for spies and resets

## Testing
- `npm run lint` *(fails: 2811 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685722e1749c83319fef803a801eca12