### PR TITLE
[Agent] Add runWithReset utility for cleaner test beds

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -14,6 +14,7 @@ import {
   createDescribeServiceSuite,
 } from '../describeSuite.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
+import { runWithReset } from '../testBedHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -79,8 +80,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Resolves once initialization completes.
    */
   async initAndReset(world = DEFAULT_TEST_WORLD) {
-    await this.init(world);
-    this.resetMocks();
+    await runWithReset(this, () => this.init(world));
   }
 
   /**
@@ -106,8 +106,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Resolves when the game has started.
    */
   async startAndReset(world, result = { success: true }) {
-    await this.start(world, result);
-    this.resetMocks();
+    await runWithReset(this, () => this.start(world, result));
   }
 
   /**

--- a/tests/common/testBedHelpers.js
+++ b/tests/common/testBedHelpers.js
@@ -40,3 +40,24 @@ export async function withTestBed(
 }
 
 export default withTestBed;
+
+/**
+ * Executes a function and automatically resets mocks on the provided bed.
+ *
+ * @description Runs the given `callback` in a `try/finally` block. If the
+ *   `bed` exposes a `resetMocks` method, it will be called in the `finally`
+ *   block after the callback completes.
+ * @param {{ resetMocks?: () => void }} bed - Test bed instance.
+ * @param {(bed: any) => (Promise<void>|void)} callback - Function executed with
+ *   the bed instance.
+ * @returns {Promise<void>} Resolves once the callback and reset logic finish.
+ */
+export async function runWithReset(bed, callback) {
+  try {
+    await callback(bed);
+  } finally {
+    if (typeof bed.resetMocks === 'function') {
+      bed.resetMocks();
+    }
+  }
+}

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -19,6 +19,7 @@ import {
   createDescribeTestBedSuite,
 } from '../describeSuite.js';
 import { flushPromisesAndTimers } from '../jestHelpers.js';
+import { runWithReset } from '../testBedHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -81,9 +82,10 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    * @returns {Promise<void>} Resolves once the manager has started.
    */
   async startWithEntities(...entities) {
-    this.setActiveEntities(...entities);
-    await this.turnManager.start();
-    this.resetMocks();
+    await runWithReset(this, async () => {
+      this.setActiveEntities(...entities);
+      await this.turnManager.start();
+    });
   }
 
   /**
@@ -92,12 +94,13 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    * @returns {Promise<void>} Resolves once the manager is running.
    */
   async startRunning() {
-    const spy = jest
-      .spyOn(this.turnManager, 'advanceTurn')
-      .mockImplementationOnce(async () => {});
-    await this.turnManager.start();
-    spy.mockRestore();
-    this.resetMocks();
+    await runWithReset(this, async () => {
+      const spy = jest
+        .spyOn(this.turnManager, 'advanceTurn')
+        .mockImplementationOnce(async () => {});
+      await this.turnManager.start();
+      spy.mockRestore();
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `runWithReset` helper
- use `runWithReset` in `GameEngineTestBed`
- update `TurnManagerTestBed` to use `runWithReset`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: known repo issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857997e04d483319a9e269bf811bef5