### PR TITLE
[Agent] add setupDebugStopSpy helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -136,6 +136,27 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
   }
 
   /**
+   * Spies on {@link TurnManager.stop} and logs when invoked.
+   *
+   * Calls {@link TurnManagerTestBed#spyOnStop} and overrides the spy
+   * implementation to emit a debug message. Useful for tests that need
+   * confirmation that stop was triggered without affecting flow.
+   *
+   * @example
+   * const stopSpy = bed.setupDebugStopSpy();
+   * await bed.turnManager.stop();
+   * expect(stopSpy).toHaveBeenCalled();
+   * @returns {import('@jest/globals').Mock} The spy instance.
+   */
+  setupDebugStopSpy() {
+    const spy = this.spyOnStop();
+    spy.mockImplementation(() => {
+      this.mocks.logger.debug('Mocked instance.stop() called.');
+    });
+    return spy;
+  }
+
+  /**
    * Spies on {@link TurnManager.advanceTurn} and tracks for cleanup.
    *
    * @returns {import('@jest/globals').Mock} The spy instance.


### PR DESCRIPTION
Summary: Adds a setupDebugStopSpy() helper in TurnManagerTestBed for easier debugging of stop() calls.

Testing Done:
- [x] Code formatted `npx prettier`
- [ ] Lint passes `npm run lint` *(fails: 569 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857bb97e49c83319b717969107ee401