### PR TITLE
[Agent] refactor handleLoadFailure tests to use engine suite

### DIFF
--- a/tests/unit/engine/handleLoadFailure.test.js
+++ b/tests/unit/engine/handleLoadFailure.test.js
@@ -2,29 +2,25 @@
 import { describe, it, expect } from '@jest/globals';
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import {
-  withGameEngineBed,
-  runUnavailableServiceSuite,
-} from '../../common/engine/gameEngineHelpers.js';
+import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 
-describe('GameEngine', () => {
+describeEngineSuite('GameEngine', (ctx) => {
   describe('_handleLoadFailure', () => {
     it('dispatches failure UI event and returns failure result', async () => {
-      await withGameEngineBed({}, async (bed, engine) => {
-        const err = new Error('bad');
-        const result = await engine._handleLoadFailure(err, 'save-001');
-        expect(bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-          ENGINE_OPERATION_FAILED_UI,
-          {
-            errorMessage: `Failed to load game: ${err.message}`,
-            errorTitle: 'Load Failed',
-          }
-        );
-        expect(result).toEqual({
-          success: false,
-          error: err.message,
-          data: null,
-        });
+      const err = new Error('bad');
+      const result = await ctx.engine._handleLoadFailure(err, 'save-001');
+      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
+        ENGINE_OPERATION_FAILED_UI,
+        {
+          errorMessage: `Failed to load game: ${err.message}`,
+          errorTitle: 'Load Failed',
+        }
+      );
+      expect(result).toEqual({
+        success: false,
+        error: err.message,
+        data: null,
       });
     });
 
@@ -38,6 +34,7 @@ describe('GameEngine', () => {
       async (bed, engine) => {
         const err = new Error('oops');
         const result = await engine._handleLoadFailure(err, 'save-002');
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(result).toEqual({
           success: false,
           error: err.message,


### PR DESCRIPTION
## Summary
- use `describeEngineSuite` in `handleLoadFailure.test.js`
- remove `withGameEngineBed`
- rewrite first test to use context variables

## Testing Done
- `npm run lint` *(fails: 607 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857de9362188331afed6b4a1b2d7b9b