### PR TITLE
[Agent] remove redundant resetMocks in engine tests

### DIFF
--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -39,7 +39,6 @@ describeEngineSuite('GameEngine', (ctx) => {
           data: null,
         };
       });
-      ctx.bed.resetMocks();
     });
 
     it('should successfully orchestrate loading a game and call helpers in order', async () => {

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -7,10 +7,6 @@ import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('showLoadGameUI', () => {
-    beforeEach(() => {
-      ctx.bed.resetMocks();
-    });
-
     it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
       ctx.engine.showLoadGameUI(); // Method is now sync
 

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -45,8 +45,6 @@ describeEngineSuite('GameEngine', (ctx) => {
       // ctx.engine is fresh, so not initialized
       expectEngineStopped(ctx.engine);
 
-      ctx.bed.resetMocks();
-
       await ctx.engine.stop();
 
       expect(

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -23,7 +23,6 @@ describeEngineSuite('GameEngine', () => {
 
     it('should dispatch error and not attempt save if engine is not initialized', async () => {
       await withGameEngineBed({}, async (bed, engine) => {
-        bed.resetMocks();
         const result = await engine.triggerManualSave(SAVE_NAME);
         const expectedErrorMsg =
           'Game engine is not initialized. Cannot save game.';


### PR DESCRIPTION
Summary: Removed unnecessary `resetMocks()` usage in four GameEngine test files to rely on automatic hooks.

Testing Done:
- [x] Code formatted `npx prettier`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857de8e2e7c8331968e26d0609799f0