### PR TITLE
[Test] Expand utility coverage

### DIFF
--- a/tests/unit/utils/objectPathUtils.test.js
+++ b/tests/unit/utils/objectPathUtils.test.js
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import { setByPath } from '../../../src/logic/utils/objectPathUtils.js';
+
+describe('setByPath', () => {
+  test('creates nested objects and sets value', () => {
+    const obj = {};
+    const result = setByPath(obj, 'a.b.c', 5);
+    expect(result).toBe(true);
+    expect(obj).toEqual({ a: { b: { c: 5 } } });
+  });
+
+  test('returns false when encountering non-object', () => {
+    const obj = { a: { b: 1 } };
+    const result = setByPath(obj, 'a.b.c', 9);
+    expect(result).toBe(false);
+    expect(obj).toEqual({ a: { b: 1 } });
+  });
+
+  test('throws on unsafe property names', () => {
+    expect(() => setByPath({}, '__proto__.x', 1)).toThrow(
+      'Unsafe property name'
+    );
+    expect(() => setByPath({}, 'constructor.y', 1)).toThrow(
+      'Unsafe property name'
+    );
+  });
+});

--- a/tests/unit/utils/safeDispatch.test.js
+++ b/tests/unit/utils/safeDispatch.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { safeDispatch } from '../../../src/utils/eventHelpers.js';
+
+describe('safeDispatch utility', () => {
+  test('logs error when dispatch rejects', async () => {
+    const bus = { dispatch: jest.fn().mockRejectedValue(new Error('boom')) };
+    const logger = { error: jest.fn() };
+    await safeDispatch(bus, 'evt', { ok: true }, logger);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Dispatch evt failed: boom',
+      expect.any(Error)
+    );
+  });
+
+  test('does not log when dispatch succeeds', async () => {
+    const bus = { dispatch: jest.fn().mockResolvedValue(true) };
+    const logger = { error: jest.fn() };
+    await safeDispatch(bus, 'evt', { ok: true }, logger);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Add new tests for recently introduced utility modules.

Changes Made:
- Added `objectPathUtils.test.js` validating path-based assignment.
- Added `safeDispatch.test.js` covering success and failure scenarios.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6857e5658d448331bb1ca9cfc35b7d2a