### PR TITLE
[Agent] centralize entity validation helpers

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -24,6 +24,10 @@ import Entity from './entity.js';
 import EntityInstanceData from './entityInstanceData.js';
 import { MapManager } from '../utils/mapManagerUtils.js';
 import EntityFactory from './factories/entityFactory.js';
+import {
+  validationSucceeded,
+  formatValidationErrors,
+} from './utils/validationHelpers.js';
 import EntityQuery from '../query/EntityQuery.js';
 import {
   assertValidId,
@@ -70,36 +74,8 @@ import {
 /* Internal Utilities                                                         */
 
 /* -------------------------------------------------------------------------- */
-
-/**
- * Normalize any validator return shape to a simple `true | false`.
- *
- * Legacy validators may return `undefined`, `null`, or a bare boolean. Newer
- * validators should return `{ isValid: boolean, errors?: any }`.
- *
- * @private
- * @param {undefined|null|boolean|ValidationResult} rawResult
- * @returns {boolean}
- */
-function validationSucceeded(rawResult) {
-  if (rawResult === undefined || rawResult === null) return true;
-  if (typeof rawResult === 'boolean') return rawResult;
-  return !!rawResult.isValid;
-}
-
-/**
- * Convert a validation result into a readable string for logs.
- *
- * @private
- * @param {ValidationResult|boolean|undefined|null} rawResult
- * @returns {string}
- */
-function formatValidationErrors(rawResult) {
-  if (rawResult && typeof rawResult === 'object' && rawResult.errors) {
-    return JSON.stringify(rawResult.errors, null, 2);
-  }
-  return '(validator returned false)';
-}
+// validationSucceeded and formatValidationErrors imported from
+// ./utils/validationHelpers.js
 
 // assertInterface removed; using validateDependency instead
 

--- a/src/entities/factories/entityFactory.js
+++ b/src/entities/factories/entityFactory.js
@@ -33,6 +33,10 @@ import {
 import { validateDependency } from '../../utils/validationUtils.js';
 import { ensureValidLogger } from '../../utils';
 import { DefinitionNotFoundError } from '../../errors/definitionNotFoundError.js';
+import {
+  validationSucceeded,
+  formatValidationErrors,
+} from '../utils/validationHelpers.js';
 
 /* -------------------------------------------------------------------------- */
 /* Type-Hint Imports (JSDoc only – removed at runtime)                        */
@@ -49,35 +53,8 @@ import { DefinitionNotFoundError } from '../../errors/definitionNotFoundError.js
 /* Internal Utilities                                                         */
 /* -------------------------------------------------------------------------- */
 
-/**
- * Normalize any validator return shape to a simple `true | false`.
- *
- * Legacy validators may return `undefined`, `null`, or a bare boolean. Newer
- * validators should return `{ isValid: boolean, errors?: any }`.
- *
- * @private
- * @param {undefined|null|boolean|ValidationResult} rawResult
- * @returns {boolean}
- */
-function validationSucceeded(rawResult) {
-  if (rawResult === undefined || rawResult === null) return true;
-  if (typeof rawResult === 'boolean') return rawResult;
-  return !!rawResult.isValid;
-}
-
-/**
- * Convert a validation result into a readable string for logs.
- *
- * @private
- * @param {ValidationResult|boolean|undefined|null} rawResult
- * @returns {string}
- */
-function formatValidationErrors(rawResult) {
-  if (rawResult && typeof rawResult === 'object' && rawResult.errors) {
-    return JSON.stringify(rawResult.errors, null, 2);
-  }
-  return '(validator returned false)';
-}
+// validationSucceeded and formatValidationErrors imported from
+// ../utils/validationHelpers.js
 
 /* -------------------------------------------------------------------------- */
 /* EntityFactory Implementation                                               */

--- a/src/entities/utils/validationHelpers.js
+++ b/src/entities/utils/validationHelpers.js
@@ -1,0 +1,40 @@
+// src/entities/utils/validationHelpers.js
+
+/**
+ * @module validationHelpers
+ * @description
+ * Utility functions used to normalize validation results and format
+ * validation error details for logging.
+ */
+
+/**
+ * Normalize any validator return shape to a simple boolean indicating success.
+ *
+ * Legacy validators may return `undefined`, `null`, or a bare boolean. Newer
+ * validators should return `{ isValid: boolean, errors?: any }`.
+ *
+ * @param {undefined|null|boolean|import('../../interfaces/coreServices.js').ValidationResult} rawResult
+ *   The raw validation result from a schema validator.
+ * @returns {boolean} `true` if validation succeeded, `false` otherwise.
+ */
+export function validationSucceeded(rawResult) {
+  if (rawResult === undefined || rawResult === null) return true;
+  if (typeof rawResult === 'boolean') return rawResult;
+  return !!rawResult.isValid;
+}
+
+/**
+ * Convert a validation result into a readable string for logs.
+ *
+ * @param {import('../../interfaces/coreServices.js').ValidationResult|boolean|undefined|null} rawResult
+ *   The raw validation result.
+ * @returns {string} Stringified error details or a fallback message.
+ */
+export function formatValidationErrors(rawResult) {
+  if (rawResult && typeof rawResult === 'object' && rawResult.errors) {
+    return JSON.stringify(rawResult.errors, null, 2);
+  }
+  return '(validator returned false)';
+}
+
+// --- FILE END ---


### PR DESCRIPTION
Summary: Introduces reusable validation helpers and refactors entity modules to use them.

Changes Made:
- Added `src/entities/utils/validationHelpers.js` exporting shared helpers.
- Updated `entityManager` and `entityFactory` to import new helpers and removed duplicate code.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on touched files (`npx eslint src/entities/utils/validationHelpers.js src/entities/entityManager.js src/entities/factories/entityFactory.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6857ba198b4883318c744ced0af71caa