### PR TITLE
[Agent] rename ctx param

### DIFF
--- a/src/turns/states/helpers/validationUtils.js
+++ b/src/turns/states/helpers/validationUtils.js
@@ -42,13 +42,13 @@ export function assertMatchingActor(expectedActor, contextActor, stateName) {
 
 /**
  * @description Validates that the provided context exposes required methods.
- * @param {object|null} ctx - ITurnContext-like object to inspect.
+ * @param {object|null} turnContext - ITurnContext-like object to inspect.
  * @param {string[]} methods - Method names expected on the context.
  * @returns {string[]} Array of method names that are missing or not functions.
  */
-export function validateContextMethods(ctx, methods) {
-  if (!ctx) {
+export function validateContextMethods(turnContext, methods) {
+  if (!turnContext) {
     return [...methods];
   }
-  return methods.filter((m) => typeof ctx[m] !== 'function');
+  return methods.filter((m) => typeof turnContext[m] !== 'function');
 }


### PR DESCRIPTION
Summary: Rename the `ctx` parameter to `turnContext` in `validationUtils.js` for clearer semantics.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 693 errors)*
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68599e286e6c8331aa24cd69bc68aaf4