### PR TITLE
[Agent] move rule-test data registry factory

### DIFF
--- a/tests/common/engine/systemLogicTestEnv.js
+++ b/tests/common/engine/systemLogicTestEnv.js
@@ -14,6 +14,7 @@ import {
   createMockLogger,
   createCapturingEventBus,
 } from '../mockFactories/index.js';
+import { createRuleTestDataRegistry } from '../mockFactories/entities.js';
 import { deepClone } from '../../../src/utils/cloneUtils.js';
 
 /**
@@ -125,18 +126,4 @@ export function createRuleTestEnvironment({
   };
 
   return env;
-}
-
-/**
- * Creates a mock data registry for testing.
- *
- * @param {Array<object>} rules - Rules to return from getAllSystemRules
- * @param {object} conditionDefinitions - Condition definitions to return from getConditionDefinition
- * @returns {object} Mock data registry
- */
-export function createMockDataRegistry(rules = [], conditionDefinitions = {}) {
-  return {
-    getAllSystemRules: jest.fn().mockReturnValue(rules),
-    getConditionDefinition: jest.fn((id) => conditionDefinitions[id]),
-  };
 }

--- a/tests/common/mockFactories/entities.js
+++ b/tests/common/mockFactories/entities.js
@@ -95,6 +95,35 @@ export const createStatefulMockDataRegistry = () => {
 };
 
 /**
+ * Creates a simple data registry for rule integration tests.
+ *
+ * @description Provides basic register/get APIs for storing rule records.
+ * @returns {{
+ *   register: (id: string, record: any) => void,
+ *   get: (id: string) => any,
+ *   getAll: () => any[],
+ *   clear: () => void
+ * }} In-memory registry instance.
+ */
+export function createRuleTestDataRegistry() {
+  const data = new Map();
+  return {
+    register(id, record) {
+      data.set(id, record);
+    },
+    get(id) {
+      return data.get(id);
+    },
+    getAll() {
+      return Array.from(data.values());
+    },
+    clear() {
+      data.clear();
+    },
+  };
+}
+
+/**
  * Creates a mock IEntityManager.
  *
  * @returns {jest.Mocked<import('../../../src/interfaces/IEntityManager.js').IEntityManager>} Mocked service

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -13,4 +13,6 @@ export {
   createMockAIPromptPipeline,
 } from './coreServices.js';
 
+export { createRuleTestDataRegistry } from './entities.js';
+
 export { createMockContainerWithRegistration } from './container.js';


### PR DESCRIPTION
## Summary
- add `createRuleTestDataRegistry` helper
- remove inline registry from `systemLogicTestEnv`
- re-export new helper in mockFactories index

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6857a57103d08331b42746cad4887f37