### PR TITLE
[Agent] refactor test bed helpers

### DIFF
--- a/tests/common/createTestBedHelpers.js
+++ b/tests/common/createTestBedHelpers.js
@@ -1,0 +1,27 @@
+/**
+ * @file Boilerplate helpers for generating test bed utilities.
+ */
+
+import { createDescribeTestBedSuite } from './describeSuite.js';
+
+/**
+ * Generates helpers for creating test beds and describe suites.
+ *
+ * @template {new (overrides: any) => any} T
+ * @param {T} TestBedCtor - Constructor used to instantiate the test bed.
+ * @param {object} [hooks] - Suite hooks forwarded to
+ *   {@link createDescribeTestBedSuite}.
+ * @returns {{
+ *   createBed: (overrides?: ConstructorParameters<T>[0]) => InstanceType<T>,
+ *   describeSuite: (title: string,
+ *                   suiteFn: (getBed: () => InstanceType<T>) => void,
+ *                   overrides?: ConstructorParameters<T>[0]) => void
+ * }} Helper functions for the provided TestBed.
+ */
+export function createTestBedHelpers(TestBedCtor, hooks = {}) {
+  const describeSuite = createDescribeTestBedSuite(TestBedCtor, hooks);
+  const createBed = (overrides) => new TestBedCtor(overrides);
+  return { createBed, describeSuite };
+}
+
+export default createTestBedHelpers;

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -9,10 +9,8 @@ import { createTestEnvironment } from './gameEngine.test-environment.js';
 import ContainerTestBed from '../containerTestBed.js';
 import { createStoppableMixin } from '../stoppableTestBedMixin.js';
 import { suppressConsoleError } from '../jestHelpers.js';
-import {
-  createDescribeTestBedSuite,
-  createDescribeServiceSuite,
-} from '../describeSuite.js';
+import { createDescribeServiceSuite } from '../describeSuite.js';
+import { createTestBedHelpers } from '../createTestBedHelpers.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
 import { runWithReset } from '../testBedHelpers.js';
 
@@ -143,29 +141,10 @@ const engineSuiteHooks = (() => {
   };
 })();
 
-/**
- * Creates a new {@link GameEngineTestBed} instance.
- *
- * @param {{[token: string]: any}} [overrides] - Optional DI token overrides.
- * @returns {GameEngineTestBed} Test bed instance.
- */
-export function createGameEngineTestBed(overrides = {}) {
-  return new GameEngineTestBed(overrides);
-}
-
-/**
- * Defines a test suite with automatic {@link GameEngineTestBed} setup.
- *
- * @param {string} title - Suite title passed to `describe`.
- * @param {(getBed: () => GameEngineTestBed) => void} suiteFn - Callback
- *   containing the tests. Receives a getter for the active test bed.
- * @param {{[token: string]: any}} [overrides] - Optional DI overrides.
- * @returns {void}
- */
-export const describeGameEngineSuite = createDescribeTestBedSuite(
-  GameEngineTestBed,
-  engineSuiteHooks
-);
+export const {
+  createBed: createGameEngineTestBed,
+  describeSuite: describeGameEngineSuite,
+} = createTestBedHelpers(GameEngineTestBed, engineSuiteHooks);
 
 /**
  * Defines an engine-focused test suite providing `bed` and `engine` variables

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -18,6 +18,7 @@ import {
   describeSuiteWithHooks,
   createDescribeTestBedSuite,
 } from '../describeSuite.js';
+import { createTestBedHelpers } from '../createTestBedHelpers.js';
 import { flushPromisesAndTimers } from '../jestHelpers.js';
 import { runWithReset } from '../testBedHelpers.js';
 
@@ -271,32 +272,18 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
  * @param overrides
  * @returns {TurnManagerTestBed} Test bed instance.
  */
-export function createTurnManagerTestBed(overrides = {}) {
-  return new TurnManagerTestBed(overrides);
-}
-
-/**
- * Defines a test suite with automatic {@link TurnManagerTestBed} setup.
- *
- * @param {string} title - Suite title passed to `describe`.
- * @param {(getBed: () => TurnManagerTestBed) => void} suiteFn - Callback
- *   containing the tests. Receives a getter for the active test bed.
- * @param {Record<string, any>} [overrides] - Optional overrides for mock
- *   creation.
- * @returns {void}
- */
-export const describeTurnManagerSuite = createDescribeTestBedSuite(
-  TurnManagerTestBed,
-  {
-    beforeEachHook(bed) {
-      jest.useFakeTimers();
-      bed.initializeDefaultMocks();
-    },
-    afterEachHook() {
-      // Timers restored via BaseTestBed cleanup; spies handled by _afterCleanup
-    },
-  }
-);
+export const {
+  createBed: createTurnManagerTestBed,
+  describeSuite: describeTurnManagerSuite,
+} = createTestBedHelpers(TurnManagerTestBed, {
+  beforeEachHook(bed) {
+    jest.useFakeTimers();
+    bed.initializeDefaultMocks();
+  },
+  afterEachHook() {
+    // Timers restored via BaseTestBed cleanup; spies handled by _afterCleanup
+  },
+});
 
 /**
  * Defines a suite where {@link TurnManager} is started before each test.


### PR DESCRIPTION
Summary:
- add createTestBedHelpers utility for reducing duplicate code
- refactor GameEngine and TurnManager test beds to use new helpers

Testing Done:
- [ ] `npm run format`
- [ ] `npm run lint` *(fails: 563 errors)*
- [ ] `npm run test`
- [ ] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857a5899a388331884ee87d66dca9ba