### PR TITLE
[Agent] Move game engine test environment

### DIFF
--- a/tests/common/engine/gameEngineEnvironment.js
+++ b/tests/common/engine/gameEngineEnvironment.js
@@ -1,6 +1,6 @@
 /**
  * @file Test environment factory for GameEngine-related tests.
- * @see tests/common/engine/gameEngine.test-environment.js
+ * @see tests/common/engine/gameEngineEnvironment.js
  */
 
 import { jest } from '@jest/globals';
@@ -16,6 +16,7 @@ import {
   createMockInitializationService,
 } from '../mockFactories';
 import { createServiceTestEnvironment } from '../mockEnvironment.js';
+
 const factoryMap = {
   logger: createMockLogger,
   entityManager: createMockEntityManager,
@@ -56,7 +57,7 @@ const tokenMap = {
  * }}
  *   Test environment utilities and mocks.
  */
-export function createTestEnvironment(overrides = {}) {
+export function createEnvironment(overrides = {}) {
   const env = createServiceTestEnvironment(
     factoryMap,
     tokenMap,

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -5,7 +5,7 @@
 /* eslint-env jest */
 /* global beforeEach, afterEach, describe */
 
-import { createTestEnvironment } from './gameEngine.test-environment.js';
+import { createEnvironment } from './gameEngineEnvironment.js';
 import ContainerTestBed from '../containerTestBed.js';
 import { createStoppableMixin } from '../stoppableTestBedMixin.js';
 import { suppressConsoleError } from '../jestHelpers.js';
@@ -21,7 +21,7 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
 const StoppableMixin = createStoppableMixin('engine');
 
 export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
-  /** @type {ReturnType<typeof createTestEnvironment>} */
+  /** @type {ReturnType<typeof createEnvironment>} */
   env;
   /** @type {import('../../../src/engine/gameEngine.js').default} */
   engine;
@@ -42,7 +42,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
    * @param {{[token: string]: any}} [overrides]
    */
   constructor(overrides = {}) {
-    const env = createTestEnvironment(overrides);
+    const env = createEnvironment(overrides);
     super(env.mockContainer, {
       logger: env.mocks.logger,
       entityManager: env.mocks.entityManager,

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -10,10 +10,34 @@ import {
   describeEngineSuite,
   describeInitializedEngineSuite,
 } from '../../../common/engine/gameEngineTestBed.js';
+import { createEnvironment } from '../../../common/engine/gameEngineEnvironment.js';
 import GameEngine from '../../../../src/engine/gameEngine.js';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 
 jest.mock('../../../../src/engine/gameEngine.js');
+
+describe('createEnvironment', () => {
+  let engine;
+
+  beforeEach(() => {
+    engine = {};
+    GameEngine.mockImplementation(() => engine);
+  });
+
+  it('returns engine instance and mocks', () => {
+    const env = createEnvironment();
+    expect(env.instance).toBe(engine);
+    expect(env.mockContainer.resolve(tokens.ILogger)).toBe(env.mocks.logger);
+    env.cleanup();
+  });
+
+  it('applies token overrides', () => {
+    const custom = {};
+    const env = createEnvironment({ [tokens.PlaytimeTracker]: custom });
+    expect(env.mockContainer.resolve(tokens.PlaytimeTracker)).toBe(custom);
+    env.cleanup();
+  });
+});
 
 describe('GameEngine Test Helpers: GameEngineTestBed', () => {
   let testBed;


### PR DESCRIPTION
## Summary
- create `gameEngineEnvironment` module for engine test helpers
- update `GameEngineTestBed` to use the new environment builder
- replace `createTestEnvironment` references
- cover environment builder in unit tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings/errors)*
- `npm test`
- `cd llm-proxy-server && npm run lint`
- `npm test` in llm-proxy-server

------
https://chatgpt.com/codex/tasks/task_e_68599dffbfb08331adc2350ebe1c44cf