### PR TITLE
[Agent] use setupMockHandlerResolver in advanceTurn tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -34,9 +34,7 @@ describeRunningTurnManagerSuite(
       testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(
         createAiActor('initial-actor-for-start')
       );
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
-        createMockTurnHandler()
-      );
+      testBed.setupMockHandlerResolver();
 
       stopSpy = testBed.spyOnStop();
       stopSpy.mockImplementation(async () => {});

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -25,12 +25,7 @@ describeRunningTurnManagerSuite(
     beforeEach(() => {
       testBed = getBed();
 
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
-      testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
-        createMockTurnHandler()
-      );
+      testBed.setupMockHandlerResolver();
 
       // Setup stop spy for call verification and debug logging
       stopSpy = testBed.setupDebugStopSpy();


### PR DESCRIPTION
Summary:
- streamline handler mocking in advanceTurn queue not empty test
- streamline handler mocking in actor identification advanceTurn test

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: many existing lint errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start` *(not run)*

------
https://chatgpt.com/codex/tasks/task_e_6857d5aec36c83319e334396ca99f070