### PR TITLE
[Agent] Remove _isValidManager helper

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -12,17 +12,6 @@ import {
 } from './entityValidationUtils.js';
 import { isNonBlankString } from './textUtils.js';
 
-/**
- * Checks that the manager or entity exposes a `getComponentData` method.
- *
- * @param {*} mgr - Value to validate.
- * @returns {boolean} True if `mgr.getComponentData` is a function.
- * @private
- */
-function _isValidManager(mgr) {
-  return !!mgr && typeof mgr.getComponentData === 'function';
-}
-
 /** @typedef {import('../entities/entity.js').default} Entity */
 
 /**
@@ -38,7 +27,7 @@ function _isValidManager(mgr) {
 export function getComponentFromEntity(entity, componentId, logger) {
   const log = getPrefixedLogger(logger, '[componentAccessUtils] ');
 
-  if (!isNonBlankString(componentId) || !_isValidManager(entity)) {
+  if (!isNonBlankString(componentId) || !isValidEntity(entity)) {
     log.debug('getComponentFromEntity: invalid entity or componentId.');
     return null;
   }
@@ -83,7 +72,7 @@ export function getComponentFromManager(
     return null;
   }
 
-  if (!_isValidManager(entityManager)) {
+  if (!isValidEntityManager(entityManager)) {
     log.debug('getComponentFromManager: invalid entityManager provided.');
     return null;
   }

--- a/tests/unit/utils/componentAccessUtils.test.js
+++ b/tests/unit/utils/componentAccessUtils.test.js
@@ -80,6 +80,10 @@ class MockManager {
     const comps = this._data.get(entityId);
     return comps ? comps[componentId] : undefined;
   }
+
+  getEntityInstance(id) {
+    return this._data.has(id) ? { id } : null;
+  }
 }
 
 describe('getComponentFromManager', () => {
@@ -107,6 +111,19 @@ describe('getComponentFromManager', () => {
     expect(getComponentFromManager('', 'foo', mgr, logger)).toBeNull();
     expect(logger.debug).toHaveBeenCalledWith(
       '[componentAccessUtils] getComponentFromManager: invalid entityId or componentId.'
+    );
+  });
+
+  it('returns null and logs debug for invalid manager', () => {
+    const logger = createMockLogger();
+    const mgr = {
+      getComponentData() {
+        return {};
+      },
+    };
+    expect(getComponentFromManager('e1', 'foo', mgr, logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[componentAccessUtils] getComponentFromManager: invalid entityManager provided.'
     );
   });
 


### PR DESCRIPTION
Summary: Remove duplicate `_isValidManager` helper in `componentAccessUtils.js` and replace usages with `isValidEntity` and `isValidEntityManager`. Updated unit tests accordingly.

Testing Done:
- [x] Code formatted (`npx prettier -w src/utils/componentAccessUtils.js tests/unit/utils/componentAccessUtils.test.js`)
- [x] Lint passes on changed files (`npx eslint src/utils/componentAccessUtils.js tests/unit/utils/componentAccessUtils.test.js`)
- [x] Root tests (`npm run test`)
- [x] Proxy tests (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68572b9a34748331b093e0407c0092db