### PR TITLE
[Agent] Add target domain constants

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -18,6 +18,11 @@ import {
   getAvailableExits,
 } from '../utils/locationUtils.js';
 import {
+  TARGET_DOMAIN_SELF,
+  TARGET_DOMAIN_NONE,
+  TARGET_DOMAIN_DIRECTION,
+} from '../constants/targetDomains.js';
+import {
   discoverSelfOrNone,
   discoverDirectionalActions,
   discoverScopedEntityActions,
@@ -89,9 +94,9 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     }
 
     this.DOMAIN_HANDLERS = {
-      none: handleSelfOrNone,
-      self: handleSelfOrNone,
-      direction: handleDirection,
+      [TARGET_DOMAIN_NONE]: handleSelfOrNone,
+      [TARGET_DOMAIN_SELF]: handleSelfOrNone,
+      [TARGET_DOMAIN_DIRECTION]: handleDirection,
     };
   }
 
@@ -231,15 +236,15 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     try {
       const handlers = this.constructor.DOMAIN_HANDLERS;
       let actions;
-      if (domain === 'none' || domain === 'self') {
+      if (domain === TARGET_DOMAIN_NONE || domain === TARGET_DOMAIN_SELF) {
         actions = handlers[domain].call(
           this,
           actionDef,
           actorEntity,
           formatterOptions
         );
-      } else if (domain === 'direction') {
-        actions = handlers.direction.call(
+      } else if (domain === TARGET_DOMAIN_DIRECTION) {
+        actions = handlers[TARGET_DOMAIN_DIRECTION].call(
           this,
           actionDef,
           actorEntity,

--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -14,6 +14,7 @@
 import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { TARGET_DOMAIN_NONE } from '../constants/targetDomains.js';
 
 /**
  * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => (string|null)>} TargetFormatterMap
@@ -97,7 +98,7 @@ function formatNoneTarget(command, _context, { actionId, logger, debug }) {
   }
   if (command.includes('{target}') || command.includes('{direction}')) {
     logger.warn(
-      `formatActionCommand: Action ${actionId} has target_domain 'none' but template "${command}" contains placeholders.`
+      `formatActionCommand: Action ${actionId} has target_domain '${TARGET_DOMAIN_NONE}' but template "${command}" contains placeholders.`
     );
   }
   return command;

--- a/src/actions/discoveryHandlers.js
+++ b/src/actions/discoveryHandlers.js
@@ -10,6 +10,11 @@
 
 import { ActionTargetContext } from '../models/actionTargetContext.js';
 import { getAvailableExits } from '../utils/locationUtils.js';
+import {
+  TARGET_DOMAIN_SELF,
+  TARGET_DOMAIN_NONE,
+  TARGET_DOMAIN_DIRECTION,
+} from '../constants/targetDomains.js';
 
 /**
  * @description Handles discovery for actions targeting 'self' or having no target.
@@ -27,7 +32,7 @@ export function discoverSelfOrNone(
   buildDiscoveredAction
 ) {
   const targetCtx =
-    actionDef.target_domain === 'self'
+    actionDef.target_domain === TARGET_DOMAIN_SELF
       ? ActionTargetContext.forEntity(actorEntity.id)
       : ActionTargetContext.noTarget();
 

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -12,6 +12,10 @@
 import { ActionTargetContext } from '../../models/actionTargetContext.js';
 import { PrerequisiteEvaluationService } from './prerequisiteEvaluationService.js';
 import { setupService } from '../../utils/serviceInitializerUtils.js';
+import {
+  TARGET_DOMAIN_SELF,
+  TARGET_DOMAIN_NONE,
+} from '../../constants/targetDomains.js';
 // --- Refactor-AVS-3.4: Remove dependency ---
 // REMOVED: import { ActionValidationContextBuilder } from './actionValidationContextBuilder.js';
 // --- End Refactor-AVS-3.4 ---
@@ -131,7 +135,7 @@ export class ActionValidationService {
   _validateDomainAndContext(actionDefinition, actorEntity, targetContext) {
     const actionId = actionDefinition.id;
     const actorId = actorEntity.id;
-    const expectedDomain = actionDefinition.target_domain || 'none';
+    const expectedDomain = actionDefinition.target_domain || TARGET_DOMAIN_NONE;
     const contextType = targetContext.type;
 
     const isCompatible = this.#domainContextCompatibilityChecker.check(
@@ -140,9 +144,12 @@ export class ActionValidationService {
     );
 
     if (!isCompatible) {
-      if (contextType === 'none' && expectedDomain !== 'none') {
+      if (
+        contextType === TARGET_DOMAIN_NONE &&
+        expectedDomain !== TARGET_DOMAIN_NONE
+      ) {
         this.#logger.debug(
-          `Validation[${actionId}]: Domain/Context check PASSED (deferred): Initial check context is 'none' but domain '${expectedDomain}' requires a target. Checker result (${isCompatible}) ignored for this step.`
+          `Validation[${actionId}]: Domain/Context check PASSED (deferred): Initial check context is '${TARGET_DOMAIN_NONE}' but domain '${expectedDomain}' requires a target. Checker result (${isCompatible}) ignored for this step.`
         );
       } else {
         this.#logger.debug(
@@ -153,12 +160,12 @@ export class ActionValidationService {
     }
 
     if (
-      expectedDomain === 'self' &&
+      expectedDomain === TARGET_DOMAIN_SELF &&
       contextType === 'entity' &&
       targetContext.entityId !== actorId
     ) {
       this.#logger.debug(
-        `Validation[${actionId}]: ← STEP 1 FAILED ('self' target mismatch). Target entity '${targetContext.entityId}' !== Actor '${actorId}'.`
+        `Validation[${actionId}]: ← STEP 1 FAILED ('${TARGET_DOMAIN_SELF}' target mismatch). Target entity '${targetContext.entityId}' !== Actor '${actorId}'.`
       );
       return false;
     }
@@ -322,7 +329,7 @@ export class ActionValidationService {
     const actorId = actorEntity.id;
 
     this.#logger.debug(
-      `START Validation: action='${actionId}', actor='${actorId}', ctxType='${targetContext.type}', target='${targetContext.entityId ?? targetContext.direction ?? 'none'}'`
+      `START Validation: action='${actionId}', actor='${actorId}', ctxType='${targetContext.type}', target='${targetContext.entityId ?? targetContext.direction ?? TARGET_DOMAIN_NONE}'`
     );
 
     try {

--- a/src/constants/targetDomains.js
+++ b/src/constants/targetDomains.js
@@ -1,0 +1,9 @@
+export const TARGET_DOMAIN_SELF = 'self';
+export const TARGET_DOMAIN_NONE = 'none';
+export const TARGET_DOMAIN_DIRECTION = 'direction';
+
+export default {
+  TARGET_DOMAIN_SELF,
+  TARGET_DOMAIN_NONE,
+  TARGET_DOMAIN_DIRECTION,
+};


### PR DESCRIPTION
## Summary
- centralize target domain strings in `src/constants/targetDomains.js`
- use new constants in action discovery, discovery handlers, action formatting, and validation services

## Testing
- `npx eslint src/actions/actionDiscoveryService.js src/actions/discoveryHandlers.js src/actions/actionFormatter.js src/actions/validation/actionValidationService.js src/constants/targetDomains.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685825e82c748331865efab755d65e0d