### PR TITLE
[Feat] add context method validator

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -17,6 +17,7 @@ import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 import {
   assertValidActor,
   assertMatchingActor,
+  validateContextMethods,
 } from './helpers/validationUtils.js';
 
 /**
@@ -46,7 +47,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
       'requestProcessingCommandStateTransition',
       'endTurn',
     ];
-    const missing = required.filter((m) => typeof ctx[m] !== 'function');
+    const missing = validateContextMethods(ctx, required);
     if (missing.length) {
       getLogger(ctx, this._handler).error(
         `${this.getStateName()}: ITurnContext missing required methods: ${missing.join(', ')}`

--- a/src/turns/states/helpers/validationUtils.js
+++ b/src/turns/states/helpers/validationUtils.js
@@ -39,3 +39,16 @@ export function assertMatchingActor(expectedActor, contextActor, stateName) {
   }
   return null;
 }
+
+/**
+ * @description Validates that the provided context exposes required methods.
+ * @param {object|null} ctx - ITurnContext-like object to inspect.
+ * @param {string[]} methods - Method names expected on the context.
+ * @returns {string[]} Array of method names that are missing or not functions.
+ */
+export function validateContextMethods(ctx, methods) {
+  if (!ctx) {
+    return [...methods];
+  }
+  return methods.filter((m) => typeof ctx[m] !== 'function');
+}

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -21,6 +21,7 @@ import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
 import { getLogger } from './helpers/contextUtils.js';
+import { validateContextMethods } from './helpers/validationUtils.js';
 import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
 
 /**
@@ -49,7 +50,7 @@ export class ProcessingCommandState extends AbstractTurnState {
       'getChosenAction',
       'getSafeEventDispatcher',
     ];
-    const missing = required.filter((m) => typeof ctx[m] !== 'function');
+    const missing = validateContextMethods(ctx, required);
     if (missing.length) {
       getLogger(ctx, this._handler).error(
         `${this.getStateName()}: ITurnContext missing required methods: ${missing.join(', ')}`

--- a/tests/unit/turns/states/helpers/validationUtils.test.js
+++ b/tests/unit/turns/states/helpers/validationUtils.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@jest/globals';
 import {
   assertValidActor,
   assertMatchingActor,
+  validateContextMethods,
 } from '../../../../../src/turns/states/helpers/validationUtils.js';
 
 const makeActor = (id = 'a1') => ({ id });
@@ -26,5 +27,15 @@ describe('validationUtils', () => {
     expect(assertMatchingActor(expected, ctx, 'State')).toMatch(
       /does not match/
     );
+  });
+
+  test('validateContextMethods detects missing methods', () => {
+    const ctx = { a: () => {}, b: 1 };
+    expect(validateContextMethods(ctx, ['a', 'b', 'c'])).toEqual(['b', 'c']);
+  });
+
+  test('validateContextMethods returns empty array when all present', () => {
+    const ctx = { x() {} };
+    expect(validateContextMethods(ctx, ['x'])).toEqual([]);
   });
 });


### PR DESCRIPTION
Summary: Added a helper to validate required context methods and integrated it into ProcessingCommandState and AwaitingActorDecisionState.

Changes Made:
- Created `validateContextMethods` in validationUtils.
- Updated ProcessingCommandState and AwaitingActorDecisionState to use the helper.
- Extended unit tests for validationUtils.

Testing Done:
- [x] Code formatted (`npx prettier` on changed files)
- [x] Lint run (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68583e856b388331aff0103bdc78ce8b