### PR TITLE
[Agent] add waitForCurrentActor helper

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -5,6 +5,7 @@
 
 import { expect } from '@jest/globals';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { flushPromisesAndTimers } from './turnManagerTestBed.js';
 
 /**
  * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
@@ -28,4 +29,22 @@ export function expectSystemErrorDispatch(
       timestamp: expect.any(String),
     },
   });
+}
+
+/**
+ * Waits until the current actor matches the given id.
+ *
+ * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Test bed instance.
+ * @param {string} id - Expected actor id.
+ * @param {number} [maxTicks] - Maximum timer flush iterations.
+ * @returns {Promise<boolean>} Resolves true if actor found before timeout.
+ */
+export async function waitForCurrentActor(bed, id, maxTicks = 50) {
+  for (let i = 0; i < maxTicks; i++) {
+    if (bed.turnManager.getCurrentActor()?.id === id) {
+      return true;
+    }
+    await flushPromisesAndTimers();
+  }
+  return false;
 }

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -3,6 +3,7 @@
 
 import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
+import { waitForCurrentActor } from '../../common/turns/turnManagerTestUtils.js';
 // import removed constant; not needed
 import {
   TURN_ENDED_ID,
@@ -47,22 +48,6 @@ describeRunningTurnManagerSuite(
 
       testBed.resetMocks();
     });
-
-    /**
-     * Waits until the current actor matches the provided id.
-     *
-     * @param {string} id - Expected actor id.
-     * @returns {Promise<boolean>} Resolves true if actor found before timeout.
-     */
-    async function waitForCurrentActor(id) {
-      for (let i = 0; i < 50; i++) {
-        if (testBed.turnManager.getCurrentActor()?.id === id) {
-          return true;
-        }
-        await flushPromisesAndTimers();
-      }
-      return false;
-    }
 
     test('Starts a new round when queue is empty and active actors exist', async () => {
       testBed.setActiveEntities(ai1, player);
@@ -223,7 +208,7 @@ describeRunningTurnManagerSuite(
       await flushPromisesAndTimers();
 
       // Wait for TurnManager to advance to ai2
-      const found = await waitForCurrentActor(ai2.id);
+      const found = await waitForCurrentActor(testBed, ai2.id);
       expect(found).toBe(true);
 
       // Simulate turn ending for actor2 (success: true)


### PR DESCRIPTION
Summary: Added shared waitForCurrentActor helper to flush timers until the desired actor is current. Updated roundLifecycle tests to use new helper.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` (fails with existing repo errors)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857c8e79d0083318fc9c95d83a5070e