### PR TITLE
[Agent] inject jsonLogic into SetVariableHandler

### DIFF
--- a/src/dependencyInjection/registrations/interpreterRegistrations.js
+++ b/src/dependencyInjection/registrations/interpreterRegistrations.js
@@ -45,6 +45,7 @@ import ModifyContextArrayHandler from '../../logic/operationHandlers/modifyConte
 import AutoMoveFollowersHandler from '../../logic/operationHandlers/autoMoveFollowersHandler.js';
 import MergeClosenessCircleHandler from '../../logic/operationHandlers/mergeClosenessCircleHandler.js';
 import RemoveFromClosenessCircleHandler from '../../logic/operationHandlers/removeFromClosenessCircleHandler.js';
+import jsonLogic from 'json-logic-js';
 
 /**
  * Registers all interpreter-layer services in the DI container.
@@ -158,7 +159,11 @@ export function registerInterpreters(container) {
     [
       tokens.SetVariableHandler,
       SetVariableHandler,
-      (c, Handler) => new Handler({ logger: c.resolve(tokens.ILogger) }),
+      (c, Handler) =>
+        new Handler({
+          logger: c.resolve(tokens.ILogger),
+          jsonLogic,
+        }),
     ],
     [
       tokens.EndTurnHandler,

--- a/tests/integration/rules/turnStartedRule.integration.test.js
+++ b/tests/integration/rules/turnStartedRule.integration.test.js
@@ -8,6 +8,7 @@ import eventIsTurnStarted from '../../../data/mods/core/conditions/event-is-turn
 import SetVariableHandler from '../../../src/logic/operationHandlers/setVariableHandler.js';
 import DispatchEventHandler from '../../../src/logic/operationHandlers/dispatchEventHandler.js';
 import AddComponentHandler from '../../../src/logic/operationHandlers/addComponentHandler.js';
+import jsonLogic from 'json-logic-js';
 import { TURN_STARTED_ID } from '../../../src/constants/eventIds.js';
 import { createRuleTestEnvironment } from '../../common/engine/systemLogicTestEnv.js';
 
@@ -22,9 +23,13 @@ import { createRuleTestEnvironment } from '../../common/engine/systemLogicTestEn
 function createHandlers(entityManager, eventBus, logger) {
   const safeEventDispatcher = { dispatch: jest.fn() };
   return {
-    SET_VARIABLE: new SetVariableHandler({ logger }),
+    SET_VARIABLE: new SetVariableHandler({ logger, jsonLogic }),
     DISPATCH_EVENT: new DispatchEventHandler({ dispatcher: eventBus, logger }),
-    ADD_COMPONENT: new AddComponentHandler({ entityManager, logger, safeEventDispatcher }),
+    ADD_COMPONENT: new AddComponentHandler({
+      entityManager,
+      logger,
+      safeEventDispatcher,
+    }),
   };
 }
 
@@ -68,6 +73,8 @@ describe('core_handle_turn_started rule integration', () => {
     // The rule should add a core:current_actor component to the entity
     const entity = testEnv.entityManager.getEntityInstance('test-entity');
     expect(entity).toBeDefined();
-    expect(testEnv.entityManager.hasComponent('test-entity', 'core:current_actor')).toBe(true);
+    expect(
+      testEnv.entityManager.hasComponent('test-entity', 'core:current_actor')
+    ).toBe(true);
   });
 });

--- a/tests/unit/config/registrations/interpreterRegistrations.test.js
+++ b/tests/unit/config/registrations/interpreterRegistrations.test.js
@@ -46,6 +46,7 @@ import AddComponentHandler from '../../../../src/logic/operationHandlers/addComp
 import RemoveComponentHandler from '../../../../src/logic/operationHandlers/removeComponentHandler.js';
 import QueryComponentHandler from '../../../../src/logic/operationHandlers/queryComponentHandler.js';
 import SetVariableHandler from '../../../../src/logic/operationHandlers/setVariableHandler.js';
+import jsonLogic from 'json-logic-js';
 
 // --- Mock Implementations ---
 const mockLogger = {
@@ -349,7 +350,7 @@ describe('registerInterpreters', () => {
     expect(handler).toBeDefined();
     expect(SetVariableHandler).toHaveBeenCalledTimes(1);
     expect(SetVariableHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ logger: mockLogger })
+      expect.objectContaining({ logger: mockLogger, jsonLogic })
     );
   });
 }); // End describe

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -86,7 +86,10 @@ describe('SetVariableHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLoggerInstance = createMockLogger();
-    handler = new SetVariableHandler({ logger: mockLoggerInstance });
+    handler = new SetVariableHandler({
+      logger: mockLoggerInstance,
+      jsonLogic,
+    });
     mockLoggerInstance.debug.mockClear();
   });
 
@@ -97,14 +100,14 @@ describe('SetVariableHandler', () => {
         /ILogger instance/
       );
       expect(
-        () => new SetVariableHandler({ logger: { info: jest.fn() } })
+        () => new SetVariableHandler({ logger: { info: jest.fn() }, jsonLogic })
       ).toThrow(/ILogger instance/);
     });
 
     test('initializes successfully with a valid logger', () => {
       const freshLogger = createMockLogger();
       expect(
-        () => new SetVariableHandler({ logger: freshLogger })
+        () => new SetVariableHandler({ logger: freshLogger, jsonLogic })
       ).not.toThrow();
       expect(freshLogger.debug).toHaveBeenCalledWith(
         'SetVariableHandler initialized.'


### PR DESCRIPTION
Summary: 
- allow SetVariableHandler to receive jsonLogic via constructor
- adjust interpreter registrations and tests for new dependency
- provide jsonLogic when instantiating handlers in integration tests

Testing Done:
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`
- `cd llm-proxy-server && npm run format && npm run lint && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68580b220420833193de72e16d072aab