### PR TITLE
[Agent] add service test environment helper

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -15,7 +15,10 @@ import {
   createMockSafeEventDispatcher,
   createMockInitializationService,
 } from '../mockFactories';
-import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+import {
+  createTestEnvironmentBuilder,
+  createServiceTestEnvironment,
+} from '../mockEnvironment.js';
 const factoryMap = {
   logger: createMockLogger,
   entityManager: createMockEntityManager,
@@ -62,8 +65,14 @@ const buildGameEngineEnv = createTestEnvironmentBuilder(
  *   Test environment utilities and mocks.
  */
 export function createTestEnvironment(overrides = {}) {
-  const { mocks, mockContainer, instance, cleanup } =
-    buildGameEngineEnv(overrides);
+  const hasOverrides = Object.keys(overrides).length > 0;
+  const { mocks, mockContainer, instance, cleanup } = hasOverrides
+    ? buildGameEngineEnv(overrides)
+    : createServiceTestEnvironment(
+        factoryMap,
+        tokenMap,
+        (container) => new GameEngine({ container })
+      );
 
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -20,7 +20,7 @@ import {
   createMockWorldLoader, // ← NEW import
 } from '../mockFactories';
 import { createLoaderMocks } from './modsLoader.test-utils.js';
-import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+import { createServiceTestEnvironment } from '../mockEnvironment.js';
 
 /**
  * List of loader types used when generating mock loaders.
@@ -62,37 +62,35 @@ export function createTestEnvironment() {
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);
 
-  const buildEnv = createTestEnvironmentBuilder(
-    factoryMap,
-    {},
-    (mockContainer, m) => {
-      m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
-        [
-          'schema:game',
-          'schema:components',
-          'schema:mod-manifest',
-          'schema:entityDefinitions',
-          'schema:actions',
-          'schema:events',
-          'schema:rules',
-          'schema:conditions',
-          'schema:entityInstances',
-          'schema:goals',
-        ].includes(id)
-      );
-      m.mockModDependencyValidator.validate.mockImplementation(() => {});
-      m.mockModVersionValidator.mockImplementation(() => {});
-      m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
+  const {
+    mocks,
+    instance: modsLoader,
+    cleanup,
+  } = createServiceTestEnvironment(factoryMap, {}, (mockContainer, m) => {
+    m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
+      [
+        'schema:game',
+        'schema:components',
+        'schema:mod-manifest',
+        'schema:entityDefinitions',
+        'schema:actions',
+        'schema:events',
+        'schema:rules',
+        'schema:conditions',
+        'schema:entityInstances',
+        'schema:goals',
+      ].includes(id)
+    );
+    m.mockModDependencyValidator.validate.mockImplementation(() => {});
+    m.mockModVersionValidator.mockImplementation(() => {});
+    m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
 
-      return new ModsLoader({
-        logger: m.mockLogger,
-        cache: { clear: jest.fn(), snapshot: jest.fn(), restore: jest.fn() },
-        session: { run: jest.fn().mockResolvedValue({}) },
-      });
-    }
-  );
-
-  const { mocks, instance: modsLoader, cleanup } = buildEnv();
+    return new ModsLoader({
+      logger: m.mockLogger,
+      cache: { clear: jest.fn(), snapshot: jest.fn(), restore: jest.fn() },
+      session: { run: jest.fn().mockResolvedValue({}) },
+    });
+  });
 
   /* ── Return the assembled environment ──────────────────────────────── */
   return {

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -128,3 +128,28 @@ export function createTestEnvironmentBuilder(factoryMap, tokenMap, createFn) {
     return buildEnvironment(factoryMap, tokenMap, overrides, createFn);
   };
 }
+
+/**
+ * Builds and immediately returns a test environment for a service.
+ *
+ * @description Convenience helper around {@link createTestEnvironmentBuilder}
+ *   that invokes the returned builder with no overrides.
+ * @param {Record<string, () => any>} factoryMap - Map of mock factory
+ *   functions to create.
+ * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
+ *   Map of DI tokens to mock keys, provider callbacks or constant values.
+ * @param {(container: any, mocks: Record<string, any>) => any} [createFn]
+ *   Function returning the system under test when provided the mock container
+ *   and generated mocks.
+ * @returns {{
+ *   mocks: Record<string, any>,
+ *   mockContainer: { resolve: jest.Mock },
+ *   instance: any,
+ *   cleanup: () => void,
+ * }}
+ *   Generated environment instance.
+ */
+export function createServiceTestEnvironment(factoryMap, tokenMap, createFn) {
+  const build = createTestEnvironmentBuilder(factoryMap, tokenMap, createFn);
+  return build();
+}


### PR DESCRIPTION
## Summary
- add `createServiceTestEnvironment` helper
- use helper in `modsLoader` and `gameEngine` test environments

## Testing Done
- `npx prettier tests/common/mockEnvironment.js tests/common/engine/gameEngine.test-environment.js tests/common/loaders/modsLoader.test-setup.js --write`
- `npx eslint tests/common/mockEnvironment.js tests/common/engine/gameEngine.test-environment.js tests/common/loaders/modsLoader.test-setup.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685734560f0483318f107269bc8884e5