### PR TITLE
[Agent] centralize loader types constant

### DIFF
--- a/tests/common/loaders/loaderConstants.js
+++ b/tests/common/loaders/loaderConstants.js
@@ -1,0 +1,13 @@
+/**
+ * Default content loader types used across ModsLoader tests.
+ *
+ * @type {string[]}
+ */
+export const DEFAULT_LOADER_TYPES = [
+  'Action',
+  'Component',
+  'Condition',
+  'Event',
+  'Rule',
+  'Entity',
+];

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -21,20 +21,14 @@ import {
   createLoaderMocks,
 } from '../mockFactories';
 import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+import { DEFAULT_LOADER_TYPES } from './loaderConstants.js';
 
 /**
  * List of loader types used when generating mock loaders.
  *
  * @type {string[]}
  */
-const loaderTypes = [
-  'Action',
-  'Component',
-  'Condition',
-  'Event',
-  'Rule',
-  'Entity',
-];
+const loaderTypes = DEFAULT_LOADER_TYPES;
 
 const factoryMap = {
   mockRegistry: createStatefulMockDataRegistry,


### PR DESCRIPTION
## Summary
- add `DEFAULT_LOADER_TYPES` constant for loader tests
- use `DEFAULT_LOADER_TYPES` in `modsLoader.test-setup`

## Testing
- `npx prettier --write tests/common/loaders/loaderConstants.js tests/common/loaders/modsLoader.test-setup.js`
- `npx eslint tests/common/loaders/loaderConstants.js tests/common/loaders/modsLoader.test-setup.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68583797712c8331a7e17241d02bcb02