### PR TITLE
[Agent] require GameStateRestorer via DI

### DIFF
--- a/data/mods/core/events/component_added.event.json
+++ b/data/mods/core/events/component_added.event.json
@@ -12,7 +12,7 @@
         "description": "The full entity instance that received the component."
       },
       "componentTypeId": {
-         "$ref": "http://example.com/schemas/common.schema.json#/definitions/namespacedId",
+        "$ref": "http://example.com/schemas/common.schema.json#/definitions/namespacedId",
         "description": "The ID of the component that was added or updated."
       },
       "componentData": {

--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -27,6 +27,7 @@ import ComponentCleaningService, {
 import GamePersistenceService from '../../persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../persistence/gameStateCaptureService.js';
 import ManualSaveCoordinator from '../../persistence/manualSaveCoordinator.js';
+import GameStateRestorer from '../../persistence/gameStateRestorer.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
 import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuilder.js';
 // import ReferenceResolver from '../../initializers/services/referenceResolver.js'; // Removed - service is deprecated
@@ -143,6 +144,11 @@ export function registerPersistence(container) {
       playtimeTracker: c.resolve(tokens.PlaytimeTracker),
       gameStateCaptureService: c.resolve(tokens.GameStateCaptureService),
       manualSaveCoordinator: c.resolve(tokens.ManualSaveCoordinator),
+      gameStateRestorer: new GameStateRestorer({
+        logger: c.resolve(tokens.ILogger),
+        entityManager: c.resolve(tokens.IEntityManager),
+        playtimeTracker: c.resolve(tokens.PlaytimeTracker),
+      }),
     });
   });
   logger.debug(

--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -25,7 +25,7 @@ import {
   normalizePersistenceFailure,
 } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
-import GameStateRestorer from './gameStateRestorer.js';
+/** @typedef {import('./gameStateRestorer.js').default} GameStateRestorer */
 
 /**
  * @class GamePersistenceService
@@ -35,9 +35,6 @@ import GameStateRestorer from './gameStateRestorer.js';
 class GamePersistenceService extends IGamePersistenceService {
   #logger;
   #saveLoadService;
-  #entityManager;
-  #playtimeTracker;
-  #gameStateCaptureService;
   #gameStateRestorer;
   #manualSaveCoordinator;
 
@@ -51,7 +48,7 @@ class GamePersistenceService extends IGamePersistenceService {
    * @param {PlaytimeTracker} dependencies.playtimeTracker - Playtime tracker.
    * @param {GameStateCaptureService} dependencies.gameStateCaptureService - Service capturing current game state.
    * @param {ManualSaveCoordinator} dependencies.manualSaveCoordinator - Coordinator for manual saves.
-   * @param {GameStateRestorer} [dependencies.gameStateRestorer] - Optional game state restorer.
+   * @param {GameStateRestorer} dependencies.gameStateRestorer - Game state restorer.
    */
   constructor({
     logger,
@@ -84,22 +81,15 @@ class GamePersistenceService extends IGamePersistenceService {
         value: manualSaveCoordinator,
         requiredMethods: ['saveGame'],
       },
-      gameStateRestorer: gameStateRestorer
-        ? { value: gameStateRestorer, requiredMethods: ['restoreGameState'] }
-        : undefined,
+      gameStateRestorer: {
+        value: gameStateRestorer,
+        requiredMethods: ['restoreGameState'],
+      },
     });
     this.#saveLoadService = saveLoadService;
-    this.#entityManager = entityManager;
-    this.#playtimeTracker = playtimeTracker;
-    this.#gameStateCaptureService = gameStateCaptureService;
+    // captureService dependencies validated via setupService
     this.#manualSaveCoordinator = manualSaveCoordinator;
-    this.#gameStateRestorer =
-      gameStateRestorer ||
-      new GameStateRestorer({
-        logger: this.#logger,
-        entityManager: this.#entityManager,
-        playtimeTracker: this.#playtimeTracker,
-      });
+    this.#gameStateRestorer = gameStateRestorer;
     this.#logger.debug('GamePersistenceService: Instance created.');
   }
 

