### PR TITLE
[Agent] refactor reconstruction error handling

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -372,7 +372,7 @@ class EntityManager extends IEntityManager {
    * @param {Error} err - Original error thrown by the factory.
    * @throws {Error|DuplicateEntityError}
    */
-  #translateFactoryError(err) {
+  #handleReconstructionError(err) {
     if (
       err instanceof Error &&
       err.message.startsWith(
@@ -382,7 +382,7 @@ class EntityManager extends IEntityManager {
       const msg =
         'EntityManager.reconstructEntity: serializedEntity data is missing or invalid.';
       this.#logger.error(msg);
-      throw new Error(msg);
+      return new Error(msg);
     }
     if (
       err instanceof Error &&
@@ -393,7 +393,7 @@ class EntityManager extends IEntityManager {
       const msg =
         'EntityManager.reconstructEntity: instanceId is missing or invalid in serialized data.';
       this.#logger.error(msg);
-      throw new Error(msg);
+      return new Error(msg);
     }
     if (
       err instanceof Error &&
@@ -409,12 +409,12 @@ class EntityManager extends IEntityManager {
           /Entity with ID '([^']+)' already exists/
         );
         if (entityMatch) {
-          throw new DuplicateEntityError(entityMatch[1], msg);
+          return new DuplicateEntityError(entityMatch[1], msg);
         }
-        throw new DuplicateEntityError('unknown', msg);
+        return new DuplicateEntityError('unknown', msg);
       }
     }
-    throw err;
+    return err instanceof Error ? err : new Error(String(err));
   }
 
   /* ---------------------------------------------------------------------- */
@@ -520,7 +520,7 @@ class EntityManager extends IEntityManager {
       });
       return entity;
     } catch (err) {
-      this.#translateFactoryError(err);
+      throw this.#handleReconstructionError(err);
     }
   }
 

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -299,6 +299,31 @@ describeEntityManagerSuite('EntityManager - Lifecycle', (getBed) => {
       );
     });
 
+    it('should map duplicate ID errors to legacy message', () => {
+      // Arrange
+      const { entityManager } = getBed();
+      const { PRIMARY } = TestData.InstanceIDs;
+      getBed().setupTestDefinitions('basic');
+
+      // Pre-create entity to trigger duplicate case
+      getBed().createBasicEntity({ instanceId: PRIMARY });
+
+      const serializedEntity = buildSerializedEntity(
+        PRIMARY,
+        TestData.DefinitionIDs.BASIC,
+        {}
+      );
+
+      // Act & Assert
+      const expectedMsg =
+        "EntityManager.reconstructEntity: Entity with ID '" +
+        PRIMARY +
+        "' already exists. Reconstruction aborted.";
+      expect(() => entityManager.reconstructEntity(serializedEntity)).toThrow(
+        expectedMsg
+      );
+    });
+
     it('should throw an error if a component fails validation', () => {
       // Arrange
       const { entityManager, mocks } = getBed();


### PR DESCRIPTION
Summary: 
- centralize reconstruction error message mapping in `#handleReconstructionError`
- update `reconstructEntity` to throw mapped error
- ensure duplicate ID errors still use legacy message

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint run `npm run lint` (fails: see logs)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857d036f4408331af7dd5f07e6e1380