### PR TITLE
[Agent] Add capturing event bus for system tests

### DIFF
--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -9,6 +9,7 @@ export {
   createMockDataFetcher,
   createMockDataFetcherForIntegration,
   createMockValidatedEventDispatcherForIntegration,
+  createCapturingEventBus,
   createMockAIPromptPipeline,
 } from './coreServices.js';
 


### PR DESCRIPTION
Summary: Implemented a new `createCapturingEventBus` factory to record dispatched events. Updated the mock factory index and `createRuleTestEnvironment` to use this bus when none is provided and expose captured events.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on modified files `npx eslint tests/common/mockFactories/coreServices.js tests/common/mockFactories/index.js tests/common/engine/systemLogicTestEnv.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68573cefcaec83319693c5e88cc8f143