### PR TITLE
[Agent] add helper for mocking initialization success

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -155,3 +155,18 @@ export function setupLoadGameSpies(engine) {
   const handleFailureSpy = jest.spyOn(engine, '_handleLoadFailure');
   return { prepareSpy, executeSpy, finalizeSpy, handleFailureSpy };
 }
+
+/**
+ * Mocks a successful initialization sequence on the provided test bed.
+ *
+ * @description Sets `initializationService.runInitializationSequence` to resolve
+ *   `{ success: true }`.
+ * @param {GameEngineTestBed} bed - Test bed containing the initialization service
+ *   mock.
+ * @returns {void}
+ */
+export function mockInitializationSuccess(bed) {
+  bed.mocks.initializationService.runInitializationSequence.mockResolvedValue({
+    success: true,
+  });
+}

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -19,23 +19,12 @@ import {
   expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
-
-/**
- * Mocks a successful initialization sequence on the provided test bed.
- *
- * @param {import('../../common/engine/gameEngineTestBed.js').GameEngineTestBed} bed - Test bed instance.
- * @returns {void}
- */
-function mockInitSuccess(bed) {
-  bed.mocks.initializationService.runInitializationSequence.mockResolvedValue({
-    success: true,
-  });
-}
+import { mockInitializationSuccess } from '../../common/engine/gameEngineHelpers.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('startNewGame', () => {
     beforeEach(() => {
-      mockInitSuccess(ctx.bed);
+      mockInitializationSuccess(ctx.bed);
     });
 
     it('should successfully start a new game', async () => {


### PR DESCRIPTION
## Summary
- add `mockInitializationSuccess` utility
- use `mockInitializationSuccess` in `startNewGame` tests

## Testing Done
- `npx prettier tests/common/engine/gameEngineHelpers.js tests/unit/engine/startNewGame.test.js -w`
- `npx eslint tests/common/engine/gameEngineHelpers.js tests/unit/engine/startNewGame.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68582820406c8331960253fd4b3c166e