### PR TITLE
[Agent] Share save constants across tests

### DIFF
--- a/tests/common/constants.js
+++ b/tests/common/constants.js
@@ -11,3 +11,17 @@ export const DEFAULT_TEST_WORLD = 'TestWorld';
  * @type {string}
  */
 export const DEFAULT_ACTIVE_WORLD_FOR_SAVE = 'TestWorldForSaving';
+
+/**
+ * Default save name used across test suites for saving games.
+ *
+ * @type {string}
+ */
+export const DEFAULT_SAVE_NAME = 'MySaveFile';
+
+/**
+ * Default save identifier used across test suites for loading games.
+ *
+ * @type {string}
+ */
+export const DEFAULT_SAVE_ID = 'savegame-001.sav';

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -7,10 +7,11 @@ import {
   runUnavailableServiceSuite,
   setupLoadGameSpies,
 } from '../../common/engine/gameEngineHelpers.js';
+import { DEFAULT_SAVE_ID } from '../../common/constants.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('loadGame', () => {
-    const SAVE_ID = 'savegame-001.sav';
+    const SAVE_ID = DEFAULT_SAVE_ID;
     const mockSaveData = {
       metadata: { gameTitle: 'My Loaded Game Adventure' },
     };
@@ -191,7 +192,10 @@ describeEngineSuite('GameEngine', (ctx) => {
       ],
       async (bed, engine, expectedMsg) => {
         const result = await engine.loadGame(SAVE_ID);
+
+        // eslint-disable-next-line jest/no-standalone-expect
         expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(result).toEqual({
           success: false,
           error: expectedMsg,

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -11,11 +11,14 @@ import {
   buildSaveDispatches,
   expectNoDispatch,
 } from '../../common/engine/dispatchTestUtils.js';
-import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../../common/constants.js';
+import {
+  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+  DEFAULT_SAVE_NAME,
+} from '../../common/constants.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('triggerManualSave', () => {
-    const SAVE_NAME = 'MySaveFile';
+    const SAVE_NAME = DEFAULT_SAVE_NAME;
     const MOCK_ACTIVE_WORLD_FOR_SAVE = DEFAULT_ACTIVE_WORLD_FOR_SAVE;
 
     it('should dispatch error and not attempt save if engine is not initialized', async () => {
@@ -43,7 +46,10 @@ describeEngineSuite('GameEngine', (ctx) => {
           ],
           async (bed, engine) => {
             const result = await engine.triggerManualSave(SAVE_NAME);
+
+            // eslint-disable-next-line jest/no-standalone-expect
             expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+            // eslint-disable-next-line jest/no-standalone-expect
             expect(result).toEqual({
               success: false,
               error:


### PR DESCRIPTION
Summary: Introduced DEFAULT_SAVE_NAME and DEFAULT_SAVE_ID for reuse in engine tests.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6858495d45f08331b6948ec7030dfe24