### PR TITLE
[Agent] add waitForCurrentActor util

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -5,6 +5,7 @@
 
 import { expect } from '@jest/globals';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { flushPromisesAndTimers } from './turnManagerTestBed.js';
 
 /**
  * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
@@ -30,4 +31,23 @@ export function expectSystemErrorDispatch(
   });
 }
 
-export default { expectSystemErrorDispatch };
+/**
+ * Waits until the TurnManager's current actor matches the provided id. Flushes
+ * pending timers and promises between checks.
+ *
+ * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Test bed instance.
+ * @param {string} id - Expected actor id.
+ * @param {number} [maxTicks] - Number of flush cycles before timing out.
+ * @returns {Promise<boolean>} Resolves `true` if actor matched before timeout.
+ */
+export async function waitForCurrentActor(bed, id, maxTicks = 50) {
+  for (let i = 0; i < maxTicks; i++) {
+    if (bed.turnManager.getCurrentActor()?.id === id) {
+      return true;
+    }
+    await flushPromisesAndTimers();
+  }
+  return false;
+}
+
+export default { expectSystemErrorDispatch, waitForCurrentActor };

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -3,6 +3,7 @@
 
 import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
+import { waitForCurrentActor } from '../../common/turns/turnManagerTestUtils.js';
 // import removed constant; not needed
 import {
   TURN_ENDED_ID,
@@ -47,22 +48,6 @@ describeRunningTurnManagerSuite(
 
       testBed.resetMocks();
     });
-
-    /**
-     * Waits until the current actor matches the provided id.
-     *
-     * @param {string} id - Expected actor id.
-     * @returns {Promise<boolean>} Resolves true if actor found before timeout.
-     */
-    async function waitForCurrentActor(id) {
-      for (let i = 0; i < 50; i++) {
-        if (testBed.turnManager.getCurrentActor()?.id === id) {
-          return true;
-        }
-        await flushPromisesAndTimers();
-      }
-      return false;
-    }
 
     test('Starts a new round when queue is empty and active actors exist', async () => {
       testBed.setActiveEntities(ai1, player);
@@ -223,7 +208,7 @@ describeRunningTurnManagerSuite(
       await flushPromisesAndTimers();
 
       // Wait for TurnManager to advance to ai2
-      const found = await waitForCurrentActor(ai2.id);
+      const found = await waitForCurrentActor(testBed, ai2.id);
       expect(found).toBe(true);
 
       // Simulate turn ending for actor2 (success: true)


### PR DESCRIPTION
Summary: Added a reusable `waitForCurrentActor` helper for turn manager tests and replaced local usage. This simplifies waiting for actor advancement in round lifecycle tests.

Changes Made:
- Implemented `waitForCurrentActor` in `turnManagerTestUtils.js` and exported it.
- Imported the helper in `turnManager.roundLifecycle.test.js` and passed the bed parameter.
- Removed the old inline helper.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` & proxy lint)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (not performed)


------
https://chatgpt.com/codex/tasks/task_e_6857c3b40fa08331a6bab4e92c10a602