### PR TITLE
[Agent] replace MOCK_WORLD_NAME constant

### DIFF
--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -8,8 +8,7 @@ import {
   REQUEST_SHOW_SAVE_GAME_UI,
   CANNOT_SAVE_GAME_INFO,
 } from '../../../src/constants/eventIds.js';
-
-const MOCK_WORLD_NAME = 'TestWorld';
+import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
 describeInitializedEngineSuite(
   'GameEngine',
@@ -84,5 +83,5 @@ describeInitializedEngineSuite(
       );
     });
   },
-  MOCK_WORLD_NAME
+  DEFAULT_TEST_WORLD
 );

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -17,8 +17,6 @@ import {
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  const MOCK_WORLD_NAME = 'TestWorld';
-
   describe('startNewGame', () => {
     beforeEach(() => {
       ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
@@ -29,11 +27,11 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should successfully start a new game', async () => {
-      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
 
       expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_INITIALIZING_UI,
-        { worldName: MOCK_WORLD_NAME },
+        { worldName: DEFAULT_TEST_WORLD },
         { allowSchemaNotFound: true }
       );
       expect(ctx.bed.mocks.entityManager.clearAll).toHaveBeenCalled();
@@ -43,12 +41,12 @@ describeEngineSuite('GameEngine', (ctx) => {
       );
       expect(
         ctx.bed.mocks.initializationService.runInitializationSequence
-      ).toHaveBeenCalledWith(MOCK_WORLD_NAME);
+      ).toHaveBeenCalledWith(DEFAULT_TEST_WORLD);
       expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
       expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
         ENGINE_READY_UI,
         {
-          activeWorld: MOCK_WORLD_NAME,
+          activeWorld: DEFAULT_TEST_WORLD,
           message: 'Enter command...',
         }
       );
@@ -57,7 +55,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expectEngineStatus(ctx.engine, {
         isInitialized: true,
         isLoopRunning: true,
-        activeWorld: MOCK_WORLD_NAME,
+        activeWorld: DEFAULT_TEST_WORLD,
       });
     });
 
@@ -70,7 +68,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValueOnce(
         { success: true }
       );
-      await ctx.engine.startNewGame(MOCK_WORLD_NAME);
+      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
 
       expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
         'GameEngine._prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
@@ -95,7 +93,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expectEngineStatus(ctx.engine, {
         isInitialized: true,
         isLoopRunning: true,
-        activeWorld: MOCK_WORLD_NAME,
+        activeWorld: DEFAULT_TEST_WORLD,
       });
     });
 
@@ -108,7 +106,7 @@ describeEngineSuite('GameEngine', (ctx) => {
         }
       );
 
-      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
         initError
       );
 
@@ -136,7 +134,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       ctx.bed.mocks.playtimeTracker.startSession.mockImplementation(() => {}); // Make sure this doesn't throw
       ctx.bed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
 
-      await expect(ctx.engine.startNewGame(MOCK_WORLD_NAME)).rejects.toThrow(
+      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
         startupError
       );
 

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -10,10 +10,9 @@ import {
   buildStopDispatches,
   expectEngineStatus,
 } from '../../common/engine/dispatchTestUtils.js';
+import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
-  const MOCK_WORLD_NAME = 'TestWorld';
-
   describe('stop', () => {
     beforeEach(() => {
       // Ensure engine is fresh for each 'stop' test
@@ -25,7 +24,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           success: true,
         }
       );
-      await ctx.bed.startAndReset(MOCK_WORLD_NAME); // Start the game first and clear mocks
+      await ctx.bed.startAndReset(DEFAULT_TEST_WORLD); // Start the game first and clear mocks
 
       await ctx.engine.stop();
 
@@ -82,7 +81,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           expectEngineStatus(engine, {
             isInitialized: true,
             isLoopRunning: true,
-            activeWorld: MOCK_WORLD_NAME,
+            activeWorld: DEFAULT_TEST_WORLD,
           });
 
           await engine.stop();


### PR DESCRIPTION
Summary: Replaced local MOCK_WORLD_NAME constants with DEFAULT_TEST_WORLD in engine test suites.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: many existing errors)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68579a9158e4833181c7917ee8469b08