### PR TITLE
[Agent] Add wrapper tests and logger validation

### DIFF
--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -4,6 +4,7 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 import { safeResolvePath } from './objectUtils.js';
 import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
+import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * Regex to find placeholders like {path.to.value} within a string.
@@ -42,7 +43,7 @@ export class PlaceholderResolver {
    * @param {ILogger} [logger] - An optional logger instance. If not provided, `console` will be used.
    */
   constructor(logger = console) {
-    this.#logger = logger;
+    this.#logger = ensureValidLogger(logger, 'PlaceholderResolver');
   }
 
   /**

--- a/src/utils/wrapperUtils.js
+++ b/src/utils/wrapperUtils.js
@@ -11,7 +11,8 @@
  * @param {object} ctx - Context for resolution.
  * @returns {{ prefix: string, suffix: string }} Resolved prefix & suffix.
  */
-export function resolveWrapper({ prefix = '', suffix = '' }, resolver, ctx) {
+export function resolveWrapper(wrappers = {}, resolver, ctx) {
+  const { prefix = '', suffix = '' } = wrappers || {};
   return {
     prefix: resolver.resolve(prefix, ctx),
     suffix: resolver.resolve(suffix, ctx),

--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -9,6 +9,7 @@ import {
   afterEach,
 } from '@jest/globals';
 import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js'; // Adjust path as needed
+import * as loggerUtils from '../../../src/utils/loggerUtils.js';
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed (assuming testUtils.js from previous adjustment)
 import { NAME_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 
@@ -39,6 +40,24 @@ describe('PlaceholderResolver', () => {
       expect(resolverWithoutLogger).toBeInstanceOf(PlaceholderResolver);
       // To truly test console, one might spy on global.console.warn temporarily.
       // For now, this is an implicit check.
+    });
+
+    it('validates the logger via ensureValidLogger', () => {
+      const spy = jest.spyOn(loggerUtils, 'ensureValidLogger');
+      const logger = createMockLogger();
+      const r = new PlaceholderResolver(logger);
+      expect(spy).toHaveBeenCalledWith(logger, 'PlaceholderResolver');
+      r.resolve('x {missing}', {});
+      spy.mockRestore();
+    });
+
+    it('falls back to console when logger is invalid', () => {
+      const badLogger = { log: 123 };
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const resolverWithBad = new PlaceholderResolver(badLogger);
+      resolverWithBad.resolve('hi {missing}', {});
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 

--- a/tests/unit/utils/wrapperUtils.test.js
+++ b/tests/unit/utils/wrapperUtils.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveWrapper } from '../../../src/utils/wrapperUtils.js';
+
+class MockResolver {
+  resolve(text, ctx) {
+    return `[${text}|${ctx.key}]`;
+  }
+}
+
+describe('resolveWrapper', () => {
+  const resolver = new MockResolver();
+  const ctx = { key: 'A' };
+
+  it('resolves defaults when no values provided', () => {
+    const result = resolveWrapper({}, resolver, ctx);
+    expect(result).toEqual({ prefix: '[|A]', suffix: '[|A]' });
+  });
+
+  it('resolves custom prefix only', () => {
+    const result = resolveWrapper({ prefix: 'P' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[P|A]', suffix: '[|A]' });
+  });
+
+  it('resolves custom suffix only', () => {
+    const result = resolveWrapper({ suffix: 'S' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[|A]', suffix: '[S|A]' });
+  });
+
+  it('resolves both prefix and suffix', () => {
+    const result = resolveWrapper({ prefix: 'P', suffix: 'S' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[P|A]', suffix: '[S|A]' });
+  });
+
+  it('handles null or undefined wrapper input', () => {
+    expect(resolveWrapper(null, resolver, ctx)).toEqual({
+      prefix: '[|A]',
+      suffix: '[|A]',
+    });
+    expect(resolveWrapper(undefined, resolver, ctx)).toEqual({
+      prefix: '[|A]',
+      suffix: '[|A]',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate logger via ensureValidLogger in PlaceholderResolver
- make wrapperUtils handle null inputs
- add tests for resolveWrapper helper
- extend PlaceholderResolver tests for logger validation

## Testing Done
- `npm run lint`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857349e63308331ae054bab883895c1