### PR TITLE
[Agent] Add withReset helper to BaseTestBed

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -5,6 +5,7 @@
 import { jest } from '@jest/globals';
 import { clearMockFunctions } from './jestHelpers.js';
 import { createMockEnvironment } from './mockEnvironment.js';
+import { runWithReset } from './testBedHelpers.js';
 
 /**
  * @description Base class that stores mocks and exposes a reset helper.
@@ -65,6 +66,16 @@ export class BaseTestBed {
    */
   resetMocks() {
     clearMockFunctions(...Object.values(this.mocks));
+  }
+
+  /**
+   * Executes a callback and resets mocks when finished.
+   *
+   * @param {(bed: this) => (Promise<void>|void)} fn - Callback executed with this test bed.
+   * @returns {Promise<void>} Resolves once the callback and reset logic complete.
+   */
+  async withReset(fn) {
+    await runWithReset(this, fn);
   }
 
   /**

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -12,7 +12,6 @@ import { suppressConsoleError } from '../jestHelpers.js';
 import { createDescribeServiceSuite } from '../describeSuite.js';
 import { createTestBedHelpers } from '../createTestBedHelpers.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
-import { runWithReset } from '../testBedHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -78,7 +77,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Resolves once initialization completes.
    */
   async initAndReset(world = DEFAULT_TEST_WORLD) {
-    await runWithReset(this, () => this.init(world));
+    await this.withReset(() => this.init(world));
   }
 
   /**
@@ -104,7 +103,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Resolves when the game has started.
    */
   async startAndReset(world, result = { success: true }) {
-    await runWithReset(this, () => this.start(world, result));
+    await this.withReset(() => this.start(world, result));
   }
 
   /**

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -20,7 +20,6 @@ import {
 } from '../describeSuite.js';
 import { createTestBedHelpers } from '../createTestBedHelpers.js';
 import { flushPromisesAndTimers } from '../jestHelpers.js';
-import { runWithReset } from '../testBedHelpers.js';
 
 /**
  * @description Utility class that instantiates {@link TurnManager} with mocked
@@ -82,7 +81,7 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    * @returns {Promise<void>} Resolves once the manager has started.
    */
   async startWithEntities(...entities) {
-    await runWithReset(this, async () => {
+    await this.withReset(async () => {
       this.setActiveEntities(...entities);
       await this.turnManager.start();
     });
@@ -94,7 +93,7 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    * @returns {Promise<void>} Resolves once the manager is running.
    */
   async startRunning() {
-    await runWithReset(this, async () => {
+    await this.withReset(async () => {
       const spy = jest
         .spyOn(this.turnManager, 'advanceTurn')
         .mockImplementationOnce(async () => {});

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -67,9 +67,12 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
   it('initAndReset runs init then clears mock history', async () => {
     const initSpy = jest.spyOn(testBed, 'init');
     const resetSpy = jest.spyOn(testBed, 'resetMocks');
+    const withResetSpy = jest.spyOn(testBed, 'withReset');
 
     await testBed.initAndReset('ResetWorld');
 
+    expect(withResetSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(withResetSpy).toHaveBeenCalledTimes(1);
     expect(initSpy).toHaveBeenCalledWith('ResetWorld');
     expect(engine.startNewGame).toHaveBeenCalledWith('ResetWorld');
     expect(resetSpy).toHaveBeenCalledTimes(1);
@@ -80,15 +83,19 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
 
     initSpy.mockRestore();
     resetSpy.mockRestore();
+    withResetSpy.mockRestore();
   });
 
   it('startAndReset calls start with result then clears mock history', async () => {
     const startSpy = jest.spyOn(testBed, 'start');
     const resetSpy = jest.spyOn(testBed, 'resetMocks');
+    const withResetSpy = jest.spyOn(testBed, 'withReset');
     const result = { success: false };
 
     await testBed.startAndReset('WorldName', result);
 
+    expect(withResetSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(withResetSpy).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledWith('WorldName', result);
     expect(engine.startNewGame).toHaveBeenCalledWith('WorldName');
     expect(resetSpy).toHaveBeenCalledTimes(1);
@@ -99,6 +106,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
 
     startSpy.mockRestore();
     resetSpy.mockRestore();
+    withResetSpy.mockRestore();
   });
 
   it('stop only stops engine when initialized', async () => {

--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -78,18 +78,26 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
     const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
     const e1 = { id: 'a' };
     bed.logger.info('pre');
+    const withResetSpy = jest.spyOn(bed, 'withReset');
     await bed.startWithEntities(e1);
     expect(bed.turnManager.start).toHaveBeenCalledTimes(1);
     expect(bed.entityManager.activeEntities.get('a')).toBe(e1);
     expect(bed.logger.info).toHaveBeenCalledTimes(0);
+    expect(withResetSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(withResetSpy).toHaveBeenCalledTimes(1);
+    withResetSpy.mockRestore();
     await bed.cleanup();
   });
 
   it('startRunning sets running without advancing', async () => {
     const bed = new TurnManagerTestBed({ TurnManagerClass: FakeManager });
+    const withResetSpy = jest.spyOn(bed, 'withReset');
     await bed.startRunning();
     expect(bed.turnManager.start).toHaveBeenCalledTimes(1);
     expect(bed.turnManager.advanceTurn).not.toHaveBeenCalled();
+    expect(withResetSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(withResetSpy).toHaveBeenCalledTimes(1);
+    withResetSpy.mockRestore();
     await bed.cleanup();
   });
 


### PR DESCRIPTION
Summary: Implemented a new `withReset` helper on `BaseTestBed` which wraps `runWithReset`. Updated `GameEngineTestBed` and `TurnManagerTestBed` to use this helper and adjusted associated unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857c52694788331827a221d785e8d6f