### PR TITLE
[Agent] refactor exit parsing helper

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -315,29 +315,10 @@ export class EntityDisplayDataProvider {
     let processedExits = [];
 
     if (exitsComponentData && Array.isArray(exitsComponentData)) {
-      processedExits = exitsComponentData
-        .map((exit) => {
-          if (typeof exit !== 'object' || exit === null) {
-            this.#logger.warn(
-              `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,
-              { exit }
-            );
-            return null;
-          }
-          const exitDescription = isNonBlankString(exit.direction)
-            ? exit.direction.trim()
-            : 'Unspecified Exit';
-          const exitTarget = isNonBlankString(exit.target)
-            ? exit.target.trim()
-            : undefined;
-
-          return {
-            description: exitDescription,
-            target: exitTarget,
-            id: exitTarget,
-          };
-        })
-        .filter((exit) => exit !== null);
+      processedExits = this._parseLocationExits(
+        exitsComponentData,
+        locationEntityId
+      );
     } else if (exitsComponentData) {
       this.#logger.warn(
         `${this._logPrefix} getLocationDetails: Exits component data for location '${locationEntityId}' is present but not an array.`,
@@ -411,6 +392,42 @@ export class EntityDisplayDataProvider {
       imagePath: fullPath,
       altText: altText,
     };
+  }
+
+  /**
+   * @description Validates and transforms raw exit data into ProcessedExit objects.
+   * @private
+   * @param {Array<*>} exitsComponentData - Raw exits component data.
+   * @param {NamespacedId | string} locationEntityId - ID of the location entity for logging context.
+   * @returns {ProcessedExit[]} Array of processed exits.
+   */
+  _parseLocationExits(exitsComponentData, locationEntityId) {
+    if (!Array.isArray(exitsComponentData)) {
+      return [];
+    }
+    return exitsComponentData
+      .map((exit) => {
+        if (typeof exit !== 'object' || exit === null) {
+          this.#logger.warn(
+            `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,
+            { exit }
+          );
+          return null;
+        }
+        const exitDescription = isNonBlankString(exit.direction)
+          ? exit.direction.trim()
+          : 'Unspecified Exit';
+        const exitTarget = isNonBlankString(exit.target)
+          ? exit.target.trim()
+          : undefined;
+
+        return {
+          description: exitDescription,
+          target: exitTarget,
+          id: exitTarget,
+        };
+      })
+      .filter((exit) => exit !== null);
   }
 
   /**


### PR DESCRIPTION
Summary: refactored getLocationDetails() by extracting exit parsing into new private `_parseLocationExits` helper.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 3004 problems)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start` *(proxy starts with default config)*


------
https://chatgpt.com/codex/tasks/task_e_6857ff0822308331bbcccf1357b91bbb