### PR TITLE
[Agent] refactor persistence services to use BaseService

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -1,5 +1,5 @@
 import { IGamePersistenceService } from '../interfaces/IGamePersistenceService.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -32,7 +32,7 @@ import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
  * @description Handles capturing, saving, and restoring game state.
  * @implements {IGamePersistenceService}
  */
-class GamePersistenceService extends IGamePersistenceService {
+class GamePersistenceService extends BaseService {
   #logger;
   #saveLoadService;
   #gameStateRestorer;
@@ -60,7 +60,7 @@ class GamePersistenceService extends IGamePersistenceService {
     gameStateRestorer,
   }) {
     super();
-    this.#logger = setupService('GamePersistenceService', logger, {
+    this.#logger = this._init('GamePersistenceService', logger, {
       saveLoadService: {
         value: saveLoadService,
         requiredMethods: ['saveManualGame', 'loadGameData'],
@@ -87,7 +87,7 @@ class GamePersistenceService extends IGamePersistenceService {
       },
     });
     this.#saveLoadService = saveLoadService;
-    // captureService dependencies validated via setupService
+    // captureService dependencies validated via BaseService
     this.#manualSaveCoordinator = manualSaveCoordinator;
     this.#gameStateRestorer = gameStateRestorer;
     this.#logger.debug('GamePersistenceService: Instance created.');

--- a/src/persistence/gameStateRestorer.js
+++ b/src/persistence/gameStateRestorer.js
@@ -1,6 +1,6 @@
 // src/persistence/gameStateRestorer.js
 
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 import {
   createPersistenceFailure,
   createPersistenceSuccess,
@@ -22,7 +22,7 @@ import {
  *
  * @class GameStateRestorer
  */
-class GameStateRestorer {
+class GameStateRestorer extends BaseService {
   /** @type {ILogger} */
   #logger;
   /** @type {EntityManager} */
@@ -39,7 +39,8 @@ class GameStateRestorer {
    * @param {PlaytimeTracker} deps.playtimeTracker - Playtime tracker.
    */
   constructor({ logger, entityManager, playtimeTracker }) {
-    this.#logger = setupService('GameStateRestorer', logger, {
+    super();
+    this.#logger = this._init('GameStateRestorer', logger, {
       entityManager: {
         value: entityManager,
         requiredMethods: ['clearAll', 'reconstructEntity'],

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -3,7 +3,9 @@ import GameStateCaptureService from '../../../src/persistence/gameStateCaptureSe
 import ManualSaveCoordinator from '../../../src/persistence/manualSaveCoordinator.js';
 import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
-import SaveFileParser from '../../../src/persistence/saveFileParser.js';
+import GameStateRestorer from '../../../src/persistence/gameStateRestorer.js';
+import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
+import { BaseService } from '../../../src/utils/serviceBase.js';
 import {
   createMockLogger,
   createMockSaveValidationService,
@@ -76,5 +78,30 @@ describe('Persistence service constructor validation', () => {
           parser,
         })
     ).toThrow();
+  });
+
+  it('GameStateRestorer extends BaseService', () => {
+    const restorer = new GameStateRestorer({
+      logger: createMockLogger(),
+      entityManager: { clearAll: jest.fn(), reconstructEntity: jest.fn() },
+      playtimeTracker: { setAccumulatedPlaytime: jest.fn() },
+    });
+    expect(restorer).toBeInstanceOf(BaseService);
+  });
+
+  it('GamePersistenceService extends BaseService', () => {
+    const service = new GamePersistenceService({
+      logger: createMockLogger(),
+      saveLoadService: { saveManualGame: jest.fn(), loadGameData: jest.fn() },
+      entityManager: { clearAll: jest.fn(), reconstructEntity: jest.fn() },
+      playtimeTracker: {
+        getTotalPlaytime: jest.fn(),
+        setAccumulatedPlaytime: jest.fn(),
+      },
+      gameStateCaptureService: { captureCurrentGameState: jest.fn() },
+      manualSaveCoordinator: { saveGame: jest.fn() },
+      gameStateRestorer: { restoreGameState: jest.fn() },
+    });
+    expect(service).toBeInstanceOf(BaseService);
   });
 });


### PR DESCRIPTION
## Summary
- derive `GameStateRestorer` and `GamePersistenceService` from `BaseService`
- use `this._init` for service initialization
- test inheritance from `BaseService`

## Testing Done
- ✅ `npm run lint` *(fails: 620 errors, 2393 warnings)*
- ✅ `npm run test`
- ✅ `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685838492de483319144156db0cdf8cd