### PR TITLE
[Agent] Extract save file parsing

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -34,6 +34,7 @@ import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuild
 import SaveLoadService from '../../persistence/saveLoadService.js';
 import GameStateSerializer from '../../persistence/gameStateSerializer.js';
 import SaveFileRepository from '../../persistence/saveFileRepository.js';
+import SaveFileParser from '../../persistence/saveFileParser.js';
 import { BrowserStorageProvider } from '../../storage/browserStorageProvider.js';
 
 /**
@@ -56,12 +57,21 @@ export function registerPersistence(container) {
   );
 
   r.singletonFactory(tokens.ISaveFileRepository, (c) => {
+    const logger = c.resolve(tokens.ILogger);
+    const storageProvider = c.resolve(tokens.IStorageProvider);
+    const serializer = new GameStateSerializer({
+      logger,
+    });
+    const parser = new SaveFileParser({
+      logger,
+      storageProvider,
+      serializer,
+    });
     return new SaveFileRepository({
-      logger: c.resolve(tokens.ILogger),
-      storageProvider: c.resolve(tokens.IStorageProvider),
-      serializer: new GameStateSerializer({
-        logger: c.resolve(tokens.ILogger),
-      }),
+      logger,
+      storageProvider,
+      serializer,
+      parser,
     });
   });
   logger.debug(

--- a/src/persistence/saveFileParser.js
+++ b/src/persistence/saveFileParser.js
@@ -1,0 +1,217 @@
+import {
+  extractSaveName,
+  getManualSavePath,
+  manualSavePath,
+} from '../utils/savePathUtils.js';
+import { validateSaveMetadataFields } from '../utils/saveMetadataUtils.js';
+import { MSG_FILE_READ_ERROR, MSG_EMPTY_FILE } from './persistenceMessages.js';
+import { PersistenceErrorCodes } from './persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from '../utils/persistenceResultUtils.js';
+import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
+
+/**
+ * @class SaveFileParser
+ * @description Reads save files from storage and extracts metadata.
+ */
+export default class SaveFileParser extends BaseService {
+  /** @type {import('../interfaces/coreServices.js').ILogger} */
+  #logger;
+  /** @type {import('../interfaces/IStorageProvider.js').IStorageProvider} */
+  #storageProvider;
+  /** @type {import('./gameStateSerializer.js').default} */
+  #serializer;
+
+  /**
+   * @param {object} deps
+   * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger instance.
+   * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} deps.storageProvider - Storage provider for file access.
+   * @param {import('./gameStateSerializer.js').default} deps.serializer - Serializer for deserialization.
+   */
+  constructor({ logger, storageProvider, serializer }) {
+    super();
+    this.#serializer = serializer;
+    this.#logger = this._init('SaveFileParser', logger, {
+      storageProvider: {
+        value: storageProvider,
+        requiredMethods: ['readFile'],
+      },
+    });
+    this.#storageProvider = storageProvider;
+  }
+
+  /**
+   * Helper to wrap persistence operations with logging.
+   *
+   * @param {() => Promise<any>} operationFn - Operation to execute.
+   * @returns {Promise<any>} Result of the wrapped operation.
+   * @private
+   */
+  #withLogging(operationFn) {
+    return wrapPersistenceOperation(this.#logger, operationFn);
+  }
+
+  /**
+   * Reads a file using the configured storage provider.
+   *
+   * @param {string} filePath - Path to the file.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Uint8Array>>}
+   *   Result containing file bytes or failure info.
+   * @private
+   */
+  async #readSaveFile(filePath) {
+    return this.#withLogging(async () => {
+      let fileContent;
+      try {
+        fileContent = await this.#storageProvider.readFile(filePath);
+      } catch (error) {
+        const userMsg = MSG_FILE_READ_ERROR;
+        this.#logger.error(`Error reading file ${filePath}:`, error);
+        return {
+          ...createPersistenceFailure(
+            PersistenceErrorCodes.FILE_READ_ERROR,
+            userMsg
+          ),
+          userFriendlyError: userMsg,
+        };
+      }
+
+      if (!fileContent || fileContent.byteLength === 0) {
+        const userMsg = MSG_EMPTY_FILE;
+        this.#logger.warn(`File is empty or could not be read: ${filePath}.`);
+        return {
+          ...createPersistenceFailure(
+            PersistenceErrorCodes.EMPTY_FILE,
+            userMsg
+          ),
+          userFriendlyError: userMsg,
+        };
+      }
+
+      return createPersistenceSuccess(fileContent);
+    });
+  }
+
+  /**
+   * Reads, decompresses and deserializes a save file.
+   *
+   * @param {string} filePath - File path to read.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
+   *   Parsed object or failure info.
+   * @private
+   */
+  async #deserializeAndDecompress(filePath) {
+    return this.#withLogging(async () => {
+      this.#logger.debug(
+        `Attempting to read and deserialize file: ${filePath}`
+      );
+      const readRes = await this.#readSaveFile(filePath);
+      if (!readRes.success) return readRes;
+
+      const parseRes = this.#serializer.decompressAndDeserialize(readRes.data);
+      if (!parseRes.success) return parseRes;
+
+      return createPersistenceSuccess(parseRes.data);
+    });
+  }
+
+  /**
+   * Read, decompress and deserialize a save file.
+   *
+   * @param {string} filePath - File path of the save.
+   * @returns {Promise<import('../interfaces/ISaveLoadService.js').SaveGameStructure|null>} Parsed object or null on failure.
+   * @private
+   */
+  async #readAndDeserialize(filePath) {
+    const deserializationResult =
+      await this.#deserializeAndDecompress(filePath);
+    if (!deserializationResult.success) {
+      this.#logger.warn(
+        `Failed to deserialize ${filePath}: ${deserializationResult.error}. Flagging as corrupted for listing.`
+      );
+      return null;
+    }
+    return /** @type {import('../interfaces/ISaveLoadService.js').SaveGameStructure} */ (
+      deserializationResult.data
+    );
+  }
+
+  /**
+   * Validate and extract metadata from a save object.
+   *
+   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} saveObject - Parsed save data.
+   * @param {string} fileName - Original file name.
+   * @returns {import('./persistenceTypes.js').ParseSaveFileResult}
+   *   Parsed metadata result.
+   * @private
+   */
+  #extractMetadata(saveObject, fileName) {
+    const validated = validateSaveMetadataFields(
+      {
+        identifier: manualSavePath(fileName),
+        saveName: saveObject.metadata.saveName,
+        timestamp: saveObject.metadata.timestamp,
+        playtimeSeconds: saveObject.metadata.playtimeSeconds,
+      },
+      fileName,
+      this.#logger
+    );
+
+    const { isCorrupted = false, ...metadata } = validated;
+    return { metadata, isCorrupted };
+  }
+
+  /**
+   * Helper for returning a corrupted metadata result.
+   *
+   * @param {string} filePath - Full path to the save file.
+   * @param {string} fileName - Name of the save file.
+   * @param {string} reason - Suffix appended to the derived save name.
+   * @returns {import('./persistenceTypes.js').ParseSaveFileResult}
+   *   Result marked as corrupted.
+   * @private
+   */
+  #corruptedResult(filePath, fileName, reason) {
+    return {
+      metadata: {
+        identifier: filePath,
+        saveName: extractSaveName(fileName) + reason,
+        timestamp: 'N/A',
+        playtimeSeconds: 0,
+      },
+      isCorrupted: true,
+    };
+  }
+
+  /**
+   * Parses a manual save file and extracts metadata.
+   *
+   * @param {string} fileName - File name within manual saves directory.
+   * @returns {Promise<import('./persistenceTypes.js').ParseSaveFileResult>} Parsed metadata result.
+   */
+  async parseManualSaveFile(fileName) {
+    const filePath = getManualSavePath(extractSaveName(fileName));
+    this.#logger.debug(`Processing file: ${filePath}`);
+
+    try {
+      const saveObject = await this.#readAndDeserialize(filePath);
+      if (!saveObject)
+        return this.#corruptedResult(filePath, fileName, ' (Corrupted)');
+
+      if (!saveObject.metadata || typeof saveObject.metadata !== 'object') {
+        this.#logger.warn(
+          `No metadata section found in ${filePath}. Flagging as corrupted for listing.`
+        );
+        return this.#corruptedResult(filePath, fileName, ' (No Metadata)');
+      }
+
+      return this.#extractMetadata(saveObject, fileName);
+    } catch (error) {
+      this.#logger.error(`Unexpected error parsing ${filePath}:`, error);
+      return this.#corruptedResult(filePath, fileName, ' (Corrupted)');
+    }
+  }
+}

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -3,6 +3,7 @@ import GameStateSerializer from './gameStateSerializer.js';
 import SaveValidationService from './saveValidationService.js';
 import { getManualSavePath } from '../utils/savePathUtils.js';
 import SaveFileRepository from './saveFileRepository.js';
