### PR TITLE
[Agent] Add unavailable service test suite helper and refactor

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -3,7 +3,7 @@
  * @see tests/common/engine/gameEngineHelpers.js
  */
 
-import { expect, jest } from '@jest/globals';
+import { expect, jest, it } from '@jest/globals';
 import { expectNoDispatch } from './dispatchTestUtils.js';
 import { GameEngineTestBed } from './gameEngineTestBed.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
@@ -83,6 +83,34 @@ export function runUnavailableServiceTest(cases, invokeFn) {
       });
     },
   ]);
+}
+
+/**
+ * Generates a Jest `it.each` suite for unavailable service scenarios.
+ *
+ * @param {Array<[string, string, { preInit?: boolean }]>} cases - Array of test
+ *   case tuples forwarded to {@link runUnavailableServiceTest}.
+ * @param {(bed: GameEngineTestBed,
+ *   engine: import('../../../src/engine/gameEngine.js').default,
+ *   expectedMessage: string) =>
+ *   Promise<[import('@jest/globals').Mock, import('@jest/globals').Mock]> |
+ *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
+ *   Callback used by {@link runUnavailableServiceTest}.
+ * @param {number} [extraAssertions] - Number of assertions performed inside
+ *   {@code invokeFn}.
+ * @returns {(title: string) => void} Function executing the generated suite.
+ */
+export function runUnavailableServiceSuite(
+  cases,
+  invokeFn,
+  extraAssertions = 0
+) {
+  const eachFn = it.each(runUnavailableServiceTest(cases, invokeFn));
+  return (title) =>
+    eachFn(title, async (_token, fn) => {
+      expect.assertions(2 + extraAssertions);
+      await fn();
+    });
 }
 
 /**

--- a/tests/unit/engine/handleLoadFailure.test.js
+++ b/tests/unit/engine/handleLoadFailure.test.js
@@ -4,7 +4,7 @@ import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   withGameEngineBed,
-  runUnavailableServiceTest,
+  runUnavailableServiceSuite,
 } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 
@@ -29,31 +29,24 @@ describe('GameEngine', () => {
       });
     });
 
-    it.each(
-      runUnavailableServiceTest(
+    runUnavailableServiceSuite(
+      [
         [
-          [
-            tokens.ISafeEventDispatcher,
-            'GameEngine._handleLoadFailure: ISafeEventDispatcher not available, cannot dispatch UI failure event.',
-          ],
+          tokens.ISafeEventDispatcher,
+          'GameEngine._handleLoadFailure: ISafeEventDispatcher not available, cannot dispatch UI failure event.',
         ],
-        async (bed, engine) => {
-          const err = new Error('oops');
-          const result = await engine._handleLoadFailure(err, 'save-002');
-          expect(result).toEqual({
-            success: false,
-            error: err.message,
-            data: null,
-          });
-          return [
-            bed.mocks.logger.error,
-            bed.mocks.safeEventDispatcher.dispatch,
-          ];
-        }
-      )
-    )('logs error if %s is unavailable', async (_token, fn) => {
-      expect.assertions(3);
-      await fn();
-    });
+      ],
+      async (bed, engine) => {
+        const err = new Error('oops');
+        const result = await engine._handleLoadFailure(err, 'save-002');
+        expect(result).toEqual({
+          success: false,
+          error: err.message,
+          data: null,
+        });
+        return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+      },
+      1
+    )('logs error if %s is unavailable');
   });
 });

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -4,7 +4,7 @@ import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import {
-  runUnavailableServiceTest,
+  runUnavailableServiceSuite,
   setupLoadGameSpies,
 } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
@@ -109,35 +109,27 @@ describeEngineSuite('GameEngine', (ctx) => {
       });
     });
 
-    it.each(
-      runUnavailableServiceTest(
+    runUnavailableServiceSuite(
+      [
         [
-          [
-            tokens.GamePersistenceService,
-            'GameEngine.loadGame: GamePersistenceService is not available. Cannot load game.',
-            { preInit: true },
-          ],
+          tokens.GamePersistenceService,
+          'GameEngine.loadGame: GamePersistenceService is not available. Cannot load game.',
+          { preInit: true },
         ],
-        async (bed, engine, expectedMsg) => {
-          const result = await engine.loadGame(SAVE_ID);
-          expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
-          expect(result).toEqual({
-            success: false,
-            error: expectedMsg,
-            data: null,
-          });
-          return [
-            bed.mocks.logger.error,
-            bed.mocks.safeEventDispatcher.dispatch,
-          ];
-        }
-      )
+      ],
+      async (bed, engine, expectedMsg) => {
+        const result = await engine.loadGame(SAVE_ID);
+        expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+        expect(result).toEqual({
+          success: false,
+          error: expectedMsg,
+          data: null,
+        });
+        return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+      },
+      2
     )(
-      'should handle %s unavailability (guard clause) and dispatch UI event directly',
-      async (_token, fn) => {
-        expect.assertions(4);
-        await fn();
-      }
+      'should handle %s unavailability (guard clause) and dispatch UI event directly'
     );
 
     it('should use _handleLoadFailure when _prepareForLoadGameSession throws an error', async () => {

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
+import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
@@ -27,28 +27,17 @@ describeEngineSuite('GameEngine', (ctx) => {
       );
     });
 
-    it.each(
-      runUnavailableServiceTest(
+    runUnavailableServiceSuite(
+      [
         [
-          [
-            tokens.GamePersistenceService,
-            'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.',
-          ],
+          tokens.GamePersistenceService,
+          'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.',
         ],
-        (bed, engine) => {
-          engine.showLoadGameUI();
-          return [
-            bed.mocks.logger.error,
-            bed.mocks.safeEventDispatcher.dispatch,
-          ];
-        }
-      )
-    )(
-      'should log error if %s is unavailable when showing load UI',
-      async (_token, fn) => {
-        expect.assertions(2);
-        await fn();
+      ],
+      (bed, engine) => {
+        engine.showLoadGameUI();
+        return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
       }
-    );
+    )('should log error if %s is unavailable when showing load UI');
   });
 });

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -2,7 +2,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeInitializedEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
+import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import {
   REQUEST_SHOW_SAVE_GAME_UI,
@@ -55,32 +55,25 @@ describeInitializedEngineSuite(
         ).toHaveBeenCalledTimes(1);
       });
 
-      it.each(
-        runUnavailableServiceTest(
+      runUnavailableServiceSuite(
+        [
           [
-            [
-              tokens.GamePersistenceService,
-              'GameEngine.showSaveGameUI: GamePersistenceService is unavailable. Cannot show Save Game UI.',
-            ],
+            tokens.GamePersistenceService,
+            'GameEngine.showSaveGameUI: GamePersistenceService is unavailable. Cannot show Save Game UI.',
           ],
-          (bed, engine) => {
-            engine.showSaveGameUI();
-            expect(
-              bed.mocks.gamePersistenceService.isSavingAllowed
-            ).not.toHaveBeenCalled();
-            return [
-              bed.mocks.logger.error,
-              bed.mocks.safeEventDispatcher.dispatch,
-            ];
-          }
-        )
-      )(
-        'should log error if %s is unavailable when showing save UI',
-        async (_token, fn) => {
-          expect.assertions(3);
-          await fn();
-        }
-      );
+        ],
+        (bed, engine) => {
+          engine.showSaveGameUI();
+          expect(
+            bed.mocks.gamePersistenceService.isSavingAllowed
+          ).not.toHaveBeenCalled();
+          return [
+            bed.mocks.logger.error,
+            bed.mocks.safeEventDispatcher.dispatch,
+          ];
+        },
+        1
+      )('should log error if %s is unavailable when showing save UI');
     });
   },
   DEFAULT_TEST_WORLD

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceTest } from '../../common/engine/gameEngineHelpers.js';
+import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
@@ -61,36 +61,31 @@ describeEngineSuite('GameEngine', (ctx) => {
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
 
-    it.each(
-      runUnavailableServiceTest(
+    runUnavailableServiceSuite(
+      [
         [
-          [
-            tokens.PlaytimeTracker,
-            'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
-            { preInit: true },
-          ],
+          tokens.PlaytimeTracker,
+          'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
+          { preInit: true },
         ],
-        async (bed, engine, expectedMsg) => {
-          expectEngineRunning(engine, DEFAULT_TEST_WORLD);
+      ],
+      async (bed, engine, expectedMsg) => {
+        expectEngineRunning(engine, DEFAULT_TEST_WORLD);
 
-          await engine.stop();
+        await engine.stop();
 
-          expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
-          expectDispatchSequence(
-            bed.mocks.safeEventDispatcher.dispatch,
-            ...buildStopDispatches()
-          );
-          expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
-          const dummyDispatch = jest.fn();
-          return [bed.mocks.logger.warn, dummyDispatch];
-        }
-      )
+        expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
+        expectDispatchSequence(
+          bed.mocks.safeEventDispatcher.dispatch,
+          ...buildStopDispatches()
+        );
+        expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+        const dummyDispatch = jest.fn();
+        return [bed.mocks.logger.warn, dummyDispatch];
+      },
+      4
     )(
-      'should log warning for %s if it is not available during stop, after a successful start',
-      async (_token, fn) => {
-        expect.assertions(6);
-        await fn();
-      }
+      'should log warning for %s if it is not available during stop, after a successful start'
     );
   });
 });

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -6,7 +6,7 @@ import {
   describeInitializedEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
 import {
-  runUnavailableServiceTest,
+  runUnavailableServiceSuite,
   withGameEngineBed,
 } from '../../common/engine/gameEngineHelpers.js';
 import '../../common/engine/engineTestTypedefs.js';
@@ -40,33 +40,29 @@ describeEngineSuite('GameEngine', () => {
     describeInitializedEngineSuite(
       'when engine is initialized',
       (ctx) => {
-        it.each(
-          runUnavailableServiceTest(
+        runUnavailableServiceSuite(
+          [
             [
-              [
-                tokens.GamePersistenceService,
-                'GameEngine.triggerManualSave: GamePersistenceService is not available. Cannot save game.',
-                { preInit: true },
-              ],
+              tokens.GamePersistenceService,
+              'GameEngine.triggerManualSave: GamePersistenceService is not available. Cannot save game.',
+              { preInit: true },
             ],
-            async (bed, engine) => {
-              const result = await engine.triggerManualSave(SAVE_NAME);
-              expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
-              expect(result).toEqual({
-                success: false,
-                error:
-                  'GamePersistenceService is not available. Cannot save game.',
-              });
-              return [
-                bed.mocks.logger.error,
-                bed.mocks.safeEventDispatcher.dispatch,
-              ];
-            }
-          )
-        )('should dispatch error if %s is unavailable', async (_token, fn) => {
-          expect.assertions(4);
-          await fn();
-        });
+          ],
+          async (bed, engine) => {
+            const result = await engine.triggerManualSave(SAVE_NAME);
+            expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+            expect(result).toEqual({
+              success: false,
+              error:
+                'GamePersistenceService is not available. Cannot save game.',
+            });
+            return [
+              bed.mocks.logger.error,
+              bed.mocks.safeEventDispatcher.dispatch,
+            ];
+          },
+          2
+        )('should dispatch error if %s is unavailable');
 
         it('should successfully save, dispatch all UI events in order, and return success result', async () => {
           const saveResultData = { success: true, filePath: 'path/to/my.sav' };


### PR DESCRIPTION
Summary: Add helper to simplify unavailable service tests and refactor affected suites.

Changes Made:
- Created `runUnavailableServiceSuite` in `gameEngineHelpers` for wrapping `it.each` suites.
- Updated engine test files to use the new helper with assertion counts.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` and `llm-proxy-server` lint)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6857b65b80288331b349e8a482834320