### PR TITLE
[Agent] propagate discovery errors

### DIFF
--- a/src/data/providers/availableActionsProvider.js
+++ b/src/data/providers/availableActionsProvider.js
@@ -98,7 +98,7 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
         logger,
       };
 
-      const discoveredActions =
+      const { actions: discoveredActions } =
         await this.#actionDiscoveryService.getValidActions(actor, actionCtx);
 
       // Index the discovered actions to create the final, ordered list.

--- a/src/interfaces/IActionDiscoveryService.js
+++ b/src/interfaces/IActionDiscoveryService.js
@@ -14,6 +14,12 @@
  */
 
 /**
+ * @typedef {object} DiscoveredActionsResult
+ * @property {DiscoveredActionInfo[]} actions - Successfully discovered actions.
+ * @property {Error[]} errors - Errors encountered during discovery.
+ */
+
+/**
  * @interface IActionDiscoveryService
  * @description Defines the contract for discovering valid actions available to an entity in the current game state.
  */
@@ -23,7 +29,7 @@ export class IActionDiscoveryService {
    *
    * @param {Entity} actingEntity - The entity for whom to discover actions.
    * @param {ActionContext} context - The current context, including location and other relevant state.
-   * @returns {Promise<DiscoveredActionInfo[]>}
+   * @returns {Promise<DiscoveredActionsResult>}
    * @throws {Error}
    */
   async getValidActions(actingEntity, context) {

--- a/tests/integration/availableActionsProvider.integration.test.js
+++ b/tests/integration/availableActionsProvider.integration.test.js
@@ -66,7 +66,10 @@ describe('Integration – AvailableActionsProvider caching', () => {
 
   it('reuses cached actions within a single turn', async () => {
     const discovered = [{ id: 'core:wait', command: 'Wait', params: {} }];
-    discoverySvc.getValidActions.mockResolvedValue(discovered);
+    discoverySvc.getValidActions.mockResolvedValue({
+      actions: discovered,
+      errors: [],
+    });
 
     const first = await pipeline.buildChoices(actor, context);
     const second = await pipeline.buildChoices(actor, context);
@@ -76,9 +79,10 @@ describe('Integration – AvailableActionsProvider caching', () => {
   });
 
   it('clears cache when turn context changes', async () => {
-    discoverySvc.getValidActions.mockResolvedValue([
-      { id: 'core:wait', command: 'Wait', params: {} },
-    ]);
+    discoverySvc.getValidActions.mockResolvedValue({
+      actions: [{ id: 'core:wait', command: 'Wait', params: {} }],
+      errors: [],
+    });
 
     await pipeline.buildChoices(actor, context);
     const newContext = { game: { turn: 2 }, getActor: () => actor };

--- a/tests/integration/guardrailIndexOverflow.integration.test.js
+++ b/tests/integration/guardrailIndexOverflow.integration.test.js
@@ -45,7 +45,10 @@ describe('Guardrail – index overflow', () => {
       params: {},
       description: `desc-${i}`,
     }));
-    discoverySvc.getValidActions.mockResolvedValue(discovered);
+    discoverySvc.getValidActions.mockResolvedValue({
+      actions: discovered,
+      errors: [],
+    });
 
     const turnContext = { game: { worldId: 'world', turn: 1 } };
     const result = await provider.get(actor, turnContext, logger);

--- a/tests/integration/humanAiTurnParity.integration.test.js
+++ b/tests/integration/humanAiTurnParity.integration.test.js
@@ -37,9 +37,10 @@ describe('Integration – Human and AI turn parity', () => {
     const logger = createLogger();
 
     const discoverySvc = {
-      getValidActions: jest
-        .fn()
-        .mockResolvedValue([{ id: 'core:wait', command: 'Wait', params: {} }]),
+      getValidActions: jest.fn().mockResolvedValue({
+        actions: [{ id: 'core:wait', command: 'Wait', params: {} }],
+        errors: [],
+      }),
     };
 
     const composite = {

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -46,10 +46,10 @@ describe('ActionDiscoveryService params exposure', () => {
   it('should include params.targetId for entity‐domain actions', async () => {
     const actor = { id: 'player1' };
     const context = { currentLocation: null };
-    const actions = await service.getValidActions(actor, context);
+    const result = await service.getValidActions(actor, context);
 
-    expect(actions).toHaveLength(1);
-    expect(actions[0]).toMatchObject({
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0]).toMatchObject({
       id: 'core:attack',
       params: { targetId: 'rat123' },
     });

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -80,9 +80,9 @@ describe('ActionDiscoveryService – directional discovery', () => {
   };
 
   test('does not throw when currentLocation is undefined and discovers directional actions', async () => {
-    const actions = await service.getValidActions(actorEntity, context);
+    const result = await service.getValidActions(actorEntity, context);
 
-    const goNorth = actions.find((a) => a.id === 'core:go');
+    const goNorth = result.actions.find((a) => a.id === 'core:go');
     expect(goNorth).toBeDefined();
     expect(goNorth.command).toBe('go north');
 

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -80,10 +80,11 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
     const actor = { id: 'actor' };
     const context = {};
 
-    const actions = await service.getValidActions(actor, context);
+    const result = await service.getValidActions(actor, context);
 
-    expect(actions).toHaveLength(1);
-    expect(actions[0].id).toBe('ok');
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0].id).toBe('ok');
+    expect(result.errors).toHaveLength(1);
     expect(safeDispatchError).toHaveBeenCalledTimes(1);
 
     ActionDiscoveryService.DOMAIN_HANDLERS.none = original;
@@ -102,14 +103,14 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
     const actor = { id: 'actor' };
     const context = {};
 
-    const actions = await service.getValidActions(actor, context);
+    const result = await service.getValidActions(actor, context);
 
     expect(getEntityIdsForScopesFn).toHaveBeenCalledWith(
       ['monster'],
       context,
       expect.any(Object)
     );
-    expect(actions).toEqual([
+    expect(result.actions).toEqual([
       {
         id: 'attack',
         name: 'attack',

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -229,13 +229,13 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
   });
 
   it('should discover "go out to town" action when player is in adventurers guild and exit is available', async () => {
-    const validActions = await actionDiscoveryService.getValidActions(
+    const result = await actionDiscoveryService.getValidActions(
       mockHeroEntity,
       mockActionContext
     );
 
-    expect(validActions).toBeDefined();
-    expect(Array.isArray(validActions)).toBe(true);
+    expect(result.actions).toBeDefined();
+    expect(Array.isArray(result.actions)).toBe(true);
 
     const waitAction = {
       id: 'core:wait',
@@ -253,8 +253,8 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       params: { targetId: TOWN_DEFINITION_ID },
     };
 
-    expect(validActions).toContainEqual(waitAction);
-    expect(validActions).toContainEqual(goAction);
+    expect(result.actions).toContainEqual(waitAction);
+    expect(result.actions).toContainEqual(goAction);
 
     expect(mockGetAvailableExits).toHaveBeenCalledWith(
       mockAdventurersGuildLocation,

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -147,12 +147,12 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   });
 
   it('should return structured action info [{id, name, command, description, params}] when core:wait is available and valid', async () => {
-    const validActions = await actionDiscoveryService.getValidActions(
+    const result = await actionDiscoveryService.getValidActions(
       mockActorEntity,
       mockActionContext
     );
 
-    expect(validActions).toEqual([
+    expect(result.actions).toEqual([
       {
         id: 'core:wait',
         name: 'Wait',
@@ -194,12 +194,12 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   it('should return an empty array if core:wait action is deemed invalid by ActionValidationService', async () => {
     mockValidationService.isValid.mockReturnValue(false);
 
-    const validActions = await actionDiscoveryService.getValidActions(
+    const result = await actionDiscoveryService.getValidActions(
       mockActorEntity,
       mockActionContext
     );
 
-    expect(validActions).toEqual([]);
+    expect(result.actions).toEqual([]);
     expect(mockFormatActionCommandFn).not.toHaveBeenCalled();
 
     // Only start and finish logs
@@ -218,12 +218,12 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
   it('should return an empty array if core:wait action definition is not provided by GameDataRepository', async () => {
     mockGameDataRepo.getAllActionDefinitions.mockReturnValue([]);
 
-    const validActions = await actionDiscoveryService.getValidActions(
+    const result = await actionDiscoveryService.getValidActions(
       mockActorEntity,
       mockActionContext
     );
 
-    expect(validActions).toEqual([]);
+    expect(result.actions).toEqual([]);
     expect(mockValidationService.isValid).not.toHaveBeenCalled();
     expect(mockFormatActionCommandFn).not.toHaveBeenCalled();
 
@@ -253,12 +253,12 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
         actionDef.id === 'core:wait' && actor.id === ACTOR_INSTANCE_ID
     );
 
-    const validActions = await actionDiscoveryService.getValidActions(
+    const result = await actionDiscoveryService.getValidActions(
       mockActorEntity,
       mockActionContext
     );
 
-    expect(validActions).toEqual([
+    expect(result.actions).toEqual([
       {
         id: 'core:wait',
         name: 'Wait',

--- a/tests/unit/data/providers/availableActionsProvider.test.js
+++ b/tests/unit/data/providers/availableActionsProvider.test.js
@@ -114,9 +114,10 @@ describe('AvailableActionsProvider', () => {
           description: 'Wait a turn',
         },
       ];
-      actionDiscoveryService.getValidActions.mockResolvedValue(
-        discoveredActions
-      );
+      actionDiscoveryService.getValidActions.mockResolvedValue({
+        actions: discoveredActions,
+        errors: [],
+      });
       actionIndexer.index.mockReturnValue(indexedActions);
 
       // Act: Call the provider twice within the same turn context
@@ -138,9 +139,10 @@ describe('AvailableActionsProvider', () => {
       const discoveredActions = [
         { id: 'core:wait', command: 'wait command', description: 'desc' },
       ];
-      actionDiscoveryService.getValidActions.mockResolvedValue(
-        discoveredActions
-      );
+      actionDiscoveryService.getValidActions.mockResolvedValue({
+        actions: discoveredActions,
+        errors: [],
+      });
       // The indexing service will be called for each turn, returning a fresh list
       actionIndexer.index
         .mockReturnValueOnce([
@@ -197,9 +199,10 @@ describe('AvailableActionsProvider', () => {
           description: a.description,
         }));
 
-      actionDiscoveryService.getValidActions.mockResolvedValue(
-        discoveredActions
-      );
+      actionDiscoveryService.getValidActions.mockResolvedValue({
+        actions: discoveredActions,
+        errors: [],
+      });
       actionIndexer.index.mockReturnValue(cappedActions);
 
       // Act
@@ -252,9 +255,10 @@ describe('AvailableActionsProvider', () => {
           description: 'Wait a turn',
         },
       ];
-      actionDiscoveryService.getValidActions.mockResolvedValue(
-        duplicateDiscoveredActions
-      );
+      actionDiscoveryService.getValidActions.mockResolvedValue({
+        actions: duplicateDiscoveredActions,
+        errors: [],
+      });
       actionIndexer.index.mockReturnValue(dedupedIndexedActions);
 
       // Act
@@ -318,9 +322,10 @@ describe('AvailableActionsProvider', () => {
           description: a.description,
         }));
 
-      actionDiscoveryService.getValidActions.mockResolvedValue(
-        discoveredActions
-      );
+      actionDiscoveryService.getValidActions.mockResolvedValue({
+        actions: discoveredActions,
+        errors: [],
+      });
       actionIndexer.index.mockReturnValue(reducedActions);
 
       // Act


### PR DESCRIPTION
Summary: add structured error reporting to action discovery. `#processActionDefinition` now returns `{actions, errors}` and `getValidActions` aggregates results. Updated `AvailableActionsProvider` and relevant tests to handle the new format.

Testing Done:
- [x] Code formatted `npx prettier --write` on touched files
- [x] Lint ran on touched files `npx eslint ... --fix`
- [x] Root tests `npm run test`
- [ ] Proxy tests
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857f5d78b808331bade0e218f27de24