### PR TITLE
[Agent] remove redundant cleanup

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -117,16 +117,6 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
       await this.engine.stop();
     }
   }
-
-  /**
-   * Stops the engine and cleans up the mock environment after base cleanup.
-   *
-   * @protected
-   * @returns {Promise<void>} Promise resolving when engine cleanup is complete.
-   */
-  async _afterCleanup() {
-    await super._afterCleanup();
-  }
 }
 
 const engineSuiteHooks = (() => {


### PR DESCRIPTION
Summary: dropped `_afterCleanup` override so `GameEngineTestBed` relies on its mixin's implementation.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (errors unrelated to change)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857bb9246e48331b7420e2dbe1e2805