### PR TITLE
[Feat] inject jsonLogic into SetVariableHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -26,6 +26,7 @@ import QueryComponentHandler from '../../logic/operationHandlers/queryComponentH
 import QueryComponentsHandler from '../../logic/operationHandlers/queryComponentsHandler.js';
 import RemoveComponentHandler from '../../logic/operationHandlers/removeComponentHandler.js';
 import SetVariableHandler from '../../logic/operationHandlers/setVariableHandler.js';
+import jsonLogic from 'json-logic-js';
 import EndTurnHandler from '../../logic/operationHandlers/endTurnHandler.js';
 import SystemMoveEntityHandler from '../../logic/operationHandlers/systemMoveEntityHandler.js';
 import GetTimestampHandler from '../../logic/operationHandlers/getTimestampHandler.js';
@@ -158,7 +159,11 @@ export function registerInterpreters(container) {
     [
       tokens.SetVariableHandler,
       SetVariableHandler,
-      (c, Handler) => new Handler({ logger: c.resolve(tokens.ILogger) }),
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          jsonLogic,
+        }),
     ],
     [
       tokens.EndTurnHandler,

--- a/tests/integration/rules/closenessActionAvailability.integration.test.js
+++ b/tests/integration/rules/closenessActionAvailability.integration.test.js
@@ -14,6 +14,7 @@ import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import MergeClosenessCircleHandler from '../../../src/logic/operationHandlers/mergeClosenessCircleHandler.js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
@@ -42,7 +43,9 @@ function init(entities) {
     dispatch: jest.fn(() => Promise.resolve(true)),
   };
 
-  const closenessCircleService = { merge: jest.fn((...arrays) => [...new Set(arrays.flat())]) };
+  const closenessCircleService = {
+    merge: jest.fn((...arrays) => [...new Set(arrays.flat())]),
+  };
 
   const handlers = {
     QUERY_COMPONENT: new QueryComponentHandler({
@@ -50,7 +53,7 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
     MERGE_CLOSENESS_CIRCLE: new MergeClosenessCircleHandler({
       logger,
       entityManager,

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -35,6 +35,7 @@ import {
 } from '../../../src/constants/componentIds.js';
 import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 
 class SimpleEntityManager {
@@ -164,7 +165,7 @@ describe('core_handle_follow rule integration', () => {
         logger,
         safeEventDispatcher: safeDispatcher,
       }),
-      SET_VARIABLE: new SetVariableHandler({ logger }),
+      SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
     };
 
     for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -17,6 +17,7 @@ import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import MergeClosenessCircleHandler from '../../../src/logic/operationHandlers/mergeClosenessCircleHandler.js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
@@ -98,7 +99,9 @@ function init(entities) {
     }),
   };
 
-  const closenessCircleService = { merge: jest.fn((...arrays) => [...new Set(arrays.flat())]) };
+  const closenessCircleService = {
+    merge: jest.fn((...arrays) => [...new Set(arrays.flat())]),
+  };
 
   // Register all necessary handlers for the rule to run
   const handlers = {
@@ -107,7 +110,7 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
     MERGE_CLOSENESS_CIRCLE: new MergeClosenessCircleHandler({
       logger,
       entityManager,

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -19,6 +19,7 @@ import { expandMacros } from '../../../src/utils/macroUtils.js';
 import QueryComponentHandler from '../../../src/logic/operationHandlers/queryComponentHandler.js';
 import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimestampHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogic from 'json-logic-js';
 import ResolveDirectionHandler from '../../../src/logic/operationHandlers/resolveDirectionHandler.js';
 import ModifyComponentHandler from '../../../src/logic/operationHandlers/modifyComponentHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
@@ -120,7 +121,7 @@ describe('core_handle_go rule integration', () => {
             }
           ),
         GET_TIMESTAMP: new GetTimestampHandler({ logger }),
-        SET_VARIABLE: new SetVariableHandler({ logger }),
+        SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic }),
         RESOLVE_DIRECTION: new ResolveDirectionHandler({
           worldContext,
           logger,

--- a/tests/integration/rules/kissCheekRule.integration.test.js
+++ b/tests/integration/rules/kissCheekRule.integration.test.js
@@ -26,6 +26,7 @@ import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimesta
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
 import {
   NAME_COMPONENT_ID,
@@ -118,7 +119,7 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
+++ b/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
@@ -19,6 +19,7 @@ import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import AddPerceptionLogEntryHandler from '../../../src/logic/operationHandlers/addPerceptionLogEntryHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import {
   PERCEPTION_LOG_COMPONENT_ID,
   POSITION_COMPONENT_ID,
@@ -137,7 +138,7 @@ function init(entities) {
       entityManager,
       safeEventDispatcher: safeDispatcher,
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -30,6 +30,7 @@ import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchE
 import DispatchPerceptibleEventHandler from '../../../src/logic/operationHandlers/dispatchPerceptibleEventHandler.js';
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogicJs from 'json-logic-js';
 import RemoveFromClosenessCircleHandler from '../../../src/logic/operationHandlers/removeFromClosenessCircleHandler.js';
 import {
   NAME_COMPONENT_ID,
@@ -39,7 +40,9 @@ import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
 import { buildABCDWorld } from '../fixtures/intimacyFixtures.js';
 import SimpleEntityManager from '../../common/entities/simpleEntityManager.js';
 
-const closenessCircleService = { repair: jest.fn((partners) => [...new Set(partners)].sort()) };
+const closenessCircleService = {
+  repair: jest.fn((partners) => [...new Set(partners)].sort()),
+};
 
 /**
  * Helper to (re)initialize the interpreter with the provided entities.
@@ -76,7 +79,7 @@ function init(entities) {
       logger,
       safeEventDispatcher: safeDispatcher,
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     DISPATCH_PERCEPTIBLE_EVENT: new DispatchPerceptibleEventHandler({
       dispatcher: eventBus,

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -22,6 +22,7 @@ import {
   validateMacroExpansion,
 } from '../../../src/utils/macroUtils.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogic from 'json-logic-js';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
@@ -86,7 +87,7 @@ const createHandlers = (entityManager, eventBus, logger) => {
         dispatch: (...args) => eventBus.dispatch(...args),
       },
     }),
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic }),
     GET_TIMESTAMP: new GetTimestampHandler({ logger }),
     IF_CO_LOCATED_FACTORY: (operationInterpreter) =>
       new IfCoLocatedHandler({

--- a/tests/integration/rules/thumbWipeCheekRule.integration.test.js
+++ b/tests/integration/rules/thumbWipeCheekRule.integration.test.js
@@ -27,6 +27,7 @@ import GetTimestampHandler from '../../../src/logic/operationHandlers/getTimesta
 import EndTurnHandler from '../../../src/logic/operationHandlers/endTurnHandler.js';
 import GetNameHandler from '../../../src/logic/operationHandlers/getNameHandler.js';
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js'; // Import the new handler
+import jsonLogicJs from 'json-logic-js';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
 import {
   NAME_COMPONENT_ID,
@@ -83,7 +84,7 @@ function init(entities) {
       safeEventDispatcher: safeDispatcher,
     }),
     // Register the new handler needed by the updated rule
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic: jsonLogicJs }),
   };
 
   for (const [type, handler] of Object.entries(handlers)) {

--- a/tests/unit/config/registrations/interpreterRegistrations.test.js
+++ b/tests/unit/config/registrations/interpreterRegistrations.test.js
@@ -349,7 +349,10 @@ describe('registerInterpreters', () => {
     expect(handler).toBeDefined();
     expect(SetVariableHandler).toHaveBeenCalledTimes(1);
     expect(SetVariableHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ logger: mockLogger })
+      expect.objectContaining({
+        logger: mockLogger,
+        jsonLogic: expect.anything(),
+      })
     );
   });
 }); // End describe

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -86,25 +86,37 @@ describe('SetVariableHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLoggerInstance = createMockLogger();
-    handler = new SetVariableHandler({ logger: mockLoggerInstance });
+    handler = new SetVariableHandler({ logger: mockLoggerInstance, jsonLogic });
     mockLoggerInstance.debug.mockClear();
   });
 
   describe('Constructor', () => {
     test('throws if logger dependency is missing or invalid', () => {
-      expect(() => new SetVariableHandler({})).toThrow(/ILogger instance/);
-      expect(() => new SetVariableHandler({ logger: null })).toThrow(
+      expect(() => new SetVariableHandler({ jsonLogic })).toThrow(
+        /ILogger instance/
+      );
+      expect(() => new SetVariableHandler({ logger: null, jsonLogic })).toThrow(
         /ILogger instance/
       );
       expect(
-        () => new SetVariableHandler({ logger: { info: jest.fn() } })
+        () => new SetVariableHandler({ logger: { info: jest.fn() }, jsonLogic })
       ).toThrow(/ILogger instance/);
+    });
+
+    test('throws if jsonLogic dependency is missing or invalid', () => {
+      const freshLogger = createMockLogger();
+      expect(() => new SetVariableHandler({ logger: freshLogger })).toThrow(
+        /jsonLogic implementation/
+      );
+      expect(
+        () => new SetVariableHandler({ logger: freshLogger, jsonLogic: {} })
+      ).toThrow(/jsonLogic implementation/);
     });
 
     test('initializes successfully with a valid logger', () => {
       const freshLogger = createMockLogger();
       expect(
-        () => new SetVariableHandler({ logger: freshLogger })
+        () => new SetVariableHandler({ logger: freshLogger, jsonLogic })
       ).not.toThrow();
       expect(freshLogger.debug).toHaveBeenCalledWith(
         'SetVariableHandler initialized.'


### PR DESCRIPTION
Summary: Injects jsonLogic dependency into SetVariableHandler and updates all usages to supply the instance. Constructor now validates this dependency and evaluation uses `this.#jsonLogic.apply`. Factory registration and tests updated accordingly.

Changes Made:
- removed direct json-logic-js import from handler
- constructor accepts jsonLogic and stores privately
- interpreter registration supplies jsonLogic
- updated unit and integration tests for new dependency

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6857f66514488331876d9f43a5d17a33