### PR TITLE
[Agent] add running engine bed helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -48,6 +48,29 @@ export function withInitializedGameEngineBed(overrides, world, testFn) {
 }
 
 /**
+ * Executes a callback with a running {@link GameEngineTestBed} instance.
+ *
+ * @description Creates a temporary test bed, starts the engine using
+ *   {@link GameEngineTestBed.startAndReset}, then runs the provided callback.
+ *   Cleanup always occurs after execution.
+ * @param {Record<string, any>} [overrides] - Optional dependency overrides.
+ * @param {string} [world] - Name of the world used for initialization.
+ * @param {(bed: GameEngineTestBed,
+ *   engine: import('../../../src/engine/gameEngine.js').default) =>
+ *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
+ * @returns {Promise<void>} Resolves when the callback completes.
+ */
+export function withRunningGameEngineBed(overrides, world, testFn) {
+  const withRunningBed = createInitializedBed(
+    GameEngineTestBed,
+    'startAndReset',
+    DEFAULT_TEST_WORLD,
+    (b) => [b, b.engine]
+  );
+  return withRunningBed(overrides, world, testFn);
+}
+
+/**
  * Builds test functions for scenarios where required services are unavailable.
  *
  * @description Generates `[token, testFn]` tuples for use with `it.each`. Each


### PR DESCRIPTION
Summary:
- add withRunningGameEngineBed helper for engine tests
- test withRunningGameEngineBed behavior

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 588 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857c9dceda083319b05f3a0099ad7a6