### PR TITLE
[Agent] replace stop dispatch expectations

### DIFF
--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -5,7 +5,11 @@ import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
-import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
+import {
+  expectDispatchSequence,
+  buildStopDispatches,
+  expectEngineStatus,
+} from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   const MOCK_WORLD_NAME = 'TestWorld';
@@ -30,9 +34,9 @@ describeEngineSuite('GameEngine', (ctx) => {
       ).toHaveBeenCalledTimes(1);
       expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
 
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENGINE_STOPPED_UI,
-        { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
+      expectDispatchSequence(
+        ctx.bed.mocks.safeEventDispatcher.dispatch,
+        ...buildStopDispatches()
       );
 
       expectEngineStatus(ctx.engine, {
@@ -84,9 +88,9 @@ describeEngineSuite('GameEngine', (ctx) => {
           await engine.stop();
 
           expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
-          expect(bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-            ENGINE_STOPPED_UI,
-            { inputDisabledMessage: 'Game stopped. Engine is inactive.' }
+          expectDispatchSequence(
+            bed.mocks.safeEventDispatcher.dispatch,
+            ...buildStopDispatches()
           );
           expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
           const dummyDispatch = jest.fn();


### PR DESCRIPTION
Summary: Replaced explicit dispatch checks in `stop` tests with `expectDispatchSequence` using `buildStopDispatches` for improved clarity.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails: 562 errors, 2294 warnings)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685732586ad08331ae4ac900ef7044cf