### PR TITLE
[Agent] Add dispatch UI helpers for tests

### DIFF
--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -14,6 +14,8 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
   ENGINE_STOPPED_UI,
+  REQUEST_SHOW_LOAD_GAME_UI,
+  REQUEST_SHOW_SAVE_GAME_UI,
 } from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
@@ -240,6 +242,26 @@ export const expectComponentRemovedDispatch = createDispatchAsserter(
     componentTypeId,
     oldComponentData: oldData,
   })
+);
+
+/**
+ * @description Asserts that the engine dispatched a request to show the Load Game UI.
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @returns {void}
+ */
+export const expectShowLoadGameUIDispatch = createDispatchAsserter(
+  REQUEST_SHOW_LOAD_GAME_UI,
+  () => ({})
+);
+
+/**
+ * @description Asserts that the engine dispatched a request to show the Save Game UI.
+ * @param {import('@jest/globals').Mock} mock - Mocked dispatch function.
+ * @returns {void}
+ */
+export const expectShowSaveGameUIDispatch = createDispatchAsserter(
+  REQUEST_SHOW_SAVE_GAME_UI,
+  () => ({})
 );
 
 /**

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -1,9 +1,9 @@
 // tests/engine/showLoadGameUI.test.js
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import { REQUEST_SHOW_LOAD_GAME_UI } from '../../../src/constants/eventIds.js';
+import { expectShowLoadGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('showLoadGameUI', () => {
@@ -13,13 +13,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
       );
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        REQUEST_SHOW_LOAD_GAME_UI,
-        {}
-      );
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledTimes(
-        1
-      );
+      expectShowLoadGameUIDispatch(ctx.bed.mocks.safeEventDispatcher.dispatch);
     });
 
     runUnavailableServiceSuite(

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -3,10 +3,8 @@ import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeInitializedEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import {
-  REQUEST_SHOW_SAVE_GAME_UI,
-  CANNOT_SAVE_GAME_INFO,
-} from '../../../src/constants/eventIds.js';
+import { CANNOT_SAVE_GAME_INFO } from '../../../src/constants/eventIds.js';
+import { expectShowSaveGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 
 describeInitializedEngineSuite(
@@ -25,13 +23,9 @@ describeInitializedEngineSuite(
         expect(
           ctx.bed.mocks.gamePersistenceService.isSavingAllowed
         ).toHaveBeenCalledWith(true); // engine is initialized
-        expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-          REQUEST_SHOW_SAVE_GAME_UI,
-          {}
-        );
-        expect(
+        expectShowSaveGameUIDispatch(
           ctx.bed.mocks.safeEventDispatcher.dispatch
-        ).toHaveBeenCalledTimes(1);
+        );
       });
 
       it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', () => {
@@ -63,6 +57,7 @@ describeInitializedEngineSuite(
         ],
         (bed, engine) => {
           engine.showSaveGameUI();
+          // eslint-disable-next-line jest/no-standalone-expect
           expect(
             bed.mocks.gamePersistenceService.isSavingAllowed
           ).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary: Added helper functions to assert load/save UI dispatch events and updated related tests.

Changes Made:
- Introduced `expectShowLoadGameUIDispatch` and `expectShowSaveGameUIDispatch` in `dispatchTestUtils.js`.
- Refactored `showLoadGameUI.test.js` and `showSaveGameUI.test.js` to use new helpers.

Testing Done:
- [x] Code formatted (`npx prettier` on changed files)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68583e8fc43c8331922cf08b66e47e25