### PR TITLE
[Agent] throw on missing getTurnContext

### DIFF
--- a/tests/unit/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/unit/turns/states/awaitingPlayerInputState.test.js
@@ -524,7 +524,7 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'AwaitingActorDecisionState: No ITurnContext available. Resetting to idle.'
+        'AwaitingActorDecisionState: _handler is invalid or missing getTurnContext method.'
       );
       expect(consoleErrorSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('CRITICAL - No ITurnContext or handler methods')


### PR DESCRIPTION
## Summary
- improve AbstractTurnState `_getTurnContext` to throw when handler is invalid
- make `_ensureContext` catch errors and reset
- add coverage for missing `getTurnContext`
- update awaitingPlayerInputState test expectations

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_6857f54155608331adbacf9629ea05f9