### PR TITLE
[Agent] introduce service test environment builder

### DIFF
--- a/tests/common/engine/gameEngine.test-environment.js
+++ b/tests/common/engine/gameEngine.test-environment.js
@@ -50,26 +50,19 @@ const tokenMap = {
  *   playtimeTracker: ReturnType<typeof createMockPlaytimeTracker>,
  *   safeEventDispatcher: ReturnType<typeof createMockSafeEventDispatcher>,
  *   initializationService: ReturnType<typeof createMockInitializationService>,
- *   createGameEngine: () => GameEngine,
+ *   instance: GameEngine,
+ *   createInstance: () => GameEngine,
  *   cleanup: () => void,
  * }}
  *   Test environment utilities and mocks.
  */
 export function createTestEnvironment(overrides = {}) {
-  const { mocks, mockContainer, instance, cleanup } =
-    createServiceTestEnvironment(
-      factoryMap,
-      tokenMap,
-      (container) => new GameEngine({ container }),
-      overrides
-    );
-  const createGameEngine = () => new GameEngine({ container: mockContainer });
-
-  return {
-    mockContainer,
-    ...mocks,
-    gameEngine: instance,
-    createGameEngine,
-    cleanup,
-  };
+  const env = createServiceTestEnvironment(
+    factoryMap,
+    tokenMap,
+    (container) => new GameEngine({ container }),
+    undefined,
+    overrides
+  );
+  return env;
 }

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -44,16 +44,16 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
   constructor(overrides = {}) {
     const env = createTestEnvironment(overrides);
     super(env.mockContainer, {
-      logger: env.logger,
-      entityManager: env.entityManager,
-      turnManager: env.turnManager,
-      gamePersistenceService: env.gamePersistenceService,
-      playtimeTracker: env.playtimeTracker,
-      safeEventDispatcher: env.safeEventDispatcher,
-      initializationService: env.initializationService,
+      logger: env.mocks.logger,
+      entityManager: env.mocks.entityManager,
+      turnManager: env.mocks.turnManager,
+      gamePersistenceService: env.mocks.gamePersistenceService,
+      playtimeTracker: env.mocks.playtimeTracker,
+      safeEventDispatcher: env.mocks.safeEventDispatcher,
+      initializationService: env.mocks.initializationService,
     });
     // Use the already created gameEngine instance if available to avoid double instantiation
-    const engine = env.gameEngine || env.createGameEngine();
+    const engine = env.instance || env.createInstance();
     this.env = env;
     this.engine = engine;
   }
@@ -64,9 +64,11 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Promise resolving when the engine has started.
    */
   async init(world = DEFAULT_TEST_WORLD) {
-    this.env.initializationService.runInitializationSequence.mockResolvedValue({
-      success: true,
-    });
+    this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      {
+        success: true,
+      }
+    );
     await this.engine.startNewGame(world);
   }
 
@@ -88,7 +90,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @returns {Promise<void>} Promise resolving when the engine has started.
    */
   async start(worldName, initResult = { success: true }) {
-    this.env.initializationService.runInitializationSequence.mockResolvedValue(
+    this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
       initResult
     );
     await this.engine.startNewGame(worldName);

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -36,8 +36,8 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
       container: testBed.env.mockContainer,
     });
     expect(testBed.engine).toBe(engine);
-    expect(testBed.logger).toBe(testBed.env.logger);
-    expect(testBed.turnManager).toBe(testBed.env.turnManager);
+    expect(testBed.logger).toBe(testBed.env.mocks.logger);
+    expect(testBed.turnManager).toBe(testBed.env.mocks.turnManager);
   });
 
   it('start presets initialization result and calls startNewGame', async () => {
@@ -46,7 +46,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
 
     expect(engine.startNewGame).toHaveBeenCalledWith('World');
     await expect(
-      testBed.env.initializationService.runInitializationSequence()
+      testBed.env.mocks.initializationService.runInitializationSequence()
     ).resolves.toEqual(initResult);
   });
 
@@ -55,7 +55,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
 
     expect(engine.startNewGame).toHaveBeenCalledWith('TestWorld');
     await expect(
-      testBed.env.initializationService.runInitializationSequence()
+      testBed.env.mocks.initializationService.runInitializationSequence()
     ).resolves.toEqual({ success: true });
   });
 
@@ -78,7 +78,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     expect(resetSpy).toHaveBeenCalledTimes(1);
 
     await expect(
-      testBed.env.initializationService.runInitializationSequence()
+      testBed.env.mocks.initializationService.runInitializationSequence()
     ).resolves.toEqual({ success: true });
 
     initSpy.mockRestore();
@@ -101,7 +101,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     expect(resetSpy).toHaveBeenCalledTimes(1);
 
     await expect(
-      testBed.env.initializationService.runInitializationSequence()
+      testBed.env.mocks.initializationService.runInitializationSequence()
     ).resolves.toEqual(result);
 
     startSpy.mockRestore();

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -60,7 +60,7 @@ describeEngineSuite('GameEngine', (ctx) => {
         throw resolutionError;
       });
 
-      expect(() => testBed.env.createGameEngine()).toThrow(
+      expect(() => testBed.env.createInstance()).toThrow(
         `GameEngine: Failed to resolve core services. ${resolutionError.message}`
       );
 


### PR DESCRIPTION
Summary: Added createServiceTestEnvironment helper returning reusable instance creator and updated GameEngine and ModsLoader test setups. Adjusted GameEngineTestBed and related tests for new API.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 627 errors)*
- [x] Root tests `npm run test`
- [ ] Proxy tests *(none)*
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68585f27ff248331bb8d509cb4710b42