### PR TITLE
[Agent] Extract helper for validation errors

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -17,6 +17,18 @@ import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { TARGET_DOMAIN_NONE } from '../constants/targetDomains.js';
 
 /**
+ * @description Helper for reporting argument validation errors.
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher for error events.
+ * @param {string} message - Error message to send.
+ * @param {object} [detail] - Optional error detail payload.
+ * @returns {null} Always returns `null`.
+ */
+function reportValidationError(dispatcher, message, detail) {
+  safeDispatchError(dispatcher, message, detail);
+  return null;
+}
+
+/**
  * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => (string|null)>} TargetFormatterMap
  */
 
@@ -148,20 +160,18 @@ export function formatActionCommand(
 
   // --- 1. Input Validation ---
   if (!actionDefinition || !actionDefinition.template) {
-    safeDispatchError(
+    return reportValidationError(
       dispatcher,
       'formatActionCommand: Invalid or missing actionDefinition or template.',
       { actionDefinition }
     );
-    return null;
   }
   if (!targetContext) {
-    safeDispatchError(
+    return reportValidationError(
       dispatcher,
       'formatActionCommand: Invalid or missing targetContext.',
       { targetContext }
     );
-    return null;
   }
   if (!entityManager || typeof entityManager.getEntityInstance !== 'function') {
     safeDispatchError(


### PR DESCRIPTION
Summary: Introduces `reportValidationError` utility in `actionFormatter.js` to reduce code duplication when handling invalid parameters.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68583747c5148331911b07d5c93533c7