### PR TITLE
[Agent] refactor slot list population

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -329,7 +329,7 @@ class LoadGameUI extends SlotModalBase {
       return;
     }
 
-    await this.populateSlotsList(
+    await this._populateSlots(
       () => this._getLoadSlotsData(),
       (slotData, index) => this._renderLoadSlotItem(slotData, index),
       () => this._getEmptyLoadSlotsMessage(),

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -339,7 +339,7 @@ export class SaveGameUI extends SlotModalBase {
       return;
     }
 
-    await this.populateSlotsList(
+    await this._populateSlots(
       () => this._getSaveSlotsData(),
       (slotData, index) => this._renderSaveSlotItem(slotData, index),
       () => this._getEmptySaveSlotsMessage(),

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -195,6 +195,40 @@ export class SlotModalBase extends BaseModalRenderer {
   }
 
   /**
+   * Core logic to populate the slots list.
+   *
+   * @protected
+   * @async
+   * @param {Function} dataFetcher - Async function returning slot data array.
+   * @param {Function} renderer - Function to render a slot item element.
+   * @param {Function} emptyMessageProvider - Function returning message for empty list.
+   * @param {string} loadingMessage - Message shown while loading.
+   * @returns {Promise<void>} Resolves when list population is complete.
+   */
+  async _populateSlots(
+    dataFetcher,
+    renderer,
+    emptyMessageProvider,
+    loadingMessage
+  ) {
+    this._setOperationInProgress(true);
+    this._displayStatusMessage(loadingMessage, 'info');
+
+    const data = await renderListCommon(
+      dataFetcher,
+      (item, index, list) => renderer(item, index, list),
+      emptyMessageProvider,
+      this.elements.listContainerElement,
+      this.logger,
+      this.domElementFactory
+    );
+    this.currentSlotsDisplayData = Array.isArray(data) ? data : [];
+
+    this._clearStatusMessage();
+    this._setOperationInProgress(false);
+  }
+
+  /**
    * Generic helper to populate the slots list.
    *
    * @protected
@@ -211,21 +245,12 @@ export class SlotModalBase extends BaseModalRenderer {
     getEmptyMessageFn,
     loadingMessage
   ) {
-    this._setOperationInProgress(true);
-    this._displayStatusMessage(loadingMessage, 'info');
-
-    const data = await renderListCommon(
+    await this._populateSlots(
       fetchDataFn,
-      (item, index, list) => renderItemFn(item, index, list),
+      renderItemFn,
       getEmptyMessageFn,
-      this.elements.listContainerElement,
-      this.logger,
-      this.domElementFactory
+      loadingMessage
     );
-    this.currentSlotsDisplayData = Array.isArray(data) ? data : [];
-
-    this._clearStatusMessage();
-    this._setOperationInProgress(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce `_populateSlots` in `SlotModalBase`
- call new base method from SaveGameUI and LoadGameUI

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` (manual smoke test)


------
https://chatgpt.com/codex/tasks/task_e_685825fdc188833181a1188b49428858