### PR TITLE
[Agent] centralize default save world constant

### DIFF
--- a/tests/common/constants.js
+++ b/tests/common/constants.js
@@ -4,3 +4,10 @@
  * @type {string}
  */
 export const DEFAULT_TEST_WORLD = 'TestWorld';
+
+/**
+ * Default active world used when validating save-related dispatches.
+ *
+ * @type {string}
+ */
+export const DEFAULT_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';

--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -13,13 +13,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
 } from '../../../src/constants/eventIds.js';
-
-/**
- * Default world used for save dispatch helper.
- *
- * @type {string}
- */
-export const DEFAULT_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';
+import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
 
 /**
  * Asserts that dispatch calls match the provided event sequence.

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -3,13 +3,13 @@ import {
   expectDispatchSequence,
   expectSingleDispatch,
   buildSaveDispatches,
-  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   expectEngineStatus,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,
   expectComponentAddedDispatch,
   expectComponentRemovedDispatch,
 } from './dispatchTestUtils.js';
+import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
   ENGINE_READY_UI,

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -11,8 +11,8 @@ import '../../common/engine/engineTestTypedefs.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
-  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
 } from '../../common/engine/dispatchTestUtils.js';
+import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../../common/constants.js';
 
 describeEngineSuite('GameEngine', () => {
   describe('triggerManualSave', () => {


### PR DESCRIPTION
Summary: Exported `DEFAULT_ACTIVE_WORLD_FOR_SAVE` from `tests/common/constants.js` and updated test utilities and suites to import it from there. Removed local constant from `dispatchTestUtils.js`.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on changed files `npx eslint`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68572908ade48331b44205478ffbcffb