### PR TITLE
[Agent] refactor context logging utilities

### DIFF
--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -14,6 +14,7 @@
 
 import { ITurnState } from '../interfaces/ITurnState.js';
 import { UNKNOWN_ACTOR_ID } from '../../constants/unknownIds.js';
+import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 
 /**
  * @class AbstractTurnState
@@ -133,36 +134,7 @@ export class AbstractTurnState extends ITurnState {
    * @returns {import('../../logging/consoleLogger.js').default | Console} The logger instance.
    */
   _resolveLogger(turnCtx, handler) {
-    try {
-      if (turnCtx && typeof turnCtx.getLogger === 'function') {
-        const logger = turnCtx.getLogger();
-        if (logger) {
-          return logger;
-        }
-      }
-    } catch (err) {
-      console.error(
-        `${this.getStateName()}: Error getting logger from turnCtx: ${err.message}`,
-        err
-      );
-    }
-
-    try {
-      const resolvedHandler = handler || this._handler;
-      if (resolvedHandler && typeof resolvedHandler.getLogger === 'function') {
-        const logger = resolvedHandler.getLogger();
-        if (logger) {
-          return logger;
-        }
-      }
-    } catch (err) {
-      console.error(
-        `${this.getStateName()}: Error getting logger from handler: ${err.message}`,
-        err
-      );
-    }
-
-    return console;
+    return getLogger(turnCtx, handler || this._handler);
   }
 
   /**
@@ -176,34 +148,7 @@ export class AbstractTurnState extends ITurnState {
    *   The resolved dispatcher or null if unavailable.
    */
   _getSafeEventDispatcher(turnCtx, handler = this._handler) {
-    if (turnCtx && typeof turnCtx.getSafeEventDispatcher === 'function') {
-      try {
-        const dispatcher = turnCtx.getSafeEventDispatcher();
-        if (dispatcher && typeof dispatcher.dispatch === 'function') {
-          return dispatcher;
-        }
-      } catch (err) {
-        this._resolveLogger(turnCtx, handler).error(
-          `${this.getStateName()}: Error calling turnCtx.getSafeEventDispatcher(): ${err.message}`,
-          err
-        );
-      }
-    }
-
-    if (
-      handler?.safeEventDispatcher &&
-      typeof handler.safeEventDispatcher.dispatch === 'function'
-    ) {
-      this._resolveLogger(turnCtx, handler).warn(
-        `${this.getStateName()}: SafeEventDispatcher not found on ITurnContext. Falling back to handler.safeEventDispatcher.`
-      );
-      return handler.safeEventDispatcher;
-    }
-
-    this._resolveLogger(turnCtx, handler).warn(
-      `${this.getStateName()}: SafeEventDispatcher unavailable.`
-    );
-    return null;
+    return getSafeEventDispatcher(turnCtx, handler);
   }
 
   // --- Interface Methods with Default Implementations ---

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -8,6 +8,7 @@
 import { AbstractTurnState } from './abstractTurnState.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
 import { getActorType } from '../../utils/actorTypeUtils.js';
