### PR TITLE
[Refactor] Consolidate none/self handler in ActionDiscoveryService

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -40,37 +40,24 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   #getAvailableExitsFn;
   #getEntityDisplayNameFn;
 
-  static DOMAIN_HANDLERS = {
+  static DOMAIN_HANDLERS;
+  static {
     /**
-     * @description Discover actions that target none or self.
+     * @description Discover actions that target none or the actor entity itself.
      * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
      * @param {Entity} actorEntity
      * @param {object} formatterOptions
      * @returns {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]}
      */
-    none(actionDef, actorEntity, formatterOptions) {
+    function handleSelfOrNone(actionDef, actorEntity, formatterOptions) {
       return discoverSelfOrNone(
         actionDef,
         actorEntity,
         formatterOptions,
         this.#buildDiscoveredAction.bind(this)
       );
-    },
-    /**
-     * @description Discover actions that target the actor entity itself.
-     * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
-     * @param {Entity} actorEntity
-     * @param {object} formatterOptions
-     * @returns {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]}
-     */
-    self(actionDef, actorEntity, formatterOptions) {
-      return discoverSelfOrNone(
-        actionDef,
-        actorEntity,
-        formatterOptions,
-        this.#buildDiscoveredAction.bind(this)
-      );
-    },
+    }
+
     /**
      * @description Discover actions that target a direction.
      * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
@@ -80,7 +67,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
      * @param {object} formatterOptions
      * @returns {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]}
      */
-    direction(
+    function handleDirection(
       actionDef,
       actorEntity,
       currentLocation,
@@ -99,8 +86,14 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
         this.#logger,
         this.#getAvailableExitsFn
       );
-    },
-  };
+    }
+
+    this.DOMAIN_HANDLERS = {
+      none: handleSelfOrNone,
+      self: handleSelfOrNone,
+      direction: handleDirection,
+    };
+  }
 
   /**
    * @param {object} deps


### PR DESCRIPTION
Summary: Unifies handling for the 'none' and 'self' target domains inside `ActionDiscoveryService`.

Changes Made:
- Added internal `handleSelfOrNone` function within a static block.
- Mapped both `'none'` and `'self'` to this function in `DOMAIN_HANDLERS`.
- Moved direction logic into `handleDirection` for consistency.

Testing Done:
- [x] Code formatted (`npx prettier --write src/actions/actionDiscoveryService.js`)
- [ ] Lint passes (`npm run lint` fails due to existing issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68580d27b90c83319f19b2bf5d0c13e5