### PR TITLE
[Feat] direction exit helper

### DIFF
--- a/src/actions/validation/contextBuilders.js
+++ b/src/actions/validation/contextBuilders.js
@@ -39,6 +39,44 @@ export function buildEntityTargetContext(entityId, entityManager, logger) {
 }
 
 /**
+ * @description Resolve exit and blocker information for a directional target.
+ * @param {string} actorId - ID of the actor performing the action.
+ * @param {string} direction - Direction keyword.
+ * @param {EntityManager} entityManager - Manager to access components.
+ * @param {ILogger} logger - Logger instance.
+ * @returns {{blocker: any, exitDetails: any}} Object containing blocker and exit details.
+ */
+export function resolveDirectionExit(
+  actorId,
+  direction,
+  entityManager,
+  logger
+) {
+  const actorPositionData = entityManager.getComponentData(
+    actorId,
+    POSITION_COMPONENT_ID
+  );
+  const actorLocationId = actorPositionData?.locationId;
+  let blocker = undefined;
+  let exitDetails = null;
+
+  if (actorLocationId) {
+    const matchedExit = getExitByDirection(
+      actorLocationId,
+      direction,
+      entityManager,
+      logger
+    );
+    if (matchedExit) {
+      exitDetails = matchedExit;
+      blocker = matchedExit.blocker ?? null;
+    }
+  }
+
+  return { blocker, exitDetails };
+}
+
+/**
  * @description Build the target portion when targeting a direction.
  * @param {string} actorId - ID of the actor performing the action.
  * @param {string} direction - Direction keyword.
@@ -53,33 +91,19 @@ export function buildDirectionContext(
   entityManager,
   logger
 ) {
-  const actorPositionData = entityManager.getComponentData(
+  const { blocker, exitDetails } = resolveDirectionExit(
     actorId,
-    POSITION_COMPONENT_ID
+    direction,
+    entityManager,
+    logger
   );
-  const actorLocationId = actorPositionData?.locationId;
-  let targetBlockerValue = undefined;
-  let targetExitDetailsValue = null;
-
-  if (actorLocationId) {
-    const matchedExit = getExitByDirection(
-      actorLocationId,
-      direction,
-      entityManager,
-      logger
-    );
-    if (matchedExit) {
-      targetExitDetailsValue = matchedExit;
-      targetBlockerValue = matchedExit.blocker ?? null;
-    }
-  }
 
   return {
     type: 'direction',
     id: null,
     direction,
     components: null,
-    blocker: targetBlockerValue,
-    exitDetails: targetExitDetailsValue,
+    blocker,
+    exitDetails,
   };
 }

--- a/tests/unit/actions/contextBuilders.test.js
+++ b/tests/unit/actions/contextBuilders.test.js
@@ -3,6 +3,7 @@ import {
   buildActorContext,
   buildDirectionContext,
   buildEntityTargetContext,
+  resolveDirectionExit,
 } from '../../../src/actions/validation/contextBuilders.js';
 
 jest.mock('../../../src/logic/componentAccessor.js', () => ({
@@ -61,6 +62,70 @@ describe('contextBuilders', () => {
         mockEntityManager,
         mockLogger
       );
+    });
+  });
+
+  describe('resolveDirectionExit', () => {
+    it('returns exit details and blocker when found', () => {
+      mockEntityManager.getComponentData.mockReturnValue({
+        locationId: 'loc1',
+      });
+      const exitObj = { blocker: 'door', some: 'data' };
+      getExitByDirection.mockReturnValue(exitObj);
+      const result = resolveDirectionExit(
+        'actor1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({ blocker: 'door', exitDetails: exitObj });
+      expect(getExitByDirection).toHaveBeenCalledWith(
+        'loc1',
+        'north',
+        mockEntityManager,
+        mockLogger
+      );
+    });
+
+    it('maps missing blocker to null', () => {
+      mockEntityManager.getComponentData.mockReturnValue({
+        locationId: 'loc1',
+      });
+      const exitObj = { some: 'data' };
+      getExitByDirection.mockReturnValue(exitObj);
+      const result = resolveDirectionExit(
+        'actor1',
+        'west',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({ blocker: null, exitDetails: exitObj });
+    });
+
+    it('returns undefined blocker when no exit', () => {
+      mockEntityManager.getComponentData.mockReturnValue({
+        locationId: 'loc1',
+      });
+      getExitByDirection.mockReturnValue(null);
+      const result = resolveDirectionExit(
+        'actor1',
+        'south',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(result).toEqual({ blocker: undefined, exitDetails: null });
+    });
+
+    it('skips lookup when actor location missing', () => {
+      mockEntityManager.getComponentData.mockReturnValue(null);
+      const result = resolveDirectionExit(
+        'actor1',
+        'east',
+        mockEntityManager,
+        mockLogger
+      );
+      expect(getExitByDirection).not.toHaveBeenCalled();
+      expect(result).toEqual({ blocker: undefined, exitDetails: null });
     });
   });
 


### PR DESCRIPTION
Summary: Adds a helper to resolve directional exits and refactors context builder to use it.

Changes Made:
- Added `resolveDirectionExit` utility in `contextBuilders.js`.
- Updated `buildDirectionContext` to use the new helper.
- Added comprehensive Jest tests for `resolveDirectionExit`.

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes (`npx eslint` on modified files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6857b98ba79c8331b16ce3ccece31d54