### PR TITLE
[Agent] Consolidate context checks with typedefs

### DIFF
--- a/src/turns/interfaces/turnStateContextTypes.js
+++ b/src/turns/interfaces/turnStateContextTypes.js
@@ -1,0 +1,36 @@
+/**
+ * @file turnStateContextTypes.js
+ * @description JSDoc typedefs describing the ITurnContext capabilities
+ * required by specific turn states.
+ */
+
+/** @typedef {import('../../entities/entity.js').default} Entity */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction */
+/** @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy */
+/** @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor */
+/** @typedef {import('../../commands/interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreter */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+
+/**
+ * @typedef {object} ProcessingCommandStateContext
+ * @property {function(): Entity|null} getActor
+ * @property {function(): ILogger} getLogger
+ * @property {function(): ITurnAction|null} getChosenAction
+ * @property {function(): ICommandProcessor} getCommandProcessor
+ * @property {function(): ICommandOutcomeInterpreter} getCommandOutcomeInterpreter
+ * @property {function(): ISafeEventDispatcher} getSafeEventDispatcher
+ */
+
+/**
+ * @typedef {object} AwaitingActorDecisionStateContext
+ * @property {function(): Entity|null} getActor
+ * @property {function(): ILogger} getLogger
+ * @property {function(): IActorTurnStrategy} getStrategy
+ * @property {function(ITurnAction): void} setChosenAction
+ * @property {function(object|null): void} setDecisionMeta
+ * @property {function(string, ITurnAction): Promise<void>} requestProcessingCommandStateTransition
+ * @property {function(Error|null): Promise<void>} endTurn
+ */
+
+export {};

--- a/tests/unit/turns/states/awaitingPlayerInputState.test.js
+++ b/tests/unit/turns/states/awaitingPlayerInputState.test.js
@@ -296,7 +296,8 @@ describe('AwaitingActorDecisionState (PTH-REFACTOR-003.5.7)', () => {
         mockHandler,
         mockPreviousState
       );
-      const expectedErrorMsg = `AwaitingActorDecisionState: turnContext.getStrategy() is not a function for actor ${testActor.id}.`;
+      const expectedErrorMsg =
+        'AwaitingActorDecisionState: ITurnContext missing required methods: getStrategy';
       expect(mockLogger.error).toHaveBeenCalledWith(expectedErrorMsg);
       expect(mockTestTurnContext.endTurn).toHaveBeenCalledWith(
         expect.any(Error)


### PR DESCRIPTION
## Summary
- add typedefs for context capabilities
- reference typedefs in AwaitingActorDecisionState and ProcessingCommandState
- centralize context method validation in `_ensureContext`
- adjust unit test for new error message

## Testing Done
- `npm run lint` *(fails: 624 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6857ff246f448331bc56418017e4e360