### PR TITLE
[Agent] Add helper for turn end flush and refactor tests

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -4,7 +4,10 @@
  */
 
 import { expect } from '@jest/globals';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  TURN_ENDED_ID,
+} from '../../../src/constants/eventIds.js';
 import { flushPromisesAndTimers } from './turnManagerTestBed.js';
 
 /**
@@ -47,4 +50,19 @@ export async function waitForCurrentActor(bed, id, maxTicks = 50) {
     await flushPromisesAndTimers();
   }
   return false;
+}
+
+/**
+ * Triggers {@link TURN_ENDED_ID} on the provided test bed then flushes timers.
+ *
+ * @description Convenience helper used by multiple TurnManager tests.
+ * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Active test
+ *   bed instance.
+ * @param {string} entityId - ID for the event payload.
+ * @param {boolean} [success] - Whether the turn ended successfully.
+ * @returns {Promise<void>} Resolves once timers have flushed.
+ */
+export async function triggerTurnEndedAndFlush(bed, entityId, success = true) {
+  bed.trigger(TURN_ENDED_ID, { entityId, success });
+  await flushPromisesAndTimers();
 }

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -2,16 +2,13 @@
 // --- FILE START (Corrected) ---
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals';
+import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
-  describeRunningTurnManagerSuite,
-  flushPromisesAndTimers,
-} from '../../common/turns/turnManagerTestBed.js';
-import { expectSystemErrorDispatch } from '../../common/turns/turnManagerTestUtils.js';
+  expectSystemErrorDispatch,
+  triggerTurnEndedAndFlush,
+} from '../../common/turns/turnManagerTestUtils.js';
 
-import {
-  TURN_ENDED_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { createMockEntity } from '../../common/mockFactories';
 import {
@@ -89,12 +86,7 @@ describeRunningTurnManagerSuite(
         );
         expect(stopSpy).not.toHaveBeenCalled();
 
-        testBed.trigger(TURN_ENDED_ID, {
-          entityId: actor.id,
-          success: true,
-        });
-
-        await flushPromisesAndTimers();
+        await triggerTurnEndedAndFlush(testBed, actor.id, true);
 
         expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -3,10 +3,11 @@
 
 import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
-import { waitForCurrentActor } from '../../common/turns/turnManagerTestUtils.js';
-// import removed constant; not needed
 import {
-  TURN_ENDED_ID,
+  waitForCurrentActor,
+  triggerTurnEndedAndFlush,
+} from '../../common/turns/turnManagerTestUtils.js';
+import {
   TURN_STARTED_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../src/constants/eventIds.js';
@@ -113,11 +114,7 @@ describeRunningTurnManagerSuite(
       expect(testBed.turnManager.getCurrentActor()).toBe(ai1);
 
       // Simulate turn ending
-      testBed.trigger(TURN_ENDED_ID, {
-        entityId: ai1.id,
-        success: true,
-      });
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai1.id, true);
 
       expect(testBed.turnManager.getCurrentActor()).toBe(ai2);
     });
@@ -142,11 +139,7 @@ describeRunningTurnManagerSuite(
       );
 
       // Simulate turn ending and advancing to AI actor
-      testBed.trigger(TURN_ENDED_ID, {
-        entityId: player.id,
-        success: true,
-      });
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, player.id, true);
       await flushPromisesAndTimers();
 
       // Check AI actor event
@@ -203,18 +196,14 @@ describeRunningTurnManagerSuite(
       expect(testBed.turnManager.getCurrentActor()?.id).toBe(ai1.id);
 
       // Simulate turn ending for actor1 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai1.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai1.id, true);
 
       // Wait for TurnManager to advance to ai2
       const found = await waitForCurrentActor(testBed, ai2.id);
       expect(found).toBe(true);
 
       // Simulate turn ending for actor2 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai2.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai2.id, true);
 
       // Wait for the TurnManager to process and start a new round
       let roundStarted = false;


### PR DESCRIPTION
## Summary
- add triggerTurnEndedAndFlush helper for tests
- refactor tests to use the helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 2939 problems (601 errors, 2338 warnings))*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6857cdabffac8331b0b4b1dfe17211b6