### PR TITLE
[Agent] adopt immutable updates

### DIFF
--- a/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
+++ b/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
@@ -106,15 +106,11 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
       }
 
       /* build next state ---------------------------------------------------- */
+      const nextLogEntries = [...logEntries, entry].slice(-maxEntries);
       const next = {
         maxEntries,
-        logEntries: [...logEntries, entry], // keep ORIGINAL reference
+        logEntries: nextLogEntries,
       };
-
-      /* trim to size -------------------------------------------------------- */
-      if (next.logEntries.length > next.maxEntries) {
-        next.logEntries = next.logEntries.slice(-next.maxEntries);
-      }
 
       /* write back ---------------------------------------------------------- */
       try {


### PR DESCRIPTION
Summary:
- compute log entries immutably in AddPerceptionLogEntryHandler
- return new arrays from ModifyArrayFieldHandler and set them immutably

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 608 errors)*
- `npm test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857db33113c8331917c9c153e23a9d2