### PR TITLE
[Agent] Refactor buildSpeechPayload immutability

### DIFF
--- a/src/turns/states/helpers/buildSpeechPayload.js
+++ b/src/turns/states/helpers/buildSpeechPayload.js
@@ -22,25 +22,35 @@ export function buildSpeechPayload(decisionMeta) {
     thoughts: thoughtsRaw,
     notes: notesRaw,
   } = decisionMeta || {};
+
   const speech = isNonBlankString(speechRaw) ? speechRaw.trim() : null;
   if (!speech) {
     return null;
   }
-  const payload = { speechContent: speech };
-  if (isNonBlankString(thoughtsRaw)) {
-    payload.thoughts = thoughtsRaw.trim();
-  }
+
+  const thoughts = isNonBlankString(thoughtsRaw)
+    ? thoughtsRaw.trim()
+    : undefined;
+
+  let notes;
   if (Array.isArray(notesRaw)) {
     const joined = notesRaw
       .map((n) => (isNonBlankString(n) ? n.trim() : ''))
       .filter(Boolean)
       .join('\n');
     if (joined) {
-      payload.notes = joined;
+      notes = joined;
     }
   } else if (isNonBlankString(notesRaw)) {
-    payload.notes = notesRaw.trim();
+    notes = notesRaw.trim();
   }
+
+  const payload = {
+    speechContent: speech,
+    ...(thoughts ? { thoughts } : {}),
+    ...(notes ? { notes } : {}),
+  };
+
   return payload;
 }
 


### PR DESCRIPTION
## Summary
- avoid mutating payload inside `buildSpeechPayload`
- compute optional fields and create final payload with object spread

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 610 errors)*
- `npm run test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f39d5f948331bf4f344c55b68a11