### PR TITLE
[Agent] Rename ActiveModsManifestBuilder.build

### DIFF
--- a/src/persistence/activeModsManifestBuilder.js
+++ b/src/persistence/activeModsManifestBuilder.js
@@ -33,7 +33,7 @@ export default class ActiveModsManifestBuilder {
    *
    * @returns {{modId: string, version: string}[]} List of mod identifiers and versions.
    */
-  build() {
+  buildManifest() {
     /** @type {import('../../data/schemas/mod-manifest.schema.json').ModManifest[]} */
     const loadedManifestObjects = this.#dataRegistry.getAll('mod_manifests');
     let activeModsManifest = [];

--- a/src/persistence/gameStateCaptureService.js
+++ b/src/persistence/gameStateCaptureService.js
@@ -67,7 +67,7 @@ class GameStateCaptureService extends BaseService {
       metadataBuilder: { value: metadataBuilder, requiredMethods: ['build'] },
       activeModsManifestBuilder: {
         value: activeModsManifestBuilder,
-        requiredMethods: ['build'],
+        requiredMethods: ['buildManifest'],
       },
     });
     this.#entityManager = entityManager;
@@ -170,7 +170,7 @@ class GameStateCaptureService extends BaseService {
       `GameStateCaptureService: Captured ${entitiesData.length} entities.`
     );
 
-    const activeModsManifest = this.#activeModsManifestBuilder.build();
+    const activeModsManifest = this.#activeModsManifestBuilder.buildManifest();
 
     const currentTotalPlaytime = this.#playtimeTracker.getTotalPlaytime();
     this.#logger.debug(

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -125,7 +125,9 @@ describe('Persistence round-trip', () => {
     };
 
     const activeModsManifestBuilder = {
-      build: jest.fn().mockReturnValue([{ modId: 'core', version: '1.0.0' }]),
+      buildManifest: jest
+        .fn()
+        .mockReturnValue([{ modId: 'core', version: '1.0.0' }]),
     };
     const captureService = new GameStateCaptureService({
       logger,

--- a/tests/unit/persistence/gameStateCaptureService.test.js
+++ b/tests/unit/persistence/gameStateCaptureService.test.js
@@ -29,7 +29,9 @@ describe('GameStateCaptureService persistence tests', () => {
         playtimeSeconds: 123,
       })),
     };
-    activeModsManifestBuilder = { build: jest.fn().mockReturnValue([]) };
+    activeModsManifestBuilder = {
+      buildManifest: jest.fn().mockReturnValue([]),
+    };
     captureService = new GameStateCaptureService({
       logger,
       entityManager,

--- a/tests/unit/services/activeModsManifestBuilder.test.js
+++ b/tests/unit/services/activeModsManifestBuilder.test.js
@@ -23,7 +23,7 @@ describe('ActiveModsManifestBuilder', () => {
       { id: 'core', version: '1.0.0' },
       { id: 'mod2', version: '2.3.4' },
     ]);
-    const result = builder.build();
+    const result = builder.buildManifest();
     expect(result).toEqual([
       { modId: 'core', version: '1.0.0' },
       { modId: 'mod2', version: '2.3.4' },
@@ -33,7 +33,7 @@ describe('ActiveModsManifestBuilder', () => {
 
   it('falls back to core mod version when registry empty', () => {
     dataRegistry.getAll.mockReturnValue([]);
-    const result = builder.build();
+    const result = builder.buildManifest();
     expect(result).toEqual([
       { modId: CORE_MOD_ID, version: 'unknown_fallback' },
     ]);
@@ -44,13 +44,13 @@ describe('ActiveModsManifestBuilder', () => {
     dataRegistry.getAll.mockReturnValue([
       { id: CORE_MOD_ID, version: '2.0.0' },
     ]);
-    const result = builder.build();
+    const result = builder.buildManifest();
     expect(result).toEqual([{ modId: CORE_MOD_ID, version: '2.0.0' }]);
   });
 
   it('handles missing registry gracefully', () => {
     dataRegistry.getAll.mockReturnValue(undefined);
-    const result = builder.build();
+    const result = builder.buildManifest();
     expect(result).toEqual([
       { modId: CORE_MOD_ID, version: 'unknown_fallback' },
     ]);
@@ -63,7 +63,7 @@ describe('ActiveModsManifestBuilder', () => {
       find: () => ({ id: CORE_MOD_ID, version: '3.3.3' }),
     };
     dataRegistry.getAll.mockReturnValue(trickyList);
-    const result = builder.build();
+    const result = builder.buildManifest();
     expect(result).toEqual([{ modId: CORE_MOD_ID, version: '3.3.3' }]);
     expect(logger.debug).toHaveBeenCalled();
   });

--- a/tests/unit/services/gamePersistenceService.additional.test.js
+++ b/tests/unit/services/gamePersistenceService.additional.test.js
@@ -55,7 +55,7 @@ describe('GamePersistenceService additional coverage', () => {
       }),
     };
     activeModsManifestBuilder = {
-      build: jest.fn(() => {
+      buildManifest: jest.fn(() => {
         logger.warn();
         return [];
       }),
@@ -106,7 +106,7 @@ describe('GamePersistenceService additional coverage', () => {
         [CURRENT_ACTOR_COMPONENT_ID]: { active: true },
       });
       entityManager.activeEntities.set('e1', entity);
-      activeModsManifestBuilder.build.mockReturnValue([
+      activeModsManifestBuilder.buildManifest.mockReturnValue([
         { modId: 'core', version: '1.0.0' },
       ]);
 
@@ -126,7 +126,7 @@ describe('GamePersistenceService additional coverage', () => {
     it('preserves primitive component data', () => {
       const entity = makeEntity('e2', 'core:item', { count: 7 });
       entityManager.activeEntities.set('e2', entity);
-      activeModsManifestBuilder.build.mockReturnValue([]);
+      activeModsManifestBuilder.buildManifest.mockReturnValue([]);
 
       const result = captureService.captureCurrentGameState('World');
       const overrides = result.gameState.entities[0].overrides;

--- a/tests/unit/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/unit/services/gamePersistenceService.edgeCases.test.js
@@ -70,7 +70,7 @@ describe('GamePersistenceService edge cases', () => {
       }),
     };
     activeModsManifestBuilder = {
-      build: jest.fn(() => {
+      buildManifest: jest.fn(() => {
         logger.warn();
         return [];
       }),
@@ -109,7 +109,7 @@ describe('GamePersistenceService edge cases', () => {
         [CURRENT_ACTOR_COMPONENT_ID]: { active: true },
       });
       entityManager.activeEntities.set('e1', entity);
-      activeModsManifestBuilder.build.mockImplementation(() => {
+      activeModsManifestBuilder.buildManifest.mockImplementation(() => {
         logger.warn();
         return [{ modId: CORE_MOD_ID, version: 'unknown_fallback' }];
       });

--- a/tests/unit/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/unit/services/gamePersistenceService.errorPaths.test.js
@@ -58,7 +58,9 @@ describe('GamePersistenceService error paths', () => {
         saveName: '',
       })),
     };
-    activeModsManifestBuilder = { build: jest.fn().mockReturnValue([]) };
+    activeModsManifestBuilder = {
+      buildManifest: jest.fn().mockReturnValue([]),
+    };
     captureService = new GameStateCaptureService({
       logger,
       entityManager,

--- a/tests/unit/services/gameStateCaptureService.additional.test.js
+++ b/tests/unit/services/gameStateCaptureService.additional.test.js
@@ -33,7 +33,7 @@ describe('GameStateCaptureService additional coverage', () => {
       })),
     };
     activeModsManifestBuilder = {
-      build: jest.fn(() => [{ modId: 'core', version: '1.0.0' }]),
+      buildManifest: jest.fn(() => [{ modId: 'core', version: '1.0.0' }]),
     };
     service = new GameStateCaptureService({
       logger,
@@ -47,7 +47,7 @@ describe('GameStateCaptureService additional coverage', () => {
 
   it('delegates to ActiveModsManifestBuilder', () => {
     service.captureCurrentGameState('World');
-    expect(activeModsManifestBuilder.build).toHaveBeenCalled();
+    expect(activeModsManifestBuilder.buildManifest).toHaveBeenCalled();
   });
 
   it('passes playtime to metadata builder', () => {

--- a/tests/unit/services/gameStateCaptureService.test.js
+++ b/tests/unit/services/gameStateCaptureService.test.js
@@ -29,7 +29,9 @@ describe('GameStateCaptureService persistence tests', () => {
         playtimeSeconds: 123,
       })),
     };
-    activeModsManifestBuilder = { build: jest.fn().mockReturnValue([]) };
+    activeModsManifestBuilder = {
+      buildManifest: jest.fn().mockReturnValue([]),
+    };
     captureService = new GameStateCaptureService({
       logger,
       entityManager,

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -21,7 +21,7 @@ describe('Persistence service constructor validation', () => {
     const playtimeTracker = {}; // missing getTotalPlaytime
     const componentCleaningService = { clean: jest.fn() };
     const metadataBuilder = { build: jest.fn() };
-    const activeModsManifestBuilder = { build: jest.fn() };
+    const activeModsManifestBuilder = { buildManifest: jest.fn() };
     expect(
       () =>
         new GameStateCaptureService({


### PR DESCRIPTION
## Summary
- rename `ActiveModsManifestBuilder.build` -> `buildManifest`
- update `GameStateCaptureService` and DI validation to use `buildManifest`
- update tests to call `buildManifest`

## Testing
- `npm run test`
- `npm run test` in `llm-proxy-server`

------
https://chatgpt.com/codex/tasks/task_e_6857fec5d3b083318daa46a80de8dbb1