### PR TITLE
[Agent] add engine status helpers tests

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -116,6 +116,35 @@ export function expectEngineStatus(engine, expectedStatus) {
 }
 
 /**
+ * Asserts that the engine is running with the provided world.
+ *
+ * @param {{ getEngineStatus: () => any }} engine - Engine instance with a
+ *   `getEngineStatus` method.
+ * @param {string} world - Expected active world name.
+ * @returns {void}
+ */
+export const expectEngineRunning = (engine, world) =>
+  expectEngineStatus(engine, {
+    isInitialized: true,
+    isLoopRunning: true,
+    activeWorld: world,
+  });
+
+/**
+ * Asserts that the engine is fully stopped.
+ *
+ * @param {{ getEngineStatus: () => any }} engine - Engine instance with a
+ *   `getEngineStatus` method.
+ * @returns {void}
+ */
+export const expectEngineStopped = (engine) =>
+  expectEngineStatus(engine, {
+    isInitialized: false,
+    isLoopRunning: false,
+    activeWorld: null,
+  });
+
+/**
  * Asserts a single dispatch call with the given id and payload.
  *
  * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
@@ -208,6 +237,8 @@ export default {
   buildStopDispatches,
   buildStartDispatches,
   expectEngineStatus,
+  expectEngineRunning,
+  expectEngineStopped,
   expectSingleDispatch,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -6,6 +6,8 @@ import {
   buildStopDispatches,
   buildStartDispatches,
   expectEngineStatus,
+  expectEngineRunning,
+  expectEngineStopped,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,
   expectComponentAddedDispatch,
@@ -157,6 +159,52 @@ describe('dispatchTestUtils', () => {
     it('throws when statuses differ', () => {
       const engine = { getEngineStatus: () => ({ ready: false }) };
       expect(() => expectEngineStatus(engine, { ready: true })).toThrow();
+    });
+  });
+
+  describe('expectEngineRunning and expectEngineStopped', () => {
+    it('validates running helper', () => {
+      const engine = {
+        getEngineStatus: () => ({
+          isInitialized: true,
+          isLoopRunning: true,
+          activeWorld: 'World',
+        }),
+      };
+      expect(() => expectEngineRunning(engine, 'World')).not.toThrow();
+    });
+
+    it('throws when running expectations fail', () => {
+      const engine = {
+        getEngineStatus: () => ({
+          isInitialized: false,
+          isLoopRunning: true,
+          activeWorld: 'World',
+        }),
+      };
+      expect(() => expectEngineRunning(engine, 'World')).toThrow();
+    });
+
+    it('validates stopped helper', () => {
+      const engine = {
+        getEngineStatus: () => ({
+          isInitialized: false,
+          isLoopRunning: false,
+          activeWorld: null,
+        }),
+      };
+      expect(() => expectEngineStopped(engine)).not.toThrow();
+    });
+
+    it('throws when stopped expectations fail', () => {
+      const engine = {
+        getEngineStatus: () => ({
+          isInitialized: true,
+          isLoopRunning: true,
+          activeWorld: 'World',
+        }),
+      };
+      expect(() => expectEngineStopped(engine)).toThrow();
     });
   });
 

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -9,7 +9,8 @@ import {
   expectDispatchSequence,
   buildStopDispatches,
   buildStartDispatches,
-  expectEngineStatus,
+  expectEngineRunning,
+  expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
@@ -41,11 +42,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
       expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
 
-      expectEngineStatus(ctx.engine, {
-        isInitialized: true,
-        isLoopRunning: true,
-        activeWorld: DEFAULT_TEST_WORLD,
-      });
+      expectEngineRunning(ctx.engine, DEFAULT_TEST_WORLD);
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {
@@ -71,11 +68,7 @@ describeEngineSuite('GameEngine', (ctx) => {
         ...buildStopDispatches(),
         ...buildStartDispatches(DEFAULT_TEST_WORLD)
       );
-      expectEngineStatus(ctx.engine, {
-        isInitialized: true,
-        isLoopRunning: true,
-        activeWorld: DEFAULT_TEST_WORLD,
-      });
+      expectEngineRunning(ctx.engine, DEFAULT_TEST_WORLD);
     });
 
     it('should handle InitializationService failure', async () => {
@@ -98,11 +91,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      expectEngineStatus(ctx.engine, {
-        isInitialized: false,
-        isLoopRunning: false,
-        activeWorld: null,
-      });
+      expectEngineStopped(ctx.engine);
     });
 
     it('should handle general errors during start-up and dispatch failure event', async () => {
@@ -126,11 +115,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           errorTitle: 'Initialization Error',
         }
       );
-      expectEngineStatus(ctx.engine, {
-        isInitialized: false, // Should be reset by _handleNewGameFailure
-        isLoopRunning: false,
-        activeWorld: null,
-      });
+      expectEngineStopped(ctx.engine);
     });
   });
 });

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -8,7 +8,8 @@ import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
   buildStopDispatches,
-  expectEngineStatus,
+  expectEngineRunning,
+  expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
@@ -38,22 +39,14 @@ describeEngineSuite('GameEngine', (ctx) => {
         ...buildStopDispatches()
       );
 
-      expectEngineStatus(ctx.engine, {
-        isInitialized: false,
-        isLoopRunning: false,
-        activeWorld: null,
-      });
+      expectEngineStopped(ctx.engine);
 
       expect(ctx.bed.mocks.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should do nothing and log if engine is already stopped', async () => {
       // ctx.engine is fresh, so not initialized
-      expectEngineStatus(ctx.engine, {
-        isInitialized: false,
-        isLoopRunning: false,
-        activeWorld: null,
-      });
+      expectEngineStopped(ctx.engine);
 
       ctx.bed.resetMocks();
 
@@ -78,11 +71,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           ],
         ],
         async (bed, engine, expectedMsg) => {
-          expectEngineStatus(engine, {
-            isInitialized: true,
-            isLoopRunning: true,
-            activeWorld: DEFAULT_TEST_WORLD,
-          });
+          expectEngineRunning(engine, DEFAULT_TEST_WORLD);
 
           await engine.stop();
 


### PR DESCRIPTION
Summary: Added `expectEngineRunning` and `expectEngineStopped` helper functions with unit tests, and updated engine tests to use these helpers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint` on modified files
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857ac681b5083318085ae5a9af37262