### PR TITLE
[Test] Improve ActiveModsManifestBuilder coverage

### DIFF
--- a/tests/unit/services/activeModsManifestBuilder.test.js
+++ b/tests/unit/services/activeModsManifestBuilder.test.js
@@ -47,4 +47,24 @@ describe('ActiveModsManifestBuilder', () => {
     const result = builder.build();
     expect(result).toEqual([{ modId: CORE_MOD_ID, version: '2.0.0' }]);
   });
+
+  it('handles missing registry gracefully', () => {
+    dataRegistry.getAll.mockReturnValue(undefined);
+    const result = builder.build();
+    expect(result).toEqual([
+      { modId: CORE_MOD_ID, version: 'unknown_fallback' },
+    ]);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('uses core mod version when list length is 0 but find returns value', () => {
+    const trickyList = {
+      length: 0,
+      find: () => ({ id: CORE_MOD_ID, version: '3.3.3' }),
+    };
+    dataRegistry.getAll.mockReturnValue(trickyList);
+    const result = builder.build();
+    expect(result).toEqual([{ modId: CORE_MOD_ID, version: '3.3.3' }]);
+    expect(logger.debug).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Summary: Add tests to cover additional branches of ActiveModsManifestBuilder when registry is missing and when a malformed list returns a core manifest.

Changes Made:
- Added new cases in `activeModsManifestBuilder.test.js` for undefined registry and tricky list objects.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6857bc380a7083319f8765e3973e1368