### PR TITLE
[Agent] Add helper to trigger turn ended

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -4,7 +4,11 @@
  */
 
 import { expect } from '@jest/globals';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  TURN_ENDED_ID,
+} from '../../../src/constants/eventIds.js';
+import { flushPromisesAndTimers } from './turnManagerTestBed.js';
 
 /**
  * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
@@ -28,4 +32,17 @@ export function expectSystemErrorDispatch(
       timestamp: expect.any(String),
     },
   });
+}
+
+/**
+ * Triggers {@link TURN_ENDED_ID} on the test bed and flushes pending timers.
+ *
+ * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Test bed instance.
+ * @param {string} entityId - Identifier for the entity whose turn ended.
+ * @param {boolean} [success] - Whether the turn ended successfully.
+ * @returns {Promise<void>} Resolves once timers are flushed.
+ */
+export async function triggerTurnEndedAndFlush(bed, entityId, success = true) {
+  bed.trigger(TURN_ENDED_ID, { entityId, success });
+  await flushPromisesAndTimers();
 }

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -2,16 +2,13 @@
 // --- FILE START (Corrected) ---
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals';
+import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
-  describeRunningTurnManagerSuite,
-  flushPromisesAndTimers,
-} from '../../common/turns/turnManagerTestBed.js';
-import { expectSystemErrorDispatch } from '../../common/turns/turnManagerTestUtils.js';
+  expectSystemErrorDispatch,
+  triggerTurnEndedAndFlush,
+} from '../../common/turns/turnManagerTestUtils.js';
 
-import {
-  TURN_ENDED_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { createMockEntity } from '../../common/mockFactories';
 import {
@@ -89,12 +86,7 @@ describeRunningTurnManagerSuite(
         );
         expect(stopSpy).not.toHaveBeenCalled();
 
-        testBed.trigger(TURN_ENDED_ID, {
-          entityId: actor.id,
-          success: true,
-        });
-
-        await flushPromisesAndTimers();
+        await triggerTurnEndedAndFlush(testBed, actor.id);
 
         expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -3,12 +3,11 @@
 
 import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
-// import removed constant; not needed
 import {
-  TURN_ENDED_ID,
   TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
+import { triggerTurnEndedAndFlush } from '../../common/turns/turnManagerTestUtils.js';
 import { beforeEach, expect, test } from '@jest/globals';
 import {
   createDefaultActors,
@@ -128,11 +127,7 @@ describeRunningTurnManagerSuite(
       expect(testBed.turnManager.getCurrentActor()).toBe(ai1);
 
       // Simulate turn ending
-      testBed.trigger(TURN_ENDED_ID, {
-        entityId: ai1.id,
-        success: true,
-      });
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai1.id);
 
       expect(testBed.turnManager.getCurrentActor()).toBe(ai2);
     });
@@ -157,11 +152,7 @@ describeRunningTurnManagerSuite(
       );
 
       // Simulate turn ending and advancing to AI actor
-      testBed.trigger(TURN_ENDED_ID, {
-        entityId: player.id,
-        success: true,
-      });
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, player.id);
       await flushPromisesAndTimers();
 
       // Check AI actor event
@@ -218,18 +209,14 @@ describeRunningTurnManagerSuite(
       expect(testBed.turnManager.getCurrentActor()?.id).toBe(ai1.id);
 
       // Simulate turn ending for actor1 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai1.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai1.id);
 
       // Wait for TurnManager to advance to ai2
       const found = await waitForCurrentActor(ai2.id);
       expect(found).toBe(true);
 
       // Simulate turn ending for actor2 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai2.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai2.id);
 
       // Wait for the TurnManager to process and start a new round
       let roundStarted = false;


### PR DESCRIPTION
## Summary
- add `triggerTurnEndedAndFlush` helper for turn tests
- refactor turn tests to use new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 588 errors, 2330 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857c9d5d888833197ad8ffcd3039ad8