### PR TITLE
[Agent] Use createTestBedHelpers for pipeline tests

### DIFF
--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -15,7 +15,7 @@ import {
   createMockEntity,
 } from '../mockFactories';
 import FactoryTestBed from '../factoryTestBed.js';
-import { createDescribeTestBedSuite } from '../describeSuite.js';
+import { createTestBedHelpers } from '../createTestBedHelpers.js';
 
 /**
  * @typedef {object} DependencySpecEntry
@@ -244,13 +244,14 @@ export class AIPromptPipelineTestBed extends FactoryTestBed {
  * @param overrides
  * @returns {void}
  */
-export const describeAIPromptPipelineSuite = createDescribeTestBedSuite(
-  AIPromptPipelineTestBed,
-  {
-    beforeEachHook(bed) {
-      bed.setupMockSuccess();
-    },
-  }
-);
+
+export const {
+  createBed: createAIPromptPipelineBed,
+  describeSuite: describeAIPromptPipelineSuite,
+} = createTestBedHelpers(AIPromptPipelineTestBed, {
+  beforeEachHook(bed) {
+    bed.setupMockSuccess();
+  },
+});
 
 export default AIPromptPipelineTestBed;

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -2,6 +2,7 @@
 import { test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
 import {
+  createAIPromptPipelineBed,
   describeAIPromptPipelineSuite,
   AIPromptPipelineDependencySpec,
 } from '../../common/prompting/promptPipelineTestBed.js';


### PR DESCRIPTION
## Summary
- use `createTestBedHelpers` for the prompt pipeline test bed
- expose `createAIPromptPipelineBed`
- update prompt pipeline tests to import the new helper

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857d5a07bdc83319d6ccdccafb218c8