### PR TITLE
[Fix] ensure array modifications are immutable

### DIFF
--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -68,7 +68,7 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
    * @param {string} field
    * @param {string} entityId
    * @param {ILogger} log
-   * @returns {{nextArray: Array, result: *}|null}
+   * @returns {{nextArray: Array, result: *, modified: boolean}|null}
    * Returns a new array via `nextArray`; the original `targetArray` is never
    * mutated.
    * @private
@@ -100,20 +100,20 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
       );
     }
 
-    const { nextArray, result } = advancedArrayModify(
+    const { nextArray, result, modified } = advancedArrayModify(
       mode,
       targetArray,
       value,
       log
     );
 
-    if (mode === 'push_unique' && nextArray === targetArray) {
+    if (mode === 'push_unique' && !modified) {
       log.debug(
         `MODIFY_ARRAY_FIELD: Value for 'push_unique' already exists in array on field '${field}'.`
       );
     }
 
-    if (mode === 'remove_by_value' && nextArray === targetArray) {
+    if (mode === 'remove_by_value' && !modified) {
       log.debug(
         `MODIFY_ARRAY_FIELD: Value for 'remove_by_value' not found in array on field '${field}'.`
       );
@@ -122,6 +122,7 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
     return {
       nextArray,
       result,
+      modified,
     };
   }
 

--- a/tests/unit/utils/advancedArrayModify.test.js
+++ b/tests/unit/utils/advancedArrayModify.test.js
@@ -14,13 +14,16 @@ describe('advancedArrayModify', () => {
     expect(nextArray).toEqual([1, 2]);
     expect(result).toEqual([1, 2]);
     expect(arr).toEqual([1]);
+    expect(nextArray).not.toBe(arr);
   });
 
   it('push_unique with object only adds when not present', () => {
     const obj = { a: 1 };
     const arr = [{ a: 1 }];
     const { nextArray } = advancedArrayModify('push_unique', arr, obj, logger);
-    expect(nextArray).toEqual(arr); // not added because deep equal
+    expect(nextArray).toEqual(arr);
+    expect(nextArray).not.toBe(arr); // returned array should be new
+    expect(arr).toEqual([{ a: 1 }]);
 
     const { nextArray: newArr } = advancedArrayModify(
       'push_unique',
@@ -29,6 +32,7 @@ describe('advancedArrayModify', () => {
       logger
     );
     expect(newArr).toEqual([...arr, { a: 2 }]);
+    expect(arr).toEqual([{ a: 1 }]);
   });
 
   it('pop returns popped item', () => {
@@ -36,6 +40,8 @@ describe('advancedArrayModify', () => {
     const { nextArray, result } = advancedArrayModify('pop', arr, null, logger);
     expect(nextArray).toEqual([1]);
     expect(result).toBe(2);
+    expect(arr).toEqual([1, 2]);
+    expect(nextArray).not.toBe(arr);
   });
 
   it('remove_by_value removes object by deep match', () => {
@@ -48,5 +54,20 @@ describe('advancedArrayModify', () => {
       logger
     );
     expect(nextArray).toEqual([{ id: 2 }]);
+    expect(arr).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(nextArray).not.toBe(arr);
+  });
+
+  it('remove_by_value returns new array when value not found', () => {
+    const arr = [1, 2];
+    const { nextArray } = advancedArrayModify(
+      'remove_by_value',
+      arr,
+      3,
+      logger
+    );
+    expect(nextArray).toEqual([1, 2]);
+    expect(nextArray).not.toBe(arr);
+    expect(arr).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
Summary: ensure immutability for array modification helpers and update tests.

Changes Made:
- refactored `advancedArrayModify` to always return new arrays and provide a `modified` flag
- updated `ModifyArrayFieldHandler` to use the flag for logging
- expanded unit tests covering immutability behavior

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - fails with existing repository errors)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)

------
https://chatgpt.com/codex/tasks/task_e_685829abead083318f738085bc7b0e3d