### PR TITLE
[Agent] simplify logger setup

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -33,32 +33,12 @@ export class ActionValidationContextBuilder {
    * @throws {Error} If dependencies are missing or invalid.
    */
   constructor({ entityManager, logger }) {
-    try {
-      this.#logger = setupService('ActionValidationContextBuilder', logger, {
-        entityManager: {
-          value: entityManager,
-          requiredMethods: ['getEntityInstance', 'getComponentData'],
-        },
-      });
-    } catch (e) {
-      const base = 'ActionValidationContextBuilder Constructor:';
-      if (e.message.includes('logger')) {
-        const errorMsg = `${base} CRITICAL - Invalid or missing ILogger instance. Error: ${e.message}`;
-        // eslint-disable-next-line no-console
-        console.error(errorMsg);
-        throw new Error(errorMsg);
-      }
-      // if logger failed we already threw above; otherwise log via console
-      // fallback if logger not available
-      const errMsg = `${base} Dependency validation failed for entityManager. Error: ${e.message}`;
-      if (this.#logger?.error) {
-        this.#logger.error(errMsg);
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(errMsg);
-      }
-      throw e;
-    }
+    this.#logger = setupService('ActionValidationContextBuilder', logger, {
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['getEntityInstance', 'getComponentData'],
+      },
+    });
 
     this.#entityManager = entityManager;
   }

--- a/tests/unit/services/actionValidationContextBuilder.test.js
+++ b/tests/unit/services/actionValidationContextBuilder.test.js
@@ -98,7 +98,7 @@ describe('ActionValidationContextBuilder', () => {
           entityManager: validEntityManager,
           logger: null,
         })
-    ).toThrow('Invalid or missing ILogger instance');
+    ).toThrow('Missing required dependency: logger.');
   });
 
   it('should successfully create an instance with valid dependencies', () => {


### PR DESCRIPTION
Summary: Refactored ActionValidationContextBuilder constructor to directly use setupService without try/catch and removed console fallbacks. Updated tests for new error message.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 589 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857c3d1c2f48331bbe5f7c83a3cd79b