### PR TITLE
[Agent] expose read deserialization on SaveFileParser

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -70,7 +70,6 @@ export function registerPersistence(container) {
     return new SaveFileRepository({
       logger,
       storageProvider,
-      serializer,
       parser,
     });
   });

--- a/src/persistence/saveFileParser.js
+++ b/src/persistence/saveFileParser.js
@@ -57,6 +57,17 @@ export default class SaveFileParser extends BaseService {
   }
 
   /**
+   * Reads, decompresses and deserializes a save file.
+   *
+   * @param {string} filePath - File path to read.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
+   *   Parsed object or failure info.
+   */
+  async readAndDeserialize(filePath) {
+    return this.#deserializeAndDecompress(filePath);
+  }
+
+  /**
    * Read, decompress and deserialize a save file.
    *
    * @param {string} filePath - File path of the save.

--- a/tests/unit/persistence/deleteSaveFile.test.js
+++ b/tests/unit/persistence/deleteSaveFile.test.js
@@ -22,7 +22,6 @@ function makeDeps() {
   const repo = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return { repo, logger, storageProvider };

--- a/tests/unit/persistence/listManualSaveFiles.test.js
+++ b/tests/unit/persistence/listManualSaveFiles.test.js
@@ -22,7 +22,6 @@ function makeDeps() {
   const repo = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return { repo, logger, storageProvider };

--- a/tests/unit/persistence/parseManualSaveMetadata.test.js
+++ b/tests/unit/persistence/parseManualSaveMetadata.test.js
@@ -22,7 +22,6 @@ function makeDeps() {
   const repo = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return { repo, logger, storageProvider, serializer };

--- a/tests/unit/persistence/saveLoadService.test.js
+++ b/tests/unit/persistence/saveLoadService.test.js
@@ -52,7 +52,6 @@ describe('SaveLoadService', () => {
     const saveFileRepository = new SaveFileRepository({
       logger,
       storageProvider,
-      serializer,
       parser,
     });
     service = new SaveLoadService({

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -73,7 +73,6 @@ describe('Persistence service constructor validation', () => {
         new SaveFileRepository({
           logger,
           storageProvider,
-          serializer,
           parser,
         })
     ).toThrow();

--- a/tests/unit/services/saveLoadService.additional.test.js
+++ b/tests/unit/services/saveLoadService.additional.test.js
@@ -48,7 +48,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return {

--- a/tests/unit/services/saveLoadService.constructor.test.js
+++ b/tests/unit/services/saveLoadService.constructor.test.js
@@ -28,7 +28,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return {

--- a/tests/unit/services/saveLoadService.edgeCases.test.js
+++ b/tests/unit/services/saveLoadService.edgeCases.test.js
@@ -52,7 +52,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   const saveValidationService = new SaveValidationService({

--- a/tests/unit/services/saveLoadService.errorPaths.test.js
+++ b/tests/unit/services/saveLoadService.errorPaths.test.js
@@ -65,7 +65,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return {

--- a/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -42,7 +42,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return {

--- a/tests/unit/services/saveLoadService.privateHelpers.test.js
+++ b/tests/unit/services/saveLoadService.privateHelpers.test.js
@@ -62,7 +62,6 @@ function makeDeps() {
   const saveFileRepository = new SaveFileRepository({
     logger,
     storageProvider,
-    serializer,
     parser,
   });
   return {


### PR DESCRIPTION
Summary:
- add `readAndDeserialize` method to `SaveFileParser`
- refactor `SaveFileRepository.readSaveFile` to use parser method
- simplify constructor dependency requirements
- update persistence service registrations
- adjust tests for new constructor

Testing Done:
- `npm run lint` *(fails: 610 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857f633b9408331b0481ee9e3b3708d