### PR TITLE
[Agent] use safeDispatchError for system error events

### DIFF
--- a/src/logic/operationHandlers/addComponentHandler.js
+++ b/src/logic/operationHandlers/addComponentHandler.js
@@ -12,7 +12,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('./modifyComponentHandler.js').EntityRefObject} EntityRefObject */ // Reuse definition
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 
@@ -103,14 +103,16 @@ class AddComponentHandler extends ComponentOperationHandler {
       );
     } catch (e) {
       const msg = `ADD_COMPONENT: Failed to add component "${trimmedComponentType}" to entity "${entityId}". Error: ${e.message}`;
-      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: msg,
-        details: {
+      safeDispatchError(
+        this.#dispatcher,
+        msg,
+        {
           raw: e.message,
           stack: e.stack,
           timestamp: new Date().toISOString(),
         },
-      });
+        log
+      );
     }
   }
 

--- a/src/logic/operationHandlers/endTurnHandler.js
+++ b/src/logic/operationHandlers/endTurnHandler.js
@@ -7,10 +7,7 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import {
-  TURN_ENDED_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../../constants/eventIds.js';
+import { TURN_ENDED_ID } from '../../constants/eventIds.js';
 
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
@@ -62,14 +59,11 @@ class EndTurnHandler {
     if (!assertParamsObject(params, logger, 'END_TURN')) return;
 
     if (typeof params.entityId !== 'string' || !params.entityId.trim()) {
-      this.#safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: 'END_TURN: Invalid or missing "entityId" parameter.',
-        details: { params },
-      });
       safeDispatchError(
         this.#safeEventDispatcher,
         'END_TURN: Invalid or missing "entityId" parameter.',
-        { params }
+        { params },
+        logger
       );
       return;
     }

--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -8,7 +8,6 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import BaseOperationHandler from './baseOperationHandler.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
@@ -136,10 +135,12 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
           partners,
         });
       } catch (err) {
-        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-          message: 'MERGE_CLOSENESS_CIRCLE: failed updating closeness',
-          details: { id, error: err.message, stack: err.stack },
-        });
+        safeDispatchError(
+          this.#dispatcher,
+          'MERGE_CLOSENESS_CIRCLE: failed updating closeness',
+          { id, error: err.message, stack: err.stack },
+          this.logger
+        );
       }
     }
     return allMembers;
@@ -162,10 +163,12 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
           locked: true,
         });
       } catch (err) {
-        this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-          message: 'MERGE_CLOSENESS_CIRCLE: failed locking movement',
-          details: { id, error: err.message, stack: err.stack },
-        });
+        safeDispatchError(
+          this.#dispatcher,
+          'MERGE_CLOSENESS_CIRCLE: failed locking movement',
+          { id, error: err.message, stack: err.stack },
+          this.logger
+        );
       }
     }
   }

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -9,9 +9,9 @@
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 import BaseOperationHandler from './baseOperationHandler.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
 class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
   /** @type {EntityManager} */
@@ -98,10 +98,12 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
     const { actor_id, result_variable } = params;
 
     if (typeof actor_id !== 'string' || !actor_id.trim()) {
-      this.#dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
-        message: 'REMOVE_FROM_CLOSENESS_CIRCLE: Invalid "actor_id" parameter',
-        details: { params },
-      });
+      safeDispatchError(
+        this.#dispatcher,
+        'REMOVE_FROM_CLOSENESS_CIRCLE: Invalid "actor_id" parameter',
+        { params },
+        this.logger
+      );
       return null;
     }
 


### PR DESCRIPTION
## Summary
- replace direct SYSTEM_ERROR_OCCURRED_ID dispatches with `safeDispatchError`
- cleanup unused imports

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68599e33828083319c2328e3dd564e00