### PR TITLE
[Agent] Flatten load restore logic

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -216,14 +216,24 @@ class GamePersistenceService extends IGamePersistenceService {
     const gameDataToRestore = /** @type {SaveGameStructure} */ (
       loadResult.data
     );
+
+    return this.#restoreAfterLoad(gameDataToRestore, saveIdentifier);
+  }
+
+  /**
+   * Handles restoration of game data after a successful load.
+   *
+   * @private
+   * @async
+   * @param {SaveGameStructure} gameDataToRestore - The loaded save data.
+   * @param {string} saveIdentifier - Identifier used for logging.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<SaveGameStructure>>}
+   *   Result of the restoration process.
+   */
+  async #restoreAfterLoad(gameDataToRestore, saveIdentifier) {
     const restoreResult = await this.restoreGameState(gameDataToRestore);
 
-    if (restoreResult.success) {
-      this.#logger.debug(
-        `GamePersistenceService.loadAndRestoreGame: Game state restored successfully for ${saveIdentifier}.`
-      );
-      return createPersistenceSuccess(gameDataToRestore);
-    } else {
+    if (!restoreResult.success) {
       this.#logger.error(
         `GamePersistenceService.loadAndRestoreGame: Failed to restore game state for ${saveIdentifier}. Error: ${restoreResult.error}`
       );
@@ -233,6 +243,11 @@ class GamePersistenceService extends IGamePersistenceService {
         restoreResult.error || 'Failed to restore game state.'
       );
     }
+
+    this.#logger.debug(
+      `GamePersistenceService.loadAndRestoreGame: Game state restored successfully for ${saveIdentifier}.`
+    );
+    return createPersistenceSuccess(gameDataToRestore);
   }
 }
 


### PR DESCRIPTION
Summary: 
- refactor GamePersistenceService.loadAndRestoreGame for early returns
- extract restoreAfterLoad helper to keep logging intact

Testing Done:
- [x] Code formatted `npm run format` (reverted unrelated changes)
- [x] Lint passes on modified file `npx eslint src/persistence/gamePersistenceService.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857dec482848331bfa72ef043f067d2