### PR TITLE
[Agent] remove redundant afterEach cleanup

### DIFF
--- a/tests/unit/turns/turnManager.errorHandling.test.js
+++ b/tests/unit/turns/turnManager.errorHandling.test.js
@@ -3,7 +3,7 @@
 
 import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 import { createMockTurnHandler } from '../../common/mockFactories';
 import { createDefaultActors } from '../../common/turns/testActors.js';
 
@@ -26,12 +26,6 @@ describeTurnManagerSuite('TurnManager - Error Handling', (getBed) => {
 
     // Default Mocks setup - configure specifically within each test if needed
     // to avoid mock state leaking or becoming confusing.
-  });
-
-  afterEach(async () => {
-    // Clears mock usage data between tests
-    jest.clearAllMocks();
-    // Timer cleanup handled by BaseTestBed
   });
 
   test('should stop advancing if handlerResolver fails', async () => {

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -7,7 +7,7 @@ import {
   TURN_ENDED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, afterEach } from '@jest/globals';
+import { beforeEach, expect, jest } from '@jest/globals';
 import { createMockTurnHandler } from '../../common/mockFactories';
 import { createAiActor } from '../../common/turns/testActors.js';
 
@@ -29,10 +29,6 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
     advanceTurnSpy.mockResolvedValue(undefined);
 
     testBed.resetMocks();
-  });
-
-  afterEach(async () => {
-    jest.clearAllMocks(); // General cleanup
   });
 
   // --- start() Tests (Largely Unchanged) ---

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -9,7 +9,7 @@ import {
   TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
-import { beforeEach, expect, jest, test, afterEach } from '@jest/globals';
+import { beforeEach, expect, test } from '@jest/globals';
 import {
   createDefaultActors,
   createAiActor,
@@ -46,11 +46,6 @@ describeTurnManagerSuite(
       stopSpy = testBed.spyOnStop();
 
       testBed.resetMocks();
-    });
-
-    afterEach(async () => {
-      jest.clearAllMocks();
-      // Timer cleanup handled by BaseTestBed
     });
 
     test('Starts a new round when queue is empty and active actors exist', async () => {


### PR DESCRIPTION
Summary: Removes unnecessary afterEach hooks from TurnManager unit tests. These hooks only cleared mocks, which TurnManagerTestBed.cleanup already handles.

Testing Done:
- [x] Code formatted `npx prettier --write tests/unit/turns/turnManager.errorHandling.test.js tests/unit/turns/turnManager.lifecycle.test.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- [x] Lint passes `npx eslint tests/unit/turns/turnManager.errorHandling.test.js tests/unit/turns/turnManager.lifecycle.test.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68572b69683c8331bbda3687331f744c