### PR TITLE
[Agent] clarify variable names in handlers

### DIFF
--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -93,56 +93,56 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
       return;
     }
 
-    const lid = leader_id.trim();
-    const dest = destination_id.trim();
+    const leaderId = leader_id.trim();
+    const destinationId = destination_id.trim();
 
-    const prevLoc =
+    const previousLocationId =
       executionContext?.event?.payload?.previousLocationId ?? null;
 
     const followersComponent = this.#entityManager.getComponentData(
-      lid,
+      leaderId,
       LEADING_COMPONENT_ID
     );
     const followerIds = Array.isArray(followersComponent?.followers)
       ? followersComponent.followers
       : [];
 
-    for (const fid of followerIds) {
+    for (const followerId of followerIds) {
       try {
         const pos = this.#entityManager.getComponentData(
-          fid,
+          followerId,
           POSITION_COMPONENT_ID
         );
-        if (prevLoc && pos?.locationId !== prevLoc) continue;
+        if (previousLocationId && pos?.locationId !== previousLocationId) continue;
 
         const originLoc = pos?.locationId ?? null;
 
         this.#moveHandler.execute(
-          { entity_ref: { entityId: fid }, target_location_id: dest },
+          { entity_ref: { entityId: followerId }, target_location_id: destinationId },
           executionContext
         );
 
         const followerName =
-          this.#entityManager.getComponentData(fid, NAME_COMPONENT_ID)?.text ||
-          fid;
+          this.#entityManager.getComponentData(followerId, NAME_COMPONENT_ID)?.text ||
+          followerId;
         const leaderName =
-          this.#entityManager.getComponentData(lid, NAME_COMPONENT_ID)?.text ||
-          lid;
+          this.#entityManager.getComponentData(leaderId, NAME_COMPONENT_ID)?.text ||
+          leaderId;
         const locationName =
-          this.#entityManager.getComponentData(dest, NAME_COMPONENT_ID)?.text ||
-          dest;
+          this.#entityManager.getComponentData(destinationId, NAME_COMPONENT_ID)?.text ||
+          destinationId;
         const message = `${followerName} follows ${leaderName} to ${locationName}.`;
 
         this.#dispatcher.dispatch('core:perceptible_event', {
           eventName: 'core:perceptible_event',
-          locationId: dest,
+          locationId: destinationId,
           descriptionText: message,
           timestamp: new Date().toISOString(),
           perceptionType: 'character_enter',
-          actorId: fid,
-          targetId: lid,
+          actorId: followerId,
+          targetId: leaderId,
           involvedEntities: [],
-          contextualData: { leaderId: lid, originLocationId: originLoc },
+          contextualData: { leaderId, originLocationId: originLoc },
         });
 
         this.#dispatcher.dispatch('core:display_successful_action_result', {
@@ -152,7 +152,7 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
         safeDispatchError(
           this.#dispatcher,
           'AUTO_MOVE_FOLLOWERS: Error moving follower',
-          { error: err.message, stack: err.stack, followerId: fid },
+          { error: err.message, stack: err.stack, followerId },
           logger
         );
       }

--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -99,24 +99,24 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
       );
       return;
     }
-    const fid = follower_id.trim();
+    const followerId = follower_id.trim();
     const currentData = this.#entityManager.getComponentData(
