### PR TITLE
[Agent] Add start/stop success test helpers

### DIFF
--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -1,6 +1,5 @@
 // tests/engine/startNewGame.test.js
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 
 import { ENGINE_OPERATION_FAILED_UI } from '../../../src/constants/eventIds.js';
@@ -8,6 +7,7 @@ import {
   expectDispatchSequence,
   buildStopDispatches,
   buildStartDispatches,
+  expectStartSuccess,
   expectEngineRunning,
   expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
@@ -25,23 +25,7 @@ describeEngineSuite('GameEngine', (ctx) => {
 
     it('should successfully start a new game', async () => {
       await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
-
-      expectDispatchSequence(
-        ctx.bed.mocks.safeEventDispatcher.dispatch,
-        buildStartDispatches(DEFAULT_TEST_WORLD)
-      );
-      expect(ctx.bed.mocks.entityManager.clearAll).toHaveBeenCalled();
-      expect(ctx.bed.mocks.playtimeTracker.reset).toHaveBeenCalled();
-      expect(ctx.bed.env.mockContainer.resolve).toHaveBeenCalledWith(
-        tokens.IInitializationService
-      );
-      expect(
-        ctx.bed.mocks.initializationService.runInitializationSequence
-      ).toHaveBeenCalledWith(DEFAULT_TEST_WORLD);
-      expect(ctx.bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
-      expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
-
-      expectEngineRunning(ctx.engine, DEFAULT_TEST_WORLD);
+      expectStartSuccess(ctx.bed, ctx.engine, DEFAULT_TEST_WORLD);
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -7,6 +7,7 @@ import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
   buildStopDispatches,
+  expectStopSuccess,
   expectEngineRunning,
   expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
@@ -22,20 +23,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       await ctx.bed.startAndReset(DEFAULT_TEST_WORLD);
 
       await ctx.engine.stop();
-
-      expect(
-        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
-      ).toHaveBeenCalledTimes(1);
-      expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
-
-      expectDispatchSequence(
-        ctx.bed.mocks.safeEventDispatcher.dispatch,
-        ...buildStopDispatches()
-      );
-
-      expectEngineStopped(ctx.engine);
-
-      expect(ctx.bed.mocks.logger.warn).not.toHaveBeenCalled();
+      expectStopSuccess(ctx.bed, ctx.engine);
     });
 
     it('should do nothing and log if engine is already stopped', async () => {


### PR DESCRIPTION
Summary:
- extend dispatch test utilities with expectStartSuccess and expectStopSuccess
- update engine start and stop tests to use new helpers

Testing Done:
- `npm run lint` *(fails: 3005 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857fed6acc083318d7c47faf6954e08