### PR TITLE
[Agent] move loader mock helper

### DIFF
--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -18,8 +18,8 @@ import {
   createMockModVersionValidator,
   createMockModLoadOrderResolver,
   createMockWorldLoader, // ← NEW import
+  createLoaderMocks,
 } from '../mockFactories';
-import { createLoaderMocks } from './modsLoader.test-utils.js';
 import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
 
 /**

--- a/tests/common/loaders/modsLoader.test-utils.js
+++ b/tests/common/loaders/modsLoader.test-utils.js
@@ -3,8 +3,6 @@
  * @see tests/common/loaders/modsLoader.test-utils.js
  */
 
-import { createMockContentLoader } from '../mockFactories';
-
 /**
  * Sets up manifest-related mocks for a ModsLoader test environment.
  *
@@ -44,22 +42,4 @@ export function setupManifests(env, manifestMap, finalModOrder) {
  */
 export function getSummaryText(logger) {
   return logger.info.mock.calls.map((c) => c[0]).join('\n');
-}
-
-/**
- * Generates mock loader objects for the given content types.
- *
- * @description Iterates over the supplied type names and returns an
- *   object containing `{ mock${type}Loader: createMockContentLoader() }`
- *   entries for each.
- * @param {string[]} types - Content loader type names.
- * @returns {Record<string, { loadItemsForMod: jest.Mock }>} Mapping of
- *   mock loader names to loader mocks.
- */
-export function createLoaderMocks(types) {
-  const loaders = {};
-  for (const type of types) {
-    loaders[`mock${type}Loader`] = createMockContentLoader();
-  }
-  return loaders;
 }

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -13,6 +13,8 @@ export {
   createMockAIPromptPipeline,
 } from './coreServices.js';
 
+export { createLoaderMocks } from './loaders.js';
+
 export { createRuleTestDataRegistry } from './entities.js';
 
 export { createMockContainerWithRegistration } from './container.js';

--- a/tests/common/mockFactories/loaders.js
+++ b/tests/common/mockFactories/loaders.js
@@ -109,3 +109,21 @@ export const createMockModVersionValidator = () => {
   fn.validate = fn;
   return fn;
 };
+
+/**
+ * Generates mock loader objects for the given content types.
+ *
+ * @description Iterates over the supplied type names and returns an
+ *   object containing `{ mock${type}Loader: createMockContentLoader() }`
+ *   entry for each.
+ * @param {string[]} types - Content loader type names.
+ * @returns {Record<string, { loadItemsForMod: jest.Mock }>} Mapping of
+ *   mock loader names to loader mocks.
+ */
+export function createLoaderMocks(types) {
+  const loaders = {};
+  for (const type of types) {
+    loaders[`mock${type}Loader`] = createMockContentLoader();
+  }
+  return loaders;
+}


### PR DESCRIPTION
Summary: moved `createLoaderMocks` to `tests/common/mockFactories/loaders.js` and re-exported via index. Updated ModsLoader test setup to import from mockFactories and removed old implementation. Cleaned up unused imports.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857c7499c68833185daccdf3d003671