### PR TITLE
[Agent] organize stop tests with initialized suite

### DIFF
--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -1,7 +1,17 @@
 // tests/engine/stop.test.js
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": [
+  "expect",
+  "expectStopSuccess",
+  "expectDispatchSequence",
+  "expectEngineRunning",
+  "expectEngineStopped"
+] }] */
+import {
+  describeEngineSuite,
+  describeInitializedEngineSuite,
+} from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
@@ -19,12 +29,45 @@ describeEngineSuite('GameEngine', (ctx) => {
       // Ensure engine is fresh for each 'stop' test
     });
 
-    it('should successfully stop a running game, with correct logging, events, and state changes', async () => {
-      await ctx.bed.startAndReset(DEFAULT_TEST_WORLD);
+    describeInitializedEngineSuite(
+      'when engine is initialized',
+      (ctx) => {
+        it('should successfully stop a running game, with correct logging, events, and state changes', async () => {
+          await ctx.engine.stop();
+          expectStopSuccess(ctx.bed, ctx.engine);
+        });
 
-      await ctx.engine.stop();
-      expectStopSuccess(ctx.bed, ctx.engine);
-    });
+        runUnavailableServiceSuite(
+          [
+            [
+              tokens.PlaytimeTracker,
+              'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
+              { preInit: true },
+            ],
+          ],
+          async (bed, engine, expectedMsg) => {
+            expectEngineRunning(engine, DEFAULT_TEST_WORLD);
+
+            await engine.stop();
+
+            // eslint-disable-next-line jest/no-standalone-expect
+            expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
+            expectDispatchSequence(
+              bed.mocks.safeEventDispatcher.dispatch,
+              ...buildStopDispatches()
+            );
+            // eslint-disable-next-line jest/no-standalone-expect
+            expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+            const dummyDispatch = jest.fn();
+            return [bed.mocks.logger.warn, dummyDispatch];
+          },
+          4
+        )(
+          'should log warning for %s if it is not available during stop, after a successful start'
+        );
+      },
+      DEFAULT_TEST_WORLD
+    );
 
     it('should do nothing and log if engine is already stopped', async () => {
       // ctx.engine is fresh, so not initialized
@@ -40,32 +83,5 @@ describeEngineSuite('GameEngine', (ctx) => {
         ctx.bed.mocks.safeEventDispatcher.dispatch
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
-
-    runUnavailableServiceSuite(
-      [
-        [
-          tokens.PlaytimeTracker,
-          'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
-          { preInit: true },
-        ],
-      ],
-      async (bed, engine, expectedMsg) => {
-        expectEngineRunning(engine, DEFAULT_TEST_WORLD);
-
-        await engine.stop();
-
-        expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
-        expectDispatchSequence(
-          bed.mocks.safeEventDispatcher.dispatch,
-          ...buildStopDispatches()
-        );
-        expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
-        const dummyDispatch = jest.fn();
-        return [bed.mocks.logger.warn, dummyDispatch];
-      },
-      4
-    )(
-      'should log warning for %s if it is not available during stop, after a successful start'
-    );
   });
 });


### PR DESCRIPTION
Summary: Grouped stop tests requiring a running engine under `describeInitializedEngineSuite`, removed redundant manual initialization, and added ESLint hints.

Testing Done:
- [x] Code formatted     `npx prettier --write tests/unit/engine/stop.test.js`
- [x] Lint passes        `npx eslint tests/unit/engine/stop.test.js`
- [x] Root tests         `npm test`
- [x] Proxy tests        `cd llm-proxy-server && npm test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68583738b15483318bb14afd463dea71