### PR TITLE
[Refactor] flatten domUI helper logic and add tests

### DIFF
--- a/src/domUI/helpers/renderListCommon.js
+++ b/src/domUI/helpers/renderListCommon.js
@@ -89,31 +89,32 @@ export async function renderListCommon(
       }
     }
     logger.debug('[renderListCommon] Empty list message displayed.');
-  } else {
-    let rendered = 0;
-    listData.forEach((item, index) => {
-      try {
-        const el = renderItem(item, index, listData);
-        if (el && el.nodeType === 1) {
-          container.appendChild(el);
-          rendered++;
-        } else if (el !== null) {
-          logger.warn(
-            '[renderListCommon] renderItem did not return an element.',
-            {
-              item,
-              returnedValue: el,
-            }
-          );
-        }
-      } catch (err) {
-        logger.error('[renderListCommon] Error in renderItem:', err, { item });
-      }
-    });
-    logger.debug(
-      `[renderListCommon] Rendered ${rendered} out of ${listData.length} items.`
-    );
+    return Array.isArray(listData) ? listData : null;
   }
+
+  let rendered = 0;
+  listData.forEach((item, index) => {
+    try {
+      const el = renderItem(item, index, listData);
+      if (el && el.nodeType === 1) {
+        container.appendChild(el);
+        rendered++;
+      } else if (el !== null) {
+        logger.warn(
+          '[renderListCommon] renderItem did not return an element.',
+          {
+            item,
+            returnedValue: el,
+          }
+        );
+      }
+    } catch (err) {
+      logger.error('[renderListCommon] Error in renderItem:', err, { item });
+    }
+  });
+  logger.debug(
+    `[renderListCommon] Rendered ${rendered} out of ${listData.length} items.`
+  );
 
   return listData;
 }

--- a/src/domUI/helpers/slotDataFormatter.js
+++ b/src/domUI/helpers/slotDataFormatter.js
@@ -24,28 +24,28 @@ import { formatPlaytime, formatTimestamp } from '../../utils/textUtils.js';
  */
 export function formatSaveFileMetadata(metadata) {
   const name = metadata.saveName || metadata.identifier;
-  let timestamp = '';
-  if (
-    metadata.timestamp &&
-    metadata.timestamp !== 'N/A' &&
-    !metadata.isCorrupted
-  ) {
-    const formatted = formatTimestamp(metadata.timestamp);
-    timestamp = `Saved: ${formatted}`;
-  } else if (metadata.isCorrupted) {
-    timestamp = 'Timestamp: N/A';
+
+  if (metadata.isCorrupted) {
+    return {
+      name,
+      timestamp: 'Timestamp: N/A',
+      playtime: '',
+      isEmpty: false,
+      isCorrupted: true,
+    };
   }
 
-  const playtime = !metadata.isCorrupted
-    ? `Playtime: ${formatPlaytime(metadata.playtimeSeconds)}`
-    : '';
+  const timestamp =
+    metadata.timestamp && metadata.timestamp !== 'N/A'
+      ? `Saved: ${formatTimestamp(metadata.timestamp)}`
+      : '';
 
   return {
     name,
     timestamp,
-    playtime,
+    playtime: `Playtime: ${formatPlaytime(metadata.playtimeSeconds)}`,
     isEmpty: false,
-    isCorrupted: !!metadata.isCorrupted,
+    isCorrupted: false,
   };
 }
 

--- a/tests/unit/domUI/helpers/renderListCommon.test.js
+++ b/tests/unit/domUI/helpers/renderListCommon.test.js
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { renderListCommon } from '../../../../src/domUI/helpers/renderListCommon.js';
+import DocumentContext from '../../../../src/domUI/documentContext.js';
+import DomElementFactory from '../../../../src/domUI/domElementFactory.js';
+
+const logger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+};
+
+describe('renderListCommon', () => {
+  let container;
+  let factory;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const ctx = new DocumentContext(document);
+    factory = new DomElementFactory(ctx);
+    container = document.createElement('div');
+  });
+
+  it('renders items returned by fetchData', async () => {
+    const data = ['a', 'b'];
+    const fetchData = jest.fn().mockResolvedValue(data);
+    const renderItem = jest.fn((item) => factory.div('item', item));
+    const emptyMsg = jest.fn(() => 'empty');
+
+    const result = await renderListCommon(
+      fetchData,
+      renderItem,
+      emptyMsg,
+      container,
+      logger,
+      factory
+    );
+
+    expect(result).toEqual(data);
+    expect(container.querySelectorAll('.item').length).toBe(2);
+  });
+
+  it('shows empty message when list is empty', async () => {
+    const fetchData = jest.fn().mockResolvedValue([]);
+    const renderItem = jest.fn();
+    const emptyMsg = jest.fn(() => 'none');
+
+    const result = await renderListCommon(
+      fetchData,
+      renderItem,
+      emptyMsg,
+      container,
+      logger,
+      factory
+    );
+
+    expect(result).toEqual([]);
+    expect(container.textContent).toBe('none');
+  });
+
+  it('returns null and displays error when fetch fails', async () => {
+    const fetchData = jest.fn().mockRejectedValue(new Error('fail'));
+    const renderItem = jest.fn();
+    const emptyMsg = jest.fn(() => 'none');
+
+    const result = await renderListCommon(
+      fetchData,
+      renderItem,
+      emptyMsg,
+      container,
+      logger,
+      factory
+    );
+
+    expect(result).toBeNull();
+    expect(container.textContent).toBe('Error loading list data.');
+  });
+});