+import SaveFileParser from './saveFileParser.js';
 import { ISaveFileRepository } from '../interfaces/ISaveFileRepository.js';
 import { BaseService } from '../utils/serviceBase.js';
 import { prepareState } from './savePreparation.js';
@@ -303,6 +304,11 @@ class SaveLoadService extends BaseService {
     crypto = globalThis.crypto,
   }) {
     const serializer = new GameStateSerializer({ logger, crypto });
+    const parser = new SaveFileParser({
+      logger,
+      storageProvider,
+      serializer,
+    });
     const validationService = new SaveValidationService({
       logger,
       gameStateSerializer: serializer,
@@ -311,6 +317,7 @@ class SaveLoadService extends BaseService {
       logger,
       storageProvider,
       serializer,
+      parser,
     });
     return new SaveLoadService({
       logger,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -10,6 +10,7 @@ import {
 } from '@jest/globals';
 import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
@@ -68,10 +69,12 @@ describe('Persistence round-trip', () => {
     storageProvider = createMemoryStorageProvider();
     const saveValidationService = createMockSaveValidationService();
     const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const parser = new SaveFileParser({ logger, storageProvider, serializer });
     const saveFileRepository = new SaveFileRepository({
       logger,
       storageProvider,
       serializer,
+      parser,
     });
     saveLoadService = new SaveLoadService({
       logger,

--- a/tests/unit/persistence/deleteSaveFile.test.js
+++ b/tests/unit/persistence/deleteSaveFile.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import { createMockLogger } from '../testUtils.js';
 
@@ -17,7 +18,13 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = {};
-  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
+  const repo = new SaveFileRepository({
+    logger,
+    storageProvider,
+    serializer,
+    parser,
+  });
   return { repo, logger, storageProvider };
 }
 

--- a/tests/unit/persistence/listManualSaveFiles.test.js
+++ b/tests/unit/persistence/listManualSaveFiles.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { createMockLogger } from '../testUtils.js';
 import { FULL_MANUAL_SAVE_DIRECTORY_PATH } from '../../../src/utils/savePathUtils.js';
 
@@ -17,7 +18,13 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = {};
-  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
+  const repo = new SaveFileRepository({
+    logger,
+    storageProvider,
+    serializer,
+    parser,
+  });
   return { repo, logger, storageProvider };
 }
 

--- a/tests/unit/persistence/parseManualSaveMetadata.test.js
+++ b/tests/unit/persistence/parseManualSaveMetadata.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { manualSavePath } from '../../../src/utils/savePathUtils.js';
 import { createMockLogger } from '../testUtils.js';
 
@@ -17,7 +18,13 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = {};
-  const repo = new SaveFileRepository({ logger, storageProvider, serializer });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
+  const repo = new SaveFileRepository({
+    logger,
+    storageProvider,
+    serializer,
+    parser,
+  });
   return { repo, logger, storageProvider, serializer };
 }
 

--- a/tests/unit/persistence/saveLoadService.test.js
+++ b/tests/unit/persistence/saveLoadService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import * as savePreparation from '../../../src/persistence/savePreparation.js';
 import {
   PersistenceError,
@@ -47,10 +48,12 @@ describe('SaveLoadService', () => {
     serializer = createMockGameStateSerializer();
     validationService = createMockSaveValidationService();
     logger = createMockLogger();
+    const parser = new SaveFileParser({ logger, storageProvider, serializer });
     const saveFileRepository = new SaveFileRepository({
       logger,
       storageProvider,
       serializer,
+      parser,
     });
     service = new SaveLoadService({
       logger,

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -3,6 +3,7 @@ import GameStateCaptureService from '../../../src/persistence/gameStateCaptureSe
 import ManualSaveCoordinator from '../../../src/persistence/manualSaveCoordinator.js';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import {
   createMockLogger,
   createMockSaveValidationService,
@@ -66,8 +67,15 @@ describe('Persistence service constructor validation', () => {
   it('SaveFileRepository validates storage provider', () => {
     const logger = createMockLogger();
     const storageProvider = {}; // missing required methods
+    const parser = { parseManualSaveFile: jest.fn() };
     expect(
-      () => new SaveFileRepository({ logger, storageProvider, serializer })
+      () =>
+        new SaveFileRepository({
+          logger,
+          storageProvider,
+          serializer,
+          parser,
+        })
     ).toThrow();
   });
 });

--- a/tests/unit/services/saveLoadService.additional.test.js
+++ b/tests/unit/services/saveLoadService.additional.test.js
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import { encode, decode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
@@ -43,10 +44,12 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   return {
     logger,

--- a/tests/unit/services/saveLoadService.constructor.test.js
+++ b/tests/unit/services/saveLoadService.constructor.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -23,10 +24,12 @@ function makeDeps() {
     fileExists: jest.fn(),
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   return {
     logger,

--- a/tests/unit/services/saveLoadService.edgeCases.test.js
+++ b/tests/unit/services/saveLoadService.edgeCases.test.js
@@ -8,6 +8,7 @@ import {
 } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { encode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
@@ -47,10 +48,12 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   const saveValidationService = new SaveValidationService({
     logger,

--- a/tests/unit/services/saveLoadService.errorPaths.test.js
+++ b/tests/unit/services/saveLoadService.errorPaths.test.js
@@ -8,6 +8,7 @@ import {
 } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
@@ -60,10 +61,12 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   return {
     logger,

--- a/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, jest } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -37,10 +38,12 @@ function makeDeps() {
     // intentionally no ensureDirectoryExists
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   return {
     logger,

--- a/tests/unit/services/saveLoadService.privateHelpers.test.js
+++ b/tests/unit/services/saveLoadService.privateHelpers.test.js
@@ -8,6 +8,7 @@ import {
 } from '@jest/globals';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import {
   MSG_FILE_READ_ERROR,
@@ -57,10 +58,12 @@ function makeDeps() {
     ensureDirectoryExists: jest.fn(),
   };
   const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
     serializer,
+    parser,
   });
   return {
     logger,


### PR DESCRIPTION
Summary: Refactored manual save parsing by introducing a new `SaveFileParser` class responsible for reading and extracting metadata. `SaveFileRepository` now receives this parser via its constructor, and `parseManualSaveMetadata` delegates to it. Updated dependency registration and `SaveLoadService.createDefault` to instantiate the parser. Tests were updated to inject the parser.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857d3a0c3948331b9b25f9ab14fc1fb