### PR TITLE
[Refactor] simplify QueryEntitiesHandler

### DIFF
--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -28,11 +28,13 @@ class QueryEntitiesHandler extends BaseOperationHandler {
   #dispatcher;
 
   /**
-   * @param {object} deps
+   * Create a new QueryEntitiesHandler instance.
+   *
+   * @param {object} deps - Constructor dependencies.
    * @param {IEntityManager} deps.entityManager - Service for entity management.
    * @param {ILogger} deps.logger - Logging service.
    * @param {JsonLogicEvaluationService} deps.jsonLogicEvaluationService - Service for evaluating JSON Logic rules.
-   * @param deps.safeEventDispatcher
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for error events.
    * @throws {Error} If any required dependencies are missing or invalid.
    */
   constructor({
@@ -72,166 +74,85 @@ class QueryEntitiesHandler extends BaseOperationHandler {
   }
 
   /**
-   * Executes the query operation.
-   * Validates parameters, starts with a set of all active entities, then sequentially applies
-   * filters to reduce the set. Finally, it stores the resulting array of entity IDs in the
-   * specified context variable.
+   * Execute the operation with validated parameters and modular filter helpers.
    *
-   * @param {object} params - The parameters for the operation.
-   * @param {string} params.result_variable - The variable name to store the array of entity IDs in the context.
-   * @param {object[]} params.filters - An array of filter objects.
-   * @param {number} [params.limit] - Optional limit on the number of results.
-   * @param {ExecutionContext} executionContext - The context of the current execution.
+   * @param {object} params - Parameters for the operation.
+   * @param {string} params.result_variable - Variable name to store results.
+   * @param {object[]} params.filters - Filters to apply.
+   * @param {number} [params.limit] - Optional result limit.
+   * @param {ExecutionContext} executionContext - Interpreter execution context.
+   * @returns {void}
    */
   execute(params, executionContext) {
-    const log = this.getLogger(executionContext);
+    const validated = this.#validateParams(params, executionContext);
+    if (!validated) return;
+    const { resultVariable, filters, limit, logger } = validated;
 
-    if (!assertParamsObject(params, log, 'QUERY_ENTITIES')) {
-      return;
-    }
-
-    // 1. Parameter Validation
-    if (
-      !params?.result_variable ||
-      typeof params.result_variable !== 'string'
-    ) {
-      log.warn(
-        'QUERY_ENTITIES: Missing or invalid "result_variable" parameter.'
-      );
-      return;
-    }
-    if (!params.filters || !Array.isArray(params.filters)) {
-      log.warn('QUERY_ENTITIES: Missing or invalid "filters" array parameter.');
-      return;
-    }
-
-    // 2. Start with all active entities
     let candidateIds = new Set(
       Array.from(this.#entityManager.entities, (e) => e.id)
     );
-    log.debug(
+    logger.debug(
       `QUERY_ENTITIES: Starting with ${candidateIds.size} total active entities.`
     );
 
-    // 3. Apply each filter sequentially
-    for (const filter of params.filters) {
+    for (const filter of filters) {
       if (candidateIds.size === 0) {
-        log.debug(
+        logger.debug(
           'QUERY_ENTITIES: Candidate set is empty, skipping remaining filters.'
         );
-        break; // Optimization: no need to process more filters if no entities are left.
+        break;
       }
+
       const filterType = Object.keys(filter)[0];
       const filterValue = filter[filterType];
 
-      if (filterType === 'by_location') {
-        if (typeof filterValue !== 'string' || !filterValue) {
-          log.warn(
-            `QUERY_ENTITIES: Invalid value for 'by_location' filter. Skipping.`
+      switch (filterType) {
+        case 'by_location':
+          candidateIds = this.#applyLocationFilter(
+            candidateIds,
+            filterValue,
+            logger
           );
-          continue;
-        }
-        const idsInLocation =
-          this.#entityManager.getEntitiesInLocation(filterValue);
-        const originalSize = candidateIds.size;
-
-        // Find the intersection of the current candidates and entities in the location
-        candidateIds = new Set(
-          [...candidateIds].filter((id) => idsInLocation.has(id))
-        );
-
-        log.debug(
-          `QUERY_ENTITIES: Applied 'by_location: ${filterValue}'. Candidates reduced from ${originalSize} to ${candidateIds.size}.`
-        );
-      } else if (filterType === 'with_component') {
-        if (typeof filterValue !== 'string' || !filterValue) {
-          log.warn(
-            `QUERY_ENTITIES: Invalid value for 'with_component' filter. Skipping.`
+          break;
+        case 'with_component':
+          candidateIds = this.#applyComponentFilter(
+            candidateIds,
+            filterValue,
+            logger
           );
-          continue;
-        }
-        const componentType = filterValue;
-        const originalSize = candidateIds.size;
-        const nextCandidateIds = new Set();
-
-        for (const id of candidateIds) {
-          if (this.#entityManager.hasComponent(id, componentType)) {
-            nextCandidateIds.add(id);
-          }
-        }
-        candidateIds = nextCandidateIds;
-        log.debug(
-          `QUERY_ENTITIES: Applied 'with_component: ${componentType}'. Candidates reduced from ${originalSize} to ${candidateIds.size}.`
-        );
-      }
-      // ---- NEW LOGIC FOR THIS TICKET ----
-      else if (filterType === 'with_component_data') {
-        const { component_type, condition } = filterValue;
-        if (typeof component_type !== 'string' || !component_type) {
-          log.warn(
-            `QUERY_ENTITIES: Invalid 'component_type' in 'with_component_data' filter. Skipping.`
+          break;
+        case 'with_component_data':
+          candidateIds = this.#applyComponentDataFilter(
+            candidateIds,
+            filterValue,
+            logger
           );
-          continue;
-        }
-        if (typeof condition !== 'object' || condition === null) {
-          log.warn(
-            `QUERY_ENTITIES: Invalid 'condition' in 'with_component_data' filter. Skipping.`
+          break;
+        default:
+          logger.warn(
+            `QUERY_ENTITIES: Encountered unknown filter type '${filterType}'. Skipping.`
           );
-          continue;
-        }
-
-        const originalSize = candidateIds.size;
-        const nextCandidateIds = new Set();
-
-        for (const id of candidateIds) {
-          const componentData = this.#entityManager.getComponentData(
-            id,
-            component_type
-          );
-          // The entity must have the component for the filter to be applicable.
-          if (componentData !== undefined) {
-            const isMatch = this.#jsonLogicEvaluationService.evaluate(
-              condition,
-              componentData
-            );
-            if (isMatch) {
-              nextCandidateIds.add(id);
-            }
-          }
-        }
-        candidateIds = nextCandidateIds;
-        log.debug(
-          `QUERY_ENTITIES: Applied 'with_component_data: ${component_type}'. Candidates reduced from ${originalSize} to ${candidateIds.size}.`
-        );
-      }
-      // ---- END NEW LOGIC ----
-      else {
-        log.warn(
-          `QUERY_ENTITIES: Encountered unknown filter type '${filterType}'. Skipping.`
-        );
       }
     }
 
-    // 4. Apply Limit and Store Result
     let finalIds = Array.from(candidateIds);
-    if (typeof params.limit === 'number' && params.limit >= 0) {
+    if (typeof limit === 'number') {
       const originalCount = finalIds.length;
-      finalIds = finalIds.slice(0, params.limit);
-      log.debug(
-        `QUERY_ENTITIES: Applied limit: ${params.limit}. Results reduced from ${originalCount} to ${finalIds.length}.`
+      finalIds = finalIds.slice(0, limit);
+      logger.debug(
+        `QUERY_ENTITIES: Applied limit: ${limit}. Results reduced from ${originalCount} to ${finalIds.length}.`
       );
     }
 
-    const resultVariable = params.result_variable;
     const res = tryWriteContextVariable(
       resultVariable,
       finalIds,
       executionContext,
       this.#dispatcher,
-      log
+      logger
     );
     if (res.success) {
-      log.debug(
+      logger.debug(
         `QUERY_ENTITIES: Stored ${finalIds.length} entity IDs in context variable "${resultVariable}".`
       );
     } else {
@@ -241,6 +162,147 @@ class QueryEntitiesHandler extends BaseOperationHandler {
         { resultVariable }
       );
     }
+  }
+
+  /**
+   * Validate and normalize execution parameters.
+   *
+   * @param {object} params - Raw parameters object.
+   * @param {ExecutionContext} execCtx - Current execution context.
+   * @returns {{resultVariable:string, filters:object[], limit:number|undefined, logger:ILogger}|null}
+   *   Normalized parameters or `null` when validation fails.
+   * @private
+   */
+  #validateParams(params, execCtx) {
+    const logger = this.getLogger(execCtx);
+
+    if (!assertParamsObject(params, logger, 'QUERY_ENTITIES')) {
+      return null;
+    }
+    const { result_variable, filters, limit } = params;
+
+    if (typeof result_variable !== 'string' || !result_variable) {
+      logger.warn(
+        'QUERY_ENTITIES: Missing or invalid "result_variable" parameter.'
+      );
+      return null;
+    }
+    if (!Array.isArray(filters)) {
+      logger.warn(
+        'QUERY_ENTITIES: Missing or invalid "filters" array parameter.'
+      );
+      return null;
+    }
+    const safeLimit =
+      typeof limit === 'number' && limit >= 0 ? Math.floor(limit) : undefined;
+
+    return {
+      resultVariable: result_variable,
+      filters,
+      limit: safeLimit,
+      logger,
+    };
+  }
+
+  /**
+   * Apply a location-based filter.
+   *
+   * @param {Set<string>} candidates - Current candidate entity ids.
+   * @param {*} locationId - Location identifier to filter by.
+   * @param {ILogger} logger - Logger for debug/warn output.
+   * @returns {Set<string>} Filtered candidate ids.
+   * @private
+   */
+  #applyLocationFilter(candidates, locationId, logger) {
+    if (typeof locationId !== 'string' || !locationId) {
+      logger.warn(
+        "QUERY_ENTITIES: Invalid value for 'by_location' filter. Skipping."
+      );
+      return candidates;
+    }
+
+    const idsInLocation = this.#entityManager.getEntitiesInLocation(locationId);
+    const originalSize = candidates.size;
+    const result = new Set(
+      [...candidates].filter((id) => idsInLocation.has(id))
+    );
+
+    logger.debug(
+      `QUERY_ENTITIES: Applied 'by_location: ${locationId}'. Candidates reduced from ${originalSize} to ${result.size}.`
+    );
+    return result;
+  }
+
+  /**
+   * Apply a simple component presence filter.
+   *
+   * @param {Set<string>} candidates - Current candidate entity ids.
+   * @param {*} componentType - Component type to require.
+   * @param {ILogger} logger - Logger for debug/warn output.
+   * @returns {Set<string>} Filtered candidate ids.
+   * @private
+   */
+  #applyComponentFilter(candidates, componentType, logger) {
+    if (typeof componentType !== 'string' || !componentType) {
+      logger.warn(
+        "QUERY_ENTITIES: Invalid value for 'with_component' filter. Skipping."
+      );
+      return candidates;
+    }
+
+    const originalSize = candidates.size;
+    const result = new Set();
+    for (const id of candidates) {
+      if (this.#entityManager.hasComponent(id, componentType)) {
+        result.add(id);
+      }
+    }
+    logger.debug(
+      `QUERY_ENTITIES: Applied 'with_component: ${componentType}'. Candidates reduced from ${originalSize} to ${result.size}.`
+    );
+    return result;
+  }
+
+  /**
+   * Apply a component data filter using JSON Logic.
+   *
+   * @param {Set<string>} candidates - Current candidate entity ids.
+   * @param {{component_type:string,condition:object}} filter - Filter descriptor.
+   * @param {ILogger} logger - Logger for debug/warn output.
+   * @returns {Set<string>} Filtered candidate ids.
+   * @private
+   */
+  #applyComponentDataFilter(candidates, filter, logger) {
+    const { component_type, condition } = filter || {};
+    if (typeof component_type !== 'string' || !component_type) {
+      logger.warn(
+        "QUERY_ENTITIES: Invalid 'component_type' in 'with_component_data' filter. Skipping."
+      );
+      return candidates;
+    }
+    if (typeof condition !== 'object' || condition === null) {
+      logger.warn(
+        "QUERY_ENTITIES: Invalid 'condition' in 'with_component_data' filter. Skipping."
+      );
+      return candidates;
+    }
+
+    const originalSize = candidates.size;
+    const result = new Set();
+    for (const id of candidates) {
+      const compData = this.#entityManager.getComponentData(id, component_type);
+      if (compData !== undefined) {
+        const match = this.#jsonLogicEvaluationService.evaluate(
+          condition,
+          compData
+        );
+        if (match) result.add(id);
+      }
+    }
+    logger.debug(
+      `QUERY_ENTITIES: Applied 'with_component_data: ${component_type}'. Candidates reduced from ${originalSize} to ${result.size}.`
+    );
+    return result;
   }
 }
 


### PR DESCRIPTION
Summary: Refactored `QueryEntitiesHandler` to isolate parameter validation and filter application into dedicated private methods. The execute flow now reads linearly and leverages helpers for location, component, and component data filtering.

Changes Made:
- Added `#validateParams`, `#applyLocationFilter`, `#applyComponentFilter`, and `#applyComponentDataFilter` methods.
- Updated constructor JSDoc and restructured `execute` to use helpers.
- Ensured existing behavior preserved while improving readability.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes for modified file (`npx eslint src/logic/operationHandlers/queryEntitiesHandler.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6857ca0b63808331a92046da20511542