### PR TITLE
[Agent] Enable DI for EntityManager defaults

### DIFF
--- a/src/entities/utils/createDefaultDeps.js
+++ b/src/entities/utils/createDefaultDeps.js
@@ -1,0 +1,27 @@
+// src/entities/utils/createDefaultDeps.js
+
+import InMemoryEntityRepository from '../../adapters/InMemoryEntityRepository.js';
+import UuidGenerator from '../../adapters/UuidGenerator.js';
+import LodashCloner from '../../adapters/LodashCloner.js';
+import DefaultComponentPolicy from '../../adapters/DefaultComponentPolicy.js';
+
+/**
+ * Create default dependencies for {@link EntityManager}.
+ *
+ * @returns {{
+ *   repository: import('../../ports/IEntityRepository.js').IEntityRepository,
+ *   idGenerator: import('../../ports/IIdGenerator.js').IIdGenerator,
+ *   cloner: import('../../ports/IComponentCloner.js').IComponentCloner,
+ *   defaultPolicy: import('../../ports/IDefaultComponentPolicy.js').IDefaultComponentPolicy,
+ * }} Object containing default implementations.
+ */
+export function createDefaultDeps() {
+  return {
+    repository: new InMemoryEntityRepository(),
+    idGenerator: UuidGenerator,
+    cloner: LodashCloner,
+    defaultPolicy: new DefaultComponentPolicy(),
+  };
+}
+
+export default createDefaultDeps;


### PR DESCRIPTION
## Summary
- factor out creation of default EntityManager dependencies
- allow passing factories or instances to EntityManager constructor
- remove leftover debug logging

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68582660c30c833185f99c94350a5594