+import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 
 /**
  * State in which the engine waits for the current actor’s turn-strategy to
@@ -203,7 +204,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
       };
     }
 
-    const dispatcher = this._getSafeEventDispatcher(turnContext);
+    const dispatcher = getSafeEventDispatcher(turnContext, this._handler);
     const logger = turnContext.getLogger();
     if (dispatcher) {
       try {
@@ -225,7 +226,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   /* --------------------------------------------------------------------- */
   async exitState(handler, nextState) {
     await super.exitState(handler, nextState);
-    const logger = this._resolveLogger(this._getTurnContext());
+    const logger = getLogger(this._getTurnContext(), this._handler);
     logger.debug(
       `${this.getStateName()}: ExitState cleanup (if any) specific to AwaitingActorDecisionState complete.`
     );
@@ -258,7 +259,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   async handleTurnEndedEvent(handlerInstance, payload) {
     const handler = handlerInstance || this._handler;
     const turnContext = this._getTurnContext();
-    const logger = this._resolveLogger(turnContext, handler);
+    const logger = getLogger(turnContext, handler);
 
     if (!turnContext) {
       logger.warn(
@@ -291,7 +292,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   async destroy(handlerInstance) {
     const handler = handlerInstance || this._handler;
     const turnContext = handler?.getTurnContext?.();
-    const logger = this._resolveLogger(turnContext, handler);
+    const logger = getLogger(turnContext, handler);
     const actorInCtx = turnContext?.getActor();
 
     if (turnContext) {

--- a/src/turns/states/helpers/contextUtils.js
+++ b/src/turns/states/helpers/contextUtils.js
@@ -1,0 +1,94 @@
+/**
+ * @file Helper utilities for retrieving logger and SafeEventDispatcher from a turn context or handler.
+ */
+
+/**
+ * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ * @typedef {import('../../logging/consoleLogger.js').default|Console} Logger
+ * @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+
+/**
+ * Resolves a logger using the provided context or handler.
+ * Falls back to the console when unavailable.
+ *
+ * @param {ITurnContext|null} turnCtx - The current ITurnContext, if any.
+ * @param {BaseTurnHandler} [handler] - Optional handler fallback.
+ * @returns {Logger} The resolved logger instance.
+ */
+export function getLogger(turnCtx, handler) {
+  try {
+    if (turnCtx && typeof turnCtx.getLogger === 'function') {
+      const logger = turnCtx.getLogger();
+      if (logger) {
+        return logger;
+      }
+    }
+  } catch (err) {
+    console.error(
+      `ContextUtils.getLogger: Error getting logger from turnCtx: ${err.message}`,
+      err
+    );
+  }
+
+  try {
+    if (handler && typeof handler.getLogger === 'function') {
+      const logger = handler.getLogger();
+      if (logger) {
+        return logger;
+      }
+    }
+  } catch (err) {
+    console.error(
+      `ContextUtils.getLogger: Error getting logger from handler: ${err.message}`,
+      err
+    );
+  }
+
+  return console;
+}
+
+/**
+ * Safely resolves a SafeEventDispatcher using the provided context or handler.
+ * Falls back to handler.safeEventDispatcher when necessary.
+ *
+ * @param {ITurnContext|null} turnCtx - The current ITurnContext, if any.
+ * @param {BaseTurnHandler} [handler] - Optional handler fallback.
+ * @returns {ISafeEventDispatcher|null} The resolved dispatcher or null if unavailable.
+ */
+export function getSafeEventDispatcher(turnCtx, handler) {
+  if (turnCtx && typeof turnCtx.getSafeEventDispatcher === 'function') {
+    try {
+      const dispatcher = turnCtx.getSafeEventDispatcher();
+      if (dispatcher && typeof dispatcher.dispatch === 'function') {
+        return dispatcher;
+      }
+    } catch (err) {
+      getLogger(turnCtx, handler).error(
+        `ContextUtils.getSafeEventDispatcher: Error calling turnCtx.getSafeEventDispatcher(): ${err.message}`,
+        err
+      );
+    }
+  }
+
+  if (
+    handler?.safeEventDispatcher &&
+    typeof handler.safeEventDispatcher.dispatch === 'function'
+  ) {
+    getLogger(turnCtx, handler).warn(
+      'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher not found on ITurnContext. Falling back to handler.safeEventDispatcher.'
+    );
+    return handler.safeEventDispatcher;
+  }
+
+  getLogger(turnCtx, handler).warn(
+    'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher unavailable.'
+  );
+  return null;
+}
+
+export default {
+  getLogger,
+  getSafeEventDispatcher,
+};

--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -9,6 +9,7 @@
 
 import { handleProcessingException } from './handleProcessingException.js';
 import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
+import { getLogger, getSafeEventDispatcher } from './contextUtils.js';
 
 /**
  * Safely obtains a service from the turn context.
@@ -27,8 +28,8 @@ export async function getServiceFromContext(
   serviceNameForLog,
   actorIdForLog
 ) {
-  const logger = state._resolveLogger(turnCtx);
-  const dispatcher = state._getSafeEventDispatcher(turnCtx);
+  const logger = getLogger(turnCtx, state._handler);
+  const dispatcher = getSafeEventDispatcher(turnCtx, state._handler);
 
   if (!turnCtx || typeof turnCtx.getLogger !== 'function') {
     const errorMsg = `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceNameForLog}, actor ${actorIdForLog}.`;

--- a/src/turns/states/helpers/handleProcessingException.js
+++ b/src/turns/states/helpers/handleProcessingException.js
@@ -14,6 +14,7 @@ import {
   resolveLogger,
   dispatchSystemError,
 } from './processingErrorUtils.js';
+import { getSafeEventDispatcher } from './contextUtils.js';
 
 /**
  * Handles exceptions that occur during command processing.
@@ -46,10 +47,7 @@ export async function handleProcessingException(
   );
 
   /** @type {ISafeEventDispatcher | null} */
-  const systemErrorDispatcher = state._getSafeEventDispatcher(
-    turnCtx,
-    state._handler
-  );
+  const systemErrorDispatcher = getSafeEventDispatcher(turnCtx, state._handler);
 
   dispatchSystemError(
     systemErrorDispatcher,

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -19,6 +19,7 @@ import { handleProcessingException } from './helpers/handleProcessingException.j
 import { ProcessingWorkflow } from './workflows/processingWorkflow.js';
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
+import { getLogger } from './helpers/contextUtils.js';
 
 /**
  * @class ProcessingCommandState
@@ -45,7 +46,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this.#commandStringForLog =
       commandString || turnAction?.commandString || null;
 
-    const logger = this._resolveLogger(null);
+    const logger = getLogger(null, this._handler);
     logger.debug(
       `${this.getStateName()} constructed. Command string (arg): "${this.#commandStringForLog}". TurnAction ID (arg): ${turnAction ? `"${turnAction.actionDefinitionId}"` : 'null'}`
     );
@@ -76,7 +77,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @returns {Promise<void>} Resolves when dispatch completes.
    */
   async _dispatchSpeech(turnCtx, actor, decisionMeta) {
-    const logger = this._resolveLogger(turnCtx);
+    const logger = getLogger(turnCtx, this._handler);
     const actorId = actor.id;
     const payloadBase = buildSpeechPayload(decisionMeta);
     const speechRaw = decisionMeta?.speech;
@@ -166,7 +167,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this._processingGuard.finish();
 
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorId = turnCtx?.getActor?.()?.id ?? 'N/A_on_exit';
 
     if (wasProcessing) {
@@ -183,7 +184,7 @@ export class ProcessingCommandState extends AbstractTurnState {
 
   async destroy(handler) {
     const turnCtx = this._getTurnContext(); // Get context before calling super, as super.destroy might clear it.
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorId = turnCtx?.getActor?.()?.id ?? 'N/A_at_destroy';
 
     logger.debug(

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -13,6 +13,7 @@
 
 import { AbstractTurnState } from './abstractTurnState.js';
 import { UNKNOWN_ENTITY_ID } from '../../constants/unknownIds.js';
+import { getLogger } from './helpers/contextUtils.js';
 
 /**
  * @class TurnIdleState
@@ -25,7 +26,7 @@ export class TurnIdleState extends AbstractTurnState {
   async enterState(handler, previousState) {
     await super.enterState(handler, previousState);
 
-    const logger = this._resolveLogger(null, handler);
+    const logger = getLogger(null, handler);
     logger.debug(
       `${this.getStateName()}: Ensuring clean state by calling handler.resetStateAndResources().`
     );
@@ -43,7 +44,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async startTurn(handler, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
 
     const actorIdForLog = actorEntity?.id ?? UNKNOWN_ENTITY_ID;
     logger.debug(
@@ -147,7 +148,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleSubmittedCommand(handler, commandString, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorIdForLog = actorEntity?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: Command ('${commandString}') submitted by ${actorIdForLog} but no turn is active (handler is Idle).`;
     logger.warn(message);
@@ -157,7 +158,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleTurnEndedEvent(handler, payload) {
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const payloadActorId = payload?.entityId ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: handleTurnEndedEvent called (for ${payloadActorId}) but no turn is active (handler is Idle).`;
     logger.warn(message);
@@ -167,7 +168,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async processCommandResult(handler, actor, cmdProcResult, commandString) {
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: processCommandResult called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
@@ -182,7 +183,7 @@ export class TurnIdleState extends AbstractTurnState {
   /** @override */
   async handleDirective(handler, actor, directive, cmdProcResult) {
     const turnCtx = this._getTurnContext();
-    const logger = this._resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     const message = `${this.getStateName()}: handleDirective called (for ${actorIdForLog}) but no turn is active.`;
     logger.warn(message);
@@ -191,7 +192,7 @@ export class TurnIdleState extends AbstractTurnState {
 
   /** @override */
   async destroy(handler) {
-    const logger = this._resolveLogger(this._getTurnContext(), handler);
+    const logger = getLogger(this._getTurnContext(), handler);
     logger.debug(
       `${this.getStateName()}: BaseTurnHandler is being destroyed while in idle state.`
     );

--- a/src/turns/states/workflows/processingWorkflow.js
+++ b/src/turns/states/workflows/processingWorkflow.js
@@ -5,6 +5,7 @@
 
 import { AbstractTurnState } from '../abstractTurnState.js';
 import { handleProcessingException } from '../helpers/handleProcessingException.js';
+import { getLogger } from '../helpers/contextUtils.js';
 
 /**
  * @class ProcessingWorkflow
@@ -39,7 +40,7 @@ export class ProcessingWorkflow {
     if (!turnCtx) return;
 
     if (this._state._isProcessing) {
-      const logger = this._state._resolveLogger(turnCtx);
+      const logger = getLogger(turnCtx, this._state._handler);
       logger.warn(
         `${this._state.getStateName()}: enterState called while already processing. Actor: ${turnCtx?.getActor()?.id ?? 'N/A'}. Aborting re-entry.`
       );
@@ -72,7 +73,7 @@ export class ProcessingWorkflow {
    * @returns {Promise<import('../../../entities/entity.js').default|null>} Resolved actor or null.
    */
   async _validateContextAndActor(turnCtx) {
-    const logger = this._state._resolveLogger(turnCtx);
+    const logger = getLogger(turnCtx, this._state._handler);
     const actor = turnCtx.getActor();
     if (!actor) {
       const noActorError = new Error(
@@ -105,7 +106,7 @@ export class ProcessingWorkflow {
    * @returns {Promise<import('../../interfaces/IActorTurnStrategy.js').ITurnAction|null>} Resolved action or null.
    */
   async _resolveTurnAction(turnCtx, actor) {
-    const logger = this._state._resolveLogger(turnCtx);
+    const logger = getLogger(turnCtx, this._state._handler);
     let turnAction = this._turnAction;
     const actorId = actor.id;
     if (!turnAction) {
@@ -185,7 +186,7 @@ export class ProcessingWorkflow {
       const currentTurnCtxForCatch = this._state._getTurnContext() ?? turnCtx;
       const errorLogger =
         currentTurnCtxForCatch?.getLogger?.() ??
-        this._state._resolveLogger(turnCtx);
+        getLogger(turnCtx, this._state._handler);
       errorLogger.error(
         `${this._state.getStateName()}: Uncaught error from _processCommandInternal scope. Error: ${error.message}`,
         error


### PR DESCRIPTION
Summary: Introduced new shared helpers for resolving loggers and event dispatchers within turn states. All state modules now import these utilities and wrapper methods in `AbstractTurnState` delegate to them. This keeps behavior identical while centralizing the logic.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` & `llm-proxy-server` lint)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6857b9fb9960833193c22ea0e239eb7b