### PR TITLE
[Agent] Implement dispatch asserter generator

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -157,6 +157,23 @@ export function expectSingleDispatch(mock, eventId, payload) {
 }
 
 /**
+ * Creates a helper function that asserts a single dispatch call with a payload
+ * generated from provided arguments.
+ *
+ * @param {string} eventId - The expected dispatched event id.
+ * @param {(...args: any[]) => any} payloadBuilder - Function that builds the
+ *   payload from the asserter arguments.
+ * @returns {(mock: import('@jest/globals').Mock, ...args: any[]) => void}
+ *   Dispatch asserter function.
+ */
+export function createDispatchAsserter(eventId, payloadBuilder) {
+  return (mock, ...args) => {
+    const payload = payloadBuilder(...args);
+    expectSingleDispatch(mock, eventId, payload);
+  };
+}
+
+/**
  * Asserts that an ENTITY_CREATED dispatch with the correct payload occurred.
  *
  * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
@@ -164,12 +181,13 @@ export function expectSingleDispatch(mock, eventId, payload) {
  * @param {boolean} wasReconstructed - Flag indicating reconstruction.
  * @returns {void}
  */
-export function expectEntityCreatedDispatch(mock, entity, wasReconstructed) {
-  expectSingleDispatch(mock, ENTITY_CREATED_ID, {
+export const expectEntityCreatedDispatch = createDispatchAsserter(
+  ENTITY_CREATED_ID,
+  (entity, wasReconstructed) => ({
     entity,
     wasReconstructed,
-  });
-}
+  })
+);
 
 /**
  * Asserts that an ENTITY_REMOVED dispatch with the correct payload occurred.
@@ -178,9 +196,10 @@ export function expectEntityCreatedDispatch(mock, entity, wasReconstructed) {
  * @param {import('../../../src/entities/entity.js').default} entity - Entity instance.
  * @returns {void}
  */
-export function expectEntityRemovedDispatch(mock, entity) {
-  expectSingleDispatch(mock, ENTITY_REMOVED_ID, { entity });
-}
+export const expectEntityRemovedDispatch = createDispatchAsserter(
+  ENTITY_REMOVED_ID,
+  (entity) => ({ entity })
+);
 
 /**
  * Asserts that a COMPONENT_ADDED dispatch with the expected payload occurred.
@@ -192,20 +211,15 @@ export function expectEntityRemovedDispatch(mock, entity) {
  * @param {object|null|undefined} oldData - Previous component data.
  * @returns {void}
  */
-export function expectComponentAddedDispatch(
-  mock,
-  entity,
-  componentTypeId,
-  newData,
-  oldData
-) {
-  expectSingleDispatch(mock, COMPONENT_ADDED_ID, {
+export const expectComponentAddedDispatch = createDispatchAsserter(
+  COMPONENT_ADDED_ID,
+  (entity, componentTypeId, newData, oldData) => ({
     entity,
     componentTypeId,
     componentData: newData,
     oldComponentData: oldData,
-  });
-}
+  })
+);
 
 /**
  * Asserts that a COMPONENT_REMOVED dispatch with the expected payload occurred.
@@ -216,18 +230,14 @@ export function expectComponentAddedDispatch(
  * @param {object|null|undefined} oldData - Previous component data.
  * @returns {void}
  */
-export function expectComponentRemovedDispatch(
-  mock,
-  entity,
-  componentTypeId,
-  oldData
-) {
-  expectSingleDispatch(mock, COMPONENT_REMOVED_ID, {
+export const expectComponentRemovedDispatch = createDispatchAsserter(
+  COMPONENT_REMOVED_ID,
+  (entity, componentTypeId, oldData) => ({
     entity,
     componentTypeId,
     oldComponentData: oldData,
-  });
-}
+  })
+);
 
 /**
  * Asserts that the dispatch function was never called.

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -8,6 +8,7 @@ import {
   expectEngineStatus,
   expectEngineRunning,
   expectEngineStopped,
+  createDispatchAsserter,
   expectEntityCreatedDispatch,
   expectEntityRemovedDispatch,
   expectComponentAddedDispatch,
@@ -71,6 +72,24 @@ describe('dispatchTestUtils', () => {
       const mock = jest.fn();
       mock('eventA', { a: 2 });
       expect(() => expectSingleDispatch(mock, 'eventA', { a: 1 })).toThrow();
+    });
+  });
+
+  describe('createDispatchAsserter', () => {
+    it('creates an asserter that validates dispatch payloads', () => {
+      const mock = jest.fn();
+      const asserter = createDispatchAsserter('eventA', (a, b) => ({ a, b }));
+      mock('eventA', { a: 1, b: 2 });
+
+      expect(() => asserter(mock, 1, 2)).not.toThrow();
+    });
+
+    it('fails when dispatch does not match', () => {
+      const mock = jest.fn();
+      const asserter = createDispatchAsserter('eventA', (a) => ({ a }));
+      mock('eventA', { a: 1 });
+
+      expect(() => asserter(mock, 2)).toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary
- implement `createDispatchAsserter`
- refactor component and entity dispatch helpers
- test the new generator

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: repository has existing lint errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm install && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857c51966148331ba328e93b34b2c19