### PR TITLE
[Feat] Improve ActionDiscoveryService testability

### DIFF
--- a/src/actions/discoveryHandlers.js
+++ b/src/actions/discoveryHandlers.js
@@ -9,7 +9,7 @@
 /** @typedef {import('../logging/consoleLogger.js').default} ILogger */
 
 import { ActionTargetContext } from '../models/actionTargetContext.js';
-import { getAvailableExits } from '../utils/locationUtils.js';
+import { getAvailableExits as defaultGetAvailableExits } from '../utils/locationUtils.js';
 
 /**
  * @description Handles discovery for actions targeting 'self' or having no target.
@@ -53,6 +53,8 @@ export function discoverSelfOrNone(
  * @param {EntityManager} entityManager - Entity manager for exit discovery.
  * @param {ISafeEventDispatcher} safeEventDispatcher - Dispatcher for safe events.
  * @param {ILogger} logger - Logger for diagnostics.
+ * @param {(location: Entity|string, mgr: EntityManager, dispatcher: ISafeEventDispatcher, logger?: ILogger) => Array<object>} [getAvailableExitsFn]
+ *  Function used to retrieve available exits from a location.
  * @returns {DiscoveredActionInfo[]}
  */
 export function discoverDirectionalActions(
@@ -64,7 +66,8 @@ export function discoverDirectionalActions(
   buildDiscoveredAction,
   entityManager,
   safeEventDispatcher,
-  logger
+  logger,
+  getAvailableExitsFn = defaultGetAvailableExits
 ) {
   if (!currentLocation) {
     logger.debug(
@@ -73,7 +76,7 @@ export function discoverDirectionalActions(
     return [];
   }
 
-  const exits = getAvailableExits(
+  const exits = getAvailableExitsFn(
     currentLocation,
     entityManager,
     safeEventDispatcher,

--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -31,6 +31,9 @@ import CommandProcessor from '../../commands/commandProcessor.js';
 // --- Helper Function Imports ---
 import { formatActionCommand } from '../../actions/actionFormatter.js';
 import { getEntityIdsForScopes } from '../../entities/entityScopeService.js';
+import { getActorLocation } from '../../utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../utils/locationUtils.js';
+import { getEntityDisplayName } from '../../utils/entityUtils.js';
 
 /**
  * Registers command and action related services.
@@ -56,6 +59,9 @@ export function registerCommandAndAction(container) {
         formatActionCommandFn: formatActionCommand,
         getEntityIdsForScopesFn: getEntityIdsForScopes,
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        getActorLocationFn: getActorLocation,
+        getAvailableExitsFn: getAvailableExits,
+        getEntityDisplayNameFn: getEntityDisplayName,
       })
   );
   logger.debug(

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -1,6 +1,9 @@
 import { jest, describe, beforeEach, expect } from '@jest/globals';
 
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
+import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../../src/utils/locationUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 
 describe('ActionDiscoveryService params exposure', () => {
   const dummyActionDef = {
@@ -40,6 +43,9 @@ describe('ActionDiscoveryService params exposure', () => {
       getEntityIdsForScopesFn,
       logger,
       safeEventDispatcher,
+      getActorLocationFn: getActorLocation,
+      getAvailableExitsFn: getAvailableExits,
+      getEntityDisplayNameFn: getEntityDisplayName,
     });
   });
 

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -5,6 +5,9 @@
 
 import { jest } from '@jest/globals';
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
+import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../../src/utils/locationUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 
 describe('ActionDiscoveryService – directional discovery', () => {
   const logger = {
@@ -69,6 +72,9 @@ describe('ActionDiscoveryService – directional discovery', () => {
     formatActionCommandFn,
     getEntityIdsForScopesFn,
     safeEventDispatcher,
+    getActorLocationFn: getActorLocation,
+    getAvailableExitsFn: getAvailableExits,
+    getEntityDisplayNameFn: getEntityDisplayName,
   });
 
   /** Bare-bones actor / context objects */

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -8,6 +8,9 @@ import {
 } from '@jest/globals';
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
 import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../../src/utils/locationUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 
 jest.mock('../../../src/utils/safeDispatchErrorUtils.js');
 
@@ -53,6 +56,9 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
       getEntityIdsForScopesFn,
       logger,
       safeEventDispatcher,
+      getActorLocationFn: getActorLocation,
+      getAvailableExitsFn: getAvailableExits,
+      getEntityDisplayNameFn: getEntityDisplayName,
     });
   });
 

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -21,6 +21,8 @@ import {
   getAvailableExits,
   getLocationIdForLog,
 } from '../../../src/utils/locationUtils.js';
+import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 
 // --- Helper Mocks/Types ---
 import { ActionTargetContext } from '../../../src/models/actionTargetContext.js';
@@ -234,6 +236,9 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
       safeEventDispatcher: mockSafeEventDispatcher,
+      getActorLocationFn: getActorLocation,
+      getAvailableExitsFn: getAvailableExits,
+      getEntityDisplayNameFn: getEntityDisplayName,
     });
   });
 

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -6,6 +6,9 @@ import coreWaitActionDefinition from '../../../data/mods/core/actions/wait.actio
 
 // --- System Under Test ---
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
+import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../../src/utils/locationUtils.js';
+import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 
 // --- Core Dependencies to Mock ---
 import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
@@ -143,6 +146,9 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
       safeEventDispatcher: mockSafeEventDispatcher,
+      getActorLocationFn: getActorLocation,
+      getAvailableExitsFn: getAvailableExits,
+      getEntityDisplayNameFn: getEntityDisplayName,
     });
   });
 


### PR DESCRIPTION
Summary: Injected optional dependencies into ActionDiscoveryService so utility functions can be mocked in tests.

Changes Made:
- Added getActorLocationFn, getAvailableExitsFn and getEntityDisplayNameFn parameters with defaults.
- Updated domain handler and discoveryHandlers to use injected functions.
- Adjusted DI registration and unit tests to provide these dependencies.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6857d580effc8331b499f57899660c19