### PR TITLE
[Agent] Expand coverage for command outcome interpreter

### DIFF
--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -1,0 +1,95 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(() => Promise.resolve()),
+}));
+
+import CommandOutcomeInterpreter from '../../../src/commands/interpreters/commandOutcomeInterpreter.js';
+import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+let logger;
+let dispatcher;
+let turnContext;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  logger = { debug: jest.fn(), error: jest.fn() };
+  dispatcher = { dispatch: jest.fn() };
+  turnContext = {
+    getActor: jest.fn(() => ({ id: 'actor-1' })),
+    getChosenAction: jest.fn(() => ({ actionDefinitionId: 'test:chosen' })),
+  };
+});
+
+describe('CommandOutcomeInterpreter additional branches', () => {
+  it('throws when logger is invalid', () => {
+    expect(
+      () => new CommandOutcomeInterpreter({ dispatcher, logger: {} })
+    ).toThrow('CommandOutcomeInterpreter: Invalid ILogger dependency.');
+  });
+
+  it('throws when dispatcher is invalid', () => {
+    expect(
+      () => new CommandOutcomeInterpreter({ dispatcher: {}, logger })
+    ).toThrow(
+      'CommandOutcomeInterpreter: Invalid ISafeEventDispatcher dependency.'
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'CommandOutcomeInterpreter Constructor: Invalid ISafeEventDispatcher.'
+    );
+  });
+
+  it('dispatches error when result lacks success flag', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    await expect(interpreter.interpret({}, turnContext)).rejects.toThrow(
+      "CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: actor-1."
+    );
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.stringContaining('Invalid CommandResult'),
+      expect.any(Object)
+    );
+  });
+
+  it('returns END_TURN_FAILURE when command fails', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    const result = {
+      success: false,
+      turnEnded: false,
+      actionResult: { actionId: 'fail:action' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.END_TURN_FAILURE);
+  });
+
+  it('uses chosen action when actionId missing', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    const result = {
+      success: true,
+      turnEnded: false,
+      actionResult: { actionId: '  ' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.WAIT_FOR_EVENT);
+    expect(logger.debug).toHaveBeenCalledWith(
+      "CommandOutcomeInterpreter: actor actor-1: result.actionResult.actionId ('  ') invalid/missing. Using action identifier: 'test:chosen'."
+    );
+  });
+
+  it('defaults to unknown action when chosen action missing', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    turnContext.getChosenAction.mockReturnValue(undefined);
+    const result = {
+      success: true,
+      turnEnded: false,
+      actionResult: {},
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.WAIT_FOR_EVENT);
+    expect(logger.debug).toHaveBeenCalledWith(
+      "CommandOutcomeInterpreter: actor actor-1: result.actionResult.actionId ('undefined') invalid/missing. Using action identifier: 'core:unknown_action'."
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added missing branch tests for CommandOutcomeInterpreter to improve coverage of its constructor and error handling paths.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` fails due to existing repo issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (not performed)


------
https://chatgpt.com/codex/tasks/task_e_6857bea1602083319671c5b2496660f3