### PR TITLE
[Agent] consolidate validation for context builder

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -57,33 +57,7 @@ export class ActionValidationContextBuilder {
    */
   buildContext(actionDefinition, actor, targetContext) {
     // --- 1. Initial Argument Validation (with added logging to match tests) ---
-    if (!actionDefinition?.id) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid actionDefinition provided (missing id).',
-        { actionDefinition }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid ActionDefinition.'
-      );
-    }
-    if (!actor?.id) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid actor entity provided (missing id).',
-        { actor }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid actor Entity.'
-      );
-    }
-    if (!targetContext?.type) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid targetContext provided (missing type).',
-        { targetContext }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid ActionTargetContext.'
-      );
-    }
+    this.#assertValidInputs(actionDefinition, actor, targetContext);
 
     this.#logger.debug(
       `ActionValidationContextBuilder: Building context for action '${actionDefinition.id}', actor '${actor.id}', target type '${targetContext.type}'.`
@@ -126,6 +100,47 @@ export class ActionValidationContextBuilder {
     };
 
     return finalContext;
+  }
+
+  /**
+   * Validates the required inputs for {@link buildContext}.
+   *
+   * @param {ActionDefinition} actionDefinition - The attempted action's definition.
+   * @param {Entity} actor - The entity performing the action.
+   * @param {ActionTargetContext} targetContext - Information about the action's target.
+   * @throws {Error} If any parameter is missing required data.
+   * @private
+   */
+  #assertValidInputs(actionDefinition, actor, targetContext) {
+    if (!actionDefinition?.id) {
+      this.#logger.error(
+        'ActionValidationContextBuilder: Invalid actionDefinition provided (missing id).',
+        { actionDefinition }
+      );
+      throw new Error(
+        'ActionValidationContextBuilder requires a valid ActionDefinition.'
+      );
+    }
+
+    if (!actor?.id) {
+      this.#logger.error(
+        'ActionValidationContextBuilder: Invalid actor entity provided (missing id).',
+        { actor }
+      );
+      throw new Error(
+        'ActionValidationContextBuilder requires a valid actor Entity.'
+      );
+    }
+
+    if (!targetContext?.type) {
+      this.#logger.error(
+        'ActionValidationContextBuilder: Invalid targetContext provided (missing type).',
+        { targetContext }
+      );
+      throw new Error(
+        'ActionValidationContextBuilder requires a valid ActionTargetContext.'
+      );
+    }
   }
 
   /**

--- a/tests/unit/services/actionValidationContextBuilder.test.js
+++ b/tests/unit/services/actionValidationContextBuilder.test.js
@@ -402,6 +402,17 @@ describe('ActionValidationContextBuilder', () => {
           { targetContext: invalidTargetContext }
         );
       });
+
+      it('should prioritize actionDefinition validation when all inputs are missing', () => {
+        const action = () => builder.buildContext(null, null, null);
+        expect(action).toThrow(
+          'ActionValidationContextBuilder requires a valid ActionDefinition.'
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('Invalid actionDefinition provided'),
+          { actionDefinition: null }
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- centralize input checks in `ActionValidationContextBuilder`
- keep `buildContext` concise by calling the helper
- test missing parameters when all inputs are null

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` *(fails: 608 errors)*
- `cd llm-proxy-server && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857de9b4af48331ba5d0217661e5805