--- a/tests/unit/domUI/helpers/renderSlotItem.test.js
+++ b/tests/unit/domUI/helpers/renderSlotItem.test.js
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import DocumentContext from '../../../../src/domUI/documentContext.js';
+import DomElementFactory from '../../../../src/domUI/domElementFactory.js';
+import { renderSlotItem } from '../../../../src/domUI/helpers/renderSlotItem.js';
+
+describe('renderSlotItem', () => {
+  let factory;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const ctx = new DocumentContext(document);
+    factory = new DomElementFactory(ctx);
+  });
+
+  it('creates slot element with info and playtime', () => {
+    const handler = jest.fn();
+    const slot = renderSlotItem(
+      factory,
+      'slotId',
+      '1',
+      {
+        name: 'Save1',
+        timestamp: 'Saved: now',
+        playtime: 'Playtime: 00:10:00',
+      },
+      handler
+    );
+    expect(slot).toBeInstanceOf(HTMLElement);
+    expect(slot.dataset.slotId).toBe('1');
+    expect(slot.querySelector('.slot-name').textContent).toBe('Save1');
+    expect(slot.querySelector('.slot-timestamp').textContent).toBe(
+      'Saved: now'
+    );
+    expect(slot.querySelector('.slot-playtime').textContent).toBe(
+      'Playtime: 00:10:00'
+    );
+    slot.click();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('returns null when factory is missing', () => {
+    const res = renderSlotItem(null, 'id', '1', {}, undefined);
+    expect(res).toBeNull();
+  });
+});

--- a/tests/unit/domUI/helpers/slotDataFormatter.test.js
+++ b/tests/unit/domUI/helpers/slotDataFormatter.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  formatSaveFileMetadata,
+  formatEmptySlot,
+} from '../../../../src/domUI/helpers/slotDataFormatter.js';
+
+describe('slotDataFormatter helpers', () => {
+  it('formats uncorrupted metadata', () => {
+    const meta = {
+      saveName: 'Slot1',
+      identifier: 'slot1',
+      timestamp: '2024-01-01T00:00:00Z',
+      playtimeSeconds: 65,
+      isCorrupted: false,
+    };
+    const result = formatSaveFileMetadata(meta);
+    expect(result.name).toBe('Slot1');
+    expect(result.isCorrupted).toBe(false);
+    expect(result.playtime).toContain('Playtime:');
+    expect(result.timestamp.startsWith('Saved:')).toBe(true);
+  });
+
+  it('formats corrupted metadata with early return', () => {
+    const meta = {
+      saveName: 'Bad',
+      identifier: 'bad1',
+      timestamp: '2024-01-01T00:00:00Z',
+      playtimeSeconds: 10,
+      isCorrupted: true,
+    };
+    const result = formatSaveFileMetadata(meta);
+    expect(result.isCorrupted).toBe(true);
+    expect(result.timestamp).toBe('Timestamp: N/A');
+    expect(result.playtime).toBe('');
+  });
+
+  it('creates empty slot metadata', () => {
+    const result = formatEmptySlot('Empty');
+    expect(result).toEqual({
+      name: 'Empty',
+      timestamp: '',
+      playtime: '',
+      isEmpty: true,
+      isCorrupted: false,
+    });
+  });
+});


### PR DESCRIPTION
Summary: Implements early returns in `renderListCommon` and `formatSaveFileMetadata` to reduce nesting and adds dedicated unit tests for domUI helper modules.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` & `cd llm-proxy-server && npm run lint`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68580b8a3ab48331972317044884a38b