### PR TITLE
[Agent] add generic withTestBed helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -4,11 +4,9 @@
  */
 
 import { expect, jest } from '@jest/globals';
-import {
-  createGameEngineTestBed,
-  GameEngineTestBed,
-} from './gameEngineTestBed.js';
+import { GameEngineTestBed } from './gameEngineTestBed.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
+import { withTestBed } from '../testBedHelpers.js';
 
 /**
  * Executes a callback with a temporary {@link GameEngineTestBed} instance.
@@ -20,13 +18,9 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
  * @returns {Promise<void>} Resolves when the callback completes.
  */
 export async function withGameEngineBed(overrides = {}, testFn) {
-  const bed = createGameEngineTestBed(overrides);
-  try {
-    bed.resetMocks();
-    await testFn(bed, bed.engine);
-  } finally {
-    await bed.cleanup();
-  }
+  await withTestBed(GameEngineTestBed, overrides, (bed) =>
+    testFn(bed, bed.engine)
+  );
 }
 
 /**
@@ -56,13 +50,12 @@ export async function withInitializedGameEngineBed(overrides, world, testFn) {
     overrides = overrides || {};
     world = world || DEFAULT_TEST_WORLD;
   }
-  const bed = createGameEngineTestBed(overrides);
-  try {
-    await bed.initAndReset(world);
-    await testFn(bed, bed.engine);
-  } finally {
-    await bed.cleanup();
-  }
+  await withTestBed(
+    GameEngineTestBed,
+    overrides,
+    (bed) => testFn(bed, bed.engine),
+    (bed) => bed.initAndReset(world)
+  );
 }
 
 /**

--- a/tests/common/testBedHelpers.js
+++ b/tests/common/testBedHelpers.js
@@ -1,0 +1,42 @@
+/**
+ * @file Generic helper for executing callbacks with temporary test beds.
+ */
+
+/**
+ * Executes a callback with a temporary test bed instance.
+ *
+ * @description Instantiates the provided `TestBedCtor` with optional overrides,
+ * optionally runs `initFn` against the bed, then runs `callback` inside a
+ * `try/finally` block ensuring `cleanup` is always called. If the bed exposes a
+ * `resetMocks` method it is invoked after initialization.
+ * @template {new (overrides: any) => any} T
+ * @param {T} TestBedCtor - Test bed constructor.
+ * @param {ConstructorParameters<T>[0]} [overrides] - Optional overrides passed to
+ *   the constructor.
+ * @param {(bed: InstanceType<T>) => (Promise<void>|void)} callback - Function to
+ *   execute with the bed.
+ * @param {(bed: InstanceType<T>) => (Promise<void>|void)} [initFn] - Optional
+ *   initialization function.
+ * @returns {Promise<void>} Resolves when the callback completes.
+ */
+export async function withTestBed(
+  TestBedCtor,
+  overrides = {},
+  callback,
+  initFn
+) {
+  const bed = new TestBedCtor(overrides);
+  if (initFn) {
+    await initFn(bed);
+  }
+  if (typeof bed.resetMocks === 'function') {
+    bed.resetMocks();
+  }
+  try {
+    await callback(bed);
+  } finally {
+    await bed.cleanup();
+  }
+}
+
+export default withTestBed;

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -19,8 +19,8 @@ describe('withGameEngineBed', () => {
       cleanup: jest.fn(),
     };
     const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+      .spyOn(bedModule, 'GameEngineTestBed')
+      .mockImplementation(() => bed);
     const testFn = jest.fn();
 
     await withGameEngineBed({ a: 1 }, testFn);
@@ -39,7 +39,7 @@ describe('withGameEngineBed', () => {
       resetMocks: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    jest.spyOn(bedModule, 'GameEngineTestBed').mockImplementation(() => bed);
 
     const error = new Error('fail');
     const testFn = jest.fn().mockRejectedValue(error);
@@ -47,7 +47,7 @@ describe('withGameEngineBed', () => {
     await expect(withGameEngineBed(undefined, testFn)).rejects.toThrow('fail');
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    bedModule.GameEngineTestBed.mockRestore();
   });
 });
 
@@ -59,8 +59,8 @@ describe('withInitializedGameEngineBed', () => {
       cleanup: jest.fn(),
     };
     const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+      .spyOn(bedModule, 'GameEngineTestBed')
+      .mockImplementation(() => bed);
     const testFn = jest.fn();
 
     await withInitializedGameEngineBed({ b: 2 }, 'World', testFn);
@@ -79,7 +79,7 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    jest.spyOn(bedModule, 'GameEngineTestBed').mockImplementation(() => bed);
     const error = new Error('oops');
     const testFn = jest.fn().mockRejectedValue(error);
 
@@ -87,7 +87,7 @@ describe('withInitializedGameEngineBed', () => {
     expect(bed.initAndReset).toHaveBeenCalledWith('TestWorld');
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    bedModule.GameEngineTestBed.mockRestore();
   });
 
   it('passes initialized bed and engine to callback', async () => {
@@ -97,8 +97,8 @@ describe('withInitializedGameEngineBed', () => {
       cleanup: jest.fn(),
     };
     const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+      .spyOn(bedModule, 'GameEngineTestBed')
+      .mockImplementation(() => bed);
     const callOrder = [];
     bed.initAndReset.mockImplementation(() => {
       callOrder.push('init');
@@ -123,7 +123,7 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    jest.spyOn(bedModule, 'GameEngineTestBed').mockImplementation(() => bed);
     const error = new Error('fail');
     const testFn = jest.fn(() => {
       throw error;
@@ -133,7 +133,7 @@ describe('withInitializedGameEngineBed', () => {
     expect(bed.initAndReset).toHaveBeenCalledWith('TestWorld');
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    bedModule.GameEngineTestBed.mockRestore();
   });
 });
 


### PR DESCRIPTION
Summary:
- introduce reusable `withTestBed` helper for generic test beds
- refactor GameEngine helpers to use the new helper
- update tests to spy on `GameEngineTestBed` constructor

Testing Done:
- `npm run format`
- `npm run lint` *(fails: many existing repo issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685725a8949c8331b9d469a96430864e