### PR TITLE
[Agent] Add dispatch helper for game start

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -6,6 +6,7 @@
 import { expect } from '@jest/globals';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_INITIALIZING_UI,
   ENGINE_READY_UI,
   GAME_SAVED_ID,
   ENTITY_CREATED_ID,
@@ -86,6 +87,19 @@ export function buildStopDispatches() {
       ENGINE_STOPPED_UI,
       { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
     ],
+  ];
+}
+
+/**
+ * Builds the dispatch sequence emitted when starting a new game.
+ *
+ * @param {string} worldName - Name of the world being initialized.
+ * @returns {Array<[string, any]>} Dispatch call sequence for engine start.
+ */
+export function buildStartDispatches(worldName) {
+  return [
+    [ENGINE_INITIALIZING_UI, { worldName }, { allowSchemaNotFound: true }],
+    [ENGINE_READY_UI, { activeWorld: worldName, message: 'Enter command...' }],
   ];
 }
 
@@ -192,6 +206,7 @@ export default {
   expectDispatchSequence,
   buildSaveDispatches,
   buildStopDispatches,
+  buildStartDispatches,
   expectEngineStatus,
   expectSingleDispatch,
   expectEntityCreatedDispatch,

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -4,6 +4,7 @@ import {
   expectSingleDispatch,
   buildSaveDispatches,
   buildStopDispatches,
+  buildStartDispatches,
   expectEngineStatus,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,
@@ -13,6 +14,7 @@ import {
 import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_INITIALIZING_UI,
   ENGINE_READY_UI,
   GAME_SAVED_ID,
   ENTITY_CREATED_ID,
@@ -123,6 +125,25 @@ describe('dispatchTestUtils', () => {
           ENGINE_STOPPED_UI,
           { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
         ],
+      ]);
+    });
+  });
+
+  describe('buildStartDispatches', () => {
+    it('returns initializing dispatch entry', () => {
+      const result = buildStartDispatches('NewWorld');
+      expect(result[0]).toEqual([
+        ENGINE_INITIALIZING_UI,
+        { worldName: 'NewWorld' },
+        { allowSchemaNotFound: true },
+      ]);
+    });
+
+    it('returns ready dispatch entry', () => {
+      const result = buildStartDispatches('NewWorld');
+      expect(result[1]).toEqual([
+        ENGINE_READY_UI,
+        { activeWorld: 'NewWorld', message: 'Enter command...' },
       ]);
     });
   });

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -4,14 +4,11 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import '../../common/engine/engineTestTypedefs.js';
 
-import {
-  ENGINE_INITIALIZING_UI,
-  ENGINE_READY_UI,
-  ENGINE_OPERATION_FAILED_UI,
-} from '../../../src/constants/eventIds.js';
+import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
   buildStopDispatches,
+  buildStartDispatches,
   expectEngineStatus,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
@@ -29,10 +26,9 @@ describeEngineSuite('GameEngine', (ctx) => {
     it('should successfully start a new game', async () => {
       await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
 
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENGINE_INITIALIZING_UI,
-        { worldName: DEFAULT_TEST_WORLD },
-        { allowSchemaNotFound: true }
+      expectDispatchSequence(
+        ctx.bed.mocks.safeEventDispatcher.dispatch,
+        buildStartDispatches(DEFAULT_TEST_WORLD)
       );
       expect(ctx.bed.mocks.entityManager.clearAll).toHaveBeenCalled();
       expect(ctx.bed.mocks.playtimeTracker.reset).toHaveBeenCalled();
@@ -43,13 +39,6 @@ describeEngineSuite('GameEngine', (ctx) => {
         ctx.bed.mocks.initializationService.runInitializationSequence
       ).toHaveBeenCalledWith(DEFAULT_TEST_WORLD);
       expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENGINE_READY_UI,
-        {
-          activeWorld: DEFAULT_TEST_WORLD,
-          message: 'Enter command...',
-        }
-      );
       expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
 
       expectEngineStatus(ctx.engine, {
@@ -80,15 +69,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expectDispatchSequence(
         ctx.bed.mocks.safeEventDispatcher.dispatch,
         ...buildStopDispatches(),
-        [
-          ENGINE_INITIALIZING_UI,
-          { worldName: DEFAULT_TEST_WORLD },
-          { allowSchemaNotFound: true },
-        ],
-        [
-          ENGINE_READY_UI,
-          { activeWorld: DEFAULT_TEST_WORLD, message: 'Enter command...' },
-        ]
+        ...buildStartDispatches(DEFAULT_TEST_WORLD)
       );
       expectEngineStatus(ctx.engine, {
         isInitialized: true,


### PR DESCRIPTION
## Summary
- add `buildStartDispatches` helper for start-up events
- test the helper and use it in game engine tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2832 problems (563 errors, 2269 warnings))*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857a8b02b508331956574c343404c2d