### PR TITLE
[Agent] DRY string checks and path setter

### DIFF
--- a/src/data/providers/actorStateProvider.js
+++ b/src/data/providers/actorStateProvider.js
@@ -19,6 +19,7 @@ import {
   DEFAULT_FALLBACK_CHARACTER_NAME,
   DEFAULT_FALLBACK_DESCRIPTION_RAW,
 } from '../../constants/textDefaults.js';
+import { isNonBlankString } from '../../utils/textUtils.js';
 import { deepClone } from '../../utils/cloneUtils.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
@@ -43,10 +44,9 @@ export class ActorStateProvider extends IActorStateProvider {
 
     const surface = (compId, fallback = '') => {
       const txt = actorState.components[compId]?.text;
-      actorState[compId] =
-        typeof txt === 'string' && txt.trim() !== ''
-          ? { text: txt.trim() }
-          : { text: fallback };
+      actorState[compId] = isNonBlankString(txt)
+        ? { text: txt.trim() }
+        : { text: fallback };
     };
 
     surface(NAME_COMPONENT_ID, DEFAULT_FALLBACK_CHARACTER_NAME);
@@ -61,7 +61,7 @@ export class ActorStateProvider extends IActorStateProvider {
       FEARS_COMPONENT_ID,
     ].forEach((id) => {
       const txt = actorState.components[id]?.text;
-      if (typeof txt === 'string' && txt.trim() !== '') {
+      if (isNonBlankString(txt)) {
         actorState[id] = { text: txt.trim() };
       }
     });
@@ -69,9 +69,7 @@ export class ActorStateProvider extends IActorStateProvider {
     if (actor.hasComponent(SPEECH_PATTERNS_COMPONENT_ID)) {
       const speechData = actorState.components[SPEECH_PATTERNS_COMPONENT_ID];
       const patterns = Array.isArray(speechData?.patterns)
-        ? speechData.patterns.filter(
-            (p) => typeof p === 'string' && p.trim() !== ''
-          )
+        ? speechData.patterns.filter((p) => isNonBlankString(p))
         : [];
       if (patterns.length) {
         actorState[SPEECH_PATTERNS_COMPONENT_ID] = { ...speechData, patterns };

--- a/src/data/providers/entitySummaryProvider.js
+++ b/src/data/providers/entitySummaryProvider.js
@@ -12,6 +12,7 @@ import {
   DEFAULT_FALLBACK_DESCRIPTION_RAW,
   DEFAULT_COMPONENT_VALUE_NA,
 } from '../../constants/textDefaults.js';
+import { isNonBlankString } from '../../utils/textUtils.js';
 
 /** @typedef {import('../../entities/entity.js').default} Entity */
 /** @typedef {import('../../interfaces/IEntitySummaryProvider.js').EntitySummaryDTO} EntitySummaryDTO */
@@ -28,7 +29,7 @@ export class EntitySummaryProvider extends IEntitySummaryProvider {
     }
     const componentData = entity.getComponentData(componentId);
     const value = componentData?.[propertyPath];
-    if (typeof value === 'string' && value.trim() !== '') {
+    if (isNonBlankString(value)) {
       return value.trim();
     }
     return defaultValue;

--- a/src/llms/environmentContext.js
+++ b/src/llms/environmentContext.js
@@ -13,6 +13,7 @@
 const DEFAULT_PROXY_SERVER_URL = 'http://localhost:3001/api/llm-request';
 const VALID_EXECUTION_ENVIRONMENTS = ['client', 'server', 'unknown'];
 import { initLogger } from '../utils/index.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
  * @description Checks if the provided object conforms to the EnvironmentContext interface.
@@ -152,7 +153,7 @@ export class EnvironmentContext {
    */
   #configureProxyUrl(url) {
     if (this.#executionEnvironment === 'client') {
-      if (url && typeof url === 'string' && url.trim() !== '') {
+      if (isNonBlankString(url)) {
         try {
           new URL(url.trim());
           this.#proxyServerUrl = url.trim();
@@ -178,7 +179,7 @@ export class EnvironmentContext {
         }
       }
     } else {
-      if (url && typeof url === 'string' && url.trim() !== '') {
+      if (isNonBlankString(url)) {
         try {
           new URL(url.trim());
           this.#proxyServerUrl = url.trim();

--- a/src/llms/services/llmConfigLoader.js
+++ b/src/llms/services/llmConfigLoader.js
@@ -7,6 +7,7 @@ import {
   formatAjvErrorToStandardizedError,
   formatSemanticErrorToStandardizedError,
 } from './llmConfigErrorFormatter.js';
+import { isNonBlankString } from '../../utils/textUtils.js';
 
 /**
  * @typedef {object} ILogger
@@ -315,10 +316,9 @@ export class LlmConfigLoader {
    * @returns {Promise<LLMRootConfiguration | LoadConfigsErrorResult>}
    */
   async loadConfigs(filePathValue) {
-    const currentPath =
-      typeof filePathValue === 'string' && filePathValue.trim() !== ''
-        ? filePathValue.trim()
-        : this.#defaultConfigPath;
+    const currentPath = isNonBlankString(filePathValue)
+      ? filePathValue.trim()
+      : this.#defaultConfigPath;
     try {
       const parsedResponse = await this.#_fetchConfigFile(currentPath);
 

--- a/src/llms/strategies/openRouterJsonSchemaStrategy.js
+++ b/src/llms/strategies/openRouterJsonSchemaStrategy.js
@@ -3,6 +3,7 @@
 import { BaseOpenRouterStrategy } from './base/baseOpenRouterStrategy.js';
 import { LLMStrategyError } from '../errors/LLMStrategyError.js';
 import { OPENROUTER_GAME_AI_ACTION_SPEECH_SCHEMA } from '../constants/llmConstants.js'; // Still potentially used for tool_calls fallback logic's expected name
+import { isNonBlankString } from '../../utils/textUtils.js';
 
 /**
  * @typedef {import('../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
@@ -120,7 +121,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
     if (
       message.content &&
       typeof message.content === 'string' &&
-      message.content.trim() !== ''
+      isNonBlankString(message.content)
     ) {
       extractedJsonString = message.content.trim();
       this.logger.debug(
@@ -137,7 +138,8 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
     } else {
       if (
         message.content === '' ||
-        (typeof message.content === 'string' && message.content.trim() === '')
+        (typeof message.content === 'string' &&
+          !isNonBlankString(message.content))
       ) {
         this.logger.warn(
           `${this.constructor.name} (${llmId}): message.content was an empty string. Will check tool_calls fallback.`,
@@ -184,7 +186,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
         toolCall.function?.name === expectedToolNameForFallback &&
         toolCall.function?.arguments &&
         typeof toolCall.function.arguments === 'string' &&
-        toolCall.function.arguments.trim() !== ''
+        isNonBlankString(toolCall.function.arguments)
       ) {
         extractedJsonString = toolCall.function.arguments.trim();
         this.logger.debug(

--- a/src/loaders/ruleLoader.js
+++ b/src/loaders/ruleLoader.js
@@ -4,6 +4,7 @@
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
 import { expandMacros, validateMacroExpansion } from '../utils/macroUtils.js';
 import { deriveBaseRuleIdFromFilename } from '../utils/ruleIdUtils.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
@@ -74,7 +75,7 @@ class RuleLoader extends BaseManifestItemLoader {
     const ruleIdInData = data?.rule_id;
     let baseRuleId;
 
-    if (typeof ruleIdInData === 'string' && ruleIdInData.trim()) {
+    if (isNonBlankString(ruleIdInData)) {
       baseRuleId = ruleIdInData.trim();
       this._logger.debug(
         `RuleLoader [${modId}]: Using rule_id '${baseRuleId}' from data in ${filename}.`

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -18,6 +18,7 @@ import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { isNonBlankString } from '../../utils/textUtils.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 
 /**
@@ -76,7 +77,7 @@ class GetNameHandler extends BaseOperationHandler {
       );
       return;
     }
-    if (typeof result_variable !== 'string' || !result_variable.trim()) {
+    if (!isNonBlankString(result_variable)) {
       safeDispatchError(
         this.#dispatcher,
         'GET_NAME: "result_variable" must be a non-empty string.',
@@ -85,10 +86,9 @@ class GetNameHandler extends BaseOperationHandler {
       return;
     }
     const resultVar = result_variable.trim();
-    const fallback =
-      typeof default_value === 'string' && default_value.trim()
-        ? default_value.trim()
-        : DEFAULT_FALLBACK_CHARACTER_NAME;
+    const fallback = isNonBlankString(default_value)
+      ? default_value.trim()
+      : DEFAULT_FALLBACK_CHARACTER_NAME;
 
     const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
@@ -112,7 +112,7 @@ class GetNameHandler extends BaseOperationHandler {
         entityId,
         NAME_COMPONENT_ID
       );
-      if (comp && typeof comp.text === 'string' && comp.text.trim()) {
+      if (comp && isNonBlankString(comp.text)) {
         name = comp.text.trim();
       }
       log.debug(`GET_NAME: Resolved name for '${entityId}' -> '${name}'.`);

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -15,6 +15,7 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { deepClone } from '../../utils/cloneUtils.js';
+import { setByPath } from '../utils/objectPathUtils.js';
 
 /**
  * @typedef {object} EntityRefObject
@@ -37,21 +38,6 @@ import { deepClone } from '../../utils/cloneUtils.js';
  * @param path
  * @param value
  */
-function setByPath(root, path, value) {
-  const parts = path.split('.').filter(Boolean);
-  let cur = root;
-  for (let i = 0; i < parts.length; i++) {
-    const key = parts[i];
-    if (i === parts.length - 1) {
-      cur[key] = value;
-      return true;
-    }
-    if (cur[key] === null || cur[key] === undefined) cur[key] = {};
-    if (typeof cur[key] !== 'object') return false;
-    cur = cur[key];
-  }
-  return false;
-}
 
 // ── handler ───────────────────────────────────────────────────────────────────
 class ModifyComponentHandler extends ComponentOperationHandler {

--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -12,33 +12,7 @@ import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { cloneDeep } from 'lodash';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import { applyArrayModification } from '../utils/arrayModifyUtils.js';
-
-/**
- * Safely sets a value on a nested object using a dot-notation path.
- *
- * @param {object} obj The object to modify.
- * @param {string} path The dot-notation path (e.g., 'a.b.c').
- * @param {*} value The value to set at the path.
- */
-function setPath(obj, path, value) {
-  const pathParts = path.split('.');
-  let current = obj;
-  for (let i = 0; i < pathParts.length - 1; i++) {
-    const part = pathParts[i];
-    if (part === '__proto__' || part === 'constructor') {
-      throw new Error(`Unsafe property name detected: ${part}`);
-    }
-    if (current[part] === undefined || typeof current[part] !== 'object') {
-      current[part] = {};
-    }
-    current = current[part];
-  }
-  const lastPart = pathParts[pathParts.length - 1];
-  if (lastPart === '__proto__' || lastPart === 'constructor') {
-    throw new Error(`Unsafe property name detected: ${lastPart}`);
-  }
-  current[lastPart] = value;
-}
+import { setByPath } from '../utils/objectPathUtils.js';
 
 /**
  * @class ModifyContextArrayHandler
@@ -200,7 +174,7 @@ class ModifyContextArrayHandler {
 
     // --- FIX: Set the modified clone back into the context ---
     const finalArray = clonedArray;
-    setPath(contextObject, variable_path, finalArray);
+    setByPath(contextObject, variable_path, finalArray);
 
     // The result variable should get the popped item or the final state of the array
     const resultForStorage = mode === 'pop' ? operationResult : clonedArray;

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -92,7 +92,7 @@ class RebuildLeaderListCacheHandler {
     for (const ent of followers) {
       const data = ent.getComponentData(FOLLOWING);
       const lid = data?.leaderId;
-      if (typeof lid === 'string' && lid.trim()) {
+      if (isNonBlankString(lid)) {
         if (!followerMap.has(lid)) followerMap.set(lid, []);
         followerMap.get(lid).push(ent.id);
       }

--- a/src/logic/utils/objectPathUtils.js
+++ b/src/logic/utils/objectPathUtils.js
@@ -1,0 +1,28 @@
+/**
+ * Safely sets a nested value on an object using a dot-separated path.
+ *
+ * @description Creates intermediate objects as needed but will not overwrite
+ *  non-object values along the path.
+ * @param {object} root - Object to modify.
+ * @param {string} path - Dot-separated path (e.g., 'a.b.c').
+ * @param {*} value - Value to assign.
+ * @returns {boolean} True if the assignment succeeded, false otherwise.
+ */
+export function setByPath(root, path, value) {
+  const parts = path.split('.').filter(Boolean);
+  let cur = root;
+  for (let i = 0; i < parts.length; i++) {
+    const key = parts[i];
+    if (key === '__proto__' || key === 'constructor') {
+      throw new Error(`Unsafe property name detected: ${key}`);
+    }
+    if (i === parts.length - 1) {
+      cur[key] = value;
+      return true;
+    }
+    if (cur[key] === null || cur[key] === undefined) cur[key] = {};
+    if (typeof cur[key] !== 'object') return false;
+    cur = cur[key];
+  }
+  return false;
+}

--- a/src/turns/states/helpers/buildSpeechPayload.js
+++ b/src/turns/states/helpers/buildSpeechPayload.js
@@ -8,6 +8,7 @@
  * @property {*} [thoughts] - Raw thoughts value.
  * @property {*} [notes] - Raw notes value.
  */
+import { isNonBlankString } from '../../../utils/textUtils.js';
 
 /**
  * Builds a sanitized payload from decision metadata for ENTITY_SPOKE_ID.
@@ -21,24 +22,23 @@ export function buildSpeechPayload(decisionMeta) {
     thoughts: thoughtsRaw,
     notes: notesRaw,
   } = decisionMeta || {};
-  const speech =
-    typeof speechRaw === 'string' && speechRaw.trim() ? speechRaw.trim() : null;
+  const speech = isNonBlankString(speechRaw) ? speechRaw.trim() : null;
   if (!speech) {
     return null;
   }
   const payload = { speechContent: speech };
-  if (typeof thoughtsRaw === 'string' && thoughtsRaw.trim()) {
+  if (isNonBlankString(thoughtsRaw)) {
     payload.thoughts = thoughtsRaw.trim();
   }
   if (Array.isArray(notesRaw)) {
     const joined = notesRaw
-      .map((n) => (typeof n === 'string' ? n.trim() : ''))
+      .map((n) => (isNonBlankString(n) ? n.trim() : ''))
       .filter(Boolean)
       .join('\n');
     if (joined) {
       payload.notes = joined;
     }
-  } else if (typeof notesRaw === 'string' && notesRaw.trim()) {
+  } else if (isNonBlankString(notesRaw)) {
     payload.notes = notesRaw.trim();
   }
   return payload;

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -58,7 +58,8 @@ function _resolveLocationEntity(
 
   if (
     !locationEntityOrId ||
-    (typeof locationEntityOrId === 'string' && locationEntityOrId.trim() === '')
+    (typeof locationEntityOrId === 'string' &&
+      !isNonBlankString(locationEntityOrId))
   ) {
     log.debug('_resolveLocationEntity: locationEntityOrId is invalid.');
     return null;

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -52,14 +52,13 @@ export function snakeToCamel(str) {
 }
 
 /**
- * Checks if the provided value is a non-blank string.
- * A non-blank string is a string containing characters other than whitespace.
+ * Checks that a string is non-empty after trimming.
  *
- * @param {*} value - Value to validate.
- * @returns {boolean} True if value is a non-blank string, otherwise false.
+ * @param {any} str
+ * @returns {boolean}
  */
-export function isNonBlankString(value) {
-  return typeof value === 'string' && value.trim() !== '';
+export function isNonBlankString(str) {
+  return typeof str === 'string' && Boolean(str.trim());
 }
 
 /**


### PR DESCRIPTION
Summary: Replace duplicated string validation with `isNonBlankString` helper and move `setByPath` into a shared utility. Updated handlers to use the new helpers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857c3ec81688331a6919e8bc1cbfe31