### PR TITLE
[Agent] Optimize length caching in StringAccumulator

### DIFF
--- a/src/utils/stringAccumulatorUtils.js
+++ b/src/utils/stringAccumulatorUtils.js
@@ -19,13 +19,29 @@ export class StringAccumulator {
   #parts = [];
 
   /**
+   * @private
+   * @type {number}
+   * @description Cached total length of all parts.
+   */
+  #length = 0;
+
+  /**
+   * Initializes a new StringAccumulator instance.
+   */
+  constructor() {
+    this.#length = 0;
+  }
+
+  /**
    * Appends a value to the accumulator, coercing it to a string.
    *
    * @param {any} value - The value to append; will be converted via `String(value)`.
    * @returns {void}
    */
   append(value) {
-    this.#parts.push(String(value));
+    const part = String(value);
+    this.#parts.push(part);
+    this.#length += part.length;
   }
 
   /**
@@ -44,6 +60,6 @@ export class StringAccumulator {
    * @returns {number} Sum of `.length` of each part.
    */
   get length() {
-    return this.#parts.reduce((sum, part) => sum + part.length, 0);
+    return this.#length;
   }
 }

--- a/tests/unit/utils/stringAccumulatorUtils.test.js
+++ b/tests/unit/utils/stringAccumulatorUtils.test.js
@@ -4,6 +4,18 @@ import { StringAccumulator } from '../../../src/utils/stringAccumulatorUtils.js'
 import { describe, test, expect } from '@jest/globals';
 
 describe('StringAccumulator', () => {
+  test('length begins at 0', () => {
+    const acc = new StringAccumulator();
+    expect(acc.length).toBe(0);
+  });
+
+  test('length increments correctly', () => {
+    const acc = new StringAccumulator();
+    acc.append('a');
+    expect(acc.length).toBe(1);
+    acc.append('bc');
+    expect(acc.length).toBe(3);
+  });
   test('append sequence returns correct final string', () => {
     const acc = new StringAccumulator();
     acc.append('a');


### PR DESCRIPTION
Summary:
- refactor StringAccumulator to maintain a cached length
- expose new tests verifying initial and incremental length values

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857347e973c8331a5f2cb9a48bd7a9b