### PR TITLE
[Agent] Centralize test world constant

### DIFF
--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -4,12 +4,11 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeInitializedEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
+import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 import {
   REQUEST_SHOW_SAVE_GAME_UI,
   CANNOT_SAVE_GAME_INFO,
 } from '../../../src/constants/eventIds.js';
-
-const MOCK_WORLD_NAME = 'TestWorld';
 
 describeInitializedEngineSuite(
   'GameEngine',
@@ -84,5 +83,5 @@ describeInitializedEngineSuite(
       );
     });
   },
-  MOCK_WORLD_NAME
+  DEFAULT_TEST_WORLD
 );

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
+import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
 import {
   ENGINE_INITIALIZING_UI,
@@ -13,8 +14,6 @@ import {
 import { expectEngineStatus } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  const MOCK_WORLD_NAME = 'TestWorld';
-
   describe('startNewGame', () => {
     beforeEach(() => {
       ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
@@ -25,11 +24,11 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should successfully start a new game', async () => {
-      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
 
       expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_INITIALIZING_UI,
-        { worldName: MOCK_WORLD_NAME },
+        { worldName: DEFAULT_TEST_WORLD },
         { allowSchemaNotFound: true }
       );
       expect(ctx.bed.mocks.entityManager.clearAll).toHaveBeenCalled();
@@ -39,12 +38,12 @@ describeEngineSuite('GameEngine', (ctx) => {
       );
       expect(
         ctx.bed.mocks.initializationService.runInitializationSequence
-      ).toHaveBeenCalledWith(MOCK_WORLD_NAME);
+      ).toHaveBeenCalledWith(DEFAULT_TEST_WORLD);
       expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
       expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_READY_UI,
         {
-          activeWorld: MOCK_WORLD_NAME,
+          activeWorld: DEFAULT_TEST_WORLD,
           message: 'Enter command...',
         }
       );
@@ -53,7 +52,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expectEngineStatus(ctx.engine, {
         isInitialized: true,
         isLoopRunning: true,
-        activeWorld: MOCK_WORLD_NAME,
+        activeWorld: DEFAULT_TEST_WORLD,
       });
     });
 
@@ -66,7 +65,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }
       );
-      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
 
       expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         'GameEngine._prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
@@ -82,14 +81,14 @@ describeEngineSuite('GameEngine', (ctx) => {
       expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_READY_UI,
         {
-          activeWorld: MOCK_WORLD_NAME,
+          activeWorld: DEFAULT_TEST_WORLD,
           message: 'Enter command...',
         }
       );
       expectEngineStatus(ctx.engine, {
         isInitialized: true,
         isLoopRunning: true,
-        activeWorld: MOCK_WORLD_NAME,
+        activeWorld: DEFAULT_TEST_WORLD,
       });
     });
 
@@ -102,7 +101,7 @@ describeEngineSuite('GameEngine', (ctx) => {
         }
       );
 
-      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
         initError
       );
 
@@ -130,7 +129,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       ctx.bed.mocks.playtimeTracker.startSession.mockImplementation(() => {}); // Make sure this doesn't throw
       ctx.bed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
 
-      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
         startupError
       );
 

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -4,6 +4,7 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
+import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
@@ -12,8 +13,6 @@ import {
 } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  const MOCK_WORLD_NAME = 'TestWorld';
-
   describe('stop', () => {
     beforeEach(() => {
       // Ensure engine is fresh for each 'stop' test
@@ -25,7 +24,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           success: true,
         }
       );
-      await ctx.bed.startAndReset(MOCK_WORLD_NAME); // Start the game first and clear mocks
+      await ctx.bed.startAndReset(DEFAULT_TEST_WORLD); // Start the game first and clear mocks
 
       await ctx.engine.stop();
 
@@ -82,7 +81,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           expectEngineStatus(engine, {
             isInitialized: true,
             isLoopRunning: true,
-            activeWorld: MOCK_WORLD_NAME,
+            activeWorld: DEFAULT_TEST_WORLD,
           });
 
           await engine.stop();


### PR DESCRIPTION
Summary: Replaced local `MOCK_WORLD_NAME` in several engine tests with the shared `DEFAULT_TEST_WORLD` constant, improving consistency across suites.

Testing Done:
- [x] Code formatted `npx prettier -w tests/unit/engine/startNewGame.test.js tests/unit/engine/stop.test.js tests/unit/engine/showSaveGameUI.test.js`
- [x] Lint passes on changed files `npx eslint tests/unit/engine/startNewGame.test.js tests/unit/engine/stop.test.js tests/unit/engine/showSaveGameUI.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68573c0746048331b56178da7a7a8039