### PR TITLE
[Agent] remove unused test helper export

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -331,16 +331,8 @@ export const describeRunningTurnManagerSuite = createDescribeTestBedSuite(
 export default TurnManagerTestBed;
 
 /**
- * Convenience export for {@link TurnManagerTestBed#startWithEntitiesAndFlush}.
- *
- * @param {TurnManagerTestBed} bed - Test bed instance.
- * @param {...{ id: string }} entities - Entities to register as active.
- * @returns {Promise<void>} Resolves once timers are flushed.
+ * Re-exports {@link flushPromisesAndTimers} for convenience in test suites.
  */
-export async function startWithEntitiesAndFlush(bed, ...entities) {
-  await bed.startWithEntitiesAndFlush(...entities);
-}
-
 export { flushPromisesAndTimers };
 
 /*


### PR DESCRIPTION
## Summary
- remove unused exported helper `startWithEntitiesAndFlush`
- export `flushPromisesAndTimers` directly

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857cd0d66cc833189209c1428860e4f