### PR TITLE
[Agent] remove redundant comment

### DIFF
--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -160,9 +160,6 @@ class GameStateCaptureService extends BaseService {
     );
 
     const entitiesData = [];
-    // *** THE FIX IS HERE ***
-    // The entityManager in the test (and likely the real one) stores entities
-    // in a Map called 'activeEntities', not an array called 'entities'.
     for (const entity of this.#entityManager.activeEntities.values()) {
       entitiesData.push(this.#serializeEntity(entity));
     }


### PR DESCRIPTION
Summary: Removed obsolete comment block from `captureCurrentGameState` while keeping existing loop functionality intact.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (`gameStateCaptureService.js`)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6857fec094d8833193583756c5fe989f