### PR TITLE
[Agent] Reduce start/flush helper duplication

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -74,13 +74,26 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
   }
 
   /**
+   * Runs a start callback inside {@link BaseTestBed#withReset}.
+   *
+   * @description Executes the provided start function within the standard
+   *   reset wrapper so that mocks are cleared before each start.
+   * @param {() => Promise<void>} startFn - Function containing start logic.
+   * @returns {Promise<void>} Resolves once the start function completes.
+   * @private
+   */
+  async #startInternal(startFn) {
+    await this.withReset(startFn);
+  }
+
+  /**
    * Adds entities then starts the manager, clearing mock call history.
    *
    * @param {...{ id: string }} entities - Entities to register as active.
    * @returns {Promise<void>} Resolves once the manager has started.
    */
   async startWithEntities(...entities) {
-    await this.withReset(async () => {
+    await this.#startInternal(async () => {
       this.setActiveEntities(...entities);
       await this.turnManager.start();
     });
@@ -92,7 +105,7 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
    * @returns {Promise<void>} Resolves once the manager is running.
    */
   async startRunning() {
-    await this.withReset(async () => {
+    await this.#startInternal(async () => {
       const spy = jest
         .spyOn(this.turnManager, 'advanceTurn')
         .mockImplementationOnce(async () => {});
@@ -107,7 +120,9 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
    * @returns {Promise<void>} Resolves once timers are flushed.
    */
   async startAndFlush() {
-    await this.turnManager.start();
+    await this.#startInternal(async () => {
+      await this.turnManager.start();
+    });
     await flushPromisesAndTimers();
   }
 


### PR DESCRIPTION
Summary: Introduced `#startInternal` to encapsulate repeated `withReset` logic in `TurnManagerTestBed`. Updated `startWithEntities`, `startRunning`, and `startAndFlush` to use this helper and kept `startWithEntitiesAndFlush` as a thin wrapper. All tests continue to pass.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails on repo-wide issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857fee3257c8331bec50e4f816b6b7a