### PR TITLE
[Agent] Clarify save file repo/parser docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ Explains how identifiers are namespaced and how reference resolution works acros
 **Action Macros ➜ docs/mods/macros.md**
 Define reusable action sequences and reference them within rules.
 
+**Persistence Overview ➜ docs/persistence/overview.md**
+Quick reference for save file repository and parser responsibilities.
+
 ### License
 
 This project is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License.  

--- a/docs/persistence/overview.md
+++ b/docs/persistence/overview.md
@@ -1,0 +1,11 @@
+# Persistence Overview
+
+This document provides a quick reference for the game's save file storage components.
+
+## SaveFileRepository
+
+`SaveFileRepository` is the sole entry point for storage operations such as writing, reading, listing, and deleting save files. All filesystem access is encapsulated within this class.
+
+## SaveFileParser
+
+`SaveFileParser` focuses exclusively on reading and parsing save files. It validates metadata and deserializes save contents but does not perform any filesystem writes or deletions.

--- a/src/persistence/saveFileParser.js
+++ b/src/persistence/saveFileParser.js
@@ -12,7 +12,10 @@ import { BaseService } from '../utils/serviceBase.js';
 
 /**
  * @class SaveFileParser
- * @description Reads save files from storage and extracts metadata.
+ * @description
+ *   Focuses exclusively on reading and parsing save files. It validates
+ *   metadata and deserializes save contents but performs no write or delete
+ *   operations itself.
  */
 export default class SaveFileParser extends BaseService {
   /** @type {import('../interfaces/coreServices.js').ILogger} */
@@ -23,7 +26,9 @@ export default class SaveFileParser extends BaseService {
   #serializer;
 
   /**
-   * @param {object} deps
+   * Creates a new SaveFileParser instance.
+   *
+   * @param {object} deps - Constructor dependencies.
    * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger instance.
    * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} deps.storageProvider - Storage provider for file access.
    * @param {import('./gameStateSerializer.js').default} deps.serializer - Serializer for deserialization.

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -15,7 +15,10 @@ const manualSaveRegex = MANUAL_SAVE_PATTERN;
 
 /**
  * @class SaveFileRepository
- * @description Handles file system interactions for manual save files.
+ * @description
+ *   Acts as the single entry point for manual save storage operations. All
+ *   reads, writes, listings and deletions of save files are funneled through
+ *   this repository which delegates parsing logic to {@link SaveFileParser}.
  */
 export default class SaveFileRepository extends BaseService {
   /** @type {import('../interfaces/coreServices.js').ILogger} */
@@ -26,10 +29,11 @@ export default class SaveFileRepository extends BaseService {
   #parser;
 
   /**
-   * @param {object} deps
+   * Creates a new repository instance.
+   *
+   * @param {object} deps - Constructor dependencies.
    * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger instance.
    * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} deps.storageProvider - Storage provider.
-   * @param {import('./gameStateSerializer.js').default} deps.serializer - Serializer used for reading/writing saves.
    * @param {SaveFileParser} deps.parser - Parser for reading save metadata.
    */
   constructor({ logger, storageProvider, parser }) {


### PR DESCRIPTION
Summary:
- add persistence overview documentation
- make SaveFileRepository the single storage entry in docs
- highlight SaveFileParser as read-only parser
- link persistence docs from README

Testing Done:
- `npx prettier --write README.md src/persistence/saveFileParser.js src/persistence/saveFileRepository.js docs/persistence/overview.md`
- `npx eslint src/persistence/saveFileRepository.js src/persistence/saveFileParser.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685826348e308331ac96ee5c51c93a59