### PR TITLE
[Agent] add expectNoDispatch test helper

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -229,6 +229,14 @@ export function expectComponentRemovedDispatch(
   });
 }
 
+/**
+ * Asserts that the dispatch function was never called.
+ *
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @returns {void}
+ */
+export const expectNoDispatch = (mock) => expect(mock).not.toHaveBeenCalled();
+
 export { expectDispatchSequence as expectDispatchCalls };
 
 export default {
@@ -244,5 +252,6 @@ export default {
   expectEntityRemovedDispatch,
   expectComponentAddedDispatch,
   expectComponentRemovedDispatch,
+  expectNoDispatch,
   expectDispatchCalls: expectDispatchSequence,
 };

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -12,6 +12,7 @@ import {
   expectEntityRemovedDispatch,
   expectComponentAddedDispatch,
   expectComponentRemovedDispatch,
+  expectNoDispatch,
 } from './dispatchTestUtils.js';
 import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
 import {
@@ -70,6 +71,19 @@ describe('dispatchTestUtils', () => {
       const mock = jest.fn();
       mock('eventA', { a: 2 });
       expect(() => expectSingleDispatch(mock, 'eventA', { a: 1 })).toThrow();
+    });
+  });
+
+  describe('expectNoDispatch', () => {
+    it('passes when no calls were made', () => {
+      const mock = jest.fn();
+      expect(() => expectNoDispatch(mock)).not.toThrow();
+    });
+
+    it('throws when mock has calls', () => {
+      const mock = jest.fn();
+      mock('eventA', {});
+      expect(() => expectNoDispatch(mock)).toThrow();
     });
   });
 

--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -4,6 +4,7 @@
  */
 
 import { expect, jest } from '@jest/globals';
+import { expectNoDispatch } from './dispatchTestUtils.js';
 import { GameEngineTestBed } from './gameEngineTestBed.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
 import { createWithBed, createInitializedBed } from '../testBedHelpers.js';
@@ -78,7 +79,7 @@ export function runUnavailableServiceTest(cases, invokeFn) {
           expectedMessage
         );
         expect(loggerMock).toHaveBeenCalledWith(expectedMessage);
-        expect(dispatchMock).not.toHaveBeenCalled();
+        expectNoDispatch(dispatchMock);
       });
     },
   ]);

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -1,5 +1,6 @@
 // tests/engine/loadGame.test.js
 import { beforeEach, describe, expect, it } from '@jest/globals';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import {
@@ -119,7 +120,7 @@ describeEngineSuite('GameEngine', (ctx) => {
         ],
         async (bed, engine, expectedMsg) => {
           const result = await engine.loadGame(SAVE_ID);
-          expect(bed.mocks.safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+          expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
           expect(result).toEqual({
             success: false,
             error: expectedMsg,

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -13,6 +13,7 @@ import '../../common/engine/engineTestTypedefs.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
+  expectNoDispatch,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../../common/constants.js';
 
@@ -28,7 +29,7 @@ describeEngineSuite('GameEngine', () => {
         const expectedErrorMsg =
           'Game engine is not initialized. Cannot save game.';
 
-        expect(bed.mocks.safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+        expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
         expect(
           bed.mocks.gamePersistenceService.saveGame
         ).not.toHaveBeenCalled();
@@ -50,9 +51,7 @@ describeEngineSuite('GameEngine', () => {
             ],
             async (bed, engine) => {
               const result = await engine.triggerManualSave(SAVE_NAME);
-              expect(
-                bed.mocks.safeEventDispatcher.dispatch
-              ).not.toHaveBeenCalled();
+              expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
               expect(result).toEqual({
                 success: false,
                 error:


### PR DESCRIPTION
Summary: Add helper to assert no dispatch calls in tests.

Changes Made:
- Added `expectNoDispatch` to dispatchTestUtils with JSDoc and export.
- Created unit tests for new helper.
- Updated engine test helpers and engine tests to use new function.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy) *(fails: existing project issues)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6857b2a41a388331a88711a80e8e79f3