### PR TITLE
[Agent] use dispatch helpers in entityManager tests

### DIFF
--- a/tests/unit/entities/entityManager.components.test.js
+++ b/tests/unit/entities/entityManager.components.test.js
@@ -15,10 +15,9 @@ import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js'
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 import { ValidationError } from '../../../src/errors/validationError.js';
 import {
-  COMPONENT_ADDED_ID,
-  COMPONENT_REMOVED_ID,
-} from '../../../src/constants/eventIds.js';
-import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
+  expectComponentAddedDispatch,
+  expectComponentRemovedDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite(
   'EntityManager - Component Manipulation',
@@ -83,15 +82,12 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectSingleDispatch(
+        expectComponentAddedDispatch(
           mocks.eventDispatcher.dispatch,
-          COMPONENT_ADDED_ID,
-          {
-            entity: entity,
-            componentTypeId: NEW_COMPONENT_ID,
-            componentData: NEW_COMPONENT_DATA,
-            oldComponentData: undefined,
-          }
+          entity,
+          NEW_COMPONENT_ID,
+          NEW_COMPONENT_DATA,
+          undefined
         );
       });
 
@@ -143,15 +139,12 @@ describeEntityManagerSuite(
         );
 
         // Assert
-        expectSingleDispatch(
+        expectComponentAddedDispatch(
           mocks.eventDispatcher.dispatch,
-          COMPONENT_ADDED_ID,
-          {
-            entity: entity,
-            componentTypeId: NAME_COMPONENT_ID,
-            componentData: UPDATED_NAME_DATA,
-            oldComponentData: originalNameData,
-          }
+          entity,
+          NAME_COMPONENT_ID,
+          UPDATED_NAME_DATA,
+          originalNameData
         );
       });
 
@@ -326,14 +319,11 @@ describeEntityManagerSuite(
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
         // Assert
-        expectSingleDispatch(
+        expectComponentRemovedDispatch(
           mocks.eventDispatcher.dispatch,
-          COMPONENT_REMOVED_ID,
-          {
-            entity: entity,
-            componentTypeId: NAME_COMPONENT_ID,
-            oldComponentData: overrideData,
-          }
+          entity,
+          NAME_COMPONENT_ID,
+          overrideData
         );
       });
 

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -20,10 +20,9 @@ import { DefinitionNotFoundError } from '../../../src/errors/definitionNotFoundE
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
 import { DuplicateEntityError } from '../../../src/errors/duplicateEntityError.js';
 import {
-  ENTITY_CREATED_ID,
-  ENTITY_REMOVED_ID,
-} from '../../../src/constants/eventIds.js';
-import { expectSingleDispatch } from '../../common/engine/dispatchTestUtils.js';
+  expectEntityCreatedDispatch,
+  expectEntityRemovedDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 import { MapManager } from '../../../src/utils/mapManagerUtils.js';
 import { buildSerializedEntity } from '../../common/entities/index.js';
@@ -124,10 +123,11 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = getBed().createBasicEntity();
 
       // Assert
-      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
+      expectEntityCreatedDispatch(
+        mocks.eventDispatcher.dispatch,
         entity,
-        wasReconstructed: false,
-      });
+        false
+      );
     });
 
     it('should throw a DefinitionNotFoundError if the definitionId does not exist', () => {
@@ -257,10 +257,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       const entity = entityManager.reconstructEntity(serializedEntity);
 
       // Assert
-      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_CREATED_ID, {
-        entity,
-        wasReconstructed: true,
-      });
+      expectEntityCreatedDispatch(mocks.eventDispatcher.dispatch, entity, true);
     });
 
     it('should throw a DefinitionNotFoundError if the definition is not found', () => {
@@ -384,9 +381,7 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       entityManager.removeEntityInstance(entity.id);
 
       // Assert
-      expectSingleDispatch(mocks.eventDispatcher.dispatch, ENTITY_REMOVED_ID, {
-        entity,
-      });
+      expectEntityRemovedDispatch(mocks.eventDispatcher.dispatch, entity);
     });
 
     it('should throw an EntityNotFoundError when trying to remove a non-existent entity', () => {


### PR DESCRIPTION
## Summary
- refactor entityManager component tests to use new dispatch helpers
- refactor entityManager lifecycle tests to use new dispatch helpers

## Testing Done
- `npm run format`
- `npx eslint tests/unit/entities/entityManager.components.test.js tests/unit/entities/entityManager.lifecycle.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68572b70446c8331b4001068f9082045