### PR TITLE
[Agent] rename handler vars, context method params

### DIFF
--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -235,8 +235,8 @@ export async function processCommandInternal(
       commandResult
     );
   } catch (error) {
-    const errorHandlingCtx = state._getTurnContext() ?? turnCtx;
-    const actorIdForHandler = errorHandlingCtx?.getActor?.()?.id ?? actorId;
+    const ctxForError = state._getTurnContext() ?? turnCtx;
+    const actorIdForHandler = ctxForError?.getActor?.()?.id ?? actorId;
     const processingError =
       error instanceof Error
         ? error
@@ -246,7 +246,7 @@ export async function processCommandInternal(
     }
     await handleProcessingException(
       state,
-      errorHandlingCtx || turnCtx,
+      ctxForError || turnCtx,
       processingError,
       actorIdForHandler
     );

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -133,15 +133,15 @@ export class ProcessingCommandState extends AbstractTurnState {
 
   async _getServiceFromContext(
     turnCtx,
-    methodName,
-    serviceNameForLog,
+    contextMethod,
+    serviceLabel,
     actorIdForLog
   ) {
     return getServiceFromContext(
       this,
       turnCtx,
-      methodName,
-      serviceNameForLog,
+      contextMethod,
+      serviceLabel,
       actorIdForLog
     );
   }


### PR DESCRIPTION
## Summary
- rename `handlerInstance` args to `handler` in awaitingActorDecisionState
- clean up destroy method
- rename `errorHandlingCtx` -> `ctxForError`
- use `contextMethod` and `serviceLabel` in getServiceFromContext
- update ProcessingCommandState

## Testing Done
- `npm run lint` *(fails: 610 errors, 2353 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857e5c3a0a48331a87fe009c43cb4a4