### PR TITLE
[Agent] map storage errors to persistence

### DIFF
--- a/src/interfaces/IStorageProvider.js
+++ b/src/interfaces/IStorageProvider.js
@@ -51,7 +51,11 @@ export class IStorageProvider {
    * Deletes a file.
    *
    * @param {string} filePath - The path to the file.
-   * @returns {Promise<{success: boolean, error?: string}>}
+   * @returns {Promise<{
+   *   success: boolean,
+   *   error?: string,
+   *   code?: import('../storage/storageErrors.js').StorageErrorCodes
+   * }>}
    * @async
    */
   async deleteFile(filePath) {

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -221,10 +221,13 @@ export default class SaveFileRepository extends BaseService {
       this.#logger.error(
         `Failed to delete manual save "${filePath}": ${deleteResult.error}`
       );
-      return createPersistenceFailure(
-        PersistenceErrorCodes.DELETE_FAILED,
-        deleteResult.error || 'Unknown delete error'
-      );
+      let code = PersistenceErrorCodes.DELETE_FAILED;
+      let userMsg = deleteResult.error || 'Unknown delete error';
+      if (deleteResult.code === StorageErrorCodes.FILE_NOT_FOUND) {
+        code = PersistenceErrorCodes.DELETE_FILE_NOT_FOUND;
+        userMsg = 'Cannot delete: Save file not found.';
+      }
+      return createPersistenceFailure(code, userMsg);
     });
   }
 }

--- a/src/storage/storageErrors.js
+++ b/src/storage/storageErrors.js
@@ -1,5 +1,6 @@
 export const StorageErrorCodes = {
   DISK_FULL: 'DISK_FULL',
+  FILE_NOT_FOUND: 'FILE_NOT_FOUND',
 };
 
 Object.freeze(StorageErrorCodes);

--- a/tests/unit/persistence/deleteSaveFile.test.js
+++ b/tests/unit/persistence/deleteSaveFile.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
+import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
 import { createMockLogger } from '../testUtils.js';
 
 /**
@@ -71,6 +72,21 @@ describe('SaveFileRepository.deleteSaveFile', () => {
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FAILED);
     expect(storageProvider.fileExists).toHaveBeenCalledWith('bad.sav');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('maps FILE_NOT_FOUND code to DELETE_FILE_NOT_FOUND', async () => {
+    storageProvider.fileExists.mockResolvedValue(true);
+    storageProvider.deleteFile.mockResolvedValue({
+      success: false,
+      error: 'missing',
+      code: StorageErrorCodes.FILE_NOT_FOUND,
+    });
+
+    const result = await repo.deleteSaveFile('missing.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.DELETE_FILE_NOT_FOUND);
     expect(logger.error).toHaveBeenCalled();
   });
 

--- a/tests/unit/persistence/writeSaveFile.test.js
+++ b/tests/unit/persistence/writeSaveFile.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
+import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
+import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
+import { createMockLogger } from '../testUtils.js';
+
+/**
+ *
+ */
+function makeDeps() {
+  const logger = createMockLogger();
+  const storageProvider = {
+    writeFileAtomically: jest.fn(),
+    listFiles: jest.fn(),
+    readFile: jest.fn(),
+    deleteFile: jest.fn(),
+    fileExists: jest.fn(),
+    ensureDirectoryExists: jest.fn(),
+  };
+  const serializer = {};
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
+  const repo = new SaveFileRepository({ logger, storageProvider, parser });
+  return { repo, logger, storageProvider };
+}
+
+describe('SaveFileRepository.writeSaveFile', () => {
+  let repo;
+  let logger;
+  let storageProvider;
+
+  beforeEach(() => {
+    ({ repo, logger, storageProvider } = makeDeps());
+  });
+
+  it('maps disk full error code to WRITE_ERROR', async () => {
+    storageProvider.writeFileAtomically.mockResolvedValue({
+      success: false,
+      error: 'disk full',
+      code: StorageErrorCodes.DISK_FULL,
+    });
+
+    const res = await repo.writeSaveFile('path.sav', new Uint8Array());
+
+    expect(res.success).toBe(false);
+    expect(res.error.code).toBe(PersistenceErrorCodes.WRITE_ERROR);
+    expect(res.error.message).toMatch(/Not enough disk space/);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary:
- handle `FILE_NOT_FOUND` in storage errors
- expose optional `code` from `deleteFile`
- map delete errors in `SaveFileRepository`
- add disk full and not-found tests

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 693 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run lint`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68599e3b04808331a4c91bb657b7fcb9