--- a/tests/integration/events/eventPayloadSchemaRefs.test.js
+++ b/tests/integration/events/eventPayloadSchemaRefs.test.js
@@ -2,6 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 // Utility to recursively find all .event.json files in a directory
+/**
+ *
+ * @param dir
+ */
 function findEventFiles(dir) {
   let results = [];
   const list = fs.readdirSync(dir);
@@ -18,6 +22,11 @@ function findEventFiles(dir) {
 }
 
 // Recursively search for $ref fields in an object
+/**
+ *
+ * @param obj
+ * @param refs
+ */
 function findRefs(obj, refs = []) {
   if (typeof obj !== 'object' || obj === null) return refs;
   for (const key of Object.keys(obj)) {
@@ -34,20 +43,23 @@ describe('Event payload schemas use only absolute $ref paths to shared schemas',
   const eventDir = path.join(__dirname, '../../../data/mods');
   const eventFiles = findEventFiles(eventDir);
 
-  test.each(eventFiles)('%s does not use relative $ref to shared schemas', (eventFile) => {
-    const json = JSON.parse(fs.readFileSync(eventFile, 'utf8'));
-    const payloadSchema = json.payloadSchema;
-    if (!payloadSchema) return; // No payloadSchema, skip
-    const refs = findRefs(payloadSchema);
-    // Only check refs that reference common.schema.json or other shared schemas
-    refs.forEach((ref) => {
-      // If it references common.schema.json, it must be absolute
-      if (ref.includes('common.schema.json')) {
-        expect(ref.startsWith('http://example.com/schemas/common.schema.json')).toBe(
-          true
-        );
-      }
-      // Optionally, add more checks for other shared schemas here
-    });
-  });
-}); 
+  test.each(eventFiles)(
+    '%s does not use relative $ref to shared schemas',
+    (eventFile) => {
+      const json = JSON.parse(fs.readFileSync(eventFile, 'utf8'));
+      const payloadSchema = json.payloadSchema;
+      if (!payloadSchema) return; // No payloadSchema, skip
+      const refs = findRefs(payloadSchema);
+      // Only check refs that reference common.schema.json or other shared schemas
+      refs.forEach((ref) => {
+        // If it references common.schema.json, it must be absolute
+        if (ref.includes('common.schema.json')) {
+          expect(
+            ref.startsWith('http://example.com/schemas/common.schema.json')
+          ).toBe(true);
+        }
+        // Optionally, add more checks for other shared schemas here
+      });
+    }
+  );
+});

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -14,6 +14,7 @@ import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import ManualSaveCoordinator from '../../src/persistence/manualSaveCoordinator.js';
+import GameStateRestorer from '../../src/persistence/gameStateRestorer.js';
 import ComponentCleaningService, {
   buildDefaultComponentCleaners,
 } from '../../src/persistence/componentCleaningService.js';
