### PR TITLE
[Agent] streamline handler dep checks

### DIFF
--- a/src/logic/operationHandlers/breakFollowRelationHandler.js
+++ b/src/logic/operationHandlers/breakFollowRelationHandler.js
@@ -36,30 +36,6 @@ class BreakFollowRelationHandler extends BaseOperationHandler {
     rebuildLeaderListCacheHandler,
     safeEventDispatcher,
   }) {
-    if (!logger || typeof logger.debug !== 'function') {
-      throw new Error('BreakFollowRelationHandler requires a valid ILogger');
-    }
-    if (!entityManager || typeof entityManager.removeComponent !== 'function') {
-      throw new Error(
-        'BreakFollowRelationHandler requires a valid EntityManager'
-      );
-    }
-    if (
-      !rebuildLeaderListCacheHandler ||
-      typeof rebuildLeaderListCacheHandler.execute !== 'function'
-    ) {
-      throw new Error(
-        'BreakFollowRelationHandler requires a valid RebuildLeaderListCacheHandler'
-      );
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      throw new Error(
-        'BreakFollowRelationHandler requires a valid ISafeEventDispatcher'
-      );
-    }
     super('BreakFollowRelationHandler', {
       logger: { value: logger },
       entityManager: {

--- a/src/logic/operationHandlers/establishFollowRelationHandler.js
+++ b/src/logic/operationHandlers/establishFollowRelationHandler.js
@@ -14,8 +14,9 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { FOLLOWING_COMPONENT_ID } from '../../constants/componentIds.js';
 import { wouldCreateCycle } from '../../utils/followUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+import BaseOperationHandler from './baseOperationHandler.js';
 
-class EstablishFollowRelationHandler {
+class EstablishFollowRelationHandler extends BaseOperationHandler {
   /** @type {ILogger} */
   #logger;
   /** @type {EntityManager} */
@@ -38,37 +39,26 @@ class EstablishFollowRelationHandler {
     rebuildLeaderListCacheHandler,
     safeEventDispatcher,
   }) {
-    if (!logger || typeof logger.debug !== 'function') {
-      throw new Error(
-        'EstablishFollowRelationHandler requires a valid ILogger'
-      );
-    }
-    if (!entityManager || typeof entityManager.addComponent !== 'function') {
-      throw new Error(
-        'EstablishFollowRelationHandler requires a valid EntityManager'
-      );
-    }
-    if (
-      !rebuildLeaderListCacheHandler ||
-      typeof rebuildLeaderListCacheHandler.execute !== 'function'
-    ) {
-      throw new Error(
-        'EstablishFollowRelationHandler requires a valid RebuildLeaderListCacheHandler'
-      );
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      throw new Error(
-        'EstablishFollowRelationHandler requires a valid ISafeEventDispatcher'
-      );
-    }
+    super('EstablishFollowRelationHandler', {
+      logger: { value: logger },
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['addComponent', 'getComponentData'],
+      },
+      rebuildLeaderListCacheHandler: {
+        value: rebuildLeaderListCacheHandler,
+        requiredMethods: ['execute'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#logger = logger;
     this.#entityManager = entityManager;
     this.#rebuildHandler = rebuildLeaderListCacheHandler;
     this.#dispatcher = safeEventDispatcher;
-    this.#logger.debug('[EstablishFollowRelationHandler] Initialized');
+    this.logger.debug('[EstablishFollowRelationHandler] Initialized');
   }
 
   /**

--- a/src/logic/operationHandlers/ifCoLocatedHandler.js
+++ b/src/logic/operationHandlers/ifCoLocatedHandler.js
@@ -13,8 +13,9 @@ import { POSITION_COMPONENT_ID } from '../../constants/componentIds.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import BaseOperationHandler from './baseOperationHandler.js';
 
-class IfCoLocatedHandler {
+class IfCoLocatedHandler extends BaseOperationHandler {
   /** @type {ILogger} */
   #logger;
   /** @type {EntityManager} */
@@ -37,13 +38,12 @@ class IfCoLocatedHandler {
     operationInterpreter,
     safeEventDispatcher,
   }) {
-    if (!logger?.debug) throw new Error('IfCoLocatedHandler requires ILogger');
-    if (!entityManager?.getComponentData)
-      throw new Error('IfCoLocatedHandler requires EntityManager');
-    if (!operationInterpreter?.execute)
-      throw new Error('IfCoLocatedHandler requires OperationInterpreter');
-    if (!safeEventDispatcher?.dispatch)
-      throw new Error('IfCoLocatedHandler requires ISafeEventDispatcher');
+    super('IfCoLocatedHandler', {
+      logger: { value: logger },
+      entityManager: { value: entityManager, requiredMethods: ['getComponentData'] },
+      operationInterpreter: { value: operationInterpreter, requiredMethods: ['execute'] },
+      safeEventDispatcher: { value: safeEventDispatcher, requiredMethods: ['dispatch'] },
+    });
     this.#logger = logger;
     this.#entityManager = entityManager;
     this.#opInterpreter = operationInterpreter;

--- a/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
+++ b/src/logic/operationHandlers/rebuildLeaderListCacheHandler.js
@@ -7,13 +7,14 @@ import { isNonBlankString } from '../../utils/textUtils.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import BaseOperationHandler from './baseOperationHandler.js';
 
 /**
  * @class RebuildLeaderListCacheHandler
  * @description Handles the REBUILD_LEADER_LIST_CACHE operation by updating the
  *  'core:leading' component for a list of leader entities.
  */
-class RebuildLeaderListCacheHandler {
+class RebuildLeaderListCacheHandler extends BaseOperationHandler {
   #logger;
   #entityManager;
   #dispatcher;
@@ -25,38 +26,26 @@ class RebuildLeaderListCacheHandler {
    * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for error events.
    */
   constructor({ logger, entityManager, safeEventDispatcher }) {
-    if (
-      !logger ||
-      typeof logger.debug !== 'function' ||
-      typeof logger.error !== 'function' ||
-      typeof logger.warn !== 'function'
-    ) {
-      throw new TypeError(
-        'RebuildLeaderListCacheHandler requires a valid ILogger.'
-      );
-    }
-    if (
-      !entityManager ||
-      typeof entityManager.getEntitiesWithComponent !== 'function' ||
-      typeof entityManager.getEntityInstance !== 'function' ||
-      typeof entityManager.addComponent !== 'function'
-    ) {
-      throw new TypeError(
-        'RebuildLeaderListCacheHandler requires a valid IEntityManager.'
-      );
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.dispatch !== 'function'
-    ) {
-      throw new TypeError(
-        'RebuildLeaderListCacheHandler requires a valid ISafeEventDispatcher.'
-      );
-    }
+    super('RebuildLeaderListCacheHandler', {
+      logger: { value: logger },
+      entityManager: {
+        value: entityManager,
+        requiredMethods: [
+          'getEntitiesWithComponent',
+          'getEntityInstance',
+          'addComponent',
+          'removeComponent',
+        ],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#logger = logger;
     this.#entityManager = entityManager;
     this.#dispatcher = safeEventDispatcher;
-    this.#logger.debug('[RebuildLeaderListCacheHandler] Initialized.');
+    this.logger.debug('[RebuildLeaderListCacheHandler] Initialized.');
   }
 
   /**

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -15,24 +15,25 @@ import { resolveEntityId } from '../../utils/entityRefUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import BaseOperationHandler from './baseOperationHandler.js';
 
-class SystemMoveEntityHandler {
+class SystemMoveEntityHandler extends BaseOperationHandler {
   /** @type {ILogger} */ #logger;
   /** @type {EntityManager} */ #entityManager;
   /** @type {ISafeEventDispatcher} */ #dispatcher;
 
   constructor({ entityManager, safeEventDispatcher, logger }) {
-    if (!logger?.debug)
-      throw new Error('SystemMoveEntityHandler requires ILogger');
-    if (
-      !entityManager ||
-      typeof entityManager.getComponentData !== 'function' ||
-      typeof entityManager.addComponent !== 'function'
-    ) {
-      throw new Error('SystemMoveEntityHandler requires EntityManager');
-    }
-    if (!safeEventDispatcher?.dispatch)
-      throw new Error('SystemMoveEntityHandler needs ISafeEventDispatcher');
+    super('SystemMoveEntityHandler', {
+      logger: { value: logger },
+      entityManager: {
+        value: entityManager,
+        requiredMethods: ['getComponentData', 'addComponent'],
+      },
+      safeEventDispatcher: {
+        value: safeEventDispatcher,
+        requiredMethods: ['dispatch'],
+      },
+    });
     this.#entityManager = entityManager;
     this.#dispatcher = safeEventDispatcher;
     this.#logger = logger;

--- a/tests/unit/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
+++ b/tests/unit/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
@@ -96,7 +96,7 @@ describe('RebuildLeaderListCacheHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: makeMockDispatcher(),
           })
-      ).toThrow('RebuildLeaderListCacheHandler requires a valid ILogger.');
+      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
       expect(
         () =>
           new RebuildLeaderListCacheHandler({
@@ -104,14 +104,14 @@ describe('RebuildLeaderListCacheHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: makeMockDispatcher(),
           })
-      ).toThrow('RebuildLeaderListCacheHandler requires a valid ILogger.');
+      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
     });
 
     test('should throw a TypeError if the entity manager dependency is missing or invalid', () => {
       expect(
         () => new RebuildLeaderListCacheHandler({ logger: mockLogger })
       ).toThrow(
-        'RebuildLeaderListCacheHandler requires a valid IEntityManager.'
+        'Missing required dependency: RebuildLeaderListCacheHandler: entityManager.'
       );
       expect(
         () =>
@@ -121,7 +121,7 @@ describe('RebuildLeaderListCacheHandler', () => {
             safeEventDispatcher: makeMockDispatcher(),
           })
       ).toThrow(
-        'RebuildLeaderListCacheHandler requires a valid IEntityManager.'
+        "Invalid or missing method 'getEntitiesWithComponent' on dependency 'RebuildLeaderListCacheHandler: entityManager'."
       );
     });
 
@@ -132,7 +132,9 @@ describe('RebuildLeaderListCacheHandler', () => {
             logger: mockLogger,
             entityManager: mockEntityManager,
           })
-      ).toThrow(/ISafeEventDispatcher/);
+      ).toThrow(
+        'Missing required dependency: RebuildLeaderListCacheHandler: safeEventDispatcher.'
+      );
       expect(
         () =>
           new RebuildLeaderListCacheHandler({
@@ -140,7 +142,9 @@ describe('RebuildLeaderListCacheHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: {},
           })
-      ).toThrow(/ISafeEventDispatcher/);
+      ).toThrow(
+        "Invalid or missing method 'dispatch' on dependency 'RebuildLeaderListCacheHandler: safeEventDispatcher'."
+      );
     });
 
     test('should initialize successfully with valid dependencies', () => {
@@ -153,7 +157,7 @@ describe('RebuildLeaderListCacheHandler', () => {
           })
       ).not.toThrow();
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[RebuildLeaderListCacheHandler] Initialized.'
+        'RebuildLeaderListCacheHandler: [RebuildLeaderListCacheHandler] Initialized.'
       );
     });
   });


### PR DESCRIPTION
## Summary
- rely on BaseOperationHandler for dependency validation
- remove manual typeof checks in operation handlers
- update tests for new validation messages

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68583e6058c0833193216c1a1e408a86