### PR TITLE
[Agent] Add directive resolver injection

### DIFF
--- a/src/turns/factories/concreteTurnStateFactory.js
+++ b/src/turns/factories/concreteTurnStateFactory.js
@@ -7,6 +7,7 @@ import { AwaitingExternalTurnEndState } from '../states/awaitingExternalTurnEndS
 import { ProcessingCommandState } from '../states/processingCommandState.js';
 import { TurnEndingState } from '../states/turnEndingState.js';
 import { TurnIdleState } from '../states/turnIdleState.js';
+import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
 
 /**
  * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
@@ -55,8 +56,18 @@ export class ConcreteTurnStateFactory extends ITurnStateFactory {
    * @param {string} commandString
    * @param {ITurnAction} turnAction
    */
-  createProcessingCommandState(handler, commandString, turnAction) {
-    return new ProcessingCommandState(handler, commandString, turnAction);
+  createProcessingCommandState(
+    handler,
+    commandString,
+    turnAction,
+    directiveResolver = TurnDirectiveStrategyResolver
+  ) {
+    return new ProcessingCommandState(
+      handler,
+      commandString,
+      turnAction,
+      directiveResolver
+    );
   }
 
   /**

--- a/src/turns/interfaces/ITurnStateFactory.js
+++ b/src/turns/interfaces/ITurnStateFactory.js
@@ -69,9 +69,15 @@ export class ITurnStateFactory {
    * @param {ITurnStateHost} handler
    * @param {string} commandString - The command string to be processed.
    * @param {ITurnAction} turnAction - The turn action associated with the command.
+   * @param {{ resolveStrategy(directive: string): ITurnDirectiveStrategy }} [directiveResolver]
    * @returns {ITurnState} The created processing command state.
    */
-  createProcessingCommandState(handler, commandString, turnAction) {
+  createProcessingCommandState(
+    handler,
+    commandString,
+    turnAction,
+    directiveResolver
+  ) {
     throw new Error(
       'ITurnStateFactory.createProcessingCommandState must be implemented by concrete classes.'
     );

--- a/src/turns/states/helpers/processCommandInternal.js
+++ b/src/turns/states/helpers/processCommandInternal.js
@@ -9,7 +9,6 @@
  * @typedef {import('../../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
  */
 
-import TurnDirectiveStrategyResolver from '../../strategies/turnDirectiveStrategyResolver.js';
 import { getServiceFromContext } from './getServiceFromContext.js';
 import { ProcessingExceptionHandler } from './processingExceptionHandler.js';
 import { finishProcessing } from './processingErrorUtils.js';
@@ -151,7 +150,7 @@ export async function executeDirectiveStrategy(
   const actorId = activeTurnCtx.getActor()?.id ?? 'UnknownActor';
 
   const directiveStrategy =
-    TurnDirectiveStrategyResolver.resolveStrategy(directiveType);
+    state._directiveResolver.resolveStrategy(directiveType);
   if (!directiveStrategy) {
     const errorMsg = `${state.getStateName()}: Could not resolve ITurnDirectiveStrategy for directive '${directiveType}' (actor ${actorId}).`;
     logger.error(errorMsg);

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -21,6 +21,7 @@ import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
 import { getLogger } from './helpers/contextUtils.js';
+import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
 
 /**
  * @class ProcessingCommandState
@@ -29,6 +30,7 @@ import { getLogger } from './helpers/contextUtils.js';
 export class ProcessingCommandState extends AbstractTurnState {
   _isProcessing = false;
   _processingGuard;
+  _directiveResolver = TurnDirectiveStrategyResolver;
   #turnActionToProcess = null;
   #commandStringForLog = null;
 
@@ -64,10 +66,17 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {BaseTurnHandler} handler - The turn handler managing this state.
    * @param {string} [commandString]
    * @param {ITurnAction} [turnAction]
+   * @param {{ resolveStrategy(directive: string): ITurnDirectiveStrategy }} [directiveResolver]
    */
-  constructor(handler, commandString, turnAction = null) {
+  constructor(
+    handler,
+    commandString,
+    turnAction = null,
+    directiveResolver = TurnDirectiveStrategyResolver
+  ) {
     super(handler);
     this._processingGuard = new ProcessingGuard(this);
+    this._directiveResolver = directiveResolver;
     finishProcessing(this);
     this.#turnActionToProcess = turnAction;
     this.#commandStringForLog =


### PR DESCRIPTION
Summary:
- inject TurnDirectiveStrategyResolver into ProcessingCommandState
- expose resolver through factories and interfaces
- call state-provided resolver in executeDirectiveStrategy

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 621 errors, 2398 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685837314138833181f2f8382436d79c