### PR TITLE
[Agent] add wrapper utils tests and logger validation

### DIFF
--- a/src/utils/wrapperUtils.js
+++ b/src/utils/wrapperUtils.js
@@ -6,12 +6,13 @@
 /**
  * Resolves the prefix and suffix strings using the provided resolver and context.
  *
- * @param {{prefix?: string, suffix?: string}} wrappers - Raw prefix/suffix.
+ * @param {{prefix?: string, suffix?: string}|null|undefined} wrappers - Raw prefix/suffix.
  * @param {import('./placeholderResolverUtils.js').PlaceholderResolver} resolver - Placeholder resolver.
  * @param {object} ctx - Context for resolution.
  * @returns {{ prefix: string, suffix: string }} Resolved prefix & suffix.
  */
-export function resolveWrapper({ prefix = '', suffix = '' }, resolver, ctx) {
+export function resolveWrapper(wrappers, resolver, ctx) {
+  const { prefix = '', suffix = '' } = wrappers || {};
   return {
     prefix: resolver.resolve(prefix, ctx),
     suffix: resolver.resolve(suffix, ctx),

--- a/tests/unit/utils/wrapperUtils.test.js
+++ b/tests/unit/utils/wrapperUtils.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveWrapper } from '../../../src/utils/wrapperUtils.js';
+
+class MockResolver {
+  resolve(text, ctx) {
+    return `[${text}|${ctx.key}]`;
+  }
+}
+
+describe('resolveWrapper', () => {
+  const ctx = { key: 'A' };
+  const resolver = new MockResolver();
+
+  it('defaults prefix and suffix when not provided', () => {
+    const result = resolveWrapper({}, resolver, ctx);
+    expect(result).toEqual({ prefix: '[|A]', suffix: '[|A]' });
+  });
+
+  it('resolves custom prefix only', () => {
+    const result = resolveWrapper({ prefix: 'P' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[P|A]', suffix: '[|A]' });
+  });
+
+  it('resolves custom suffix only', () => {
+    const result = resolveWrapper({ suffix: 'S' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[|A]', suffix: '[S|A]' });
+  });
+
+  it('resolves both prefix and suffix', () => {
+    const result = resolveWrapper({ prefix: 'P', suffix: 'S' }, resolver, ctx);
+    expect(result).toEqual({ prefix: '[P|A]', suffix: '[S|A]' });
+  });
+
+  it('handles null or undefined wrapper inputs', () => {
+    const resNull = resolveWrapper(null, resolver, ctx);
+    const resUndefined = resolveWrapper(undefined, resolver, ctx);
+    expect(resNull).toEqual({ prefix: '[|A]', suffix: '[|A]' });
+    expect(resUndefined).toEqual({ prefix: '[|A]', suffix: '[|A]' });
+  });
+});


### PR DESCRIPTION
## Summary
- handle null inputs in `resolveWrapper` and add unit tests
- verify `PlaceholderResolver` validates malformed loggers

## Testing Done
- `npm run format`
- `npx eslint src/utils/wrapperUtils.js tests/unit/utils/wrapperUtils.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68573cdd02e883318637197575a02393