### PR TITLE
[Fix] finalize processing flag utility

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -10,6 +10,7 @@
 import { handleProcessingException } from './handleProcessingException.js';
 import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
 import { getLogger, getSafeEventDispatcher } from './contextUtils.js';
+import { finishProcessing } from './processingErrorUtils.js';
 
 /**
  * Safely obtains a service from the turn context.
@@ -48,11 +49,7 @@ export async function getServiceFromContext(
     logger.error(errorMsg);
 
     if (state._isProcessing) {
-      if (state._processingGuard) {
-        state._processingGuard.finish();
-      } else {
-        state._isProcessing = false;
-      }
+      finishProcessing(state);
     }
     return null;
   }

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -12,6 +12,7 @@
 import TurnDirectiveStrategyResolver from '../../strategies/turnDirectiveStrategyResolver.js';
 import { getServiceFromContext } from './getServiceFromContext.js';
 import { handleProcessingException } from './handleProcessingException.js';
+import { finishProcessing } from './processingErrorUtils.js';
 
 /**
  * Executes the main command processing workflow.
@@ -144,20 +145,12 @@ export async function processCommandInternal(
       logger.debug(
         `${state.getStateName()}: Directive strategy executed for ${actorId}, state remains ${state.getStateName()}. Processing complete for this state instance.`
       );
-      if (state._processingGuard) {
-        state._processingGuard.finish();
-      } else {
-        state._isProcessing = false;
-      }
+      finishProcessing(state);
     } else if (state._isProcessing) {
       logger.debug(
         `${state.getStateName()}: Directive strategy executed for ${actorId}, but state changed from ${state.getStateName()} to ${state._handler.getCurrentState()?.getStateName() ?? 'Unknown'}. Processing considered complete for previous state instance.`
       );
-      if (state._processingGuard) {
-        state._processingGuard.finish();
-      } else {
-        state._isProcessing = false;
-      }
+      finishProcessing(state);
     }
   } catch (error) {
     const errorHandlingCtx = state._getTurnContext() ?? turnCtx;
@@ -182,11 +175,7 @@ export async function processCommandInternal(
       finalLogger.warn(
         `${state.getStateName()}: _isProcessing was unexpectedly true at the end of _processCommandInternal for ${actorId}. Forcing to false.`
       );
-      if (state._processingGuard) {
-        state._processingGuard.finish();
-      } else {
-        state._isProcessing = false;
-      }
+      finishProcessing(state);
     }
   }
 }

--- a/src/turns/states/helpers/processingErrorUtils.js
+++ b/src/turns/states/helpers/processingErrorUtils.js
@@ -19,12 +19,22 @@ import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
  */
 export function resetProcessingFlags(state) {
   const wasProcessing = state._isProcessing;
+  finishProcessing(state);
+  return wasProcessing;
+}
+
+/**
+ * Marks processing as finished on the provided state.
+ *
+ * @param {ProcessingCommandStateLike} state - Owning state instance.
+ * @returns {void}
+ */
+export function finishProcessing(state) {
   if (state._processingGuard) {
     state._processingGuard.finish();
   } else {
     state._isProcessing = false;
   }
-  return wasProcessing;
 }
 
 /**

--- a/tests/unit/turns/states/helpers/processingErrorUtils.test.js
+++ b/tests/unit/turns/states/helpers/processingErrorUtils.test.js
@@ -3,6 +3,7 @@ import {
   resetProcessingFlags,
   resolveLogger,
   dispatchSystemError,
+  finishProcessing,
 } from '../../../../../src/turns/states/helpers/processingErrorUtils.js';
 import { ProcessingGuard } from '../../../../../src/turns/states/helpers/processingGuard.js';
 import { safeDispatchError } from '../../../../../src/utils/safeDispatchErrorUtils.js';
@@ -28,6 +29,21 @@ describe('processingErrorUtils', () => {
     const owner = { _isProcessing: true };
     const was = resetProcessingFlags(owner);
     expect(was).toBe(true);
+    expect(owner._isProcessing).toBe(false);
+  });
+
+  test('finishProcessing uses guard when present', () => {
+    const owner = { _isProcessing: true };
+    owner._processingGuard = new ProcessingGuard(owner);
+    const spy = jest.spyOn(owner._processingGuard, 'finish');
+    finishProcessing(owner);
+    expect(spy).toHaveBeenCalled();
+    expect(owner._isProcessing).toBe(false);
+  });
+
+  test('finishProcessing toggles flag directly when guard missing', () => {
+    const owner = { _isProcessing: true };
+    finishProcessing(owner);
     expect(owner._isProcessing).toBe(false);
   });
 


### PR DESCRIPTION
Summary: Add new `finishProcessing` helper to centralize resetting of `_isProcessing`. Replaced duplicate guard checks in `processCommandInternal` and `getServiceFromContext`. Updated `resetProcessingFlags` to reuse new helper and added unit tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857db17011883318a580cfcfd42144c