### PR TITLE
[Agent] add entity utility tests

### DIFF
--- a/tests/unit/entities/defaultComponentInjector.test.js
+++ b/tests/unit/entities/defaultComponentInjector.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { injectDefaultComponents } from '../../../src/entities/utils/defaultComponentInjector.js';
+import {
+  ACTOR_COMPONENT_ID,
+  SHORT_TERM_MEMORY_COMPONENT_ID,
+  NOTES_COMPONENT_ID,
+  GOALS_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+import { createMockLogger } from '../../common/mockFactories.js';
+
+/**
+ * Creates a minimal mock Entity used for injection tests.
+ *
+ * @param {object} [options] - Configuration options.
+ * @param {boolean} [options.hasActor] - Whether the mock has the actor component.
+ * @param {Record<string, object>} [options.existing] - Pre-existing components.
+ * @returns {object} Mock entity implementing `hasComponent` and `addComponent`.
+ */
+function createMockEntity({ hasActor = true, existing = {} } = {}) {
+  const components = new Map(Object.entries(existing));
+  return {
+    id: 'e1',
+    definitionId: 'def1',
+    hasComponent: jest.fn((id) => {
+      if (id === ACTOR_COMPONENT_ID) return hasActor;
+      return components.has(id);
+    }),
+    addComponent: jest.fn((id, data) => {
+      components.set(id, data);
+    }),
+    getComponentData: (id) => components.get(id),
+  };
+}
+
+describe('injectDefaultComponents', () => {
+  const defaults = {
+    [SHORT_TERM_MEMORY_COMPONENT_ID]: { thoughts: [], maxEntries: 10 },
+    [NOTES_COMPONENT_ID]: { notes: [] },
+    [GOALS_COMPONENT_ID]: { goals: [] },
+  };
+
+  it('injects STM, notes, and goals for actor entities', () => {
+    const entity = createMockEntity();
+    const logger = createMockLogger();
+    const validate = jest.fn((id, data) => data);
+
+    injectDefaultComponents(entity, logger, validate);
+
+    expect(validate).toHaveBeenCalledTimes(3);
+    expect(entity.addComponent).toHaveBeenCalledWith(
+      SHORT_TERM_MEMORY_COMPONENT_ID,
+      defaults[SHORT_TERM_MEMORY_COMPONENT_ID]
+    );
+    expect(entity.addComponent).toHaveBeenCalledWith(
+      NOTES_COMPONENT_ID,
+      defaults[NOTES_COMPONENT_ID]
+    );
+    expect(entity.addComponent).toHaveBeenCalledWith(
+      GOALS_COMPONENT_ID,
+      defaults[GOALS_COMPONENT_ID]
+    );
+  });
+
+  it('does nothing for non-actor entities', () => {
+    const entity = createMockEntity({ hasActor: false });
+    const logger = createMockLogger();
+    const validate = jest.fn();
+
+    injectDefaultComponents(entity, logger, validate);
+
+    expect(entity.addComponent).not.toHaveBeenCalled();
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it('skips components that already exist', () => {
+    const existing = { [NOTES_COMPONENT_ID]: { notes: ['hi'] } };
+    const entity = createMockEntity({ existing });
+    const logger = createMockLogger();
+    const validate = jest.fn((id, data) => data);
+
+    injectDefaultComponents(entity, logger, validate);
+
+    expect(entity.addComponent).toHaveBeenCalledTimes(2);
+    expect(entity.addComponent).not.toHaveBeenCalledWith(
+      NOTES_COMPONENT_ID,
+      expect.anything()
+    );
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs an error when validation fails but continues', () => {
+    const entity = createMockEntity();
+    const logger = createMockLogger();
+    const error = new Error('boom');
+    const validate = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw error;
+      })
+      .mockImplementation((id, data) => data);
+
+    injectDefaultComponents(entity, logger, validate);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(SHORT_TERM_MEMORY_COMPONENT_ID)
+    );
+    expect(entity.addComponent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/entities/entityManager.reconstructionErrors.test.js
+++ b/tests/unit/entities/entityManager.reconstructionErrors.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import EntityFactory from '../../../src/entities/factories/entityFactory.js';
+import { TestBed, TestData } from '../../common/entities/index.js';
+import { buildSerializedEntity } from '../../common/entities/index.js';
+import { DuplicateEntityError } from '../../../src/errors/duplicateEntityError.js';
+
+describe('EntityManager - Factory Error Translation', () => {
+  const errorCases = [
+    [
+      'invalid serializedEntity data',
+      'EntityFactory.reconstruct: serializedEntity data is missing or invalid.',
+      new Error(
+        'EntityManager.reconstructEntity: serializedEntity data is missing or invalid.'
+      ),
+    ],
+    [
+      'invalid instanceId',
+      'EntityFactory.reconstruct: instanceId is missing or invalid in serialized data.',
+      new Error(
+        'EntityManager.reconstructEntity: instanceId is missing or invalid in serialized data.'
+      ),
+    ],
+  ];
+
+  it.each(errorCases)('translates %s', (_, factoryMsg, expected) => {
+    const testBed = new TestBed();
+    jest
+      .spyOn(EntityFactory.prototype, 'reconstruct')
+      .mockImplementation(() => {
+        throw new Error(factoryMsg);
+      });
+    testBed.setupTestDefinitions('basic');
+    const serialized = buildSerializedEntity(
+      TestData.InstanceIDs.PRIMARY,
+      TestData.DefinitionIDs.BASIC,
+      {}
+    );
+
+    expect(() => testBed.entityManager.reconstructEntity(serialized)).toThrow(
+      expected
+    );
+  });
+
+  it('translates duplicate ID errors to DuplicateEntityError', () => {
+    const testBed = new TestBed();
+    const message =
+      "EntityFactory.reconstruct: Entity with ID 'dup-1' already exists. Reconstruction aborted.";
+    jest
+      .spyOn(EntityFactory.prototype, 'reconstruct')
+      .mockImplementation(() => {
+        throw new Error(message);
+      });
+    testBed.setupTestDefinitions('basic');
+    const serialized = buildSerializedEntity(
+      'dup-1',
+      TestData.DefinitionIDs.BASIC,
+      {}
+    );
+
+    expect(() => testBed.entityManager.reconstructEntity(serialized)).toThrow(
+      new DuplicateEntityError(
+        'dup-1',
+        "EntityManager.reconstructEntity: Entity with ID 'dup-1' already exists. Reconstruction aborted."
+      )
+    );
+  });
+});

--- a/tests/unit/entities/validationHelpers.test.js
+++ b/tests/unit/entities/validationHelpers.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  validationSucceeded,
+  formatValidationErrors,
+} from '../../../src/entities/utils/validationHelpers.js';
+
+describe('validationHelpers', () => {
+  describe('validationSucceeded', () => {
+    it('returns true for undefined or null', () => {
+      expect(validationSucceeded(undefined)).toBe(true);
+      expect(validationSucceeded(null)).toBe(true);
+    });
+
+    it('returns the boolean value if passed a boolean', () => {
+      expect(validationSucceeded(true)).toBe(true);
+      expect(validationSucceeded(false)).toBe(false);
+    });
+
+    it('returns true or false based on the isValid property of objects', () => {
+      expect(validationSucceeded({ isValid: true })).toBe(true);
+      expect(validationSucceeded({ isValid: false })).toBe(false);
+    });
+
+    it('returns false for objects without isValid property', () => {
+      expect(validationSucceeded({})).toBe(false);
+    });
+  });
+
+  describe('formatValidationErrors', () => {
+    it('stringifies the errors property when present', () => {
+      const errors = { foo: 'bar' };
+      const result = formatValidationErrors({ isValid: false, errors });
+      expect(result).toBe(JSON.stringify(errors, null, 2));
+    });
+
+    it('returns fallback message when no errors are provided', () => {
+      expect(formatValidationErrors(false)).toBe('(validator returned false)');
+      expect(formatValidationErrors({})).toBe('(validator returned false)');
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added unit tests for validation helpers and default component injection utilities, and verified EntityManager error translation logic. All project tests pass.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 605 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857d8198f5083319e8f71e8af44c006