### PR TITLE
[Agent] Add disk full error code handling

### DIFF
--- a/src/interfaces/IStorageProvider.js
+++ b/src/interfaces/IStorageProvider.js
@@ -13,7 +13,11 @@ export class IStorageProvider {
    *
    * @param {string} filePath - The final path for the file.
    * @param {Uint8Array} data - The data to write.
-   * @returns {Promise<{success: boolean, error?: string}>}
+   * @returns {Promise<{
+   *   success: boolean,
+   *   error?: string,
+   *   code?: import('../storage/storageErrors.js').StorageErrorCodes
+   * }>}
    * @async
    */
   async writeFileAtomically(filePath, data) {

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -6,6 +6,7 @@ import {
 } from '../utils/savePathUtils.js';
 import SaveFileParser from './saveFileParser.js';
 import { PersistenceErrorCodes } from './persistenceErrors.js';
+import { StorageErrorCodes } from '../storage/storageErrors.js';
 import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
 import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
 import { BaseService } from '../utils/serviceBase.js';
@@ -116,10 +117,7 @@ export default class SaveFileRepository extends BaseService {
         `Failed to write manual save to ${filePath}: ${writeResult.error}`
       );
       let userError = `Failed to save game: ${writeResult.error}`;
-      if (
-        writeResult.error &&
-        writeResult.error.toLowerCase().includes('disk full')
-      ) {
+      if (writeResult.code === StorageErrorCodes.DISK_FULL) {
         userError = 'Failed to save game: Not enough disk space.';
       }
       return createPersistenceFailure(

--- a/src/storage/storageErrors.js
+++ b/src/storage/storageErrors.js
@@ -1,0 +1,7 @@
+export const StorageErrorCodes = {
+  DISK_FULL: 'DISK_FULL',
+};
+
+Object.freeze(StorageErrorCodes);
+
+export default StorageErrorCodes;

--- a/tests/unit/services/saveLoadService.edgeCases.test.js
+++ b/tests/unit/services/saveLoadService.edgeCases.test.js
@@ -11,6 +11,7 @@ import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { encode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
+import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 import SaveValidationService from '../../../src/persistence/saveValidationService.js';
@@ -314,6 +315,7 @@ describe('SaveLoadService edge cases', () => {
       storageProvider.writeFileAtomically.mockResolvedValue({
         success: false,
         error: 'disk full',
+        code: StorageErrorCodes.DISK_FULL,
       });
       const obj = {
         metadata: {},

--- a/tests/unit/services/saveLoadService.privateHelpers.test.js
+++ b/tests/unit/services/saveLoadService.privateHelpers.test.js
@@ -10,6 +10,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
 import {
   MSG_FILE_READ_ERROR,
   MSG_EMPTY_FILE,
@@ -233,6 +234,7 @@ describe('SaveLoadService new private helper error paths', () => {
     storageProvider.writeFileAtomically.mockResolvedValue({
       success: false,
       error: 'disk full',
+      code: StorageErrorCodes.DISK_FULL,
     });
     const obj = {
       metadata: {},


### PR DESCRIPTION
Summary:
- introduce `StorageErrorCodes` with a `DISK_FULL` value
- update `IStorageProvider.writeFileAtomically` docs to include optional error codes
- check for `StorageErrorCodes.DISK_FULL` when saving files
- adjust save load service tests for new error code

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 621 errors, 2397 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685838522c748331805b0c7a6a8e38fc