### PR TITLE
[Agent] Add generic TestBed helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -4,10 +4,8 @@
  */
 
 import { expect, jest } from '@jest/globals';
-import {
-  createGameEngineTestBed,
-  GameEngineTestBed,
-} from './gameEngineTestBed.js';
+import { GameEngineTestBed } from './gameEngineTestBed.js';
+import { withTestBed } from '../testBedUtils.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
 
 /**
@@ -20,13 +18,10 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
  * @returns {Promise<void>} Resolves when the callback completes.
  */
 export async function withGameEngineBed(overrides = {}, testFn) {
-  const bed = createGameEngineTestBed(overrides);
-  try {
+  await withTestBed(GameEngineTestBed, overrides, async (bed) => {
     bed.resetMocks();
     await testFn(bed, bed.engine);
-  } finally {
-    await bed.cleanup();
-  }
+  });
 }
 
 /**
@@ -56,13 +51,10 @@ export async function withInitializedGameEngineBed(overrides, world, testFn) {
     overrides = overrides || {};
     world = world || DEFAULT_TEST_WORLD;
   }
-  const bed = createGameEngineTestBed(overrides);
-  try {
+  await withTestBed(GameEngineTestBed, overrides, async (bed) => {
     await bed.initAndReset(world);
     await testFn(bed, bed.engine);
-  } finally {
-    await bed.cleanup();
-  }
+  });
 }
 
 /**

--- a/tests/common/testBedUtils.js
+++ b/tests/common/testBedUtils.js
@@ -1,0 +1,23 @@
+/**
+ * @file Utility functions for working with generic TestBeds.
+ */
+
+/**
+ * Executes a callback with a temporary test bed instance.
+ *
+ * @param {new (overrides?: any) => { cleanup: () => Promise<void> }} TestBedCtor -
+ *   Constructor for the test bed.
+ * @param {object} [overrides] - Optional overrides passed to the constructor.
+ * @param {(bed: any) => (Promise<void>|void)} callback - Function run with the test bed.
+ * @returns {Promise<void>} Resolves when the callback completes.
+ */
+export async function withTestBed(TestBedCtor, overrides = {}, callback) {
+  const bed = new TestBedCtor(overrides);
+  try {
+    await callback(bed);
+  } finally {
+    await bed.cleanup();
+  }
+}
+
+export default withTestBed;

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -10,6 +10,7 @@ import {
 } from '../../../common/engine/gameEngineHelpers.js';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import * as bedModule from '../../../common/engine/gameEngineTestBed.js';
+import * as utils from '../../../common/testBedUtils.js';
 
 describe('withGameEngineBed', () => {
   it('creates bed, resets mocks, runs callback and cleans up', async () => {
@@ -18,19 +19,26 @@ describe('withGameEngineBed', () => {
       resetMocks: jest.fn(),
       cleanup: jest.fn(),
     };
-    const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        await cb(bed);
+        await bed.cleanup();
+      });
     const testFn = jest.fn();
 
     await withGameEngineBed({ a: 1 }, testFn);
 
-    expect(createSpy).toHaveBeenCalledWith({ a: 1 });
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      { a: 1 },
+      expect.any(Function)
+    );
     expect(bed.resetMocks).toHaveBeenCalledTimes(1);
     expect(testFn).toHaveBeenCalledWith(bed, bed.engine);
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    createSpy.mockRestore();
+    spy.mockRestore();
   });
 
   it('cleans up even when callback throws', async () => {
@@ -39,15 +47,27 @@ describe('withGameEngineBed', () => {
       resetMocks: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        try {
+          await cb(bed);
+        } finally {
+          await bed.cleanup();
+        }
+      });
 
-    const error = new Error('fail');
-    const testFn = jest.fn().mockRejectedValue(error);
+    const testFn = jest.fn().mockRejectedValue(new Error('fail'));
 
     await expect(withGameEngineBed(undefined, testFn)).rejects.toThrow('fail');
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      {},
+      expect.any(Function)
+    );
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    spy.mockRestore();
   });
 });
 
@@ -58,19 +78,26 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        await cb(bed);
+        await bed.cleanup();
+      });
     const testFn = jest.fn();
 
     await withInitializedGameEngineBed({ b: 2 }, 'World', testFn);
 
-    expect(createSpy).toHaveBeenCalledWith({ b: 2 });
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      { b: 2 },
+      expect.any(Function)
+    );
     expect(bed.initAndReset).toHaveBeenCalledWith('World');
     expect(testFn).toHaveBeenCalledWith(bed, bed.engine);
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    createSpy.mockRestore();
+    spy.mockRestore();
   });
 
   it('uses defaults and cleans up on error', async () => {
@@ -79,15 +106,28 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        try {
+          await cb(bed);
+        } finally {
+          await bed.cleanup();
+        }
+      });
     const error = new Error('oops');
     const testFn = jest.fn().mockRejectedValue(error);
 
     await expect(withInitializedGameEngineBed(testFn)).rejects.toThrow('oops');
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      {},
+      expect.any(Function)
+    );
     expect(bed.initAndReset).toHaveBeenCalledWith('TestWorld');
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    spy.mockRestore();
   });
 
   it('passes initialized bed and engine to callback', async () => {
@@ -96,9 +136,12 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    const createSpy = jest
-      .spyOn(bedModule, 'createGameEngineTestBed')
-      .mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        await cb(bed);
+        await bed.cleanup();
+      });
     const callOrder = [];
     bed.initAndReset.mockImplementation(() => {
       callOrder.push('init');
@@ -109,12 +152,17 @@ describe('withInitializedGameEngineBed', () => {
 
     await withInitializedGameEngineBed({ c: 3 }, 'World', testFn);
 
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      { c: 3 },
+      expect.any(Function)
+    );
     expect(bed.initAndReset).toHaveBeenCalledWith('World');
     expect(testFn).toHaveBeenCalledWith(bed, bed.engine);
     expect(callOrder).toEqual(['init', 'callback']);
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    createSpy.mockRestore();
+    spy.mockRestore();
   });
 
   it('cleans up even when callback throws', async () => {
@@ -123,17 +171,30 @@ describe('withInitializedGameEngineBed', () => {
       initAndReset: jest.fn(),
       cleanup: jest.fn(),
     };
-    jest.spyOn(bedModule, 'createGameEngineTestBed').mockReturnValue(bed);
+    const spy = jest
+      .spyOn(utils, 'withTestBed')
+      .mockImplementation(async (_ctor, _ovr, cb) => {
+        try {
+          await cb(bed);
+        } finally {
+          await bed.cleanup();
+        }
+      });
     const error = new Error('fail');
     const testFn = jest.fn(() => {
       throw error;
     });
 
     await expect(withInitializedGameEngineBed(testFn)).rejects.toThrow('fail');
+    expect(spy).toHaveBeenCalledWith(
+      bedModule.GameEngineTestBed,
+      {},
+      expect.any(Function)
+    );
     expect(bed.initAndReset).toHaveBeenCalledWith('TestWorld');
     expect(bed.cleanup).toHaveBeenCalledTimes(1);
 
-    bedModule.createGameEngineTestBed.mockRestore();
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Summary: Added a reusable `withTestBed` helper for temporary TestBed usage and refactored GameEngine helpers to leverage it. Updated unit tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` (fails: see output)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685728e6d63c8331af16b2dc8a2217cc