### PR TITLE
[Agent] expose state accessor methods

### DIFF
--- a/src/turns/handlers/baseTurnHandler.js
+++ b/src/turns/handlers/baseTurnHandler.js
@@ -68,6 +68,54 @@ export class BaseTurnHandler {
     return this._currentTurnContext;
   }
 
+  /**
+   * Retrieves the current turn state.
+   *
+   * @returns {ITurnState|null} The active state instance or null.
+   */
+  getCurrentState() {
+    return this._currentState;
+  }
+
+  /**
+   * Resolves a SafeEventDispatcher for use by states.
+   * Attempts to use the active ITurnContext first, falling back
+   * to a `safeEventDispatcher` property on the handler if available.
+   *
+   * @returns {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher|null}
+   *   The dispatcher instance or null if unavailable.
+   */
+  getSafeEventDispatcher() {
+    if (
+      this._currentTurnContext &&
+      typeof this._currentTurnContext.getSafeEventDispatcher === 'function'
+    ) {
+      try {
+        const dispatcher = this._currentTurnContext.getSafeEventDispatcher();
+        if (dispatcher && typeof dispatcher.dispatch === 'function') {
+          return dispatcher;
+        }
+      } catch (err) {
+        this.getLogger().warn(
+          `${this.constructor.name}.getSafeEventDispatcher: ` +
+            `Error accessing dispatcher from TurnContext – ${err.message}`
+        );
+      }
+    }
+
+    if (
+      this.safeEventDispatcher &&
+      typeof this.safeEventDispatcher.dispatch === 'function'
+    ) {
+      return this.safeEventDispatcher;
+    }
+
+    this.getLogger().warn(
+      `${this.constructor.name}.getSafeEventDispatcher: dispatcher unavailable.`
+    );
+    return null;
+  }
+
   getCurrentActor() {
     if (this._currentTurnContext) {
       try {

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -139,7 +139,7 @@ export class AbstractTurnState extends ITurnState {
 
   /**
    * Safely resolves a SafeEventDispatcher using the provided context or handler.
-   * Falls back to this._handler.safeEventDispatcher when necessary.
+   * Falls back to this._handler.getSafeEventDispatcher() when necessary.
    *
    * @protected
    * @param {ITurnContext | null} turnCtx - The current ITurnContext, if any.

--- a/src/turns/states/helpers/contextUtils.js
+++ b/src/turns/states/helpers/contextUtils.js
@@ -51,7 +51,7 @@ export function getLogger(turnCtx, handler) {
 
 /**
  * Safely resolves a SafeEventDispatcher using the provided context or handler.
- * Falls back to handler.safeEventDispatcher when necessary.
+ * Falls back to handler.getSafeEventDispatcher() when necessary.
  *
  * @param {ITurnContext|null} turnCtx - The current ITurnContext, if any.
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
@@ -72,14 +72,21 @@ export function getSafeEventDispatcher(turnCtx, handler) {
     }
   }
 
-  if (
-    handler?.safeEventDispatcher &&
-    typeof handler.safeEventDispatcher.dispatch === 'function'
-  ) {
-    getLogger(turnCtx, handler).warn(
-      'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher not found on ITurnContext. Falling back to handler.safeEventDispatcher.'
-    );
-    return handler.safeEventDispatcher;
+  if (handler && typeof handler.getSafeEventDispatcher === 'function') {
+    try {
+      const dispatcher = handler.getSafeEventDispatcher();
+      if (dispatcher && typeof dispatcher.dispatch === 'function') {
+        getLogger(turnCtx, handler).warn(
+          'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher not found on ITurnContext. Falling back to handler.getSafeEventDispatcher().'
+        );
+        return dispatcher;
+      }
+    } catch (err) {
+      getLogger(turnCtx, handler).error(
+        `ContextUtils.getSafeEventDispatcher: Error calling handler.getSafeEventDispatcher(): ${err.message}`,
+        err
+      );
+    }
   }
 
   getLogger(turnCtx, handler).warn(

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -140,7 +140,7 @@ export async function processCommandInternal(
       `${state.getStateName()}: Actor ${actorId} - Directive strategy ${directiveStrategy.constructor.name} executed.`
     );
 
-    if (state._isProcessing && state._handler._currentState === state) {
+    if (state._isProcessing && state._handler.getCurrentState() === state) {
       logger.debug(
         `${state.getStateName()}: Directive strategy executed for ${actorId}, state remains ${state.getStateName()}. Processing complete for this state instance.`
       );
@@ -151,7 +151,7 @@ export async function processCommandInternal(
       }
     } else if (state._isProcessing) {
       logger.debug(
-        `${state.getStateName()}: Directive strategy executed for ${actorId}, but state changed from ${state.getStateName()} to ${state._handler._currentState?.getStateName() ?? 'Unknown'}. Processing considered complete for previous state instance.`
+        `${state.getStateName()}: Directive strategy executed for ${actorId}, but state changed from ${state.getStateName()} to ${state._handler.getCurrentState()?.getStateName() ?? 'Unknown'}. Processing considered complete for previous state instance.`
       );
       if (state._processingGuard) {
         state._processingGuard.finish();
@@ -176,7 +176,7 @@ export async function processCommandInternal(
       actorIdForHandler
     );
   } finally {
-    if (state._isProcessing && state._handler._currentState === state) {
+    if (state._isProcessing && state._handler.getCurrentState() === state) {
       const finalLogger =
         state._getTurnContext()?.getLogger() ?? turnCtx.getLogger();
       finalLogger.warn(

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -156,8 +156,8 @@ export class TurnEndingState extends AbstractTurnState {
 
     if (
       ctx?.requestIdleStateTransition &&
-      !handler._currentState?.isIdle?.() &&
-      handler._currentState !== this
+      !handler.getCurrentState()?.isIdle?.() &&
+      handler.getCurrentState() !== this
     ) {
       try {
         await ctx.requestIdleStateTransition();

--- a/tests/unit/turns/states/abstractTurnState.test.js
+++ b/tests/unit/turns/states/abstractTurnState.test.js
@@ -13,6 +13,9 @@ const makeLogger = () => ({
 const makeHandler = (logger = makeLogger(), dispatcher) => ({
   getLogger: jest.fn(() => logger),
   safeEventDispatcher: dispatcher,
+  getSafeEventDispatcher: jest.fn(function () {
+    return this.safeEventDispatcher;
+  }),
 });
 
 describe('AbstractTurnState._resolveLogger', () => {
@@ -102,6 +105,7 @@ describe('AbstractTurnState._getSafeEventDispatcher', () => {
     expect(result).toBe(dispatcher);
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
+    expect(handler.getSafeEventDispatcher).not.toHaveBeenCalled();
   });
 
   test('warns once and falls back to handler dispatcher when context missing', () => {
@@ -113,6 +117,7 @@ describe('AbstractTurnState._getSafeEventDispatcher', () => {
     };
     const result = state._getSafeEventDispatcher(ctx, handler);
     expect(result).toBe(dispatcher);
+    expect(handler.getSafeEventDispatcher).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn.mock.calls[0][0]).toMatch(/Falling back/);
   });
@@ -128,6 +133,7 @@ describe('AbstractTurnState._getSafeEventDispatcher', () => {
     };
     const result = state._getSafeEventDispatcher(ctx, handler);
     expect(result).toBe(dispatcher);
+    expect(handler.getSafeEventDispatcher).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -56,6 +56,12 @@ beforeEach(() => {
     safeEventDispatcher: {
       dispatch: jest.fn().mockResolvedValue(undefined),
     },
+    getSafeEventDispatcher: jest.fn(function () {
+      return this.safeEventDispatcher;
+    }),
+    getCurrentState: jest.fn(function () {
+      return this._currentState;
+    }),
   };
 
   // Construct a fresh ProcessingCommandState with no initial commandString or turnAction
@@ -412,6 +418,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
         message: expect.stringContaining('Invalid turnCtx'),
       })
     );
+    expect(mockHandler.getSafeEventDispatcher).toHaveBeenCalled();
   });
 
   test('should log error when turnCtx lacks getLogger', async () => {
@@ -468,6 +475,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
         details: expect.any(Object),
       })
     );
+    expect(mockHandler.getSafeEventDispatcher).toHaveBeenCalled();
   });
 
   test('should catch service method returning null or undefined and dispatch SYSTEM_ERROR_OCCURRED_ID', async () => {

--- a/tests/unit/turns/states/turnEndingState.test.js
+++ b/tests/unit/turns/states/turnEndingState.test.js
@@ -90,6 +90,7 @@ const createMockBaseTurnHandler = (loggerInstance = mockSystemLogger) => {
     _currentTurnContext: null,
     _currentActor: null,
     _isDestroyed: false,
+    safeEventDispatcher: null,
 
     getLogger: jest.fn().mockReturnValue(loggerInstance),
     getTurnContext: jest.fn(() => handlerMock._currentTurnContext),
@@ -111,6 +112,12 @@ const createMockBaseTurnHandler = (loggerInstance = mockSystemLogger) => {
       if (!(handlerMock._currentState instanceof TurnIdleState)) {
         await handlerMock._transitionToState(new TurnIdleState(handlerMock));
       }
+    }),
+    getSafeEventDispatcher: jest.fn(function () {
+      return this.safeEventDispatcher;
+    }),
+    getCurrentState: jest.fn(function () {
+      return this._currentState;
     }),
 
     // Helpers for tests


### PR DESCRIPTION
Summary: add getCurrentState/getSafeEventDispatcher to BaseTurnHandler and replace direct state/dispatcher property access in turn states. Updated tests ensure states call new APIs.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails: 589 errors)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857c3ff703483319dfc527cc267999e