### PR TITLE
[Agent] add combined validation helper for component ops

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -77,25 +77,17 @@ class AddComponentHandler extends ComponentOperationHandler {
     const { entity_ref, component_type, value } = params;
 
     // 2. Resolve and validate entity reference
-    const entityId = this.validateEntityRef(
+    const validated = this.validateEntityAndType(
       entity_ref,
+      component_type,
       log,
       'ADD_COMPONENT',
       executionContext
     );
-    if (!entityId) {
+    if (!validated) {
       return;
     }
-
-    // 3. Validate component type
-    const trimmedComponentType = this.requireComponentType(
-      component_type,
-      log,
-      'ADD_COMPONENT'
-    );
-    if (!trimmedComponentType) {
-      return;
-    }
+    const { entityId, type: trimmedComponentType } = validated;
 
     // 4. Validate value object
     if (!this.#validateValueObject(value, log)) {

--- a/src/logic/operationHandlers/componentOperationHandler.js
+++ b/src/logic/operationHandlers/componentOperationHandler.js
@@ -91,6 +91,24 @@ class ComponentOperationHandler extends BaseOperationHandler {
     }
     return trimmed;
   }
+
+  /**
+   * Validate entity reference and component type together.
+   *
+   * @param {'actor'|'target'|string|EntityRefObject} entityRef
+   * @param {*} componentType
+   * @param {ILogger} logger
+   * @param {string} [opName]
+   * @param {ExecutionContext} ctx
+   * @returns {{ entityId: string, type: string } | null}
+   */
+  validateEntityAndType(entityRef, componentType, logger, opName, ctx) {
+    const entityId = this.validateEntityRef(entityRef, logger, opName, ctx);
+    if (!entityId) return null;
+    const type = this.requireComponentType(componentType, logger, opName);
+    if (!type) return null;
+    return { entityId, type };
+  }
 }
 
 export default ComponentOperationHandler;

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -195,25 +195,20 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
     if (!assertParamsObject(params, log, 'MODIFY_ARRAY_FIELD')) {
       return;
     }
-    // 1. Resolve and validate entity reference
-    const entityId = this.validateEntityRef(
-      params.entity_ref,
+    const { entity_ref, component_type, field, mode, result_variable, value } =
+      params;
+    const validated = this.validateEntityAndType(
+      entity_ref,
+      component_type,
       log,
       'MODIFY_ARRAY_FIELD',
       executionContext
     );
-    if (!entityId) {
+    if (!validated) {
       return;
     }
-
-    // 2. Validate Parameters
-    const { component_type, field, mode, result_variable, value } = params;
-    const compType = this.requireComponentType(
-      component_type,
-      log,
-      'MODIFY_ARRAY_FIELD'
-    );
-    if (!compType || !field || !mode) {
+    const { entityId, type: compType } = validated;
+    if (!field || !mode) {
       log.warn(
         `MODIFY_ARRAY_FIELD: Missing required parameters (component_type, field, or mode) for entity ${entityId}.`
       );

--- a/src/logic/operationHandlers/modifyComponentHandler.js
+++ b/src/logic/operationHandlers/modifyComponentHandler.js
@@ -75,26 +75,18 @@ class ModifyComponentHandler extends ComponentOperationHandler {
     }
     const { entity_ref, component_type, field, mode = 'set', value } = params;
 
-    // ── resolve and validate entity reference ───────────────────────
-    const entityId = this.validateEntityRef(
+    // ── validate entity and component type together ─────────────────
+    const validated = this.validateEntityAndType(
       entity_ref,
+      component_type,
       log,
       'MODIFY_COMPONENT',
       executionContext
     );
-    if (!entityId) {
+    if (!validated) {
       return;
     }
-
-    // ── validate component type ─────────────────────────────────────
-    const compType = this.requireComponentType(
-      component_type,
-      log,
-      'MODIFY_COMPONENT'
-    );
-    if (!compType) {
-      return;
-    }
+    const { entityId, type: compType } = validated;
     if (mode !== 'set') {
       log.warn(
         `MODIFY_COMPONENT: Unsupported mode "${mode}". Only "set" is allowed now.`

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -71,33 +71,22 @@ class QueryComponentHandler extends ComponentOperationHandler {
     const { entity_ref, component_type, result_variable, missing_value } =
       params;
 
-    const entityId = this.validateEntityRef(
+    const validated = this.validateEntityAndType(
       entity_ref,
+      component_type,
       logger,
       'QueryComponentHandler',
       executionContext
     );
-    if (!entityId) {
+    if (!validated) {
       safeDispatchError(
         this.#dispatcher,
-        'QueryComponentHandler: Could not resolve entity id from entity_ref.',
-        { entityRef: entity_ref }
-      );
-      return;
-    }
-    const trimmedComponentType = this.requireComponentType(
-      component_type,
-      logger,
-      'QueryComponentHandler'
-    );
-    if (!trimmedComponentType) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentHandler: Missing or invalid required "component_type" parameter (must be non-empty string).',
+        'QueryComponentHandler: Could not resolve entity id from entity_ref or component_type.',
         { params }
       );
       return;
     }
+    const { entityId, type: trimmedComponentType } = validated;
 
     if (typeof result_variable !== 'string' || !result_variable.trim()) {
       safeDispatchError(

--- a/src/logic/operationHandlers/queryComponentsHandler.js
+++ b/src/logic/operationHandlers/queryComponentsHandler.js
@@ -80,20 +80,6 @@ class QueryComponentsHandler extends ComponentOperationHandler {
 
     const { entity_ref, pairs } = params;
 
-    const entityId = this.validateEntityRef(
-      entity_ref,
-      logger,
-      'QueryComponentsHandler',
-      executionContext
-    );
-    if (!entityId) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentsHandler: Could not resolve entity id from entity_ref.',
-        { entityRef: entity_ref }
-      );
-      return;
-    }
     if (!Array.isArray(pairs) || pairs.length === 0) {
       safeDispatchError(
         this.#dispatcher,
@@ -106,19 +92,22 @@ class QueryComponentsHandler extends ComponentOperationHandler {
     for (const pair of pairs) {
       if (!pair || typeof pair !== 'object') continue;
       const { component_type, result_variable } = pair;
-      const trimmedType = this.requireComponentType(
+      const validated = this.validateEntityAndType(
+        entity_ref,
         component_type,
         logger,
-        'QueryComponentsHandler'
+        'QueryComponentsHandler',
+        executionContext
       );
-      if (!trimmedType) {
+      if (!validated) {
         safeDispatchError(
           this.#dispatcher,
-          'QueryComponentsHandler: Invalid component_type in pair.',
+          'QueryComponentsHandler: Invalid entity_ref or component_type in pair.',
           { pair }
         );
         continue;
       }
+      const { entityId, type: trimmedType } = validated;
       if (
         !result_variable ||
         typeof result_variable !== 'string' ||

--- a/src/logic/operationHandlers/removeComponentHandler.js
+++ b/src/logic/operationHandlers/removeComponentHandler.js
@@ -88,25 +88,17 @@ class RemoveComponentHandler extends ComponentOperationHandler {
     const { entity_ref, component_type } = params;
 
     // 2. Resolve and validate entity reference
-    const entityId = this.validateEntityRef(
+    const validated = this.validateEntityAndType(
       entity_ref,
+      component_type,
       log,
       'REMOVE_COMPONENT',
       executionContext
     );
-    if (!entityId) {
+    if (!validated) {
       return;
     }
-
-    // 3. Validate component type
-    const trimmedComponentType = this.requireComponentType(
-      component_type,
-      log,
-      'REMOVE_COMPONENT'
-    );
-    if (!trimmedComponentType) {
-      return;
-    }
+    const { entityId, type: trimmedComponentType } = validated;
 
     // 3. Execute Remove Component
     try {

--- a/tests/unit/logic/operationHandlers/queryComponentHandler.context.test.js
+++ b/tests/unit/logic/operationHandlers/queryComponentHandler.context.test.js
@@ -219,7 +219,9 @@ describe('QueryComponentHandler (Context Alignment Test Suite)', () => {
     expect(dispatcherMock.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: expect.stringContaining('"component_type"'),
+        message: expect.stringContaining(
+          'Could not resolve entity id from entity_ref or component_type.'
+        ),
       })
     );
     expect(entityManagerMock.getComponentData).not.toHaveBeenCalled();

--- a/tests/unit/logic/operationHandlers/queryComponentHandler.test.js
+++ b/tests/unit/logic/operationHandlers/queryComponentHandler.test.js
@@ -190,7 +190,9 @@ describe('QueryComponentHandler', () => {
       result_variable: 'targetPos',
     };
     const context = getMockContext();
-    mockEntityManager.getComponentData.mockReturnValue({ locationId: 'test:location' });
+    mockEntityManager.getComponentData.mockReturnValue({
+      locationId: 'test:location',
+    });
     handler.execute(params, context);
     expect(mockEntityManager.getComponentData).toHaveBeenCalledWith(
       mockTargetId,
@@ -387,7 +389,9 @@ describe('QueryComponentHandler', () => {
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: expect.stringContaining('"component_type" parameter'),
+        message: expect.stringContaining(
+          'Could not resolve entity id from entity_ref or component_type.'
+        ),
       })
     );
     expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();
@@ -400,7 +404,9 @@ describe('QueryComponentHandler', () => {
     expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: expect.stringContaining('"component_type" parameter'),
+        message: expect.stringContaining(
+          'Could not resolve entity id from entity_ref or component_type.'
+        ),
       })
     );
     expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add `validateEntityAndType` helper to `ComponentOperationHandler`
- streamline component handlers to use new validation method
- update associated tests

## Testing Done
- `npm run lint` *(fails: 629 errors, 2441 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68584925fa1c8331830832c1c45256ae