### PR TITLE
[Feat] add stop dispatch test util

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -12,6 +12,7 @@ import {
   ENTITY_REMOVED_ID,
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
+  ENGINE_STOPPED_UI,
 } from '../../../src/constants/eventIds.js';
 import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
 
@@ -72,6 +73,20 @@ export function buildSaveDispatches(saveName, filePath) {
   ]);
 
   return sequence;
+}
+
+/**
+ * Builds the dispatch sequence emitted when the engine stops.
+ *
+ * @returns {Array<[string, any]>} Dispatch call sequence for engine stop.
+ */
+export function buildStopDispatches() {
+  return [
+    [
+      ENGINE_STOPPED_UI,
+      { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
+    ],
+  ];
 }
 
 /**
@@ -176,6 +191,7 @@ export { expectDispatchSequence as expectDispatchCalls };
 export default {
   expectDispatchSequence,
   buildSaveDispatches,
+  buildStopDispatches,
   expectEngineStatus,
   expectSingleDispatch,
   expectEntityCreatedDispatch,

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -3,6 +3,7 @@ import {
   expectDispatchSequence,
   expectSingleDispatch,
   buildSaveDispatches,
+  buildStopDispatches,
   expectEngineStatus,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,
@@ -18,6 +19,7 @@ import {
   ENTITY_REMOVED_ID,
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
+  ENGINE_STOPPED_UI,
 } from '../../../src/constants/eventIds.js';
 
 describe('dispatchTestUtils', () => {
@@ -108,6 +110,18 @@ describe('dispatchTestUtils', () => {
             activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
             message: 'Save operation finished. Ready.',
           },
+        ],
+      ]);
+    });
+  });
+
+  describe('buildStopDispatches', () => {
+    it('returns expected stop dispatch sequence', () => {
+      const result = buildStopDispatches();
+      expect(result).toEqual([
+        [
+          ENGINE_STOPPED_UI,
+          { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
         ],
       ]);
     });


### PR DESCRIPTION
Summary: Implemented `buildStopDispatches` in test utilities to standardize engine stop dispatch sequences.

Changes Made:
- Added new `buildStopDispatches` helper returning the expected `ENGINE_STOPPED_UI` dispatch.
- Documented the function with JSDoc comments and updated exports.
- Created corresponding unit tests verifying the dispatch sequence.

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes on modified files (`npx eslint`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68572b7d14ac833191287796c7b9d914