### PR TITLE
[Agent] standardize execution context naming

### DIFF
--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -204,7 +204,8 @@ class InitializationService extends IInitializationService {
       this.#logger.debug(
         'WorldInitializer resolved. Initializing world entities...'
       );
-      const worldInitSuccess = await worldInitializer.initializeWorldEntities(worldName);
+      const worldInitSuccess =
+        await worldInitializer.initializeWorldEntities(worldName);
       if (!worldInitSuccess) {
         throw new Error('World initialization failed via WorldInitializer.');
       }

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -162,7 +162,11 @@ class WorldInitializer {
       );
     }
 
-    if (!worldData.instances || !Array.isArray(worldData.instances) || worldData.instances.length === 0) {
+    if (
+      !worldData.instances ||
+      !Array.isArray(worldData.instances) ||
+      worldData.instances.length === 0
+    ) {
       this.#logger.error(
         `WorldInitializer (Pass 1): World '${worldName}' has no instances defined. Game cannot start without entities.`
       );
@@ -187,7 +191,11 @@ class WorldInitializer {
     );
 
     for (const worldInstance of worldData.instances) {
-      if (!worldInstance || !worldInstance.instanceId || !worldInstance.definitionId) {
+      if (
+        !worldInstance ||
+        !worldInstance.instanceId ||
+        !worldInstance.definitionId
+      ) {
         this.#logger.warn(
           `WorldInitializer (Pass 1): Skipping invalid world instance (missing instanceId or definitionId):`,
           worldInstance
@@ -196,9 +204,10 @@ class WorldInitializer {
       }
 
       const { instanceId, definitionId, componentOverrides } = worldInstance;
-      
+
       // Get the entity instance definition
-      const entityInstanceDef = this.#repository.getEntityInstanceDefinition(instanceId);
+      const entityInstanceDef =
+        this.#repository.getEntityInstanceDefinition(instanceId);
       if (!entityInstanceDef) {
         safeDispatchError(
           this.#validatedEventDispatcher,
@@ -218,7 +227,7 @@ class WorldInitializer {
       // Create the entity instance
       const instance = this.#entityManager.createEntityInstance(definitionId, {
         instanceId,
-        componentOverrides
+        componentOverrides,
       });
 
       if (instance) {

--- a/src/loaders/phases/LoaderPhase.js
+++ b/src/loaders/phases/LoaderPhase.js
@@ -8,9 +8,9 @@ export default class LoaderPhase {
     this.name = name;
   }
   /**
-   * @param {LoadContext} _ctx
+   * @param {LoadContext} executionContext
    */
-  async execute(_ctx) {
+  async execute(executionContext) {
     throw new Error('execute() not implemented');
   }
 }

--- a/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
+++ b/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
@@ -43,10 +43,10 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
 
   /**
    * @param {AddPerceptionLogEntryParams} params
-   * @param {import('../defs.js').ExecutionContext} _ctx – Unused for now.
+   * @param {import('../defs.js').ExecutionContext} executionContext – Unused for now.
    */
-  execute(params, _ctx) {
-    const log = this.getLogger(_ctx);
+  execute(params, executionContext) {
+    const log = this.getLogger(executionContext);
 
     /* ── validation ─────────────────────────────────────────────── */
     if (
@@ -91,12 +91,12 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
       }
 
       /* pull current data; fall back to sane defaults */
-      const raw =
+      const currentComponent =
         this.#entityManager.getComponentData(id, PERCEPTION_LOG_COMPONENT_ID) ??
         {};
 
       /* normalise / repair corrupted shapes -------------------------------- */
-      let { maxEntries, logEntries } = raw;
+      let { maxEntries, logEntries } = currentComponent;
 
       if (!Array.isArray(logEntries)) {
         logEntries = []; // recover from bad type
@@ -105,20 +105,26 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
         maxEntries = DEFAULT_MAX_LOG_ENTRIES; // recover from bad value
       }
 
-      /* build next state ---------------------------------------------------- */
-      const next = {
+      /* build updated state ---------------------------------------------------- */
+      const updatedComponent = {
         maxEntries,
         logEntries: [...logEntries, entry], // keep ORIGINAL reference
       };
 
       /* trim to size -------------------------------------------------------- */
-      if (next.logEntries.length > next.maxEntries) {
-        next.logEntries = next.logEntries.slice(-next.maxEntries);
+      if (updatedComponent.logEntries.length > updatedComponent.maxEntries) {
+        updatedComponent.logEntries = updatedComponent.logEntries.slice(
+          -updatedComponent.maxEntries
+        );
       }
 
       /* write back ---------------------------------------------------------- */
       try {
-        this.#entityManager.addComponent(id, PERCEPTION_LOG_COMPONENT_ID, next);
+        this.#entityManager.addComponent(
+          id,
+          PERCEPTION_LOG_COMPONENT_ID,
+          updatedComponent
+        );
         updated++;
       } catch (e) {
         safeDispatchError(

--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -67,10 +67,10 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
    * Move followers from the leader's previous location to the destination.
    *
    * @param {AutoMoveFollowersParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.logger;
     if (!assertParamsObject(params, logger, 'AUTO_MOVE_FOLLOWERS')) return;
 
     const { leader_id, destination_id } = params;
@@ -96,7 +96,8 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
     const lid = leader_id.trim();
     const dest = destination_id.trim();
 
-    const prevLoc = execCtx?.event?.payload?.previousLocationId ?? null;
+    const prevLoc =
+      executionContext?.event?.payload?.previousLocationId ?? null;
 
     const followersComponent = this.#entityManager.getComponentData(
       lid,
@@ -118,7 +119,7 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
 
         this.#moveHandler.execute(
           { entity_ref: { entityId: fid }, target_location_id: dest },
-          execCtx
+          executionContext
         );
 
         const followerName =

--- a/src/logic/operationHandlers/baseOperationHandler.js
+++ b/src/logic/operationHandlers/baseOperationHandler.js
@@ -67,12 +67,12 @@ class BaseOperationHandler {
   /**
    * Retrieve the logger appropriate for a specific execution context.
    *
-   * @param {ExecutionContext} [execCtx] - Optional execution context which may
+   * @param {ExecutionContext} [executionContext] - Optional execution context which may
    *   provide a contextual logger.
    * @returns {ILogger} Logger instance for the current execution.
    */
-  getLogger(execCtx) {
-    return getExecLogger(this.#logger, execCtx);
+  getLogger(executionContext) {
+    return getExecLogger(this.#logger, executionContext);
   }
 }
 

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -83,10 +83,10 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
 
   /**
    * @param {{ follower_id: string }} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'BREAK_FOLLOW_RELATION')) return;
 
     const { follower_id } = params;
@@ -124,7 +124,7 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
     if (currentData.leaderId) {
       this.#rebuildHandler.execute(
         { leaderIds: [currentData.leaderId] },
-        execCtx
+        executionContext
       );
     }
   }

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -50,9 +50,9 @@ class CheckFollowCycleHandler {
 
   /**
    * @param {CheckFollowCycleParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
+  execute(params, executionContext) {
     const log = this.#logger;
     if (!assertParamsObject(params, log, 'CHECK_FOLLOW_CYCLE')) return;
 
@@ -98,7 +98,7 @@ class CheckFollowCycleHandler {
     const res = tryWriteContextVariable(
       result_variable,
       result,
-      execCtx,
+      executionContext,
       this.#dispatcher,
       log
     );

--- a/src/logic/operationHandlers/componentOperationHandler.js
+++ b/src/logic/operationHandlers/componentOperationHandler.js
@@ -27,12 +27,12 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * Resolve an entity reference to an ID string.
    *
    * @param {'actor'|'target'|string|EntityRefObject} entityRef
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {string|null} The resolved ID or null if invalid.
    */
-  resolveEntity(entityRef, execCtx) {
+  resolveEntity(entityRef, executionContext) {
     if (!entityRef) return null;
-    return resolveEntityId(entityRef, execCtx);
+    return resolveEntityId(entityRef, executionContext);
   }
 
   /**

--- a/src/logic/operationHandlers/dispatchEventHandler.js
+++ b/src/logic/operationHandlers/dispatchEventHandler.js
@@ -50,9 +50,9 @@ class DispatchEventHandler {
    * Emit a new game-event using pre-resolved parameters.
    *
    * @param {DispatchEventParameters|null|undefined} params - Parameters with placeholders already resolved.
-   * @param {ExecutionContext} _executionContext - The context (used for services, not resolution here).
+   * @param {ExecutionContext} executionContext - The context (used for services, not resolution here).
    */
-  execute(params, _executionContext) {
+  execute(params, executionContext) {
     const logger = this.#logger; // Use the injected logger
     if (!assertParamsObject(params, logger, 'DISPATCH_EVENT')) return;
 

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -67,9 +67,9 @@ class DispatchPerceptibleEventHandler {
    * {@link AddPerceptionLogEntryHandler} to store the log entry for observers.
    *
    * @param {DispatchPerceptibleEventParams} params - Resolved parameters.
-   * @param {ExecutionContext} _ctx - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _ctx) {
+  execute(params, executionContext) {
     if (
       !assertParamsObject(
         params,

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -52,10 +52,10 @@ class DispatchSpeechHandler {
    * Construct payload and dispatch {@link DISPLAY_SPEECH_ID}.
    *
    * @param {DispatchSpeechParams|null|undefined} params - Resolved parameters.
-   * @param {ExecutionContext} _ctx - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _ctx) {
-    const logger = _ctx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'DISPATCH_SPEECH')) return;
 
     if (

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -55,10 +55,10 @@ class EndTurnHandler {
    * Dispatch the core:turn_ended event.
    *
    * @param {EndTurnParameters} params - Resolved parameters.
-   * @param {ExecutionContext} _executionContext - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _executionContext) {
-    const logger = _executionContext?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'END_TURN')) return;
 
     if (typeof params.entityId !== 'string' || !params.entityId.trim()) {

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -73,10 +73,10 @@ class EstablishFollowRelationHandler {
 
   /**
    * @param {{ follower_id: string, leader_id: string }} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'ESTABLISH_FOLLOW_RELATION'))
       return;
 
@@ -142,7 +142,7 @@ class EstablishFollowRelationHandler {
     const leaderIds = [lid];
     if (oldData?.leaderId && oldData.leaderId !== lid)
       leaderIds.push(oldData.leaderId);
-    this.#rebuildHandler.execute({ leaderIds }, execCtx);
+    this.#rebuildHandler.execute({ leaderIds }, executionContext);
   }
 }
 

--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -14,8 +14,8 @@ class GetTimestampHandler {
     this.#logger = logger;
   }
 
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
 
     const rv = params.result_variable.trim();
@@ -23,7 +23,7 @@ class GetTimestampHandler {
     const result = tryWriteContextVariable(
       rv,
       timestamp,
-      execCtx,
+      executionContext,
       undefined,
       this.#logger
     );

--- a/src/logic/operationHandlers/ifCoLocatedHandler.js
+++ b/src/logic/operationHandlers/ifCoLocatedHandler.js
@@ -60,10 +60,10 @@ class IfCoLocatedHandler {
 
   /**
    * @param {IfCoLocatedParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const log = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const log = executionContext?.logger ?? this.#logger;
 
     if (!assertParamsObject(params, this.#dispatcher, 'IF_CO_LOCATED')) {
       return;
@@ -84,8 +84,8 @@ class IfCoLocatedHandler {
       return;
     }
 
-    const idA = resolveEntityId(entity_ref_a, execCtx);
-    const idB = resolveEntityId(entity_ref_b, execCtx);
+    const idA = resolveEntityId(entity_ref_a, executionContext);
+    const idB = resolveEntityId(entity_ref_b, executionContext);
 
     if (!idA || !idB) {
       log.debug(
@@ -124,7 +124,7 @@ class IfCoLocatedHandler {
       : [];
     for (const op of actions) {
       try {
-        this.#opInterpreter.execute(op, execCtx);
+        this.#opInterpreter.execute(op, executionContext);
       } catch (err) {
         safeDispatchError(
           this.#dispatcher,

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -153,8 +153,8 @@ class MathHandler {
     if (operand && typeof operand === 'object') {
       if (Object.prototype.hasOwnProperty.call(operand, 'var')) {
         try {
-          const raw = jsonLogic.apply({ var: operand.var }, ctx);
-          const num = Number(raw);
+          const currentComponent = jsonLogic.apply({ var: operand.var }, ctx);
+          const num = Number(currentComponent);
           return Number.isNaN(num) ? NaN : num;
         } catch (e) {
           safeDispatchError(

--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -54,13 +54,13 @@ class MergeClosenessCircleHandler {
    * Validate parameters for execute.
    *
    * @param {object} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {{ actorId:string, targetId:string, resultVar:string|null, logger:ILogger }|null}
    * @private
    */
-  #validateParams(params, execCtx) {
+  #validateParams(params, executionContext) {
     const { actor_id, target_id, result_variable } = params || {};
-    const log = execCtx?.logger ?? this.#logger;
+    const log = executionContext?.logger ?? this.#logger;
     if (typeof actor_id !== 'string' || !actor_id.trim()) {
       safeDispatchError(
         this.#dispatcher,
@@ -167,10 +167,10 @@ class MergeClosenessCircleHandler {
    * Merge the actor and target circles and lock movement for all members.
    *
    * @param {{ actor_id:string, target_id:string, result_variable?:string }} params - Operation parameters.
-   * @param {ExecutionContext} execCtx - Execution context.
+   * @param {ExecutionContext} executionContext - Execution context.
    */
-  execute(params, execCtx) {
-    const validated = this.#validateParams(params, execCtx);
+  execute(params, executionContext) {
+    const validated = this.#validateParams(params, executionContext);
     if (!validated) return;
     const { actorId, targetId, resultVar, logger } = validated;
 
@@ -181,7 +181,7 @@ class MergeClosenessCircleHandler {
       tryWriteContextVariable(
         resultVar,
         members,
-        execCtx,
+        executionContext,
         this.#dispatcher,
         logger
       );

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -64,10 +64,10 @@ class ModifyComponentHandler extends ComponentOperationHandler {
    * Executes a MODIFY_COMPONENT operation (mode = "set" only).
    *
    * @param {ModifyComponentOperationParams|null|undefined} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const log = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const log = this.getLogger(executionContext);
 
     // ── validate base params ───────────────────────────────────────
     if (!assertParamsObject(params, log, 'MODIFY_COMPONENT')) {
@@ -101,7 +101,7 @@ class ModifyComponentHandler extends ComponentOperationHandler {
     }
 
     // ── resolve entity ─────────────────────────────────────────────
-    const entityId = this.resolveEntity(entity_ref, execCtx);
+    const entityId = this.resolveEntity(entity_ref, executionContext);
     if (!entityId) {
       log.warn('MODIFY_COMPONENT: could not resolve entity id.', {
         entity_ref,
@@ -126,10 +126,10 @@ class ModifyComponentHandler extends ComponentOperationHandler {
       return;
     }
 
-    const next = deepClone(current);
+    const updatedComponent = deepClone(current);
 
     // ── apply “set” mutation ───────────────────────────────────────
-    const ok = setByPath(next, field.trim(), value);
+    const ok = setByPath(updatedComponent, field.trim(), value);
     if (!ok) {
       log.warn(
         `MODIFY_COMPONENT: Failed to set path "${field}" on component "${compType}".`
@@ -142,7 +142,7 @@ class ModifyComponentHandler extends ComponentOperationHandler {
       const success = this.#entityManager.addComponent(
         entityId,
         compType,
-        next
+        updatedComponent
       );
       if (success) {
         log.debug(

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -168,13 +168,13 @@ class QueryEntitiesHandler extends BaseOperationHandler {
    * Validate and normalize execution parameters.
    *
    * @param {object} params - Raw parameters object.
-   * @param {ExecutionContext} execCtx - Current execution context.
+   * @param {ExecutionContext} executionContext - Current execution context.
    * @returns {{resultVariable:string, filters:object[], limit:number|undefined, logger:ILogger}|null}
    *   Normalized parameters or `null` when validation fails.
    * @private
    */
-  #validateParams(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  #validateParams(params, executionContext) {
+    const logger = this.getLogger(executionContext);
 
     if (!assertParamsObject(params, logger, 'QUERY_ENTITIES')) {
       return null;

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -57,10 +57,10 @@ class RemoveFromClosenessCircleHandler {
 
   /**
    * @param {{ actor_id: string, result_variable?: string } | null | undefined} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const validated = this.#validateParams(params, execCtx);
+  execute(params, executionContext) {
+    const validated = this.#validateParams(params, executionContext);
     if (!validated) return;
     const { actorId, resultVar, logger } = validated;
 
@@ -71,7 +71,7 @@ class RemoveFromClosenessCircleHandler {
       tryWriteContextVariable(
         resultVar,
         partners,
-        execCtx,
+        executionContext,
         this.#dispatcher,
         logger
       );
@@ -82,12 +82,12 @@ class RemoveFromClosenessCircleHandler {
    * Validate parameters for execute.
    *
    * @param {object} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {{ actorId:string, resultVar:string|null, logger:ILogger }|null}
    * @private
    */
-  #validateParams(params, execCtx) {
-    const log = getExecLogger(this.#logger, execCtx);
+  #validateParams(params, executionContext) {
+    const log = getExecLogger(this.#logger, executionContext);
 
     if (!assertParamsObject(params, log, 'REMOVE_FROM_CLOSENESS_CIRCLE')) {
       return null;

--- a/src/logic/operationHandlers/resolveDirectionHandler.js
+++ b/src/logic/operationHandlers/resolveDirectionHandler.js
@@ -19,8 +19,8 @@ class ResolveDirectionHandler {
     this.#logger = logger;
   }
 
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'RESOLVE_DIRECTION')) return;
 
     // Safely destructure params, providing a default empty object to avoid errors if params is null/undefined.
@@ -47,7 +47,7 @@ class ResolveDirectionHandler {
     const res = tryWriteContextVariable(
       trimmedVar,
       target,
-      execCtx,
+      executionContext,
       undefined,
       this.#logger
     );

--- a/src/logic/operationHandlers/setVariableHandler.js
+++ b/src/logic/operationHandlers/setVariableHandler.js
@@ -175,10 +175,10 @@ class SetVariableHandler {
    * @description Store the variable in executionContext.evaluationContext.context.
    * @param {string} name - Variable name.
    * @param {*} value - Value to store.
-   * @param {OperationExecutionContext} execCtx - Execution context providing the variable store.
+   * @param {OperationExecutionContext} executionContext - Execution context providing the variable store.
    * @private
    */
-  #storeVariable(name, value, execCtx) {
+  #storeVariable(name, value, executionContext) {
     const logger = this.#logger;
     let finalValueStringForLog;
     try {
@@ -198,7 +198,7 @@ class SetVariableHandler {
     const result = tryWriteContextVariable(
       name,
       value,
-      execCtx,
+      executionContext,
       undefined,
       logger
     );

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -57,9 +57,9 @@ class SystemMoveEntityHandler {
    */
   async execute(params, executionContext) {
     const log = executionContext?.logger ?? this.#logger;
-    const opName = 'SYSTEM_MOVE_ENTITY'; // Use a constant for the name
+    const operationName = 'SYSTEM_MOVE_ENTITY'; // Use a constant for the name
 
-    if (!assertParamsObject(params, log, opName)) return;
+    if (!assertParamsObject(params, log, operationName)) return;
 
     // 1. Validate parameters
     const { entity_ref, target_location_id } = params;
@@ -71,7 +71,7 @@ class SystemMoveEntityHandler {
       !target_location_id
     ) {
       log.warn(
-        `${opName}: "entity_ref" and "target_location_id" are required.`
+        `${operationName}: "entity_ref" and "target_location_id" are required.`
       );
       return;
     }
@@ -79,7 +79,9 @@ class SystemMoveEntityHandler {
     // 2. Resolve the entity ID
     const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
-      log.warn(`${opName}: Could not resolve entity_ref.`, { entity_ref });
+      log.warn(`${operationName}: Could not resolve entity_ref.`, {
+        entity_ref,
+      });
       return;
     }
 
@@ -93,7 +95,7 @@ class SystemMoveEntityHandler {
       );
       if (!positionComponent) {
         log.warn(
-          `${opName}: Entity "${entityId}" has no 'core:position' component. Cannot move.`
+          `${operationName}: Entity "${entityId}" has no 'core:position' component. Cannot move.`
         );
         return;
       }
@@ -103,7 +105,7 @@ class SystemMoveEntityHandler {
       // Prevent moving if already there
       if (fromLocationId === target_location_id) {
         log.debug(
-          `${opName}: Entity "${entityId}" is already in location "${target_location_id}". No move needed.`
+          `${operationName}: Entity "${entityId}" is already in location "${target_location_id}". No move needed.`
         );
         return;
       }
@@ -118,13 +120,13 @@ class SystemMoveEntityHandler {
 
       if (!success) {
         log.warn(
-          `${opName}: EntityManager reported failure for addComponent on entity "${entityId}".`
+          `${operationName}: EntityManager reported failure for addComponent on entity "${entityId}".`
         );
         return;
       }
 
       log.debug(
-        `${opName}: Moved entity "${entityId}" from "${fromLocationId}" to "${target_location_id}".`
+        `${operationName}: Moved entity "${entityId}" from "${fromLocationId}" to "${target_location_id}".`
       );
 
       // 4. **Dispatch core:entity_moved with a compliant payload**
@@ -139,7 +141,7 @@ class SystemMoveEntityHandler {
     } catch (e) {
       safeDispatchError(
         this.#dispatcher,
-        `${opName}: Failed to move entity "${entityId}". Error: ${e.message}`,
+        `${operationName}: Failed to move entity "${entityId}". Error: ${e.message}`,
         {
           error: e.message,
           stack: e.stack,

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -9,11 +9,11 @@ import { isNonBlankString } from './textUtils.js';
  * Validate that the context exists and the variable name is valid.
  *
  * @param {string} variableName Variable name to validate.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext Execution context.
  * @returns {{valid: boolean, error?: Error, name?: string}} Validation result.
  * @private
  */
-function _validateContextAndName(variableName, execCtx) {
+function _validateContextAndName(variableName, executionContext) {
   if (!isNonBlankString(variableName)) {
     return {
       valid: false,
@@ -22,9 +22,9 @@ function _validateContextAndName(variableName, execCtx) {
   }
 
   const hasContext =
-    execCtx?.evaluationContext &&
-    typeof execCtx.evaluationContext.context === 'object' &&
-    execCtx.evaluationContext.context !== null;
+    executionContext?.evaluationContext &&
+    typeof executionContext.evaluationContext.context === 'object' &&
+    executionContext.evaluationContext.context !== null;
 
   if (!hasContext) {
     return {
@@ -39,13 +39,13 @@ function _validateContextAndName(variableName, execCtx) {
 }
 
 /**
- * Safely stores a value into `execCtx.evaluationContext.context`. If the context
+ * Safely stores a value into `executionContext.evaluationContext.context`. If the context
  * is missing, an error is dispatched (or logged) and the function returns a
  * failure result.
  *
  * @param {string} variableName - Name of the variable to store.
  * @param {*} value - The value to store.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] -
  * Optional dispatcher for error events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger used when no dispatcher is provided.
@@ -54,13 +54,17 @@ function _validateContextAndName(variableName, execCtx) {
 export function writeContextVariable(
   variableName,
   value,
-  execCtx,
+  executionContext,
   dispatcher,
   logger
 ) {
   const log = getModuleLogger('contextVariableUtils', logger);
-  const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
-  const { valid, error, name } = _validateContextAndName(variableName, execCtx);
+  const safeDispatcher =
+    dispatcher || resolveSafeDispatcher(executionContext, log);
+  const { valid, error, name } = _validateContextAndName(
+    variableName,
+    executionContext
+  );
 
   if (!valid) {
     if (safeDispatcher) {
@@ -70,7 +74,7 @@ export function writeContextVariable(
   }
 
   try {
-    execCtx.evaluationContext.context[name] = value;
+    executionContext.evaluationContext.context[name] = value;
     return { success: true };
   } catch (e) {
     const err = new Error(
@@ -98,7 +102,7 @@ export function writeContextVariable(
  *
  * @param {string|null|undefined} variableName - Target context variable name.
  * @param {*} value - Value to store.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher]
  *   Optional dispatcher for error events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger used when no dispatcher is provided.
@@ -107,14 +111,15 @@ export function writeContextVariable(
 export function tryWriteContextVariable(
   variableName,
   value,
-  execCtx,
+  executionContext,
   dispatcher,
   logger
 ) {
   const log = getModuleLogger('contextVariableUtils', logger);
-  const validation = _validateContextAndName(variableName, execCtx);
+  const validation = _validateContextAndName(variableName, executionContext);
   if (!validation.valid) {
-    const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
+    const safeDispatcher =
+      dispatcher || resolveSafeDispatcher(executionContext, log);
     if (safeDispatcher) {
       safeDispatchError(
         safeDispatcher,
@@ -131,7 +136,7 @@ export function tryWriteContextVariable(
   return writeContextVariable(
     validation.name,
     value,
-    execCtx,
+    executionContext,
     dispatcher,
     logger
   );

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -9,7 +9,7 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  * Instantiates and returns a dispatcher when the execution context contains a
  * validatedEventDispatcher. A custom dispatcher class can be provided for
  * testing. Construction failures result in `null`.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the dispatcher.
  * @param {typeof SafeEventDispatcher} [DispatcherClass] -
  *   Class used to instantiate the dispatcher when needed.
@@ -17,14 +17,14 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  *   The resolved dispatcher or `null` when unavailable.
  */
 export function resolveSafeDispatcher(
-  execCtx,
+  executionContext,
   logger,
   DispatcherClass = SafeEventDispatcher
 ) {
-  if (execCtx?.validatedEventDispatcher) {
+  if (executionContext?.validatedEventDispatcher) {
     try {
       return new DispatcherClass({
-        validatedEventDispatcher: execCtx.validatedEventDispatcher,
+        validatedEventDispatcher: executionContext.validatedEventDispatcher,
         logger,
       });
     } catch {

--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -17,11 +17,11 @@ export {
  * execution context provides a logger, it takes precedence over the
  * handler's default logger.
  * @param {ILogger} defaultLogger - Default logger from the handler.
- * @param {import('../../logic/defs.js').ExecutionContext} [execCtx] - Optional execution context.
+ * @param {import('../../logic/defs.js').ExecutionContext} [executionContext] - Optional execution context.
  * @returns {ILogger} Logger instance for execution.
  */
-export function getExecLogger(defaultLogger, execCtx) {
-  return execCtx?.logger ?? defaultLogger;
+export function getExecLogger(defaultLogger, executionContext) {
+  return executionContext?.logger ?? defaultLogger;
 }
 
 // --- FILE END ---

--- a/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
+++ b/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
@@ -164,7 +164,7 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
     // Verify that entity instances are also loaded
     const allInstances = registry.getAll('entityInstances');
     expect(allInstances).toHaveLength(6);
-    expect(allInstances.map(i => i.instanceId)).toEqual(
+    expect(allInstances.map((i) => i.instanceId)).toEqual(
       expect.arrayContaining([
         'isekai:adventurers_guild_instance',
         'isekai:hero_instance',
@@ -176,7 +176,10 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
     );
 
     // Test individual instance retrieval
-    const instance = registry.get('entityInstances', 'isekai:adventurers_guild_instance');
+    const instance = registry.get(
+      'entityInstances',
+      'isekai:adventurers_guild_instance'
+    );
   });
 
   const MOD_ID = 'isekai';

--- a/tests/integration/loaders/modsLoader.entityInstances.integration.test.js
+++ b/tests/integration/loaders/modsLoader.entityInstances.integration.test.js
@@ -80,24 +80,47 @@ describe('Integration: Entity Instances Loader and World Initialization', () => 
   const MOD_ID = 'isekai';
   const MODS_BASE_PATH = './data/mods';
   const INSTANCES_DIR = path.join(MODS_BASE_PATH, MOD_ID, 'entities/instances');
-  const WORLD_FILE = path.join(MODS_BASE_PATH, MOD_ID, 'worlds/isekai.world.json');
+  const WORLD_FILE = path.join(
+    MODS_BASE_PATH,
+    MOD_ID,
+    'worlds/isekai.world.json'
+  );
 
   beforeAll(async () => {
     logger = new ConsoleLogger('info');
     container = new AppContainer();
     container.register(tokens.ILogger, logger);
-    validatedEventDispatcher = createMockValidatedEventDispatcherForIntegration();
-    container.register(tokens.IValidatedEventDispatcher, validatedEventDispatcher);
+    validatedEventDispatcher =
+      createMockValidatedEventDispatcherForIntegration();
+    container.register(
+      tokens.IValidatedEventDispatcher,
+      validatedEventDispatcher
+    );
     registerLoaders(container);
-    container.register(tokens.IDataFetcher, createMockDataFetcherForIntegration());
+    container.register(
+      tokens.IDataFetcher,
+      createMockDataFetcherForIntegration()
+    );
     const schemaValidator = new AjvSchemaValidator(logger);
-    await schemaValidator.addSchema(commonSchema, 'http://example.com/schemas/common.schema.json');
-    await schemaValidator.addSchema(modManifestSchema, 'http://example.com/schemas/mod-manifest.schema.json');
-    await schemaValidator.addSchema(entityDefinitionSchema, 'http://example.com/schemas/entity-definition.schema.json');
-    await schemaValidator.addSchema(entityInstanceSchema, 'http://example.com/schemas/entity-instance.schema.json');
+    await schemaValidator.addSchema(
+      commonSchema,
+      'http://example.com/schemas/common.schema.json'
+    );
+    await schemaValidator.addSchema(
+      modManifestSchema,
+      'http://example.com/schemas/mod-manifest.schema.json'
+    );
+    await schemaValidator.addSchema(
+      entityDefinitionSchema,
+      'http://example.com/schemas/entity-definition.schema.json'
+    );
+    await schemaValidator.addSchema(
+      entityInstanceSchema,
+      'http://example.com/schemas/entity-instance.schema.json'
+    );
     container.register(tokens.ISchemaValidator, schemaValidator);
     registry = container.resolve(tokens.IDataRegistry);
-    
+
     const phases = [
       new MockSchemaPhase(logger),
       new MockGameConfigPhase(logger),
@@ -133,14 +156,14 @@ describe('Integration: Entity Instances Loader and World Initialization', () => 
       )
     );
     const files = manifest.content.entities?.instances || [];
-    
+
     for (const file of files) {
       const filePath = path.join(INSTANCES_DIR, file);
       const instanceData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       const instanceId = instanceData.instanceId;
-      
+
       const instance = registry.get('entityInstances', instanceId);
-      
+
       expect(instance).toBeDefined();
       expect(instance.instanceId).toBe(instanceId);
     }
@@ -149,17 +172,24 @@ describe('Integration: Entity Instances Loader and World Initialization', () => 
   it('should allow WorldInitializer to instantiate all world instances when all are present', async () => {
     const worldData = JSON.parse(fs.readFileSync(WORLD_FILE, 'utf8'));
     const worldName = worldData.id;
-    
+
     // Create a mock repository with the required methods
     const mockRepository = {
       getWorld: jest.fn(() => worldData),
-      getEntityInstanceDefinition: jest.fn((instanceId) => registry.get('entityInstances', instanceId)),
+      getEntityInstanceDefinition: jest.fn((instanceId) =>
+        registry.get('entityInstances', instanceId)
+      ),
       getEntityDefinition: jest.fn(() => ({})),
       getComponentDefinition: jest.fn(() => ({})),
     };
-    
+
     const worldInitializer = new WorldInitializer({
-      entityManager: { createEntityInstance: jest.fn(() => ({ id: 'dummy', definitionId: 'dummyDef' })) },
+      entityManager: {
+        createEntityInstance: jest.fn(() => ({
+          id: 'dummy',
+          definitionId: 'dummyDef',
+        })),
+      },
       worldContext: {},
       gameDataRepository: mockRepository,
       validatedEventDispatcher,
@@ -175,31 +205,42 @@ describe('Integration: Entity Instances Loader and World Initialization', () => 
     const worldData = JSON.parse(fs.readFileSync(WORLD_FILE, 'utf8'));
     const worldName = worldData.id;
     const missingInstanceId = worldData.instances[0].instanceId;
-    
+
     // Create a mock repository that returns undefined for the missing instance
     const mockRepository = {
       getWorld: jest.fn(() => worldData),
-      getEntityInstanceDefinition: jest.fn((instanceId) => 
-        instanceId === missingInstanceId ? undefined : registry.get('entityInstances', instanceId)
+      getEntityInstanceDefinition: jest.fn((instanceId) =>
+        instanceId === missingInstanceId
+          ? undefined
+          : registry.get('entityInstances', instanceId)
       ),
       getEntityDefinition: jest.fn(() => ({})),
       getComponentDefinition: jest.fn(() => ({})),
     };
-    
+
     const worldInitializer = new WorldInitializer({
-      entityManager: { createEntityInstance: jest.fn(() => ({ id: 'dummy', definitionId: 'dummyDef' })) },
+      entityManager: {
+        createEntityInstance: jest.fn(() => ({
+          id: 'dummy',
+          definitionId: 'dummyDef',
+        })),
+      },
       worldContext: {},
       gameDataRepository: mockRepository,
       validatedEventDispatcher,
       logger,
       spatialIndexManager: { addEntity: jest.fn() },
     });
-    await expect(worldInitializer.initializeWorldEntities(worldName)).rejects.toThrow(
-      /not found/i
-    );
+    await expect(
+      worldInitializer.initializeWorldEntities(worldName)
+    ).rejects.toThrow(/not found/i);
   });
 });
 
+/**
+ *
+ * @param phases
+ */
 function makeSession(phases) {
   return {
     async run(ctx) {
@@ -210,4 +251,4 @@ function makeSession(phases) {
       return context;
     },
   };
-} 
+}

--- a/tests/unit/initializers/worldInitializer.test.js
+++ b/tests/unit/initializers/worldInitializer.test.js
@@ -172,19 +172,21 @@ describe('WorldInitializer', () => {
         instances: [
           {
             instanceId: 'test:hero_instance',
-            definitionId: 'test:hero'
-          }
-        ]
+            definitionId: 'test:hero',
+          },
+        ],
       };
-      
+
       const entityInstanceDef = {
         instanceId: 'test:hero_instance',
-        definitionId: 'test:hero'
+        definitionId: 'test:hero',
       };
 
       mockGameDataRepository.getWorld.mockReturnValue(worldData);
-      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-      
+      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+        entityInstanceDef
+      );
+
       const mockInstance1 = createMockEntityInstance(
         'test:hero_instance',
         'test:hero',
@@ -194,13 +196,17 @@ describe('WorldInitializer', () => {
 
       await worldInitializer.initializeWorldEntities('test:world');
 
-      expect(mockGameDataRepository.getWorld).toHaveBeenCalledWith('test:world');
-      expect(mockGameDataRepository.getEntityInstanceDefinition).toHaveBeenCalledWith('test:hero_instance');
+      expect(mockGameDataRepository.getWorld).toHaveBeenCalledWith(
+        'test:world'
+      );
+      expect(
+        mockGameDataRepository.getEntityInstanceDefinition
+      ).toHaveBeenCalledWith('test:hero_instance');
       expect(mockEntityManager.createEntityInstance).toHaveBeenCalledWith(
         'test:hero',
         {
           instanceId: 'test:hero_instance',
-          componentOverrides: undefined
+          componentOverrides: undefined,
         }
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -222,18 +228,20 @@ describe('WorldInitializer', () => {
         instances: [
           {
             instanceId: 'test:broken_instance',
-            definitionId: 'test:broken'
-          }
-        ]
+            definitionId: 'test:broken',
+          },
+        ],
       };
-      
+
       const entityInstanceDef = {
         instanceId: 'test:broken_instance',
-        definitionId: 'test:broken'
+        definitionId: 'test:broken',
       };
 
       mockGameDataRepository.getWorld.mockReturnValue(worldData);
-      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
+      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+        entityInstanceDef
+      );
       mockEntityManager.createEntityInstance.mockReturnValueOnce(null);
 
       await worldInitializer.initializeWorldEntities('test:world');
@@ -256,19 +264,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:location_instance',
-              definitionId: 'test:location'
-            }
-          ]
+              definitionId: 'test:location',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:location_instance',
-          definitionId: 'test:location'
+          definitionId: 'test:location',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         const locationInstance = createMockEntityInstance(
           'test:location_instance',
           'test:location',
@@ -312,19 +322,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:problem_instance',
-              definitionId: 'test:problem'
-            }
-          ]
+              definitionId: 'test:problem',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:problem_instance',
-          definitionId: 'test:problem'
+          definitionId: 'test:problem',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         const problematicInstance = createMockEntityInstance(
           'test:problem_instance',
           'test:problem',
@@ -369,19 +381,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:baditerator_instance',
-              definitionId: 'test:baditerator'
-            }
-          ]
+              definitionId: 'test:baditerator',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:baditerator_instance',
-          definitionId: 'test:baditerator'
+          definitionId: 'test:baditerator',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         const mockInstance = createMockEntityInstance(
           'test:baditerator_instance',
           'test:baditerator'
@@ -414,19 +428,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:noniter_instance',
-              definitionId: 'test:noniter'
-            }
-          ]
+              definitionId: 'test:noniter',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:noniter_instance',
-          definitionId: 'test:noniter'
+          definitionId: 'test:noniter',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         const nonIterableEntity = createMockEntityInstance(
           'test:noniter_instance',
           'test:noniter'
@@ -461,19 +477,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:spatialDummy_instance',
-              definitionId: 'test:spatialDummy'
-            }
-          ]
+              definitionId: 'test:spatialDummy',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:spatialDummy_instance',
-          definitionId: 'test:spatialDummy'
+          definitionId: 'test:spatialDummy',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         // Mock entity instance creation
         const mockInstance = createMockEntityInstance(
           'test:spatialDummy_instance',
@@ -512,19 +530,21 @@ describe('WorldInitializer', () => {
           instances: [
             {
               instanceId: 'test:roomPos1_instance',
-              definitionId: 'test:roomPos1'
-            }
-          ]
+              definitionId: 'test:roomPos1',
+            },
+          ],
         };
-        
+
         const entityInstanceDef = {
           instanceId: 'test:roomPos1_instance',
-          definitionId: 'test:roomPos1'
+          definitionId: 'test:roomPos1',
         };
 
         mockGameDataRepository.getWorld.mockReturnValue(worldData);
-        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-        
+        mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+          entityInstanceDef
+        );
+
         const roomInstancePos1 = createMockEntityInstance(
           'test:roomPos1_instance',
           'test:roomPos1',
@@ -565,34 +585,34 @@ describe('WorldInitializer', () => {
         instances: [
           {
             instanceId: 'test:valid_instance',
-            definitionId: 'test:valid'
+            definitionId: 'test:valid',
           },
           {
             // Invalid instance - missing instanceId
-            definitionId: 'test:invalid'
+            definitionId: 'test:invalid',
           },
           {
             instanceId: 'test:another_valid_instance',
-            definitionId: 'test:another_valid'
-          }
-        ]
+            definitionId: 'test:another_valid',
+          },
+        ],
       };
-      
+
       const validInstanceDef1 = {
         instanceId: 'test:valid_instance',
-        definitionId: 'test:valid'
+        definitionId: 'test:valid',
       };
-      
+
       const validInstanceDef2 = {
         instanceId: 'test:another_valid_instance',
-        definitionId: 'test:another_valid'
+        definitionId: 'test:another_valid',
       };
 
       mockGameDataRepository.getWorld.mockReturnValue(worldData);
       mockGameDataRepository.getEntityInstanceDefinition
         .mockReturnValueOnce(validInstanceDef1)
         .mockReturnValueOnce(validInstanceDef2);
-      
+
       const mockInstance1 = createMockEntityInstance(
         'test:valid_instance',
         'test:valid',
@@ -603,7 +623,7 @@ describe('WorldInitializer', () => {
         'test:another_valid',
         {}
       );
-      
+
       mockEntityManager.createEntityInstance
         .mockReturnValueOnce(mockInstance1)
         .mockReturnValueOnce(mockInstance2);
@@ -623,12 +643,14 @@ describe('WorldInitializer', () => {
     it('should throw an error when world is not found', async () => {
       mockGameDataRepository.getWorld.mockReturnValue(null);
 
-      await expect(worldInitializer.initializeWorldEntities('nonexistent:world')).rejects.toThrow(
-        'Game cannot start: World \'nonexistent:world\' not found in the world data. Please ensure the world is properly defined.'
+      await expect(
+        worldInitializer.initializeWorldEntities('nonexistent:world')
+      ).rejects.toThrow(
+        "Game cannot start: World 'nonexistent:world' not found in the world data. Please ensure the world is properly defined."
       );
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'WorldInitializer (Pass 1): World \'nonexistent:world\' not found in repository.'
+        "WorldInitializer (Pass 1): World 'nonexistent:world' not found in repository."
       );
     });
 
@@ -636,17 +658,19 @@ describe('WorldInitializer', () => {
       const worldData = {
         id: 'test:world',
         name: 'Test World',
-        instances: []
+        instances: [],
       };
 
       mockGameDataRepository.getWorld.mockReturnValue(worldData);
 
-      await expect(worldInitializer.initializeWorldEntities('test:world')).rejects.toThrow(
-        'Game cannot start: World \'test:world\' has no entities defined. Please ensure at least one entity is defined in the world.'
+      await expect(
+        worldInitializer.initializeWorldEntities('test:world')
+      ).rejects.toThrow(
+        "Game cannot start: World 'test:world' has no entities defined. Please ensure at least one entity is defined in the world."
       );
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'WorldInitializer (Pass 1): World \'test:world\' has no instances defined. Game cannot start without entities.'
+        "WorldInitializer (Pass 1): World 'test:world' has no instances defined. Game cannot start without entities."
       );
     });
   });
@@ -666,19 +690,21 @@ describe('WorldInitializer', () => {
         instances: [
           {
             instanceId: 'test:eventTest_instance',
-            definitionId: 'test:eventTest'
-          }
-        ]
+            definitionId: 'test:eventTest',
+          },
+        ],
       };
-      
+
       const entityInstanceDef = {
         instanceId: 'test:eventTest_instance',
-        definitionId: 'test:eventTest'
+        definitionId: 'test:eventTest',
       };
 
       mockGameDataRepository.getWorld.mockReturnValue(worldData);
-      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(entityInstanceDef);
-      
+      mockGameDataRepository.getEntityInstanceDefinition.mockReturnValue(
+        entityInstanceDef
+      );
+
       const mockInstance1 = createMockEntityInstance(
         'test:eventTest_instance',
         'test:eventTest'


### PR DESCRIPTION
Summary:
- rename execCtx to executionContext across handlers
- rename opName -> operationName, raw -> currentComponent, next -> updatedComponent
- update related tests and formatting

Testing Done:
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857cff7f7e88331b775b4b4b5800fa6