### PR TITLE
[Fix] simplify game engine test environment

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -15,10 +15,7 @@ import {
   createMockSafeEventDispatcher,
   createMockInitializationService,
 } from '../mockFactories';
-import {
-  createTestEnvironmentBuilder,
-  createServiceTestEnvironment,
-} from '../mockEnvironment.js';
+import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
 const factoryMap = {
   logger: createMockLogger,
   entityManager: createMockEntityManager,
@@ -65,15 +62,8 @@ const buildGameEngineEnv = createTestEnvironmentBuilder(
  *   Test environment utilities and mocks.
  */
 export function createTestEnvironment(overrides = {}) {
-  const hasOverrides = Object.keys(overrides).length > 0;
-  const { mocks, mockContainer, instance, cleanup } = hasOverrides
-    ? buildGameEngineEnv(overrides)
-    : createServiceTestEnvironment(
-        factoryMap,
-        tokenMap,
-        (container) => new GameEngine({ container })
-      );
-
+  const { mocks, mockContainer, instance, cleanup } =
+    buildGameEngineEnv(overrides);
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 
   return {


### PR DESCRIPTION
Summary: Simplifies the helper used to create game engine test environments.

Changes Made:
- removed unused `createServiceTestEnvironment` import
- streamlined `createTestEnvironment` to always use `buildGameEngineEnv`

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6857bf3a43848331a77487bb41d26174