### PR TITLE
[Agent] Refactor turnManager tests with helpers

### DIFF
--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -60,7 +60,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     it('should handle subscription failure gracefully (invalid return value)', async () => {
       testBed.mocks.dispatcher.subscribe.mockReturnValue(null);
-      const stopSpy = testBed.spyOnStop();
+      const stopSpy = testBed.setupStopSpyNoOp();
       await testBed.turnManager.start();
       expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
@@ -95,7 +95,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
       testBed.mocks.dispatcher.subscribe.mockImplementation(() => {
         throw subscribeError;
       });
-      const stopSpy = testBed.spyOnStop();
+      const stopSpy = testBed.setupStopSpyNoOp();
       await testBed.turnManager.start();
       expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,


### PR DESCRIPTION
## Summary
- use `setupStopSpyNoOp` for lifecycle tests
- simplify roundLifecycle setup with `addDefaultActors`
- replace queue mocks with `mockNextActor` and `mockEmptyQueue`

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 619 errors)*
- [x] `npm run test tests/unit/turns/turnManager.roundLifecycle.test.js tests/unit/turns/turnManager.lifecycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68583ed31c388331b6a6f3d045849e2b