### PR TITLE
[Agent] improve branch coverage for persistenceErrorUtils

### DIFF
--- a/tests/unit/utils/persistenceErrorUtils.test.js
+++ b/tests/unit/utils/persistenceErrorUtils.test.js
@@ -23,6 +23,17 @@ describe('wrapPersistenceOperation', () => {
     expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
     expect(res.error.message).toBe('boom');
   });
+
+  it('handles non-Error rejections', async () => {
+    const logger = { error: jest.fn() };
+    const res = await wrapPersistenceOperation(logger, async () => {
+      throw 'string err';
+    });
+    expect(logger.error).toHaveBeenCalled();
+    expect(res.success).toBe(false);
+    expect(res.error.code).toBe(PersistenceErrorCodes.UNEXPECTED_ERROR);
+    expect(res.error.message).toBe('string err');
+  });
 });
 
 describe('wrapSyncPersistenceOperation', () => {


### PR DESCRIPTION
## Summary
- add test covering non-Error rejection for `wrapPersistenceOperation`

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685826b6f9408331956ddf5c02a2da91