### PR TITLE
[Agent] inject ILogger into spatial index

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -228,7 +228,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     formatterOptions
   ) {
     const targetIds =
-      this.#getEntityIdsForScopesFn([domain], context) ?? new Set();
+      this.#getEntityIdsForScopesFn([domain], context, this.#logger) ??
+      new Set();
     /** @type {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]} */
     const discoveredActions = [];
 

--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -68,7 +68,7 @@ export function registerInfrastructure(container) {
 
   container.register(
     tokens.ISpatialIndexManager,
-    () => new SpatialIndexManager(),
+    (c) => new SpatialIndexManager({ logger: c.resolve(tokens.ILogger) }),
     { lifecycle: 'singleton' }
   );
   log.debug(

--- a/src/entities/entityScopeService.js
+++ b/src/entities/entityScopeService.js
@@ -1,5 +1,5 @@
 // src/entities/entityScopeService.js
-/* eslint-disable no-console */
+ 
 
 import {
   EQUIPMENT_COMPONENT_ID,
@@ -23,6 +23,7 @@ import { isNonBlankString } from '../utils/textUtils.js';
  * @description A factory function that creates a scope handler for scopes that are
  * derived from a component on the acting entity.
  * @param {string} componentId - The ID of the component to look for.
+ * @param logger
  * @param {(componentData: object) => (string[] | null | undefined)} idExtractor -
  * A function that takes the component's data and returns an array of entity IDs.
  * @param {string} scopeNameForLogging - The name of the scope for logging purposes.
@@ -31,7 +32,8 @@ import { isNonBlankString } from '../utils/textUtils.js';
 function _createActorComponentScopeHandler(
   componentId,
   idExtractor,
-  scopeNameForLogging
+  scopeNameForLogging,
+  logger
 ) {
   /**
    * @param {ActionContext} context - The action context.
@@ -40,7 +42,7 @@ function _createActorComponentScopeHandler(
   return (context) => {
     const { actingEntity } = context;
     if (!actingEntity) {
-      console.warn(
+      logger.warn(
         `entityScopeService(#createActorComponentScopeHandler): Scope '${scopeNameForLogging}' requested but actingEntity is missing in context.`
       );
       return new Set();
@@ -53,7 +55,7 @@ function _createActorComponentScopeHandler(
 
     const componentData = actingEntity.getComponentData(componentId);
     if (!componentData) {
-      console.warn(
+      logger.warn(
         `entityScopeService(#createActorComponentScopeHandler): Component data for '${componentId}' on actor ${actingEntity.id} is missing or malformed.`
       );
       return new Set();
@@ -61,7 +63,7 @@ function _createActorComponentScopeHandler(
 
     const ids = idExtractor(componentData);
     if (!Array.isArray(ids)) {
-      console.warn(
+      logger.warn(
         `entityScopeService(#createActorComponentScopeHandler): idExtractor for scope '${scopeNameForLogging}' did not return a valid array for actor ${actingEntity.id}.`
       );
       return new Set();
@@ -75,43 +77,50 @@ function _createActorComponentScopeHandler(
 
 // --- Internal Scope Handler Functions ---
 
-const _handleInventory = _createActorComponentScopeHandler(
-  INVENTORY_COMPONENT_ID,
-  (data) => data.items,
-  'inventory'
-);
+const _handleInventory = (logger) =>
+  _createActorComponentScopeHandler(
+    INVENTORY_COMPONENT_ID,
+    (data) => data.items,
+    'inventory',
+    logger
+  );
 
-const _handleEquipment = _createActorComponentScopeHandler(
-  EQUIPMENT_COMPONENT_ID,
-  (data) => (data && data.slots ? Object.values(data.slots) : []),
-  'equipment'
-);
+const _handleEquipment = (logger) =>
+  _createActorComponentScopeHandler(
+    EQUIPMENT_COMPONENT_ID,
+    (data) => (data && data.slots ? Object.values(data.slots) : []),
+    'equipment',
+    logger
+  );
 
-const _handleFollowers = _createActorComponentScopeHandler(
-  LEADING_COMPONENT_ID,
-  (data) => data.followers,
-  'followers'
-);
+const _handleFollowers = (logger) =>
+  _createActorComponentScopeHandler(
+    LEADING_COMPONENT_ID,
+    (data) => data.followers,
+    'followers',
+    logger
+  );
 
 /**
  * Retrieves entity IDs from the current location, excluding the player.
  *
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleLocation(context) {
+function _handleLocation(context, logger) {
   const { currentLocation, entityManager, actingEntity } = context;
   const results = new Set();
 
   if (!currentLocation) {
-    console.warn(
+    logger.warn(
       "entityScopeService._handleLocation: Scope 'location' requested but currentLocation is null."
     );
     return results;
   }
   if (!entityManager) {
-    console.error(
+    logger.error(
       'entityScopeService._handleLocation: entityManager is missing in context. Cannot perform location lookup.'
     );
     return results;
@@ -134,18 +143,19 @@ function _handleLocation(context) {
  * Retrieves entity IDs from the current location that have an ItemComponent.
  *
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleLocationItems(context) {
+function _handleLocationItems(context, logger) {
   const { entityManager } = context;
   if (!entityManager) {
-    console.error(
+    logger.error(
       'entityScopeService._handleLocationItems: entityManager is missing in context.'
     );
     return new Set();
   }
-  const locationIds = _handleLocation(context);
+  const locationIds = _handleLocation(context, logger);
   const itemIds = new Set();
   for (const id of locationIds) {
     const entity = entityManager.getEntityInstance(id);
@@ -160,18 +170,19 @@ function _handleLocationItems(context) {
  * Retrieves entity IDs from the current location that DO NOT have an ItemComponent.
  *
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleLocationNonItems(context) {
+function _handleLocationNonItems(context, logger) {
   const { entityManager } = context;
   if (!entityManager) {
-    console.error(
+    logger.error(
       'entityScopeService._handleLocationNonItems: entityManager is missing in context.'
     );
     return new Set();
   }
-  const locationIds = _handleLocation(context);
+  const locationIds = _handleLocation(context, logger);
   const nonItemIds = new Set();
   for (const id of locationIds) {
     const entity = entityManager.getEntityInstance(id);
@@ -186,12 +197,13 @@ function _handleLocationNonItems(context) {
  * Retrieves entity IDs from both inventory and location.
  *
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleNearby(context) {
-  const inventoryIds = _handleInventory(context);
-  const locationIds = _handleLocation(context);
+function _handleNearby(context, logger) {
+  const inventoryIds = _handleInventory(logger)(context);
+  const locationIds = _handleLocation(context, logger);
   return new Set([...inventoryIds, ...locationIds]);
 }
 
@@ -199,11 +211,12 @@ function _handleNearby(context) {
  * Retrieves entity IDs from nearby scopes including blockers in exits.
  *
  * @param {ActionContext} context - Current action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleNearbyIncludingBlockers(context) {
-  const aggregatedIds = _handleNearby(context);
+function _handleNearbyIncludingBlockers(context, logger) {
+  const aggregatedIds = _handleNearby(context, logger);
   const { currentLocation, entityManager } = context;
   if (!entityManager || !currentLocation) return aggregatedIds;
 
@@ -222,13 +235,14 @@ function _handleNearbyIncludingBlockers(context) {
  * Retrieves the entity ID of the actor itself.
  *
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>}
  * @private
  */
-function _handleSelf(context) {
+function _handleSelf(context, logger) {
   const { actingEntity } = context;
   if (!actingEntity || !actingEntity.id) {
-    console.warn(
+    logger.warn(
       "entityScopeService._handleSelf: Scope 'self' requested but actingEntity or its ID is missing."
     );
     return new Set();
@@ -242,21 +256,6 @@ function _handleSelf(context) {
  * @type {{[key: string]: (context: ActionContext) => Set<EntityId>}}
  * @private
  */
-const scopeHandlers = {
-  // Component-based scopes (refactored)
-  inventory: _handleInventory,
-  equipment: _handleEquipment,
-  followers: _handleFollowers,
-
-  // Location-based and other scopes (unchanged)
-  location: _handleLocation,
-  location_items: _handleLocationItems,
-  location_non_items: _handleLocationNonItems,
-  nearby: _handleNearby,
-  nearby_including_blockers: _handleNearbyIncludingBlockers,
-  self: _handleSelf,
-  environment: _handleLocation, // Maps domain to existing scope handler
-};
 
 // --- Public Aggregator Function ---
 
@@ -265,20 +264,35 @@ const scopeHandlers = {
  *
  * @param {string | string[] | TargetDomain | TargetDomain[]} scopes - A single scope name or an array of them.
  * @param {ActionContext} context - The action context.
+ * @param logger
  * @returns {Set<EntityId>} A single set of unique entity IDs.
  */
-function getEntityIdsForScopes(scopes, context) {
+function getEntityIdsForScopes(scopes, context, logger = console) {
   const requestedScopes = Array.isArray(scopes) ? scopes : [scopes];
   const aggregatedIds = new Set();
 
   if (!context || !context.entityManager) {
     // FIX: Add the context object to the log call to provide more detail.
-    console.error(
+    logger.error(
       'getEntityIdsForScopes: Invalid or incomplete context provided. Cannot proceed.',
       { context }
     );
     return aggregatedIds;
   }
+
+  const scopeHandlers = {
+    inventory: _handleInventory(logger),
+    equipment: _handleEquipment(logger),
+    followers: _handleFollowers(logger),
+    location: (ctx) => _handleLocation(ctx, logger),
+    location_items: (ctx) => _handleLocationItems(ctx, logger),
+    location_non_items: (ctx) => _handleLocationNonItems(ctx, logger),
+    nearby: (ctx) => _handleNearby(ctx, logger),
+    nearby_including_blockers: (ctx) =>
+      _handleNearbyIncludingBlockers(ctx, logger),
+    self: (ctx) => _handleSelf(ctx, logger),
+    environment: (ctx) => _handleLocation(ctx, logger),
+  };
 
   for (const scopeName of requestedScopes) {
     const handler = scopeHandlers[scopeName];
@@ -287,13 +301,13 @@ function getEntityIdsForScopes(scopes, context) {
         const scopeIds = handler(context);
         scopeIds.forEach((id) => aggregatedIds.add(id));
       } catch (error) {
-        console.error(
+        logger.error(
           `getEntityIdsForScopes: Error executing handler for scope '${scopeName}':`,
           error
         );
       }
     } else if (scopeName !== 'none' && scopeName !== 'direction') {
-      console.warn(
+      logger.warn(
         `getEntityIdsForScopes: Unknown scope requested: '${scopeName}'. Skipping.`
       );
     }

--- a/src/entities/spatialIndexManager.js
+++ b/src/entities/spatialIndexManager.js
@@ -12,8 +12,14 @@ import { assertValidId } from '../utils/parameterGuards.js';
  * @implements {ISpatialIndexManager}
  */
 class SpatialIndexManager extends MapManager {
-  constructor() {
+  /**
+   * @param {object} dependencies
+   * @param {import('../interfaces/coreServices.js').ILogger} dependencies.logger
+   */
+  constructor({ logger } = {}) {
     super();
+    /** @type {import('../interfaces/coreServices.js').ILogger} */
+    this.logger = logger || console;
     /**
      * The core spatial index.
      * Maps locationId (string) to a Set of entityIds (string) present in that location.
@@ -22,14 +28,14 @@ class SpatialIndexManager extends MapManager {
      * @type {Map<string, Set<string>>}
      */
     this.locationIndex = this.items; // Inherits `items` from MapManager
-    console.log('SpatialIndexManager initialized.');
+    this.logger.info('SpatialIndexManager initialized.');
   }
 
   /**
    * @override
    */
   onInvalidId(id, operation) {
-    console.warn(
+    this.logger.warn(
       `SpatialIndexManager.${operation}: Invalid id (${id}). Skipping.`
     );
   }
@@ -44,9 +50,9 @@ class SpatialIndexManager extends MapManager {
    */
   addEntity(entityId, locationId) {
     try {
-      assertValidId(entityId, 'SpatialIndexManager.addEntity', console);
+      assertValidId(entityId, 'SpatialIndexManager.addEntity', this.logger);
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         `SpatialIndexManager.addEntity: Invalid entityId (${entityId}). Skipping.`
       );
       return;
@@ -54,7 +60,7 @@ class SpatialIndexManager extends MapManager {
 
     // Only proceed if locationId is a valid, non-empty string
     try {
-      assertValidId(locationId, 'SpatialIndexManager.addEntity', console);
+      assertValidId(locationId, 'SpatialIndexManager.addEntity', this.logger);
     } catch (error) {
       // console.debug(`SpatialIndexManager.addEntity: Invalid or null locationId (${locationId}) for entity ${entityId}. Skipping.`);
       return;
@@ -79,16 +85,20 @@ class SpatialIndexManager extends MapManager {
    */
   removeEntity(entityId, locationId) {
     try {
-      assertValidId(entityId, 'SpatialIndexManager.removeEntity', console);
+      assertValidId(entityId, 'SpatialIndexManager.removeEntity', this.logger);
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         `SpatialIndexManager.removeEntity: Invalid entityId (${entityId}). Skipping.`
       );
       return;
     }
 
     try {
-      assertValidId(locationId, 'SpatialIndexManager.removeEntity', console);
+      assertValidId(
+        locationId,
+        'SpatialIndexManager.removeEntity',
+        this.logger
+      );
     } catch (error) {
       // console.debug(`SpatialIndexManager.removeEntity: Invalid or null locationId (${locationId}) for entity ${entityId}. Skipping.`);
       return;
@@ -116,10 +126,10 @@ class SpatialIndexManager extends MapManager {
       assertValidId(
         entityId,
         'SpatialIndexManager.updateEntityLocation',
-        console
+        this.logger
       );
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         'SpatialIndexManager.updateEntityLocation: Invalid entityId. Skipping.'
       );
       return;
@@ -157,7 +167,7 @@ class SpatialIndexManager extends MapManager {
       assertValidId(
         locationId,
         'SpatialIndexManager.getEntitiesInLocation',
-        console
+        this.logger
       );
     } catch (error) {
       return new Set();
@@ -184,7 +194,7 @@ class SpatialIndexManager extends MapManager {
       !entityManager ||
       typeof entityManager.entities?.values !== 'function'
     ) {
-      console.error(
+      this.logger.error(
         'SpatialIndexManager.buildIndex: Invalid entityManager provided.'
       );
       return;
@@ -220,7 +230,7 @@ class SpatialIndexManager extends MapManager {
    */
   clearIndex() {
     this.clear(); // clear is from MapManager, acts on this.items (this.locationIndex)
-    console.log('SpatialIndexManager: Index cleared.');
+    this.logger.info('SpatialIndexManager: Index cleared.');
   }
 }
 

--- a/tests/integration/scope.integration.test.js
+++ b/tests/integration/scope.integration.test.js
@@ -59,8 +59,8 @@ describe('entityScopeService integration', () => {
     });
 
     // Act
-    const invSet = getEntityIdsForScopes('inventory', ctx);
-    const locationSet = getEntityIdsForScopes('location', ctx);
+    const invSet = getEntityIdsForScopes('inventory', ctx, console);
+    const locationSet = getEntityIdsForScopes('location', ctx, console);
 
     // Assert
     expect(invSet.has(swordId)).toBe(true);

--- a/tests/unit/entities/entityScopeService.followers.test.js
+++ b/tests/unit/entities/entityScopeService.followers.test.js
@@ -34,18 +34,20 @@ const mockEntityManager = {
 };
 
 describe('entityScopeService - "followers" scope', () => {
-  let consoleWarnSpy;
+  let mockLogger;
 
   beforeEach(() => {
-    // Reset mocks to ensure test isolation
     jest.resetAllMocks();
-    // Spy on console.warn to check for warnings in failure cases
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockLogger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
   });
 
   afterEach(() => {
-    // Restore original console.warn behavior
-    consoleWarnSpy.mockRestore();
+    jest.clearAllMocks();
   });
 
   // Test Case 1: Standard success case with followers
@@ -62,7 +64,7 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes('followers', context);
+    const result = getEntityIdsForScopes('followers', context, mockLogger);
 
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(2);
@@ -86,7 +88,7 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes('followers', context);
+    const result = getEntityIdsForScopes('followers', context, mockLogger);
 
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(0);
@@ -104,7 +106,7 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes('followers', context);
+    const result = getEntityIdsForScopes('followers', context, mockLogger);
 
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(0);
@@ -128,7 +130,7 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes('followers', context);
+    const result = getEntityIdsForScopes('followers', context, mockLogger);
 
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(0);
@@ -142,12 +144,12 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes('followers', context);
+    const result = getEntityIdsForScopes('followers', context, mockLogger);
 
     expect(result).toBeInstanceOf(Set);
     expect(result.size).toBe(0);
     // FIX: Update the expected warning to check for "actingEntity".
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
+    expect(mockLogger.warn).toHaveBeenCalledWith(
       "entityScopeService(#createActorComponentScopeHandler): Scope 'followers' requested but actingEntity is missing in context."
     );
   });
@@ -169,7 +171,11 @@ describe('entityScopeService - "followers" scope', () => {
       entityManager: mockEntityManager,
     };
 
-    const result = getEntityIdsForScopes(['followers', 'inventory'], context);
+    const result = getEntityIdsForScopes(
+      ['followers', 'inventory'],
+      context,
+      mockLogger
+    );
 
     expect(result).toBeInstanceOf(Set);
     // FIX: This check will now pass as both scope handlers find the actingEntity.


### PR DESCRIPTION
Summary: 
- allow `SpatialIndexManager` to accept a logger and replace console usage
- update DI registration and ActionDiscoveryService
- refactor entityScopeService to accept a logger
- update all tests with mock loggers

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: numerous existing issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857b4443ba883319a79c0b59d36cba6