### PR TITLE
[Agent] Add spy tracking mixin for TurnManager tests

### DIFF
--- a/tests/common/spyTrackerMixin.js
+++ b/tests/common/spyTrackerMixin.js
@@ -1,0 +1,46 @@
+/**
+ * @file Mixin providing automatic restoration for jest spies in test beds.
+ */
+
+/**
+ * @description Extends a base test bed class with spy tracking utilities.
+ * @param {typeof import('./baseTestBed.js').default} Base - Base class to extend.
+ * @returns {typeof import('./baseTestBed.js').default} Extended class with spy tracking.
+ */
+export function SpyTrackerMixin(Base) {
+  return class SpyTracker extends Base {
+    /**
+     * Collection of tracked spies to be restored after each test.
+     *
+     * @type {Array<import('@jest/globals').Mock>}
+     */
+    _spies = [];
+
+    /**
+     * Registers a spy to be automatically restored during cleanup.
+     *
+     * @param {import('@jest/globals').Mock} spy - Spy instance to track.
+     * @returns {void}
+     */
+    trackSpy(spy) {
+      this._spies.push(spy);
+    }
+
+    /**
+     * Restores all tracked spies then delegates to the base cleanup.
+     *
+     * @protected
+     * @override
+     * @returns {Promise<void>} Promise resolving when cleanup completes.
+     */
+    async _afterCleanup() {
+      for (const spy of this._spies) {
+        spy.mockRestore();
+      }
+      this._spies.length = 0;
+      await super._afterCleanup();
+    }
+  };
+}
+
+export default SpyTrackerMixin;

--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -14,6 +14,7 @@ import {
 import { createMockEntityManager } from '../mockFactories/entities.js';
 import FactoryTestBed from '../factoryTestBed.js';
 import { createStoppableMixin } from '../stoppableTestBedMixin.js';
+import { SpyTrackerMixin } from '../spyTrackerMixin.js';
 import {
   describeSuiteWithHooks,
   createDescribeTestBedSuite,
@@ -28,11 +29,11 @@ import { flushPromisesAndTimers } from '../jestHelpers.js';
  */
 const StoppableMixin = createStoppableMixin('turnManager');
 
-export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
+export class TurnManagerTestBed extends SpyTrackerMixin(
+  StoppableMixin(FactoryTestBed)
+) {
   /** @type {TurnManager} */
   turnManager;
-  /** @type {Array<import('@jest/globals').Mock>} */
-  #spies = [];
 
   constructor(overrides = {}) {
     super({
@@ -130,7 +131,7 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    */
   spyOnStop() {
     const spy = jest.spyOn(this.turnManager, 'stop');
-    this.#spies.push(spy);
+    this.trackSpy(spy);
     return spy;
   }
 
@@ -162,7 +163,7 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    */
   spyOnAdvanceTurn() {
     const spy = jest.spyOn(this.turnManager, 'advanceTurn');
-    this.#spies.push(spy);
+    this.trackSpy(spy);
     return spy;
   }
 
@@ -276,13 +277,6 @@ export class TurnManagerTestBed extends StoppableMixin(FactoryTestBed) {
    * @protected
    * @returns {Promise<void>} Promise resolving when manager cleanup is complete.
    */
-  async _afterCleanup() {
-    for (const spy of this.#spies) {
-      spy.mockRestore();
-    }
-    this.#spies.length = 0;
-    await super._afterCleanup();
-  }
 }
 
 /**
@@ -300,7 +294,7 @@ export const {
     bed.initializeDefaultMocks();
   },
   afterEachHook() {
-    // Timers restored via BaseTestBed cleanup; spies handled by _afterCleanup
+    // Timers restored via BaseTestBed cleanup; spies restored by SpyTrackerMixin
   },
 });
 


### PR DESCRIPTION
Summary: Implement spy tracking mixin and integrate into TurnManager test bed for automatic spy cleanup.

Changes Made:
- Added `SpyTrackerMixin` providing `_spies` array, `trackSpy`, and cleanup override.
- Extended `TurnManagerTestBed` with `SpyTrackerMixin` and replaced manual spy tracking with `trackSpy`.
- Removed unused spy cleanup logic.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6857cfc12d488331bdefa1df6013a378