### PR TITLE
[Feat] Add withLogging helper to SaveFileRepository

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -57,6 +57,17 @@ export default class SaveFileRepository extends BaseService {
   }
 
   /**
+   * Helper to wrap persistence operations with logging.
+   *
+   * @param {() => Promise<any>} operationFn - Operation to execute.
+   * @returns {Promise<any>} Result of the wrapped operation.
+   * @private
+   */
+  #withLogging(operationFn) {
+    return wrapPersistenceOperation(this.#logger, operationFn);
+  }
+
+  /**
    * Ensures the manual save directory exists if supported.
    *
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result of directory creation.
@@ -193,7 +204,7 @@ export default class SaveFileRepository extends BaseService {
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Uint8Array>>}
    */
   async #readSaveFile(filePath) {
-    return wrapPersistenceOperation(this.#logger, async () => {
+    return this.#withLogging(async () => {
       let fileContent;
       try {
         fileContent = await this.#storageProvider.readFile(filePath);
@@ -232,7 +243,7 @@ export default class SaveFileRepository extends BaseService {
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
    */
   async #deserializeAndDecompress(filePath) {
-    return wrapPersistenceOperation(this.#logger, async () => {
+    return this.#withLogging(async () => {
       this.#logger.debug(
         `Attempting to read and deserialize file: ${filePath}`
       );


### PR DESCRIPTION
Summary: Centralizes persistence logging logic in SaveFileRepository for reuse.

Changes Made:
- Introduced private `#withLogging` method to wrap operations with `wrapPersistenceOperation`.
- Refactored `#readSaveFile` and `#deserializeAndDecompress` to use the helper.

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)



------
https://chatgpt.com/codex/tasks/task_e_6857cfcf07b8833198070fa2e5d49a19