### PR TITLE
[Agent] validate manual save name

### DIFF
--- a/src/persistence/saveFileParser.js
+++ b/src/persistence/saveFileParser.js
@@ -3,6 +3,7 @@ import {
   getManualSavePath,
   manualSavePath,
 } from '../utils/savePathUtils.js';
+import { isValidSaveString } from './saveInputValidators.js';
 import { validateSaveMetadataFields } from '../utils/saveMetadataUtils.js';
 import { MSG_FILE_READ_ERROR, MSG_EMPTY_FILE } from './persistenceMessages.js';
 import { PersistenceErrorCodes } from './persistenceErrors.js';
@@ -142,7 +143,16 @@ export default class SaveFileParser extends BaseService {
    * @returns {Promise<import('./persistenceTypes.js').ParseSaveFileResult>} Parsed metadata result.
    */
   async parseManualSaveFile(fileName) {
-    const filePath = getManualSavePath(extractSaveName(fileName));
+    const isValidName = isValidSaveString(fileName);
+    const filePath = isValidName
+      ? getManualSavePath(extractSaveName(fileName))
+      : manualSavePath(String(fileName));
+
+    if (!isValidName) {
+      this.#logger.error(`Invalid manual save file name: ${fileName}`);
+      return this.#corruptedResult(filePath, fileName, ' (Invalid Name)');
+    }
+
     this.#logger.debug(`Processing file: ${filePath}`);
 
     try {

--- a/tests/unit/persistence/parseManualSaveMetadata.test.js
+++ b/tests/unit/persistence/parseManualSaveMetadata.test.js
@@ -97,4 +97,19 @@ describe('SaveFileRepository.parseManualSaveMetadata', () => {
       isCorrupted: true,
     });
   });
+
+  it('flags invalid file names early', async () => {
+    const result = await repo.parseManualSaveMetadata('');
+
+    expect(result).toEqual({
+      metadata: {
+        identifier: manualSavePath(''),
+        saveName: ' (Invalid Name)',
+        timestamp: 'N/A',
+        playtimeSeconds: 0,
+      },
+      isCorrupted: true,
+    });
+    expect(logger.error).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Summary: Added validation of manual save filenames using isValidSaveString in SaveFileParser.parseManualSaveFile. Parser now logs errors and returns a corrupted result for invalid names. Updated tests cover this scenario.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68580bbf7e788331a53a246b0d62e015