### PR TITLE
[Feat] centralize save file utilities

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -5,13 +5,10 @@ import {
   MANUAL_SAVE_PATTERN,
 } from '../utils/savePathUtils.js';
 import SaveFileParser from './saveFileParser.js';
-import { MSG_FILE_READ_ERROR, MSG_EMPTY_FILE } from './persistenceMessages.js';
 import { PersistenceErrorCodes } from './persistenceErrors.js';
-import {
-  createPersistenceFailure,
-  createPersistenceSuccess,
-} from '../utils/persistenceResultUtils.js';
+import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
+import { readAndDeserialize as utilReadAndDeserialize } from '../utils/saveFileReadUtils.js';
 import { BaseService } from '../utils/serviceBase.js';
 
 // Precompile manual save file regex once for reuse
@@ -65,10 +62,6 @@ export default class SaveFileRepository extends BaseService {
    * @returns {Promise<any>} Result of the wrapped operation.
    * @private
    */
-  #withLogging(operationFn) {
-    return wrapPersistenceOperation(this.#logger, operationFn);
-  }
-
   /**
    * Ensures the manual save directory exists if supported.
    *
@@ -205,38 +198,6 @@ export default class SaveFileRepository extends BaseService {
    * @param {string} filePath - Path to the file.
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<Uint8Array>>}
    */
-  async #readSaveFile(filePath) {
-    return this.#withLogging(async () => {
-      let fileContent;
-      try {
-        fileContent = await this.#storageProvider.readFile(filePath);
-      } catch (error) {
-        const userMsg = MSG_FILE_READ_ERROR;
-        this.#logger.error(`Error reading file ${filePath}:`, error);
-        return {
-          ...createPersistenceFailure(
-            PersistenceErrorCodes.FILE_READ_ERROR,
-            userMsg
-          ),
-          userFriendlyError: userMsg,
-        };
-      }
-
-      if (!fileContent || fileContent.byteLength === 0) {
-        const userMsg = MSG_EMPTY_FILE;
-        this.#logger.warn(`File is empty or could not be read: ${filePath}.`);
-        return {
-          ...createPersistenceFailure(
-            PersistenceErrorCodes.EMPTY_FILE,
-            userMsg
-          ),
-          userFriendlyError: userMsg,
-        };
-      }
-
-      return createPersistenceSuccess(fileContent);
-    });
-  }
 
   /**
    * Reads, decompresses and deserializes a save file.
@@ -245,18 +206,12 @@ export default class SaveFileRepository extends BaseService {
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
    */
   async #deserializeAndDecompress(filePath) {
-    return this.#withLogging(async () => {
-      this.#logger.debug(
-        `Attempting to read and deserialize file: ${filePath}`
-      );
-      const readRes = await this.#readSaveFile(filePath);
-      if (!readRes.success) return readRes;
-
-      const parseRes = this.#serializer.decompressAndDeserialize(readRes.data);
-      if (!parseRes.success) return parseRes;
-
-      return createPersistenceSuccess(parseRes.data);
-    });
+    return utilReadAndDeserialize(
+      this.#storageProvider,
+      this.#serializer,
+      this.#logger,
+      filePath
+    );
   }
 
   /**

--- a/src/utils/saveFileReadUtils.js
+++ b/src/utils/saveFileReadUtils.js
@@ -1,0 +1,93 @@
+// src/utils/saveFileReadUtils.js
+
+import {
+  MSG_FILE_READ_ERROR,
+  MSG_EMPTY_FILE,
+} from '../persistence/persistenceMessages.js';
+import { PersistenceErrorCodes } from '../persistence/persistenceErrors.js';
+import {
+  createPersistenceFailure,
+  createPersistenceSuccess,
+} from './persistenceResultUtils.js';
+import { wrapPersistenceOperation } from './persistenceErrorUtils.js';
+
+/**
+ * Reads a file using a storage provider.
+ *
+ * @description Wrapper around {@link IStorageProvider.readFile} that handles
+ * common error cases and logging.
+ * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} storageProvider - Storage provider instance.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for diagnostics.
+ * @param {string} filePath - Path to the file on disk.
+ * @returns {Promise<import('../persistence/persistenceTypes.js').PersistenceResult<Uint8Array>>}
+ *   File contents or error information.
+ */
+export async function readSaveFile(storageProvider, logger, filePath) {
+  return wrapPersistenceOperation(logger, async () => {
+    let fileContent;
+    try {
+      fileContent = await storageProvider.readFile(filePath);
+    } catch (error) {
+      const userMsg = MSG_FILE_READ_ERROR;
+      logger.error(`Error reading file ${filePath}:`, error);
+      return {
+        ...createPersistenceFailure(
+          PersistenceErrorCodes.FILE_READ_ERROR,
+          userMsg
+        ),
+        userFriendlyError: userMsg,
+      };
+    }
+
+    if (!fileContent || fileContent.byteLength === 0) {
+      const userMsg = MSG_EMPTY_FILE;
+      logger.warn(`File is empty or could not be read: ${filePath}.`);
+      return {
+        ...createPersistenceFailure(PersistenceErrorCodes.EMPTY_FILE, userMsg),
+        userFriendlyError: userMsg,
+      };
+    }
+
+    return createPersistenceSuccess(fileContent);
+  });
+}
+
+/**
+ * Decompresses and deserializes a save buffer.
+ *
+ * @param {import('../persistence/gameStateSerializer.js').default} serializer - Serializer instance.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for diagnostics.
+ * @param {Uint8Array} buffer - Compressed save data.
+ * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<object>}
+ *   Parsed object or failure result.
+ */
+export function deserializeAndDecompress(serializer, logger, buffer) {
+  const parseRes = serializer.decompressAndDeserialize(buffer);
+  if (!parseRes.success) return parseRes;
+  return createPersistenceSuccess(parseRes.data);
+}
+
+/**
+ * Reads, decompresses and deserializes a save file.
+ *
+ * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} storageProvider - Storage provider instance.
+ * @param {import('../persistence/gameStateSerializer.js').default} serializer - Serializer used for decoding.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for diagnostics.
+ * @param {string} filePath - Path to the save file.
+ * @returns {Promise<import('../persistence/persistenceTypes.js').PersistenceResult<object>>}
+ *   Parsed object or failure result.
+ */
+export async function readAndDeserialize(
+  storageProvider,
+  serializer,
+  logger,
+  filePath
+) {
+  return wrapPersistenceOperation(logger, async () => {
+    logger.debug(`Attempting to read and deserialize file: ${filePath}`);
+    const readRes = await readSaveFile(storageProvider, logger, filePath);
+    if (!readRes.success) return readRes;
+
+    return deserializeAndDecompress(serializer, logger, readRes.data);
+  });
+}


### PR DESCRIPTION
Summary: Extracted shared save file read/decompress logic into new `saveFileReadUtils` and updated repository and parser modules to leverage it.

Changes Made:
- Added `src/utils/saveFileReadUtils.js` with helpers for reading and deserializing save files.
- Replaced custom implementations in `SaveFileParser` and `SaveFileRepository` with utility calls.
- Removed now-unused helper methods and updated imports.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint src/persistence/saveFileParser.js src/persistence/saveFileRepository.js src/utils/saveFileReadUtils.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6857ef1e3918833189fc9a3b94828069