### PR TITLE
[Agent] Inject dependencies for ActionDiscoveryService

### DIFF
--- a/src/actions/discoveryHandlers.js
+++ b/src/actions/discoveryHandlers.js
@@ -53,6 +53,8 @@ export function discoverSelfOrNone(
  * @param {EntityManager} entityManager - Entity manager for exit discovery.
  * @param {ISafeEventDispatcher} safeEventDispatcher - Dispatcher for safe events.
  * @param {ILogger} logger - Logger for diagnostics.
+ * @param {function(Entity|string, EntityManager, ISafeEventDispatcher, ILogger): import('../utils/locationUtils.js').ExitData[]} [getAvailableExitsFn] -
+ *  Function to fetch available exits.
  * @returns {DiscoveredActionInfo[]}
  */
 export function discoverDirectionalActions(
@@ -64,7 +66,8 @@ export function discoverDirectionalActions(
   buildDiscoveredAction,
   entityManager,
   safeEventDispatcher,
-  logger
+  logger,
+  getAvailableExitsFn = getAvailableExits
 ) {
   if (!currentLocation) {
     logger.debug(
@@ -73,7 +76,7 @@ export function discoverDirectionalActions(
     return [];
   }
 
-  const exits = getAvailableExits(
+  const exits = getAvailableExitsFn(
     currentLocation,
     entityManager,
     safeEventDispatcher,

--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -31,6 +31,9 @@ import CommandProcessor from '../../commands/commandProcessor.js';
 // --- Helper Function Imports ---
 import { formatActionCommand } from '../../actions/actionFormatter.js';
 import { getEntityIdsForScopes } from '../../entities/entityScopeService.js';
+import { getActorLocation } from '../../utils/actorLocationUtils.js';
+import { getAvailableExits } from '../../utils/locationUtils.js';
+import { getEntityDisplayName } from '../../utils/entityUtils.js';
 
 /**
  * Registers command and action related services.
@@ -56,6 +59,9 @@ export function registerCommandAndAction(container) {
         formatActionCommandFn: formatActionCommand,
         getEntityIdsForScopesFn: getEntityIdsForScopes,
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        getActorLocationFn: getActorLocation,
+        getAvailableExitsFn: getAvailableExits,
+        getEntityDisplayNameFn: getEntityDisplayName,
       })
   );
   logger.debug(

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -17,10 +17,6 @@ import { ActionValidationService } from '../../../src/actions/validation/actionV
 import ConsoleLogger from '../../../src/logging/consoleLogger.js';
 import { formatActionCommand as formatActionCommandFn } from '../../../src/actions/actionFormatter.js';
 import { getEntityIdsForScopes as getEntityIdsForScopesFn } from '../../../src/entities/entityScopeService.js';
-import {
-  getAvailableExits,
-  getLocationIdForLog,
-} from '../../../src/utils/locationUtils.js';
 
 // --- Helper Mocks/Types ---
 import { ActionTargetContext } from '../../../src/models/actionTargetContext.js';
@@ -40,7 +36,6 @@ jest.mock('../../../src/actions/validation/actionValidationService.js');
 jest.mock('../../../src/logging/consoleLogger.js');
 jest.mock('../../../src/actions/actionFormatter.js');
 jest.mock('../../../src/entities/entityScopeService.js');
-jest.mock('../../../src/utils/locationUtils.js');
 
 describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   let actionDiscoveryService;
@@ -51,7 +46,6 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   let mockFormatActionCommandFn;
   let mockGetEntityIdsForScopesFn;
   let mockGetAvailableExits;
-  let mockGetLocationIdForLog;
   let availableExits;
   let mockSafeEventDispatcher;
 
@@ -122,8 +116,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
 
     mockFormatActionCommandFn = formatActionCommandFn;
     mockGetEntityIdsForScopesFn = getEntityIdsForScopesFn;
-    mockGetAvailableExits = getAvailableExits;
-    mockGetLocationIdForLog = getLocationIdForLog;
+    mockGetAvailableExits = jest.fn();
     mockSafeEventDispatcher = { dispatch: jest.fn() };
 
     mockHeroEntity = createTestEntity(
@@ -179,9 +172,6 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       { direction: 'out to town', target: TOWN_DEFINITION_ID, blocker: null },
     ];
     mockGetAvailableExits.mockReturnValue(availableExits);
-    mockGetLocationIdForLog.mockImplementation((loc) =>
-      typeof loc === 'string' ? loc : (loc?.id ?? 'unknown')
-    );
 
     mockValidationService.isValid.mockImplementation(
       (actionDef, actor, targetContext) => {
@@ -234,6 +224,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       formatActionCommandFn: mockFormatActionCommandFn,
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
       safeEventDispatcher: mockSafeEventDispatcher,
+      getAvailableExitsFn: mockGetAvailableExits,
     });
   });
 


### PR DESCRIPTION
Summary: Added optional dependency injection for location and display utilities in ActionDiscoveryService. Updated discovery handlers and DI registration to pass through injected functions, enabling easier mocking. Adjusted corresponding unit test to supply mocked utility.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857daaa5470833199155f07fc6b2ca5