### PR TITLE
[Agent] add startWithEntitiesAndFlush helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -111,6 +111,17 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
   }
 
   /**
+   * Starts the manager with entities then flushes timers/promises.
+   *
+   * @param {...{ id: string }} entities - Entities to register as active.
+   * @returns {Promise<void>} Resolves once timers are flushed.
+   */
+  async startWithEntitiesAndFlush(...entities) {
+    await this.startWithEntities(...entities);
+    await flushPromisesAndTimers();
+  }
+
+  /**
    * Spies on {@link TurnManager.stop} and tracks for cleanup.
    *
    * @returns {import('@jest/globals').Mock} The spy instance.
@@ -285,4 +296,16 @@ export const describeTurnManagerSuite = createDescribeTestBedSuite(
 );
 
 export default TurnManagerTestBed;
+
+/**
+ * Convenience export for {@link TurnManagerTestBed#startWithEntitiesAndFlush}.
+ *
+ * @param {TurnManagerTestBed} bed - Test bed instance.
+ * @param {...{ id: string }} entities - Entities to register as active.
+ * @returns {Promise<void>} Resolves once timers are flushed.
+ */
+export async function startWithEntitiesAndFlush(bed, ...entities) {
+  await bed.startWithEntitiesAndFlush(...entities);
+}
+
 export { flushPromisesAndTimers };

--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -132,6 +132,20 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
     await bed.cleanup();
   });
 
+  it('startWithEntitiesAndFlush adds entities and flushes timers', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false });
+    const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
+    const entity = { id: 'x' };
+    const fn = jest.fn();
+    setTimeout(fn, 50);
+    await bed.startWithEntitiesAndFlush(entity);
+    expect(bed.turnManager.start).toHaveBeenCalled();
+    expect(bed.entityManager.activeEntities.get('x')).toBe(entity);
+    expect(fn).toHaveBeenCalled();
+    jest.useRealTimers();
+    await bed.cleanup();
+  });
+
   it('spy helpers restore spies during cleanup', async () => {
     const bed = new TurnManagerTestBed({ TurnManagerClass: RealManager });
     const stopSpy = bed.spyOnStop();


### PR DESCRIPTION
Summary: Added startWithEntitiesAndFlush method in TurnManagerTestBed and exported helper for tests. Updated unit tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 562 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857342f159c83318ef469a85ef23681