### PR TITLE
[Agent] Refactor actionFormatter helpers

### DIFF
--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -81,6 +81,21 @@ describe('formatActionCommand', () => {
     expect(result).toBe('move north');
   });
 
+  it("returns template as-is for 'none' target type", () => {
+    const actionDef = { id: 'core:wait', template: 'wait' };
+    const context = { type: 'none' };
+
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      { logger, safeEventDispatcher: dispatcher },
+      displayNameFn
+    );
+
+    expect(result).toBe('wait');
+  });
+
   it('returns null for missing action template', () => {
     const result = formatActionCommand(
       { id: 'bad' },


### PR DESCRIPTION
Summary:
- refactor `formatActionCommand` to use dedicated helper functions
- keep behaviour intact using lookup table
- extend unit tests for `formatActionCommand` with none-type case

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857b56d432c83319560eaf64c493e5b