### PR TITLE
[Agent] validate cleaner functions

### DIFF
--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -113,6 +113,10 @@ class ComponentCleaningService {
    * @returns {void}
    */
   registerCleaner(componentId, cleanerFn) {
+    if (typeof cleanerFn !== 'function') {
+      this.#logger.error(`Cleaner for ${componentId} must be a function.`);
+      return;
+    }
     if (this.#cleaners.has(componentId)) {
       this.#logger.warn(
         `Cleaner for component '${componentId}' already registered. Overwriting.`

--- a/tests/unit/services/componentCleaningService.test.js
+++ b/tests/unit/services/componentCleaningService.test.js
@@ -83,4 +83,15 @@ describe('ComponentCleaningService', () => {
     const result = service.clean('dup:comp', {});
     expect(result).toEqual({ second: true });
   });
+
+  it('logs error and ignores invalid cleaner registrations', () => {
+    service.registerCleaner('bad:comp', null);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'ComponentCleaningService: Cleaner for bad:comp must be a function.'
+    );
+
+    const result = service.clean('bad:comp', { foo: 'bar' });
+    expect(result).toEqual({ foo: 'bar' });
+  });
 });


### PR DESCRIPTION
## Summary
- safeguard `registerCleaner` against non-function arguments
- test ignoring invalid cleaner registrations with a logged error

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857fecc2a1483319b668c156d28ae97