-      fid,
+      followerId,
       FOLLOWING_COMPONENT_ID
     );
     if (!currentData) {
       this.logger.debug(
-        `[BreakFollowRelationHandler] ${fid} is not following anyone.`
+        `[BreakFollowRelationHandler] ${followerId} is not following anyone.`
       );
       return;
     }
     try {
-      this.#entityManager.removeComponent(fid, FOLLOWING_COMPONENT_ID);
+      this.#entityManager.removeComponent(followerId, FOLLOWING_COMPONENT_ID);
     } catch (err) {
       safeDispatchError(
         this.#dispatcher,
         'BREAK_FOLLOW_RELATION: Failed removing following component',
-        { error: err.message, stack: err.stack, follower_id: fid },
+        { error: err.message, stack: err.stack, follower_id: followerId },
         logger
       );
       return;

--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -85,13 +85,13 @@ class CheckFollowCycleHandler extends BaseOperationHandler {
       return;
     }
 
-    const fid = follower_id.trim();
-    const lid = leader_id.trim();
+    const followerId = follower_id.trim();
+    const leaderId = leader_id.trim();
     log.debug(
-      `CHECK_FOLLOW_CYCLE: Checking cycle for follower=${fid}, leader=${lid}`
+      `CHECK_FOLLOW_CYCLE: Checking cycle for follower=${followerId}, leader=${leaderId}`
     );
 
-    const cycleDetected = wouldCreateCycle(fid, lid, this.#entityManager);
+    const cycleDetected = wouldCreateCycle(followerId, leaderId, this.#entityManager);
     const result = { success: true, cycleDetected };
 
     const res = tryWriteContextVariable(

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -100,29 +100,29 @@ class EstablishFollowRelationHandler {
       return;
     }
 
-    const fid = follower_id.trim();
-    const lid = leader_id.trim();
+    const followerId = follower_id.trim();
+    const leaderId = leader_id.trim();
     this.#logger.debug(
-      `[EstablishFollowRelationHandler] establishing follow: follower=${fid}, leader=${lid}`
+      `[EstablishFollowRelationHandler] establishing follow: follower=${followerId}, leader=${leaderId}`
     );
 
-    if (wouldCreateCycle(fid, lid, this.#entityManager)) {
+    if (wouldCreateCycle(followerId, leaderId, this.#entityManager)) {
       safeDispatchError(
         this.#dispatcher,
         'ESTABLISH_FOLLOW_RELATION: Following would create a cycle',
-        { follower_id: fid, leader_id: lid },
+        { follower_id: followerId, leader_id: leaderId },
         logger
       );
       return;
     }
 
     const oldData = this.#entityManager.getComponentData(
-      fid,
+      followerId,
       FOLLOWING_COMPONENT_ID
     );
     try {
-      this.#entityManager.addComponent(fid, FOLLOWING_COMPONENT_ID, {
-        leaderId: lid,
+      this.#entityManager.addComponent(followerId, FOLLOWING_COMPONENT_ID, {
+        leaderId: leaderId,
       });
     } catch (err) {
       safeDispatchError(
@@ -131,16 +131,16 @@ class EstablishFollowRelationHandler {
         {
           error: err.message,
           stack: err.stack,
-          follower_id: fid,
-          leader_id: lid,
+          follower_id: followerId,
+          leader_id: leaderId,
         },
         logger
       );
       return;
     }
 
-    const leaderIds = [lid];
-    if (oldData?.leaderId && oldData.leaderId !== lid)
+    const leaderIds = [leaderId];
+    if (oldData?.leaderId && oldData.leaderId !== leaderId)
       leaderIds.push(oldData.leaderId);
     this.#rebuildHandler.execute({ leaderIds }, executionContext);
   }

--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -18,17 +18,17 @@ class GetTimestampHandler extends BaseOperationHandler {
     const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
 
-    const rv = params.result_variable.trim();
+    const resultVariable = params.result_variable.trim();
     const timestamp = new Date().toISOString();
     const result = tryWriteContextVariable(
-      rv,
+      resultVariable,
       timestamp,
       executionContext,
       undefined,
       logger
     );
     if (result.success) {
-      logger.debug(`GET_TIMESTAMP → ${rv} = ${timestamp}`);
+      logger.debug(`GET_TIMESTAMP → ${resultVariable} = ${timestamp}`);
     }
   }
 }

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -91,10 +91,10 @@ class RebuildLeaderListCacheHandler {
     const followers = this.#entityManager.getEntitiesWithComponent(FOLLOWING);
     for (const ent of followers) {
       const data = ent.getComponentData(FOLLOWING);
-      const lid = data?.leaderId;
-      if (isNonBlankString(lid)) {
-        if (!followerMap.has(lid)) followerMap.set(lid, []);
-        followerMap.get(lid).push(ent.id);
+      const leaderId = data?.leaderId;
+      if (isNonBlankString(leaderId)) {
+        if (!followerMap.has(leaderId)) followerMap.set(leaderId, []);
+        followerMap.get(leaderId).push(ent.id);
       }
     }
 


### PR DESCRIPTION
## Summary
- rename rv to resultVariable in timestamp handler
- use followerId and leaderId in follow relation handlers
- clean up similar abbreviations in related handlers

## Testing Done
- `npm run lint` *(fails: 3015 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68580ba025b88331a5dfc4acb31510b7