### PR TITLE
[Agent] rename obj param to gameState

### DIFF
--- a/src/persistence/savePreparation.js
+++ b/src/persistence/savePreparation.js
@@ -8,13 +8,13 @@ import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
  * Deep clones and augments the provided game state for saving.
  *
  * @param {string} saveName - Name of the save slot.
- * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} obj - Original game state object.
+ * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} gameState - Original game state object.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for error reporting.
  * @returns {import('./persistenceTypes.js').PersistenceResult<import('../interfaces/ISaveLoadService.js').SaveGameStructure>}
  *   Result containing the cloned object or error.
  */
-export function cloneAndPrepareState(saveName, obj, logger) {
-  const cloneResult = cloneValidatedState(obj, logger);
+export function cloneAndPrepareState(saveName, gameState, logger) {
+  const cloneResult = cloneValidatedState(gameState, logger);
   if (!cloneResult.success || !cloneResult.data) {
     return { success: false, error: cloneResult.error };
   }


### PR DESCRIPTION
Summary: Rename `obj` parameter to `gameState` in `cloneAndPrepareState` and update references.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857debb645c83319c5a44fc8e329713