### PR TITLE
[Agent] implement actor id utilities

### DIFF
--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -31,25 +31,9 @@ export class TurnEndingState extends AbstractTurnState {
       handler
     );
 
+    this.#actorToEndId = this._resolveActorId(actorToEndId);
     if (!actorToEndId) {
-      const message =
-        'TurnEndingState Constructor: actorToEndId must be provided.';
-      if (dispatcher) {
-        safeDispatchError(
-          dispatcher,
-          message,
-          {
-            providedActorId: actorToEndId ?? null,
-          },
-          log
-        );
-      }
-      this.#actorToEndId = handler.getCurrentActor()?.id ?? UNKNOWN_ACTOR_ID;
-      log.warn(
-        `TurnEndingState Constructor: actorToEndId was missing, fell back to '${this.#actorToEndId}'.`
-      );
-    } else {
-      this.#actorToEndId = actorToEndId;
+      this._notifyMissingActorId(dispatcher, log, actorToEndId);
     }
 
     this.#turnError = turnError ?? null;
@@ -184,5 +168,48 @@ export class TurnEndingState extends AbstractTurnState {
   /* ────────────────────────────────────────────────────────────────── */
   isEnding() {
     return true;
+  }
+
+  //───────────────────────────────────────────────────────────────────────────
+  // Private utilities
+  //───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolves the actor ID to end the turn for.
+   *
+   * @param {string | null | undefined} actorToEndId - Actor id passed to the
+   *   constructor.
+   * @returns {string} The resolved actor id.
+   */
+  _resolveActorId(actorToEndId) {
+    return (
+      actorToEndId || this._handler?.getCurrentActor?.()?.id || UNKNOWN_ACTOR_ID
+    );
+  }
+
+  /**
+   * Dispatches and logs a warning when no actor id was provided.
+   *
+   * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher|null} dispatcher
+   * @param {import('../../logging/consoleLogger.js').default | Console} log
+   * @param {string | null | undefined} providedId - The originally supplied id.
+   * @returns {void}
+   */
+  _notifyMissingActorId(dispatcher, log, providedId) {
+    const message =
+      'TurnEndingState Constructor: actorToEndId must be provided.';
+    if (dispatcher) {
+      safeDispatchError(
+        dispatcher,
+        message,
+        {
+          providedActorId: providedId ?? null,
+        },
+        log
+      );
+    }
+    log.warn(
+      `TurnEndingState Constructor: actorToEndId was missing, fell back to '${this.#actorToEndId}'.`
+    );
   }
 }

--- a/tests/unit/turns/states/turnEndingState.helpers.test.js
+++ b/tests/unit/turns/states/turnEndingState.helpers.test.js
@@ -1,0 +1,70 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { TurnEndingState } from '../../../../src/turns/states/turnEndingState.js';
+import { UNKNOWN_ACTOR_ID } from '../../../../src/constants/unknownIds.js';
+import { safeDispatchError } from '../../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+const makeLogger = () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+});
+
+describe('TurnEndingState helper methods', () => {
+  let handler;
+  let logger;
+  let dispatcher;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = makeLogger();
+    dispatcher = { dispatch: jest.fn() };
+    handler = {
+      getCurrentActor: jest.fn(() => ({ id: 'h-actor' })),
+      getLogger: jest.fn(() => logger),
+      getTurnContext: jest.fn(() => null),
+      getSafeEventDispatcher: jest.fn(() => dispatcher),
+    };
+  });
+
+  test('_resolveActorId returns provided id', () => {
+    const state = new TurnEndingState(handler, 'a1');
+    expect(state._resolveActorId('x')).toBe('x');
+  });
+
+  test('_resolveActorId falls back to handler actor then unknown', () => {
+    const state = new TurnEndingState(handler, null);
+    expect(state._resolveActorId(null)).toBe('h-actor');
+    handler.getCurrentActor.mockReturnValueOnce(null);
+    expect(state._resolveActorId(undefined)).toBe(UNKNOWN_ACTOR_ID);
+  });
+
+  test('_notifyMissingActorId dispatches and logs warning', () => {
+    const state = new TurnEndingState(handler, null);
+    state._notifyMissingActorId(dispatcher, logger, undefined);
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.any(String),
+      { providedActorId: null },
+      logger
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('actorToEndId was missing')
+    );
+  });
+
+  test('constructor uses helper methods', () => {
+    const spyResolve = jest.spyOn(TurnEndingState.prototype, '_resolveActorId');
+    const spyNotify = jest.spyOn(
+      TurnEndingState.prototype,
+      '_notifyMissingActorId'
+    );
+    new TurnEndingState(handler, null);
+    expect(spyResolve).toHaveBeenCalledWith(null);
+    expect(spyNotify).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Added helper methods to resolve and report actor IDs when constructing `TurnEndingState`. Updated constructor to use these helpers and added accompanying unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: 693 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68599e20ef0483318adc16b5c4446ab8