### PR TITLE
[Agent] add component value validator

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -98,16 +98,7 @@ class AddComponentHandler extends ComponentOperationHandler {
     }
 
     // 4. Validate value object
-    if (typeof value !== 'object' || value === null) {
-      log.warn(
-        'ADD_COMPONENT: Invalid or missing "value" parameter (must be a non-null object).'
-      );
-      return;
-    }
-    if (typeof value !== 'object' || value === null) {
-      log.warn(
-        'ADD_COMPONENT: Invalid or missing "value" parameter (must be a non-null object).'
-      );
+    if (!this.#validateValueObject(value, log)) {
       return;
     }
 
@@ -129,6 +120,24 @@ class AddComponentHandler extends ComponentOperationHandler {
         },
       });
     }
+  }
+
+  /**
+   * Validate that the provided component value is a non-null object.
+   *
+   * @param {*} value - Raw component value parameter.
+   * @param {ILogger} logger - Logger used for warning output.
+   * @returns {boolean} `true` when valid, `false` otherwise.
+   * @private
+   */
+  #validateValueObject(value, logger) {
+    if (typeof value !== 'object' || value === null) {
+      logger.warn(
+        'ADD_COMPONENT: Invalid or missing "value" parameter (must be a non-null object).'
+      );
+      return false;
+    }
+    return true;
   }
 }
 


### PR DESCRIPTION
Summary:
- create `#validateValueObject` helper in `addComponentHandler`
- call the new helper when executing add component operations

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6858349c61088331a1b71e7a67859017