### PR TITLE
[Agent] centralize engine test typedefs

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -31,3 +31,6 @@ if (typeof window !== 'undefined') {
 } else {
   console.log('jest.setup.js: Non-jsdom environment detected.');
 }
+
+// Provide shared typedefs for test suites
+require('./tests/common/engine/engineTestTypedefs.js');

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -4,7 +4,6 @@ import { describe, expect, it } from '@jest/globals';
 import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import '../../common/engine/engineTestTypedefs.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('Constructor', () => {

--- a/tests/unit/engine/handleLoadFailure.test.js
+++ b/tests/unit/engine/handleLoadFailure.test.js
@@ -6,7 +6,6 @@ import {
   withGameEngineBed,
   runUnavailableServiceSuite,
 } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 
 describe('GameEngine', () => {
   describe('_handleLoadFailure', () => {

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -7,7 +7,6 @@ import {
   runUnavailableServiceSuite,
   setupLoadGameSpies,
 } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('loadGame', () => {

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -3,7 +3,6 @@ import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeInitializedEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 import {
   REQUEST_SHOW_SAVE_GAME_UI,
   CANNOT_SAVE_GAME_INFO,

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -2,7 +2,6 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import '../../common/engine/engineTestTypedefs.js';
 
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 import {

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -9,7 +9,6 @@ import {
   runUnavailableServiceSuite,
   withGameEngineBed,
 } from '../../common/engine/gameEngineHelpers.js';
-import '../../common/engine/engineTestTypedefs.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,


### PR DESCRIPTION
Summary: Added shared engine typedef import to jest setup and removed redundant imports across engine test files.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 2860 problems)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   *(not executed)*

------
https://chatgpt.com/codex/tasks/task_e_6857bbb9b25c83318ec247761e116932