### PR TITLE
[Agent] refactor test environment helpers

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -15,7 +15,7 @@ import {
   createMockSafeEventDispatcher,
   createMockInitializationService,
 } from '../mockFactories';
-import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+import { createServiceTestEnvironment } from '../mockEnvironment.js';
 const factoryMap = {
   logger: createMockLogger,
   entityManager: createMockEntityManager,
@@ -35,12 +35,6 @@ const tokenMap = {
   [tokens.ISafeEventDispatcher]: 'safeEventDispatcher',
   [tokens.IInitializationService]: 'initializationService',
 };
-
-const buildGameEngineEnv = createTestEnvironmentBuilder(
-  factoryMap,
-  tokenMap,
-  (container) => new GameEngine({ container })
-);
 
 /**
  * Creates a set of mocks and a container for GameEngine.
@@ -63,7 +57,12 @@ const buildGameEngineEnv = createTestEnvironmentBuilder(
  */
 export function createTestEnvironment(overrides = {}) {
   const { mocks, mockContainer, instance, cleanup } =
-    buildGameEngineEnv(overrides);
+    createServiceTestEnvironment(
+      factoryMap,
+      tokenMap,
+      (container) => new GameEngine({ container }),
+      overrides
+    );
   const createGameEngine = () => new GameEngine({ container: mockContainer });
 
   return {

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -20,7 +20,7 @@ import {
   createMockWorldLoader, // ← NEW import
   createLoaderMocks,
 } from '../mockFactories';
-import { createTestEnvironmentBuilder } from '../mockEnvironment.js';
+import { createServiceTestEnvironment } from '../mockEnvironment.js';
 import { DEFAULT_LOADER_TYPES } from './loaderConstants.js';
 
 /**
@@ -45,35 +45,31 @@ const factoryMap = {
   mockWorldLoader: createMockWorldLoader,
 };
 
-const buildModsLoaderEnv = createTestEnvironmentBuilder(
-  factoryMap,
-  {},
-  (mockContainer, m) => {
-    m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
-      [
-        'schema:game',
-        'schema:components',
-        'schema:mod-manifest',
-        'schema:entityDefinitions',
-        'schema:actions',
-        'schema:events',
-        'schema:rules',
-        'schema:conditions',
-        'schema:entityInstances',
-        'schema:goals',
-      ].includes(id)
-    );
-    m.mockModDependencyValidator.validate.mockImplementation(() => {});
-    m.mockModVersionValidator.mockImplementation(() => {});
-    m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
+const serviceFactory = (mockContainer, m) => {
+  m.mockValidator.isSchemaLoaded.mockImplementation((id) =>
+    [
+      'schema:game',
+      'schema:components',
+      'schema:mod-manifest',
+      'schema:entityDefinitions',
+      'schema:actions',
+      'schema:events',
+      'schema:rules',
+      'schema:conditions',
+      'schema:entityInstances',
+      'schema:goals',
+    ].includes(id)
+  );
+  m.mockModDependencyValidator.validate.mockImplementation(() => {});
+  m.mockModVersionValidator.mockImplementation(() => {});
+  m.mockModLoadOrderResolver.resolve.mockImplementation((ids) => ids);
 
-    return new ModsLoader({
-      logger: m.mockLogger,
-      cache: { clear: jest.fn(), snapshot: jest.fn(), restore: jest.fn() },
-      session: { run: jest.fn().mockResolvedValue({}) },
-    });
-  }
-);
+  return new ModsLoader({
+    logger: m.mockLogger,
+    cache: { clear: jest.fn(), snapshot: jest.fn(), restore: jest.fn() },
+    session: { run: jest.fn().mockResolvedValue({}) },
+  });
+};
 
 /**
  * Builds a fully mocked environment for ModsLoader tests.
@@ -86,7 +82,11 @@ export function createTestEnvironment() {
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);
 
-  const { mocks, instance: modsLoader, cleanup } = buildModsLoaderEnv();
+  const {
+    mocks,
+    instance: modsLoader,
+    cleanup,
+  } = createServiceTestEnvironment(factoryMap, {}, serviceFactory);
 
   /* ── Return the assembled environment ──────────────────────────────── */
   return {

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -133,7 +133,8 @@ export function createTestEnvironmentBuilder(factoryMap, tokenMap, createFn) {
  * Builds and immediately returns a test environment for a service.
  *
  * @description Convenience helper around {@link createTestEnvironmentBuilder}
- *   that invokes the returned builder with no overrides.
+ *   that invokes the returned builder. Overrides can be supplied to alter
+ *   token mappings per test.
  * @param {Record<string, () => any>} factoryMap - Map of mock factory
  *   functions to create.
  * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
@@ -141,6 +142,8 @@ export function createTestEnvironmentBuilder(factoryMap, tokenMap, createFn) {
  * @param {(container: any, mocks: Record<string, any>) => any} [createFn]
  *   Function returning the system under test when provided the mock container
  *   and generated mocks.
+ * @param {Record<string | symbol, any>} [overrides] - Per-test DI token
+ *   overrides.
  * @returns {{
  *   mocks: Record<string, any>,
  *   mockContainer: { resolve: jest.Mock },
@@ -149,7 +152,12 @@ export function createTestEnvironmentBuilder(factoryMap, tokenMap, createFn) {
  * }}
  *   Generated environment instance.
  */
-export function createServiceTestEnvironment(factoryMap, tokenMap, createFn) {
+export function createServiceTestEnvironment(
+  factoryMap,
+  tokenMap,
+  createFn,
+  overrides = {}
+) {
   const build = createTestEnvironmentBuilder(factoryMap, tokenMap, createFn);
-  return build();
+  return build(overrides);
 }


### PR DESCRIPTION
Summary: Consolidate environment setup using createServiceTestEnvironment.

Changes Made:
- Updated `gameEngine.test-environment.js` to construct environments via `createServiceTestEnvironment` with override support.
- Refactored `modsLoader.test-setup.js` to use the same helper and extracted service factory logic.
- Extended `createServiceTestEnvironment` in `mockEnvironment.js` to accept optional overrides.

Testing Done:
- [x] Code formatted (`npx prettier` on changed files)
- [x] Lint passes (`npx eslint` on changed files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685851c8f6a4833193fa14d8ace0a056