### PR TITLE
[Agent] Remove redundant slot navigation handlers

### DIFF
--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -300,16 +300,6 @@ export class LlmSelectionModal extends SlotModalBase {
   }
 
   /**
-   * Keyboard navigation handler for the LLM list.
-   *
-   * @param {KeyboardEvent} event - Key event to process.
-   * @private
-   */
-  _handleSlotNavigation(event) {
-    super._handleSlotNavigation(event);
-  }
-
-  /**
    * Orchestrates rendering the LLM list: fetches data, clears container,
    * renders items or empty message, and calls post-render hook.
    *

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -352,16 +352,6 @@ class LoadGameUI extends SlotModalBase {
   }
 
   /**
-   * Keyboard navigation handler for the slot list.
-   *
-   * @param {KeyboardEvent} event - Key event to process.
-   * @private
-   */
-  _handleSlotNavigation(event) {
-    super._handleSlotNavigation(event);
-  }
-
-  /**
    * Handles the "Load" button click.
    *
    * @private

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -368,16 +368,6 @@ export class SaveGameUI extends SlotModalBase {
   }
 
   /**
-   * Keyboard navigation handler for the slot list.
-   *
-   * @param {KeyboardEvent} event - Key event to process.
-   * @private
-   */
-  _handleSlotNavigation(event) {
-    super._handleSlotNavigation(event);
-  }
-
-  /**
    * Validates the necessary conditions before saving.
    *
    * @private


### PR DESCRIPTION
Summary: Remove subclass implementations of `_handleSlotNavigation` so navigation is handled entirely by `SlotModalBase`.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: numerous existing issues)*
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68599e5f90948331a354882ca595e892