### PR TITLE
[Agent] share component validation util

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -21,10 +21,7 @@ import Entity from './entity.js';
 import EntityInstanceData from './entityInstanceData.js';
 import { MapManager } from '../utils/mapManagerUtils.js';
 import EntityFactory from './factories/entityFactory.js';
-import {
-  validationSucceeded,
-  formatValidationErrors,
-} from './utils/validationHelpers.js';
+import { validateAndClone as validateAndCloneUtil } from './utils/componentValidation.js';
 import {
   validateAddComponentParams as validateAddComponentParamsUtil,
   validateRemoveComponentParams as validateRemoveComponentParamsUtil,
@@ -69,8 +66,8 @@ import {
 /* Internal Utilities                                                         */
 
 /* -------------------------------------------------------------------------- */
-// validationSucceeded and formatValidationErrors imported from
-// ./utils/validationHelpers.js
+// validateAndCloneUtil imported from
+// ./utils/componentValidation.js
 
 // assertInterface removed; using validateDependency instead
 
@@ -242,15 +239,14 @@ class EntityManager extends IEntityManager {
    * @returns {object} The validated (and potentially cloned/modified by validator) data.
    */
   #validateAndClone(componentTypeId, data, errorContext) {
-    const clone = this.#cloner(data);
-    const result = this.#validator.validate(componentTypeId, clone);
-    if (!validationSucceeded(result)) {
-      const details = formatValidationErrors(result);
-      const msg = `${errorContext} Errors:\n${details}`;
-      this.#logger.error(msg);
-      throw new Error(msg);
-    }
-    return clone;
+    return validateAndCloneUtil(
+      componentTypeId,
+      data,
+      this.#validator,
+      this.#logger,
+      errorContext,
+      this.#cloner
+    );
   }
 
   /**

--- a/src/entities/factories/entityFactory.js
+++ b/src/entities/factories/entityFactory.js
@@ -27,10 +27,7 @@ import { injectDefaultComponents } from '../utils/defaultComponentInjector.js';
 import { validateDependency } from '../../utils/validationUtils.js';
 import { ensureValidLogger } from '../../utils';
 import { DefinitionNotFoundError } from '../../errors/definitionNotFoundError.js';
-import {
-  validationSucceeded,
-  formatValidationErrors,
-} from '../utils/validationHelpers.js';
+import { validateAndClone as validateAndCloneUtil } from '../utils/componentValidation.js';
 
 /* -------------------------------------------------------------------------- */
 /* Type-Hint Imports (JSDoc only – removed at runtime)                        */
@@ -47,8 +44,8 @@ import {
 /* Internal Utilities                                                         */
 /* -------------------------------------------------------------------------- */
 
-// validationSucceeded and formatValidationErrors imported from
-// ../utils/validationHelpers.js
+// validateAndCloneUtil imported from
+// ../utils/componentValidation.js
 
 /* -------------------------------------------------------------------------- */
 /* EntityFactory Implementation                                               */
@@ -122,15 +119,14 @@ class EntityFactory {
    * @returns {object} The validated (and potentially cloned/modified by validator) data.
    */
   #validateAndClone(componentTypeId, data, errorContext) {
-    const clone = this.#cloner(data);
-    const result = this.#validator.validate(componentTypeId, clone);
-    if (!validationSucceeded(result)) {
-      const details = formatValidationErrors(result);
-      const msg = `${errorContext} Errors:\n${details}`;
-      this.#logger.error(`[EntityFactory] ${msg}`);
-      throw new Error(msg);
-    }
-    return clone;
+    return validateAndCloneUtil(
+      componentTypeId,
+      data,
+      this.#validator,
+      this.#logger,
+      `[EntityFactory] ${errorContext}`,
+      this.#cloner
+    );
   }
 
   /**

--- a/src/entities/utils/componentValidation.js
+++ b/src/entities/utils/componentValidation.js
@@ -1,0 +1,41 @@
+// src/entities/utils/componentValidation.js
+
+import {
+  validationSucceeded,
+  formatValidationErrors,
+} from './validationHelpers.js';
+
+/**
+ * Validate component data and return a deep clone.
+ *
+ * @description
+ * Shared helper used by EntityManager and EntityFactory to validate and clone
+ * component payloads with consistent error handling.
+ * @param {string} componentTypeId - Component type ID.
+ * @param {object} data - Raw component data to validate and clone.
+ * @param {import('../../interfaces/coreServices.js').IValidator} validator - Schema validator.
+ * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for reporting validation errors.
+ * @param {string} contextMsg - Context information for error messages.
+ * @param {function(object): object} cloner - Function used to deep clone the data.
+ * @returns {object} The validated (and cloned) data.
+ */
+export function validateAndClone(
+  componentTypeId,
+  data,
+  validator,
+  logger,
+  contextMsg,
+  cloner
+) {
+  const clone = cloner(data);
+  const result = validator.validate(componentTypeId, clone);
+  if (!validationSucceeded(result)) {
+    const details = formatValidationErrors(result);
+    const msg = `${contextMsg} Errors:\n${details}`;
+    logger.error(msg);
+    throw new Error(msg);
+  }
+  return clone;
+}
+
+export default validateAndClone;


### PR DESCRIPTION
## Summary
- centralize component data validation in new `componentValidation.js`
- reuse validation helper in `EntityManager` and `EntityFactory`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6858498d6cf88331be4c423985c2a264