### PR TITLE
[Agent] add expectSystemErrorDispatch helper

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -1,0 +1,33 @@
+/**
+ * @file Utility assertions for TurnManager dispatches.
+ * @see tests/common/turns/turnManagerTestUtils.js
+ */
+
+import { expect } from '@jest/globals';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+
+/**
+ * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
+ * payload structure used across TurnManager tests.
+ *
+ * @param {import('@jest/globals').Mock} mockDispatch - Mocked dispatch function.
+ * @param {string} message - Expected public error message.
+ * @param {string} [rawMessage] - Expected raw error message in details.
+ * @returns {void}
+ */
+export function expectSystemErrorDispatch(
+  mockDispatch,
+  message,
+  rawMessage = message
+) {
+  expect(mockDispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
+    message,
+    details: {
+      raw: rawMessage,
+      stack: expect.any(String),
+      timestamp: expect.any(String),
+    },
+  });
+}
+
+export default { expectSystemErrorDispatch };


### PR DESCRIPTION
## Summary
- add `expectSystemErrorDispatch` for TurnManager tests

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685734383b148331ab66b81ad7ab0907