### PR TITLE
[Agent] simplify stop engine test

### DIFF
--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -2,7 +2,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import {
+  runUnavailableServiceSuite,
+  withRunningGameEngineBed,
+} from '../../common/engine/gameEngineHelpers.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
@@ -19,28 +22,23 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should successfully stop a running game, with correct logging, events, and state changes', async () => {
-      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
-        {
-          success: true,
-        }
-      );
-      await ctx.bed.startAndReset(DEFAULT_TEST_WORLD); // Start the game first and clear mocks
+      await withRunningGameEngineBed({}, async (bed, engine) => {
+        await engine.stop();
 
-      await ctx.engine.stop();
+        expect(
+          bed.mocks.playtimeTracker.endSessionAndAccumulate
+        ).toHaveBeenCalledTimes(1);
+        expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
 
-      expect(
-        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
-      ).toHaveBeenCalledTimes(1);
-      expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+        expectDispatchSequence(
+          bed.mocks.safeEventDispatcher.dispatch,
+          ...buildStopDispatches()
+        );
 
-      expectDispatchSequence(
-        ctx.bed.mocks.safeEventDispatcher.dispatch,
-        ...buildStopDispatches()
-      );
+        expectEngineStopped(engine);
 
-      expectEngineStopped(ctx.engine);
-
-      expect(ctx.bed.mocks.logger.warn).not.toHaveBeenCalled();
+        expect(bed.mocks.logger.warn).not.toHaveBeenCalled();
+      });
     });
 
     it('should do nothing and log if engine is already stopped', async () => {


### PR DESCRIPTION
Summary: Replace manual initialization in `stop.test.js` with `withRunningGameEngineBed` for clearer setup.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 603 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857cfe4fa4c8331b20c15d25b1c0299