### PR TITLE
[Agent] Add turn end helper and refactor tests

### DIFF
--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -4,7 +4,10 @@
  */
 
 import { expect } from '@jest/globals';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  TURN_ENDED_ID,
+} from '../../../src/constants/eventIds.js';
 import { flushPromisesAndTimers } from './turnManagerTestBed.js';
 
 /**
@@ -47,4 +50,17 @@ export async function waitForCurrentActor(bed, id, maxTicks = 50) {
     await flushPromisesAndTimers();
   }
   return false;
+}
+
+/**
+ * Triggers a TURN_ENDED event for the given actor and flushes pending timers.
+ *
+ * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Test bed instance.
+ * @param {string} entityId - Actor entity id that ended the turn.
+ * @param {boolean} [success] - Whether the turn was successful.
+ * @returns {Promise<void>} Resolves when pending promises and timers are flushed.
+ */
+export async function triggerTurnEndedAndFlush(bed, entityId, success = true) {
+  bed.trigger(TURN_ENDED_ID, { entityId, success });
+  await flushPromisesAndTimers();
 }

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -2,16 +2,13 @@
 // --- FILE START (Corrected) ---
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals';
+import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
-  describeRunningTurnManagerSuite,
-  flushPromisesAndTimers,
-} from '../../common/turns/turnManagerTestBed.js';
-import { expectSystemErrorDispatch } from '../../common/turns/turnManagerTestUtils.js';
+  expectSystemErrorDispatch,
+  triggerTurnEndedAndFlush,
+} from '../../common/turns/turnManagerTestUtils.js';
 
-import {
-  TURN_ENDED_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../../../src/constants/eventIds.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { PLAYER_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { createMockEntity } from '../../common/mockFactories';
 import {
@@ -89,12 +86,7 @@ describeRunningTurnManagerSuite(
         );
         expect(stopSpy).not.toHaveBeenCalled();
 
-        testBed.trigger(TURN_ENDED_ID, {
-          entityId: actor.id,
-          success: true,
-        });
-
-        await flushPromisesAndTimers();
+        await triggerTurnEndedAndFlush(testBed, actor.id);
 
         expect(mockHandler.destroy).toHaveBeenCalledTimes(1);
 

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -6,6 +6,7 @@ import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
 import {
   waitForCurrentActor,
   expectSystemErrorDispatch,
+  triggerTurnEndedAndFlush,
 } from '../../common/turns/turnManagerTestUtils.js';
 // import removed constant; not needed
 import {
@@ -137,11 +138,7 @@ describeRunningTurnManagerSuite(
       );
 
       // Simulate turn ending and advancing to AI actor
-      testBed.trigger(TURN_ENDED_ID, {
-        entityId: player.id,
-        success: true,
-      });
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, player.id);
       await flushPromisesAndTimers();
 
       // Check AI actor event
@@ -198,18 +195,14 @@ describeRunningTurnManagerSuite(
       expect(testBed.turnManager.getCurrentActor()?.id).toBe(ai1.id);
 
       // Simulate turn ending for actor1 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai1.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai1.id);
 
       // Wait for TurnManager to advance to ai2
       const found = await waitForCurrentActor(testBed, ai2.id);
       expect(found).toBe(true);
 
       // Simulate turn ending for actor2 (success: true)
-      testBed.trigger(TURN_ENDED_ID, { entityId: ai2.id, success: true });
-
-      await flushPromisesAndTimers();
+      await triggerTurnEndedAndFlush(testBed, ai2.id);
 
       // Wait for the TurnManager to process and start a new round
       let roundStarted = false;


### PR DESCRIPTION
## Summary
- provide helper to trigger a TURN_ENDED event
- refactor advanceTurn.actorIdentification test to use helper
- refactor roundLifecycle test to use helper

## Testing Done
- `npm run lint`
- `npx eslint tests/common/turns/turnManagerTestUtils.js tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857d3900a388331a2dbf47976f903ab