@@ -57,6 +58,7 @@ describe('Persistence round-trip', () => {
   let componentCleaningService;
   let metadataBuilder;
   let safeEventDispatcher;
+  let gameStateRestorer;
   let persistence;
   let entity;
   const saveName = 'RoundTripTest';
@@ -130,6 +132,11 @@ describe('Persistence round-trip', () => {
       metadataBuilder,
       activeModsManifestBuilder,
     });
+    gameStateRestorer = new GameStateRestorer({
+      logger,
+      entityManager,
+      playtimeTracker,
+    });
     const manualSaveCoordinator = new ManualSaveCoordinator({
       logger,
       gameStateCaptureService: captureService,
@@ -142,6 +149,7 @@ describe('Persistence round-trip', () => {
       playtimeTracker,
       gameStateCaptureService: captureService,
       manualSaveCoordinator,
+      gameStateRestorer,
     });
   });
 

--- a/tests/unit/services/gamePersistenceService.constructor.test.js
+++ b/tests/unit/services/gamePersistenceService.constructor.test.js
@@ -17,6 +17,7 @@ function makeDeps() {
     playtimeTracker: {},
     gameStateCaptureService: {},
     manualSaveCoordinator: {},
+    gameStateRestorer: { restoreGameState: jest.fn() },
   };
 }
 
@@ -28,6 +29,7 @@ describe('GamePersistenceService constructor validation', () => {
     'playtimeTracker',
     'gameStateCaptureService',
     'manualSaveCoordinator',
+    'gameStateRestorer',
   ];
 
   test.each(required)('throws if %s is missing', (prop) => {

--- a/tests/unit/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/unit/services/gamePersistenceService.edgeCases.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../../src/persistence/gameStateCaptureService.js';
+import GameStateRestorer from '../../../src/persistence/gameStateRestorer.js';
 import ComponentCleaningService, {
   buildDefaultComponentCleaners,
 } from '../../../src/persistence/componentCleaningService.js';
@@ -37,6 +38,7 @@ describe('GamePersistenceService edge cases', () => {
   let safeEventDispatcher;
   let activeModsManifestBuilder;
   let manualSaveCoordinator;
+  let gameStateRestorer;
   let service;
   let captureService;
 
@@ -82,6 +84,11 @@ describe('GamePersistenceService edge cases', () => {
       activeModsManifestBuilder,
     });
     manualSaveCoordinator = { saveGame: jest.fn() };
+    gameStateRestorer = new GameStateRestorer({
+      logger,
+      entityManager,
+      playtimeTracker,
+    });
     service = new GamePersistenceService({
       logger,
       saveLoadService,
@@ -89,6 +96,7 @@ describe('GamePersistenceService edge cases', () => {
       playtimeTracker,
       gameStateCaptureService: captureService,
       manualSaveCoordinator,
+      gameStateRestorer,
     });
   });
 

--- a/tests/unit/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/unit/services/gamePersistenceService.errorPaths.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../../src/persistence/gameStateCaptureService.js';
+import GameStateRestorer from '../../../src/persistence/gameStateRestorer.js';
 import ComponentCleaningService, {
   buildDefaultComponentCleaners,
 } from '../../../src/persistence/componentCleaningService.js';
@@ -29,6 +30,7 @@ describe('GamePersistenceService error paths', () => {
   let metadataBuilder;
   let activeModsManifestBuilder;
   let safeEventDispatcher;
+  let gameStateRestorer;
   let service;
   let captureService;
 
@@ -65,6 +67,11 @@ describe('GamePersistenceService error paths', () => {
       metadataBuilder,
       activeModsManifestBuilder,
     });
+    gameStateRestorer = new GameStateRestorer({
+      logger,
+      entityManager,
+      playtimeTracker,
+    });
     service = new GamePersistenceService({
       logger,
       saveLoadService,
@@ -72,6 +79,7 @@ describe('GamePersistenceService error paths', () => {
       playtimeTracker,
       gameStateCaptureService: captureService,
       manualSaveCoordinator: { saveGame: jest.fn() },
+      gameStateRestorer,
     });
   });
 

--- a/tests/unit/services/gamePersistenceService.privateHelpers.test.js
+++ b/tests/unit/services/gamePersistenceService.privateHelpers.test.js
@@ -26,6 +26,12 @@ function makeService() {
   };
   const manualSaveCoordinator = { saveGame: jest.fn() };
 
+  const restorer = new GameStateRestorer({
+    logger,
+    entityManager,
+    playtimeTracker,
+  });
+
   const service = new GamePersistenceService({
     logger,
     saveLoadService,
@@ -33,11 +39,7 @@ function makeService() {
     playtimeTracker,
     gameStateCaptureService: captureService,
     manualSaveCoordinator,
-  });
-  const restorer = new GameStateRestorer({
-    logger,
-    entityManager,
-    playtimeTracker,
+    gameStateRestorer: restorer,
   });
 
   return {


### PR DESCRIPTION
## Summary
- make GameStateRestorer mandatory in `GamePersistenceService`
- construct GameStateRestorer in DI registration
- adapt tests to supply GameStateRestorer
- format event schema and event payload tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 590 errors, 2330 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857ca4914b08331afd7d1bf61ddc771