### PR TITLE
[Agent] Reset mocks in engine suite hooks

### DIFF
--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -121,8 +121,12 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
 const engineSuiteHooks = (() => {
   let consoleSpy;
   return {
-    beforeEachHook() {
+    /**
+     * @param {GameEngineTestBed} bed
+     */
+    beforeEachHook(bed) {
       consoleSpy = suppressConsoleError();
+      bed.resetMocks();
     },
     afterEachHook() {
       consoleSpy.mockRestore();


### PR DESCRIPTION
## Summary
- ensure game engine hooks reset mocks before tests

## Testing Done
- `npm run lint` *(fails: jsdoc/no-undefined-types etc.)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857d7e513c88331987ceb57c0b61405