### PR TITLE
[Agent] configurable timeout for AwaitingExternalTurnEndState

### DIFF
--- a/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
@@ -12,8 +12,8 @@ import { safeDispatchError } from '../../../../src/utils/safeDispatchErrorUtils.
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 describe('AwaitingExternalTurnEndState – action propagation', () => {
-  // In the implementation TIMEOUT_MS is 3 000 ms when NODE_ENV === "test"
-  const TIMEOUT_MS = 3_000;
+  // Use a short timeout for faster tests
+  const TIMEOUT_MS = 10;
 
   let mockCtx;
   let mockSafeEventDispatcher; // Renamed for clarity
@@ -68,7 +68,7 @@ describe('AwaitingExternalTurnEndState – action propagation', () => {
     };
 
     /* ── state under test ──────────────────────────────────────────────── */
-    state = new AwaitingExternalTurnEndState(mockHandler);
+    state = new AwaitingExternalTurnEndState(mockHandler, TIMEOUT_MS);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Summary: add per-instance timeout option for AwaitingExternalTurnEndState to improve test speed. updated tests use a short timeout.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` (fails: see log)
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857d0033da8833189948cbe58bcd453