### PR TITLE
[Agent] unify dataFetcher mocks

### DIFF
--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -7,7 +7,6 @@ export * from './container.js';
 export {
   createMockPathResolver,
   createMockDataFetcher,
-  createMockDataFetcherForIntegration,
   createMockValidatedEventDispatcherForIntegration,
   createCapturingEventBus,
   createMockAIPromptPipeline,

--- a/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
+++ b/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
@@ -18,7 +18,7 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { registerLoaders } from '../../../src/dependencyInjection/registrations/loadersRegistrations.js';
 import ConsoleLogger from '../../../src/logging/consoleLogger.js';
 import {
-  createMockDataFetcherForIntegration,
+  createMockDataFetcher,
   createMockValidatedEventDispatcherForIntegration,
 } from '../../common/mockFactories/index.js';
 import ManifestPhase from '../../../src/loaders/phases/ManifestPhase.js';
@@ -97,7 +97,7 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
     // Register mock data fetcher AFTER loader registration to overwrite
     container.register(
       tokens.IDataFetcher,
-      createMockDataFetcherForIntegration()
+      createMockDataFetcher({ fromDisk: true })
     );
     // Register and load AjvSchemaValidator with schemas
     const schemaValidator = new AjvSchemaValidator(logger);
@@ -164,7 +164,7 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
     // Verify that entity instances are also loaded
     const allInstances = registry.getAll('entityInstances');
     expect(allInstances).toHaveLength(6);
-    expect(allInstances.map(i => i.instanceId)).toEqual(
+    expect(allInstances.map((i) => i.instanceId)).toEqual(
       expect.arrayContaining([
         'isekai:adventurers_guild_instance',
         'isekai:hero_instance',
@@ -176,7 +176,10 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
     );
 
     // Test individual instance retrieval
-    const instance = registry.get('entityInstances', 'isekai:adventurers_guild_instance');
+    const instance = registry.get(
+      'entityInstances',
+      'isekai:adventurers_guild_instance'
+    );
   });
 
   const MOD_ID = 'isekai';

--- a/tests/unit/loaders/promptTextLoader.test.js
+++ b/tests/unit/loaders/promptTextLoader.test.js
@@ -58,7 +58,9 @@ beforeEach(() => {
   configuration = createMockConfiguration();
   pathResolver = createMockPathResolver();
   dataFetcher = createMockDataFetcher({
-    '/path/prompts/corePromptText.json': { example: true },
+    pathToResponse: {
+      '/path/prompts/corePromptText.json': { example: true },
+    },
   });
   schemaValidator = createMockSchemaValidator();
   dataRegistry = createMockDataRegistry();

--- a/tests/unit/mockFactories/createMockDataFetcher.test.js
+++ b/tests/unit/mockFactories/createMockDataFetcher.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+
+import { describe, it, expect } from '@jest/globals';
+import { createMockDataFetcher } from '../../common/mockFactories/index.js';
+import fs from 'fs';
+
+describe('createMockDataFetcher (in-memory)', () => {
+  it('returns mapped data and clones results', async () => {
+    const data = { value: 1 };
+    const fetcher = createMockDataFetcher({
+      pathToResponse: { '/test/path': data },
+    });
+
+    const result1 = await fetcher.fetch('/test/path');
+    expect(result1).toEqual(data);
+    result1.value = 2;
+    const result2 = await fetcher.fetch('/test/path');
+    expect(result2).toEqual(data);
+  });
+
+  it('rejects for unmapped paths', async () => {
+    const fetcher = createMockDataFetcher();
+    await expect(fetcher.fetch('/missing')).rejects.toThrow('404');
+  });
+});
+
+describe('createMockDataFetcher (disk)', () => {
+  it('reads JSON files from disk when fromDisk is true', async () => {
+    const fetcher = createMockDataFetcher({ fromDisk: true });
+    const data = await fetcher.fetch('./data/game.json');
+    const actual = JSON.parse(fs.readFileSync('data/game.json', 'utf8'));
+    expect(data).toEqual(actual);
+  });
+});

--- a/tests/unit/services/macroLoader.happyPath.core.test.js
+++ b/tests/unit/services/macroLoader.happyPath.core.test.js
@@ -71,10 +71,12 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
         ),
       }),
       createMockDataFetcher({
-        [`./data/mods/${CORE_MOD_ID}/macros/logSuccessAndEndTurn.macro.json`]:
-          logSuccess,
-        [`./data/mods/${CORE_MOD_ID}/macros/logFailureAndEndTurn.macro.json`]:
-          logFailure,
+        pathToResponse: {
+          [`./data/mods/${CORE_MOD_ID}/macros/logSuccessAndEndTurn.macro.json`]:
+            logSuccess,
+          [`./data/mods/${CORE_MOD_ID}/macros/logFailureAndEndTurn.macro.json`]:
+            logFailure,
+        },
       }),
       createMockSchemaValidator(),
       mockRegistry,
@@ -101,7 +103,7 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
         _fullId: 'core:logSuccessAndEndTurn',
         description: logSuccess.description,
         actions: logSuccess.actions,
-        _modId: "core",
+        _modId: 'core',
       })
     );
     expect(mockRegistry.store).toHaveBeenCalledWith(
@@ -112,7 +114,7 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
         _fullId: 'core:logFailureAndEndTurn',
         description: logFailure.description,
         actions: logFailure.actions,
-        _modId: "core",
+        _modId: 'core',
       })
     );
 
@@ -126,7 +128,7 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
     const loader = new MacroLoader(
       realConfig,
       createMockPathResolver(),
-      createMockDataFetcher({}),
+      createMockDataFetcher(),
       createMockSchemaValidator(),
       mockRegistry,
       tempLogger


### PR DESCRIPTION
Summary:
- replace createMockDataFetcherForIntegration with an option on createMockDataFetcher
- update re-exports and tests to use the new API
- add unit tests for in-memory and disk based mock data fetcher

Testing Done:
- [ ] Code formatted `npx prettier --write tests/common/mockFactories/coreServices.js tests/common/mockFactories/index.js tests/integration/loaders/modsLoader.entityInstances.integration.test.js tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js tests/unit/services/macroLoader.happyPath.core.test.js tests/unit/loaders/promptTextLoader.test.js tests/unit/mockFactories/createMockDataFetcher.test.js`
- [ ] Lint passes `npm run lint` *(fails: 629 errors)*
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685851c034608331906de1aeddaa18c7