### PR TITLE
[Agent] refactor base TurnManager test suite

### DIFF
--- a/tests/unit/turns/turnManager.base.test.js
+++ b/tests/unit/turns/turnManager.base.test.js
@@ -1,40 +1,29 @@
 // src/tests/turns/turnManager.base.test.js
 // --- FILE START (Corrected) ---
 
-import { TurnManagerTestBed } from '../../common/turns/turnManagerTestBed.js';
+import { describeTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import {
   ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
-import {
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-  afterEach,
-} from '@jest/globals';
+import { beforeEach, expect, test } from '@jest/globals';
 import { createDefaultActors } from '../../common/turns/testActors.js';
 
-describe('TurnManager', () => {
+describeTurnManagerSuite('TurnManager', (getBed) => {
   let testBed;
   let mockPlayerEntity;
   let mockAiEntity1;
 
   beforeEach(() => {
-    testBed = new TurnManagerTestBed();
+    testBed = getBed();
 
     ({ player: mockPlayerEntity, ai1: mockAiEntity1 } = createDefaultActors());
   });
 
-  afterEach(() => testBed.cleanup());
-
   // --- Basic Sanity / Setup Tests ---
 
   test('should exist and be a class', () => {
-    // Re-instantiate to check constructor log specifically
-    jest.clearAllMocks(); // Clear previous beforeEach logs
-    const instance = new TurnManagerTestBed().turnManager;
+    const instance = testBed.turnManager;
 
     expect(instance).toBeDefined();
     expect(instance).toBeInstanceOf(testBed.turnManager.constructor);


### PR DESCRIPTION
## Summary
- migrate TurnManager base suite to `describeTurnManagerSuite`
- use provided test bed rather than manual setup/cleanup

## Testing Done
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857dec9dd2c8331a540a3a53b40dcf0