### PR TITLE
[Agent] Standardize execution context naming

### DIFF
--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -67,10 +67,10 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
    * Move followers from the leader's previous location to the destination.
    *
    * @param {AutoMoveFollowersParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.logger;
     if (!assertParamsObject(params, logger, 'AUTO_MOVE_FOLLOWERS')) return;
 
     const { leader_id, destination_id } = params;
@@ -96,7 +96,8 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
     const lid = leader_id.trim();
     const dest = destination_id.trim();
 
-    const prevLoc = execCtx?.event?.payload?.previousLocationId ?? null;
+    const prevLoc =
+      executionContext?.event?.payload?.previousLocationId ?? null;
 
     const followersComponent = this.#entityManager.getComponentData(
       lid,
@@ -118,7 +119,7 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
 
         this.#moveHandler.execute(
           { entity_ref: { entityId: fid }, target_location_id: dest },
-          execCtx
+          executionContext
         );
 
         const followerName =

--- a/src/logic/operationHandlers/baseOperationHandler.js
+++ b/src/logic/operationHandlers/baseOperationHandler.js
@@ -67,12 +67,12 @@ class BaseOperationHandler {
   /**
    * Retrieve the logger appropriate for a specific execution context.
    *
-   * @param {ExecutionContext} [execCtx] - Optional execution context which may
+   * @param {ExecutionContext} [executionContext] - Optional execution context which may
    *   provide a contextual logger.
    * @returns {ILogger} Logger instance for the current execution.
    */
-  getLogger(execCtx) {
-    return getExecLogger(this.#logger, execCtx);
+  getLogger(executionContext) {
+    return getExecLogger(this.#logger, executionContext);
   }
 }
 

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -83,10 +83,10 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
 
   /**
    * @param {{ follower_id: string }} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'BREAK_FOLLOW_RELATION')) return;
 
     const { follower_id } = params;
@@ -124,7 +124,7 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
     if (currentData.leaderId) {
       this.#rebuildHandler.execute(
         { leaderIds: [currentData.leaderId] },
-        execCtx
+        executionContext
       );
     }
   }

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -49,10 +49,10 @@ class CheckFollowCycleHandler extends BaseOperationHandler {
 
   /**
    * @param {CheckFollowCycleParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const log = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const log = this.getLogger(executionContext);
     if (!assertParamsObject(params, log, 'CHECK_FOLLOW_CYCLE')) return;
 
     const { follower_id, leader_id, result_variable } = params;
@@ -97,7 +97,7 @@ class CheckFollowCycleHandler extends BaseOperationHandler {
     const res = tryWriteContextVariable(
       result_variable,
       result,
-      execCtx,
+      executionContext,
       this.#dispatcher,
       log
     );

--- a/src/logic/operationHandlers/componentOperationHandler.js
+++ b/src/logic/operationHandlers/componentOperationHandler.js
@@ -27,12 +27,12 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * Resolve an entity reference to an ID string.
    *
    * @param {'actor'|'target'|string|EntityRefObject} entityRef
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {string|null} The resolved ID or null if invalid.
    */
-  resolveEntity(entityRef, execCtx) {
+  resolveEntity(entityRef, executionContext) {
     if (!entityRef) return null;
-    return resolveEntityId(entityRef, execCtx);
+    return resolveEntityId(entityRef, executionContext);
   }
 
   /**

--- a/src/logic/operationHandlers/dispatchEventHandler.js
+++ b/src/logic/operationHandlers/dispatchEventHandler.js
@@ -50,9 +50,10 @@ class DispatchEventHandler {
    * Emit a new game-event using pre-resolved parameters.
    *
    * @param {DispatchEventParameters|null|undefined} params - Parameters with placeholders already resolved.
-   * @param {ExecutionContext} _executionContext - The context (used for services, not resolution here).
+   * @param {ExecutionContext} executionContext - The context (used for services, not resolution here).
    */
-  execute(params, _executionContext) {
+  execute(params, executionContext) {
+    void executionContext;
     const logger = this.#logger; // Use the injected logger
     if (!assertParamsObject(params, logger, 'DISPATCH_EVENT')) return;
 

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -67,9 +67,10 @@ class DispatchPerceptibleEventHandler {
    * {@link AddPerceptionLogEntryHandler} to store the log entry for observers.
    *
    * @param {DispatchPerceptibleEventParams} params - Resolved parameters.
-   * @param {ExecutionContext} _ctx - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _ctx) {
+  execute(params, executionContext) {
+    void executionContext;
     if (
       !assertParamsObject(
         params,

--- a/src/logic/operationHandlers/dispatchSpeechHandler.js
+++ b/src/logic/operationHandlers/dispatchSpeechHandler.js
@@ -46,10 +46,10 @@ class DispatchSpeechHandler extends BaseOperationHandler {
    * Construct payload and dispatch {@link DISPLAY_SPEECH_ID}.
    *
    * @param {DispatchSpeechParams|null|undefined} params - Resolved parameters.
-   * @param {ExecutionContext} _ctx - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _ctx) {
-    const logger = this.getLogger(_ctx);
+  execute(params, executionContext) {
+    const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'DISPATCH_SPEECH')) return;
 
     if (

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -55,10 +55,10 @@ class EndTurnHandler {
    * Dispatch the core:turn_ended event.
    *
    * @param {EndTurnParameters} params - Resolved parameters.
-   * @param {ExecutionContext} _executionContext - Execution context (unused).
+   * @param {ExecutionContext} executionContext - Execution context (unused).
    */
-  execute(params, _executionContext) {
-    const logger = _executionContext?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'END_TURN')) return;
 
     if (typeof params.entityId !== 'string' || !params.entityId.trim()) {

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -73,10 +73,10 @@ class EstablishFollowRelationHandler {
 
   /**
    * @param {{ follower_id: string, leader_id: string }} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const logger = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const logger = executionContext?.logger ?? this.#logger;
     if (!assertParamsObject(params, logger, 'ESTABLISH_FOLLOW_RELATION'))
       return;
 
@@ -142,7 +142,7 @@ class EstablishFollowRelationHandler {
     const leaderIds = [lid];
     if (oldData?.leaderId && oldData.leaderId !== lid)
       leaderIds.push(oldData.leaderId);
-    this.#rebuildHandler.execute({ leaderIds }, execCtx);
+    this.#rebuildHandler.execute({ leaderIds }, executionContext);
   }
 }
 

--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -14,8 +14,8 @@ class GetTimestampHandler extends BaseOperationHandler {
     });
   }
 
-  execute(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
 
     const rv = params.result_variable.trim();
@@ -23,7 +23,7 @@ class GetTimestampHandler extends BaseOperationHandler {
     const result = tryWriteContextVariable(
       rv,
       timestamp,
-      execCtx,
+      executionContext,
       undefined,
       logger
     );

--- a/src/logic/operationHandlers/ifCoLocatedHandler.js
+++ b/src/logic/operationHandlers/ifCoLocatedHandler.js
@@ -60,10 +60,10 @@ class IfCoLocatedHandler {
 
   /**
    * @param {IfCoLocatedParams} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const log = execCtx?.logger ?? this.#logger;
+  execute(params, executionContext) {
+    const log = executionContext?.logger ?? this.#logger;
 
     if (!assertParamsObject(params, this.#dispatcher, 'IF_CO_LOCATED')) {
       return;
@@ -84,8 +84,8 @@ class IfCoLocatedHandler {
       return;
     }
 
-    const idA = resolveEntityId(entity_ref_a, execCtx);
-    const idB = resolveEntityId(entity_ref_b, execCtx);
+    const idA = resolveEntityId(entity_ref_a, executionContext);
+    const idB = resolveEntityId(entity_ref_b, executionContext);
 
     if (!idA || !idB) {
       log.debug(
@@ -124,7 +124,7 @@ class IfCoLocatedHandler {
       : [];
     for (const op of actions) {
       try {
-        this.#opInterpreter.execute(op, execCtx);
+        this.#opInterpreter.execute(op, executionContext);
       } catch (err) {
         safeDispatchError(
           this.#dispatcher,

--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -31,7 +31,12 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Error dispatcher.
    * @param {object} deps.closenessCircleService - Closeness circle service.
    */
-  constructor({ logger, entityManager, safeEventDispatcher, closenessCircleService }) {
+  constructor({
+    logger,
+    entityManager,
+    safeEventDispatcher,
+    closenessCircleService,
+  }) {
     super('MergeClosenessCircleHandler', {
       logger: { value: logger },
       entityManager: {
@@ -56,13 +61,13 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
    * Validate parameters for execute.
    *
    * @param {object} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {{ actorId:string, targetId:string, resultVar:string|null, logger:ILogger }|null}
    * @private
    */
-  #validateParams(params, execCtx) {
+  #validateParams(params, executionContext) {
     const { actor_id, target_id, result_variable } = params || {};
-    const log = this.getLogger(execCtx);
+    const log = this.getLogger(executionContext);
     if (typeof actor_id !== 'string' || !actor_id.trim()) {
       safeDispatchError(
         this.#dispatcher,
@@ -169,10 +174,10 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
    * Merge the actor and target circles and lock movement for all members.
    *
    * @param {{ actor_id:string, target_id:string, result_variable?:string }} params - Operation parameters.
-   * @param {ExecutionContext} execCtx - Execution context.
+   * @param {ExecutionContext} executionContext - Execution context.
    */
-  execute(params, execCtx) {
-    const validated = this.#validateParams(params, execCtx);
+  execute(params, executionContext) {
+    const validated = this.#validateParams(params, executionContext);
     if (!validated) return;
     const { actorId, targetId, resultVar, logger } = validated;
 
@@ -183,7 +188,7 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
       tryWriteContextVariable(
         resultVar,
         members,
-        execCtx,
+        executionContext,
         this.#dispatcher,
         logger
       );

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -64,10 +64,10 @@ class ModifyComponentHandler extends ComponentOperationHandler {
    * Executes a MODIFY_COMPONENT operation (mode = "set" only).
    *
    * @param {ModifyComponentOperationParams|null|undefined} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const log = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const log = this.getLogger(executionContext);
 
     // ── validate base params ───────────────────────────────────────
     if (!assertParamsObject(params, log, 'MODIFY_COMPONENT')) {
@@ -101,7 +101,7 @@ class ModifyComponentHandler extends ComponentOperationHandler {
     }
 
     // ── resolve entity ─────────────────────────────────────────────
-    const entityId = this.resolveEntity(entity_ref, execCtx);
+    const entityId = this.resolveEntity(entity_ref, executionContext);
     if (!entityId) {
       log.warn('MODIFY_COMPONENT: could not resolve entity id.', {
         entity_ref,
@@ -126,10 +126,10 @@ class ModifyComponentHandler extends ComponentOperationHandler {
       return;
     }
 
-    const next = deepClone(current);
+    const updatedComponent = deepClone(current);
 
     // ── apply “set” mutation ───────────────────────────────────────
-    const ok = setByPath(next, field.trim(), value);
+    const ok = setByPath(updatedComponent, field.trim(), value);
     if (!ok) {
       log.warn(
         `MODIFY_COMPONENT: Failed to set path "${field}" on component "${compType}".`
@@ -142,7 +142,7 @@ class ModifyComponentHandler extends ComponentOperationHandler {
       const success = this.#entityManager.addComponent(
         entityId,
         compType,
-        next
+        updatedComponent
       );
       if (success) {
         log.debug(

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -168,13 +168,13 @@ class QueryEntitiesHandler extends BaseOperationHandler {
    * Validate and normalize execution parameters.
    *
    * @param {object} params - Raw parameters object.
-   * @param {ExecutionContext} execCtx - Current execution context.
+   * @param {ExecutionContext} executionContext - Current execution context.
    * @returns {{resultVariable:string, filters:object[], limit:number|undefined, logger:ILogger}|null}
    *   Normalized parameters or `null` when validation fails.
    * @private
    */
-  #validateParams(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  #validateParams(params, executionContext) {
+    const logger = this.getLogger(executionContext);
 
     if (!assertParamsObject(params, logger, 'QUERY_ENTITIES')) {
       return null;

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -28,7 +28,12 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher
    * @param {object} deps.closenessCircleService
    */
-  constructor({ logger, entityManager, safeEventDispatcher, closenessCircleService }) {
+  constructor({
+    logger,
+    entityManager,
+    safeEventDispatcher,
+    closenessCircleService,
+  }) {
     super('RemoveFromClosenessCircleHandler', {
       logger: { value: logger },
       entityManager: {
@@ -55,10 +60,10 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
 
   /**
    * @param {{ actor_id: string, result_variable?: string } | null | undefined} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    */
-  execute(params, execCtx) {
-    const validated = this.#validateParams(params, execCtx);
+  execute(params, executionContext) {
+    const validated = this.#validateParams(params, executionContext);
     if (!validated) return;
     const { actorId, resultVar, logger } = validated;
 
@@ -69,7 +74,7 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
       tryWriteContextVariable(
         resultVar,
         partners,
-        execCtx,
+        executionContext,
         this.#dispatcher,
         logger
       );
@@ -80,12 +85,12 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
    * Validate parameters for execute.
    *
    * @param {object} params
-   * @param {ExecutionContext} execCtx
+   * @param {ExecutionContext} executionContext
    * @returns {{ actorId:string, resultVar:string|null, logger:ILogger }|null}
    * @private
    */
-  #validateParams(params, execCtx) {
-    const log = this.getLogger(execCtx);
+  #validateParams(params, executionContext) {
+    const log = this.getLogger(executionContext);
 
     if (!assertParamsObject(params, log, 'REMOVE_FROM_CLOSENESS_CIRCLE')) {
       return null;

--- a/src/logic/operationHandlers/resolveDirectionHandler.js
+++ b/src/logic/operationHandlers/resolveDirectionHandler.js
@@ -21,8 +21,8 @@ class ResolveDirectionHandler extends BaseOperationHandler {
     this.#worldContext = worldContext;
   }
 
-  execute(params, execCtx) {
-    const logger = this.getLogger(execCtx);
+  execute(params, executionContext) {
+    const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'RESOLVE_DIRECTION')) return;
 
     // Safely destructure params, providing a default empty object to avoid errors if params is null/undefined.
@@ -49,7 +49,7 @@ class ResolveDirectionHandler extends BaseOperationHandler {
     const res = tryWriteContextVariable(
       trimmedVar,
       target,
-      execCtx,
+      executionContext,
       undefined,
       logger
     );

--- a/src/logic/operationHandlers/setVariableHandler.js
+++ b/src/logic/operationHandlers/setVariableHandler.js
@@ -175,10 +175,10 @@ class SetVariableHandler {
    * @description Store the variable in executionContext.evaluationContext.context.
    * @param {string} name - Variable name.
    * @param {*} value - Value to store.
-   * @param {OperationExecutionContext} execCtx - Execution context providing the variable store.
+   * @param {OperationExecutionContext} executionContext - Execution context providing the variable store.
    * @private
    */
-  #storeVariable(name, value, execCtx) {
+  #storeVariable(name, value, executionContext) {
     const logger = this.#logger;
     let finalValueStringForLog;
     try {
@@ -198,7 +198,7 @@ class SetVariableHandler {
     const result = tryWriteContextVariable(
       name,
       value,
-      execCtx,
+      executionContext,
       undefined,
       logger
     );

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -57,9 +57,9 @@ class SystemMoveEntityHandler {
    */
   async execute(params, executionContext) {
     const log = executionContext?.logger ?? this.#logger;
-    const opName = 'SYSTEM_MOVE_ENTITY'; // Use a constant for the name
+    const operationName = 'SYSTEM_MOVE_ENTITY'; // Use a constant for the name
 
-    if (!assertParamsObject(params, log, opName)) return;
+    if (!assertParamsObject(params, log, operationName)) return;
 
     // 1. Validate parameters
     const { entity_ref, target_location_id } = params;
@@ -71,7 +71,7 @@ class SystemMoveEntityHandler {
       !target_location_id
     ) {
       log.warn(
-        `${opName}: "entity_ref" and "target_location_id" are required.`
+        `${operationName}: "entity_ref" and "target_location_id" are required.`
       );
       return;
     }
@@ -79,7 +79,9 @@ class SystemMoveEntityHandler {
     // 2. Resolve the entity ID
     const entityId = resolveEntityId(entity_ref, executionContext);
     if (!entityId) {
-      log.warn(`${opName}: Could not resolve entity_ref.`, { entity_ref });
+      log.warn(`${operationName}: Could not resolve entity_ref.`, {
+        entity_ref,
+      });
       return;
     }
 
@@ -93,7 +95,7 @@ class SystemMoveEntityHandler {
       );
       if (!positionComponent) {
         log.warn(
-          `${opName}: Entity "${entityId}" has no 'core:position' component. Cannot move.`
+          `${operationName}: Entity "${entityId}" has no 'core:position' component. Cannot move.`
         );
         return;
       }
@@ -103,7 +105,7 @@ class SystemMoveEntityHandler {
       // Prevent moving if already there
       if (fromLocationId === target_location_id) {
         log.debug(
-          `${opName}: Entity "${entityId}" is already in location "${target_location_id}". No move needed.`
+          `${operationName}: Entity "${entityId}" is already in location "${target_location_id}". No move needed.`
         );
         return;
       }
@@ -118,13 +120,13 @@ class SystemMoveEntityHandler {
 
       if (!success) {
         log.warn(
-          `${opName}: EntityManager reported failure for addComponent on entity "${entityId}".`
+          `${operationName}: EntityManager reported failure for addComponent on entity "${entityId}".`
         );
         return;
       }
 
       log.debug(
-        `${opName}: Moved entity "${entityId}" from "${fromLocationId}" to "${target_location_id}".`
+        `${operationName}: Moved entity "${entityId}" from "${fromLocationId}" to "${target_location_id}".`
       );
 
       // 4. **Dispatch core:entity_moved with a compliant payload**
@@ -139,7 +141,7 @@ class SystemMoveEntityHandler {
     } catch (e) {
       safeDispatchError(
         this.#dispatcher,
-        `${opName}: Failed to move entity "${entityId}". Error: ${e.message}`,
+        `${operationName}: Failed to move entity "${entityId}". Error: ${e.message}`,
         {
           error: e.message,
           stack: e.stack,

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -9,11 +9,11 @@ import { isNonBlankString } from './textUtils.js';
  * Validate that the context exists and the variable name is valid.
  *
  * @param {string} variableName Variable name to validate.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext Execution context.
  * @returns {{valid: boolean, error?: Error, name?: string}} Validation result.
  * @private
  */
-function _validateContextAndName(variableName, execCtx) {
+function _validateContextAndName(variableName, executionContext) {
   if (!isNonBlankString(variableName)) {
     return {
       valid: false,
@@ -22,9 +22,9 @@ function _validateContextAndName(variableName, execCtx) {
   }
 
   const hasContext =
-    execCtx?.evaluationContext &&
-    typeof execCtx.evaluationContext.context === 'object' &&
-    execCtx.evaluationContext.context !== null;
+    executionContext?.evaluationContext &&
+    typeof executionContext.evaluationContext.context === 'object' &&
+    executionContext.evaluationContext.context !== null;
 
   if (!hasContext) {
     return {
@@ -39,13 +39,13 @@ function _validateContextAndName(variableName, execCtx) {
 }
 
 /**
- * Safely stores a value into `execCtx.evaluationContext.context`. If the context
+ * Safely stores a value into `executionContext.evaluationContext.context`. If the context
  * is missing, an error is dispatched (or logged) and the function returns a
  * failure result.
  *
  * @param {string} variableName - Name of the variable to store.
  * @param {*} value - The value to store.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] -
  * Optional dispatcher for error events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger used when no dispatcher is provided.
@@ -54,13 +54,17 @@ function _validateContextAndName(variableName, execCtx) {
 export function writeContextVariable(
   variableName,
   value,
-  execCtx,
+  executionContext,
   dispatcher,
   logger
 ) {
   const log = getModuleLogger('contextVariableUtils', logger);
-  const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
-  const { valid, error, name } = _validateContextAndName(variableName, execCtx);
+  const safeDispatcher =
+    dispatcher || resolveSafeDispatcher(executionContext, log);
+  const { valid, error, name } = _validateContextAndName(
+    variableName,
+    executionContext
+  );
 
   if (!valid) {
     if (safeDispatcher) {
@@ -70,7 +74,7 @@ export function writeContextVariable(
   }
 
   try {
-    execCtx.evaluationContext.context[name] = value;
+    executionContext.evaluationContext.context[name] = value;
     return { success: true };
   } catch (e) {
     const err = new Error(
@@ -98,7 +102,7 @@ export function writeContextVariable(
  *
  * @param {string|null|undefined} variableName - Target context variable name.
  * @param {*} value - Value to store.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher]
  *   Optional dispatcher for error events.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger used when no dispatcher is provided.
@@ -107,14 +111,15 @@ export function writeContextVariable(
 export function tryWriteContextVariable(
   variableName,
   value,
-  execCtx,
+  executionContext,
   dispatcher,
   logger
 ) {
   const log = getModuleLogger('contextVariableUtils', logger);
-  const validation = _validateContextAndName(variableName, execCtx);
+  const validation = _validateContextAndName(variableName, executionContext);
   if (!validation.valid) {
-    const safeDispatcher = dispatcher || resolveSafeDispatcher(execCtx, log);
+    const safeDispatcher =
+      dispatcher || resolveSafeDispatcher(executionContext, log);
     if (safeDispatcher) {
       safeDispatchError(
         safeDispatcher,
@@ -131,7 +136,7 @@ export function tryWriteContextVariable(
   return writeContextVariable(
     validation.name,
     value,
-    execCtx,
+    executionContext,
     dispatcher,
     logger
   );

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -9,7 +9,7 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  * Instantiates and returns a dispatcher when the execution context contains a
  * validatedEventDispatcher. A custom dispatcher class can be provided for
  * testing. Construction failures result in `null`.
- * @param {import('../logic/defs.js').ExecutionContext} execCtx - Execution context.
+ * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the dispatcher.
  * @param {typeof SafeEventDispatcher} [DispatcherClass] -
  *   Class used to instantiate the dispatcher when needed.
@@ -17,14 +17,14 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  *   The resolved dispatcher or `null` when unavailable.
  */
 export function resolveSafeDispatcher(
-  execCtx,
+  executionContext,
   logger,
   DispatcherClass = SafeEventDispatcher
 ) {
-  if (execCtx?.validatedEventDispatcher) {
+  if (executionContext?.validatedEventDispatcher) {
     try {
       return new DispatcherClass({
-        validatedEventDispatcher: execCtx.validatedEventDispatcher,
+        validatedEventDispatcher: executionContext.validatedEventDispatcher,
         logger,
       });
     } catch {

--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -17,11 +17,11 @@ export {
  * execution context provides a logger, it takes precedence over the
  * handler's default logger.
  * @param {ILogger} defaultLogger - Default logger from the handler.
- * @param {import('../../logic/defs.js').ExecutionContext} [execCtx] - Optional execution context.
+ * @param {import('../../logic/defs.js').ExecutionContext} [executionContext] - Optional execution context.
  * @returns {ILogger} Logger instance for execution.
  */
-export function getExecLogger(defaultLogger, execCtx) {
-  return execCtx?.logger ?? defaultLogger;
+export function getExecLogger(defaultLogger, executionContext) {
+  return executionContext?.logger ?? defaultLogger;
 }
 
 // --- FILE END ---


### PR DESCRIPTION
## Summary
- rename opName to operationName in SystemMoveEntityHandler
- clarify variable names in addPerceptionLogEntryHandler and modifyComponentHandler
- unify `executionContext` parameter across all operation handlers
- update utility helpers to use `executionContext`

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857d5314b14833193d989c9f6236ef7