### PR TITLE
[Agent] use stop spy helper in tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -32,11 +32,8 @@ describeRunningTurnManagerSuite(
         createMockTurnHandler()
       );
 
-      // Spy on stop to verify calls and simulate unsubscribe
-      stopSpy = testBed.spyOnStop();
-      stopSpy.mockImplementation(async () => {
-        testBed.mocks.logger.debug('Mocked instance.stop() called.');
-      });
+      // Setup stop spy for call verification and debug logging
+      stopSpy = testBed.setupDebugStopSpy();
 
       // Re-apply default isEmpty mock after resetting call history
       testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -27,11 +27,8 @@ describeTurnManagerSuite(
       // Define the spy here for the actual advanceTurn method
       advanceTurnSpy = testBed.spyOnAdvanceTurn();
 
-      // Spy on stop - Keep the condition to ensure start was called.
-      stopSpy = testBed.spyOnStop();
-      stopSpy.mockImplementation(async () => {
-        testBed.mocks.logger.debug('Mocked instance.stop() called.');
-      });
+      // Spy on stop with debug logging for verification
+      stopSpy = testBed.setupDebugStopSpy();
 
       // Clear constructor/setup logs AFTER instantiation and spy setup
       testBed.resetMocks();


### PR DESCRIPTION
## Summary
- swap manual stop spies for `setupDebugStopSpy` in advanceTurn tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857bf19758c833197284be62bb17a50