### PR TITLE
[Agent] add TestBed utility generators

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -6,7 +6,7 @@
 import { expect, jest } from '@jest/globals';
 import { GameEngineTestBed } from './gameEngineTestBed.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
-import { withTestBed } from '../testBedHelpers.js';
+import { createWithBed, createInitializedBed } from '../testBedHelpers.js';
 
 /**
  * Executes a callback with a temporary {@link GameEngineTestBed} instance.
@@ -17,10 +17,9 @@ import { withTestBed } from '../testBedHelpers.js';
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export async function withGameEngineBed(overrides = {}, testFn) {
-  await withTestBed(GameEngineTestBed, overrides, (bed) =>
-    testFn(bed, bed.engine)
-  );
+export function withGameEngineBed(overrides = {}, testFn) {
+  const withBed = createWithBed(GameEngineTestBed, (b) => [b, b.engine]);
+  return withBed(overrides, testFn);
 }
 
 /**
@@ -37,25 +36,14 @@ export async function withGameEngineBed(overrides = {}, testFn) {
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export async function withInitializedGameEngineBed(overrides, world, testFn) {
-  if (typeof overrides === 'function') {
-    testFn = overrides;
-    overrides = {};
-    world = DEFAULT_TEST_WORLD;
-  } else if (typeof world === 'function') {
-    testFn = world;
-    world = DEFAULT_TEST_WORLD;
-    overrides = overrides || {};
-  } else {
-    overrides = overrides || {};
-    world = world || DEFAULT_TEST_WORLD;
-  }
-  await withTestBed(
+export function withInitializedGameEngineBed(overrides, world, testFn) {
+  const withInitBed = createInitializedBed(
     GameEngineTestBed,
-    overrides,
-    (bed) => testFn(bed, bed.engine),
-    (bed) => bed.initAndReset(world)
+    'initAndReset',
+    DEFAULT_TEST_WORLD,
+    (b) => [b, b.engine]
   );
+  return withInitBed(overrides, world, testFn);
 }
 
 /**

--- a/tests/common/testBedHelpers.js
+++ b/tests/common/testBedHelpers.js
@@ -39,4 +39,76 @@ export async function withTestBed(
   }
 }
 
+/**
+ * Generates a helper that executes callbacks with a temporary test bed.
+ *
+ * @description Returns a function mirroring {@link withTestBed} but mapping
+ *   the created bed instance to arguments expected by the callback. The mapping
+ *   is performed via {@code mapFn}, allowing helpers to expose specific
+ *   services from the bed.
+ * @template {new (overrides: any) => any} T
+ * @param {T} TestBedCtor - Constructor used to create the test bed.
+ * @param {(bed: InstanceType<T>) => any[]} mapFn - Maps the bed to callback
+ *   arguments.
+ * @returns {(overrides: ConstructorParameters<T>[0],
+ *   callback: (...args: any[]) => (Promise<void>|void)) => Promise<void>} Helper
+ *   invoking {@link withTestBed}.
+ */
+export function createWithBed(TestBedCtor, mapFn) {
+  return async function withBed(overrides = {}, callback) {
+    if (typeof overrides === 'function') {
+      callback = overrides;
+      overrides = {};
+    }
+    await withTestBed(TestBedCtor, overrides, (bed) => callback(...mapFn(bed)));
+  };
+}
+
+/**
+ * Generates a helper that initializes a test bed before invoking the callback.
+ *
+ * @description Similar to {@link createWithBed} but automatically calls a
+ *   specified initialization method on the bed. Optional parameters mirror those
+ *   of the original helper, defaulting the initialization argument when omitted.
+ * @template {new (overrides: any) => any} T
+ * @param {T} TestBedCtor - Constructor used to create the test bed.
+ * @param {keyof InstanceType<T>} initMethod - Name of the initialization method
+ *   on the bed.
+ * @param {any} defaultArg - Default argument passed to the initialization
+ *   method.
+ * @param {(bed: InstanceType<T>) => any[]} mapFn - Maps the bed to callback
+ *   arguments.
+ * @returns {(overrides?: ConstructorParameters<T>[0], arg?: any,
+ *   callback?: (...args: any[]) => (Promise<void>|void)) => Promise<void>} Helper
+ *   invoking {@link withTestBed} with initialization.
+ */
+export function createInitializedBed(
+  TestBedCtor,
+  initMethod,
+  defaultArg,
+  mapFn
+) {
+  return async function withInitializedBed(overrides, arg, callback) {
+    if (typeof overrides === 'function') {
+      callback = overrides;
+      overrides = {};
+      arg = defaultArg;
+    } else if (typeof arg === 'function') {
+      callback = arg;
+      arg = defaultArg;
+      overrides = overrides || {};
+    } else {
+      overrides = overrides || {};
+      arg = arg !== undefined ? arg : defaultArg;
+    }
+
+    await withTestBed(
+      TestBedCtor,
+      overrides,
+      (bed) => callback(...mapFn(bed)),
+      (bed) => bed[initMethod](arg)
+    );
+  };
+}
+
 export default withTestBed;


### PR DESCRIPTION
## Summary
- add `createWithBed` and `createInitializedBed` helpers
- refactor GameEngine helper functions to use new generators

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 563 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685799936914833197bae8296484d56d