### PR TITLE
[Agent] finishProcessing integration

### DIFF
--- a/tests/unit/turns/states/helpers/processingErrorUtils.test.js
+++ b/tests/unit/turns/states/helpers/processingErrorUtils.test.js
@@ -47,6 +47,15 @@ describe('processingErrorUtils', () => {
     expect(owner._isProcessing).toBe(false);
   });
 
+  test('ProcessingGuard.start and finishProcessing sequence toggles flag', () => {
+    const owner = { _isProcessing: false };
+    owner._processingGuard = new ProcessingGuard(owner);
+    owner._processingGuard.start();
+    expect(owner._isProcessing).toBe(true);
+    finishProcessing(owner);
+    expect(owner._isProcessing).toBe(false);
+  });
+
   test('resolveLogger uses context logger when available', () => {
     const logger = { debug: jest.fn() };
     const turnCtx = { getLogger: () => logger, getActor: () => ({ id: 'a1' }) };


### PR DESCRIPTION
Summary: Replaced direct _isProcessing assignments with `finishProcessing` in ProcessingCommandState and added a test covering ProcessingGuard.start with finishProcessing. Updated imports accordingly.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint` (fails on pre-existing issues)
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6857f38d3754833185c7a372054952a4