### PR TITLE
[Agent] Rename private save parser method

### DIFF
--- a/src/persistence/saveFileParser.js
+++ b/src/persistence/saveFileParser.js
@@ -64,10 +64,10 @@ export default class SaveFileParser extends BaseService {
    * Reads, decompresses and deserializes a save file.
    *
    * @param {string} filePath - File path to read.
-   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>}
-   *   Parsed object or failure info.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<import('../interfaces/ISaveLoadService.js').SaveGameStructure>>}
+   *   Parsed save object or failure info.
    */
-  async readAndDeserialize(filePath) {
+  async readParsedSaveObject(filePath) {
     return this.#deserializeAndDecompress(filePath);
   }
 
@@ -138,7 +138,7 @@ export default class SaveFileParser extends BaseService {
     this.#logger.debug(`Processing file: ${filePath}`);
 
     try {
-      const result = await this.readAndDeserialize(filePath);
+      const result = await this.readParsedSaveObject(filePath);
       if (!result.success || !result.data) {
         this.#logger.warn(
           `Failed to deserialize ${filePath}: ${result.error}. Flagging as corrupted for listing.`

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -52,7 +52,7 @@ export default class SaveFileRepository extends BaseService {
       },
       parser: {
         value: parser,
-        requiredMethods: ['parseManualSaveFile', 'readAndDeserialize'],
+        requiredMethods: ['parseManualSaveFile', 'readParsedSaveObject'],
       },
     });
     this.#storageProvider = storageProvider;
@@ -187,10 +187,10 @@ export default class SaveFileRepository extends BaseService {
    * Reads and deserializes a manual save file.
    *
    * @param {string} filePath - Full path to the save file.
-   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<object>>} Deserialized save data.
+   * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<import('../interfaces/ISaveLoadService.js').SaveGameStructure>>} Deserialized save data.
    */
   async readSaveFile(filePath) {
-    return this.#parser.readAndDeserialize(filePath);
+    return this.#parser.readParsedSaveObject(filePath);
   }
 
   /**


### PR DESCRIPTION
## Summary
- rename `readAndDeserialize` to `readParsedSaveObject`
- update SaveFileRepository to use the renamed method

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685848f754d48331b7a1ee04dd6f8913