### PR TITLE
[Agent] Factor out processing error utilities

### DIFF
--- a/src/turns/states/helpers/processingErrorUtils.js
+++ b/src/turns/states/helpers/processingErrorUtils.js
@@ -1,0 +1,100 @@
+/**
+ * @file Utilities for processing error handling.
+ */
+
+/**
+ * @typedef {import('../../../types/stateTypes.js').ProcessingCommandStateLike} ProcessingCommandStateLike
+ * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+
+import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
+
+/**
+ * Resets processing flags on the provided state.
+ *
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
+ * @returns {boolean} The previous _isProcessing value.
+ */
+export function resetProcessingFlags(state) {
+  const wasProcessing = state._isProcessing;
+  if (state._processingGuard) {
+    state._processingGuard.finish();
+  } else {
+    state._isProcessing = false;
+  }
+  return wasProcessing;
+}
+
+/**
+ * Resolves the logger and actor ID for diagnostics.
+ *
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
+ * @param {ITurnContext} turnCtx - Current turn context.
+ * @param {string} actorIdFallback - Fallback actor ID when context is missing.
+ * @returns {{ logger: ILogger, actorId: string }} The resolved logger and actor ID.
+ */
+export function resolveLogger(state, turnCtx, actorIdFallback) {
+  let logger = console;
+  let actorId = actorIdFallback;
+
+  if (turnCtx && typeof turnCtx.getLogger === 'function') {
+    logger = turnCtx.getLogger();
+    actorId = turnCtx.getActor?.()?.id ?? actorIdFallback;
+  } else {
+    console.error(
+      `${state.getStateName()}: Critical error - turnCtx is invalid in resolveLogger. Using console for logging. Actor context for this error: ${actorId}`
+    );
+  }
+
+  return { logger, actorId };
+}
+
+/**
+ * Dispatches a standardized system error event.
+ *
+ * @param {ISafeEventDispatcher|null} dispatcher - Dispatcher used for the event.
+ * @param {ILogger} logger - Logger for error logging.
+ * @param {string} stateName - Name of the state reporting the error.
+ * @param {string} actorId - Actor ID for logging context.
+ * @param {Error} error - The error that occurred.
+ * @returns {void}
+ */
+export function dispatchSystemError(
+  dispatcher,
+  logger,
+  stateName,
+  actorId,
+  error
+) {
+  if (dispatcher) {
+    try {
+      safeDispatchError(
+        dispatcher,
+        `System error in ${stateName} for actor ${actorId}: ${error.message}`,
+        {
+          raw: `OriginalError: ${error.name} - ${error.message}`,
+          stack: error.stack,
+          timestamp: new Date().toISOString(),
+        },
+        logger
+      );
+    } catch (dispatchError) {
+      logger.error(
+        `${stateName}: Unexpected error dispatching SYSTEM_ERROR_OCCURRED_ID via SafeEventDispatcher for ${actorId}: ${dispatchError.message}`,
+        dispatchError
+      );
+    }
+  } else {
+    logger.warn(
+      `${stateName}: SafeEventDispatcher not available for actor ${actorId}. Cannot dispatch system error event.`
+    );
+  }
+}
+
+export default {
+  resetProcessingFlags,
+  resolveLogger,
+  dispatchSystemError,
+};

--- a/tests/unit/turns/states/helpers/processingErrorUtils.test.js
+++ b/tests/unit/turns/states/helpers/processingErrorUtils.test.js
@@ -1,0 +1,84 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import {
+  resetProcessingFlags,
+  resolveLogger,
+  dispatchSystemError,
+} from '../../../../../src/turns/states/helpers/processingErrorUtils.js';
+import { ProcessingGuard } from '../../../../../src/turns/states/helpers/processingGuard.js';
+import { safeDispatchError } from '../../../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../../../src/utils/safeDispatchErrorUtils.js');
+
+describe('processingErrorUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('resetProcessingFlags uses guard when present', () => {
+    const owner = { _isProcessing: true };
+    owner._processingGuard = new ProcessingGuard(owner);
+    const spy = jest.spyOn(owner._processingGuard, 'finish');
+    const was = resetProcessingFlags(owner);
+    expect(was).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    expect(owner._isProcessing).toBe(false);
+  });
+
+  test('resetProcessingFlags toggles flag directly when guard missing', () => {
+    const owner = { _isProcessing: true };
+    const was = resetProcessingFlags(owner);
+    expect(was).toBe(true);
+    expect(owner._isProcessing).toBe(false);
+  });
+
+  test('resolveLogger uses context logger when available', () => {
+    const logger = { debug: jest.fn() };
+    const turnCtx = { getLogger: () => logger, getActor: () => ({ id: 'a1' }) };
+    const result = resolveLogger(
+      { getStateName: () => 'State' },
+      turnCtx,
+      'fallback'
+    );
+    expect(result.logger).toBe(logger);
+    expect(result.actorId).toBe('a1');
+  });
+
+  test('resolveLogger falls back to console and logs error', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const result = resolveLogger(
+      { getStateName: () => 'State' },
+      null,
+      'fallback'
+    );
+    expect(result.logger).toBe(console);
+    expect(result.actorId).toBe('fallback');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('dispatchSystemError dispatches via safeDispatchError', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = { error: jest.fn(), warn: jest.fn() };
+    dispatchSystemError(
+      dispatcher,
+      logger,
+      'State',
+      'actorX',
+      new Error('boom')
+    );
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.stringContaining('System error in State'),
+      expect.any(Object),
+      logger
+    );
+  });
+
+  test('dispatchSystemError logs warn when dispatcher missing', () => {
+    const logger = { warn: jest.fn(), error: jest.fn() };
+    dispatchSystemError(null, logger, 'State', 'actorX', new Error('boom'));
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- isolate flag reset, logger resolution, and error dispatch into processingErrorUtils
- refactor handleProcessingException to use helpers
- test new helpers and orchestrated exception handler

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 563 errors)*
- [x] `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857b4295ae48331a67baee95c3ce1be