### PR TITLE
[Agent] add actor validation helpers

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -9,6 +9,10 @@ import { AbstractTurnState } from './abstractTurnState.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
 import { getActorType } from '../../utils/actorTypeUtils.js';
 import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
+import {
+  assertValidActor,
+  assertMatchingActor,
+} from './helpers/validationUtils.js';
 
 /**
  * State in which the engine waits for the current actor’s turn-strategy to
@@ -94,7 +98,8 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   validateActor(turnContext) {
     const logger = turnContext.getLogger();
     const actor = turnContext.getActor();
-    if (!actor) {
+    const errorMsg = assertValidActor(actor, this.getStateName());
+    if (errorMsg) {
       logger.error(
         `${this.getStateName()}: No actor found in TurnContext. Ending turn.`
       );
@@ -118,6 +123,11 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
    */
   retrieveStrategy(turnContext, actor) {
     const logger = turnContext.getLogger();
+    const actorError = assertValidActor(actor, this.getStateName());
+    if (actorError) {
+      logger.error(actorError);
+      throw new Error(actorError);
+    }
 
     if (typeof turnContext.getStrategy !== 'function') {
       const msg = `${this.getStateName()}: turnContext.getStrategy() is not a function for actor ${actor.id}.`;

--- a/src/turns/states/helpers/validationUtils.js
+++ b/src/turns/states/helpers/validationUtils.js
@@ -1,0 +1,41 @@
+/**
+ * @file Validation utilities for turn state actors.
+ */
+
+/**
+ * @typedef {import('../../../entities/entity.js').default} Entity
+ */
+
+/**
+ * Ensures the provided actor is valid.
+ *
+ * @param {Entity} actor - Actor entity to validate.
+ * @param {string} stateName - Name of the calling state.
+ * @returns {?string} Error message when actor is invalid, otherwise `null`.
+ */
+export function assertValidActor(actor, stateName) {
+  if (!actor || typeof actor.id === 'undefined') {
+    return `${stateName}: invalid actorEntity.`;
+  }
+  return null;
+}
+
+/**
+ * Validates that two actors represent the same entity.
+ *
+ * @param {Entity} expectedActor - Actor expected by the state.
+ * @param {Entity} contextActor - Actor retrieved from context.
+ * @param {string} stateName - Name of the calling state.
+ * @returns {?string} Error message when actors do not match, otherwise `null`.
+ */
+export function assertMatchingActor(expectedActor, contextActor, stateName) {
+  const expectedError = assertValidActor(expectedActor, stateName);
+  if (expectedError) return expectedError;
+  const contextError = assertValidActor(contextActor, stateName);
+  if (contextError) return contextError;
+
+  if (expectedActor.id !== contextActor.id) {
+    return `${stateName}: Actor in ITurnContext ('${contextActor.id}') does not match actor provided to state's startTurn ('${expectedActor.id}').`;
+  }
+  return null;
+}

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -14,6 +14,10 @@
 import { AbstractTurnState } from './abstractTurnState.js';
 import { UNKNOWN_ENTITY_ID } from '../../constants/unknownIds.js';
 import { getLogger } from './helpers/contextUtils.js';
+import {
+  assertValidActor,
+  assertMatchingActor,
+} from './helpers/validationUtils.js';
 
 /**
  * @class TurnIdleState
@@ -74,8 +78,8 @@ export class TurnIdleState extends AbstractTurnState {
    * @param {import('../../utils/loggerUtils.js').Logger} logger - Logger instance.
    */
   _validateActorEntity(handler, actorEntity, logger) {
-    if (!actorEntity || typeof actorEntity.id === 'undefined') {
-      const errorMsg = `${this.getStateName()}: startTurn called with invalid actorEntity.`;
+    const errorMsg = assertValidActor(actorEntity, this.getStateName());
+    if (errorMsg) {
       logger.error(errorMsg);
       handler.resetStateAndResources(`invalid-actor-${this.getStateName()}`);
       handler.requestIdleStateTransition();
@@ -110,8 +114,12 @@ export class TurnIdleState extends AbstractTurnState {
    */
   _validateActorMatch(handler, turnCtx, actorEntity, logger) {
     const contextActor = turnCtx.getActor();
-    if (!contextActor || contextActor.id !== actorEntity.id) {
-      const errorMsg = `${this.getStateName()}: Actor in ITurnContext ('${contextActor?.id}') does not match actor provided to state's startTurn ('${actorEntity.id}').`;
+    const errorMsg = assertMatchingActor(
+      actorEntity,
+      contextActor,
+      this.getStateName()
+    );
+    if (errorMsg) {
       logger.error(errorMsg);
       handler.resetStateAndResources(`actor-mismatch-${this.getStateName()}`);
       handler.requestIdleStateTransition();

--- a/tests/unit/turns/states/helpers/validationUtils.test.js
+++ b/tests/unit/turns/states/helpers/validationUtils.test.js
@@ -1,0 +1,30 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  assertValidActor,
+  assertMatchingActor,
+} from '../../../../../src/turns/states/helpers/validationUtils.js';
+
+const makeActor = (id = 'a1') => ({ id });
+
+describe('validationUtils', () => {
+  test('assertValidActor returns null for valid actor', () => {
+    expect(assertValidActor(makeActor(), 'State')).toBeNull();
+  });
+
+  test('assertValidActor returns message for invalid actor', () => {
+    expect(assertValidActor(null, 'State')).toMatch(/invalid actorEntity/);
+  });
+
+  test('assertMatchingActor returns null for matching actors', () => {
+    const a = makeActor('a1');
+    expect(assertMatchingActor(a, makeActor('a1'), 'State')).toBeNull();
+  });
+
+  test('assertMatchingActor returns message for mismatched actors', () => {
+    const expected = makeActor('a1');
+    const ctx = makeActor('a2');
+    expect(assertMatchingActor(expected, ctx, 'State')).toMatch(
+      /does not match/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add validationUtils with actor validation helpers
- integrate actor helpers into TurnIdleState and AwaitingActorDecisionState
- test new validationUtils helper functions

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857d01067248331b63abe64c9f990d0