### PR TITLE
[Test] split turn manager lifecycle tests

### DIFF
--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -17,16 +17,12 @@ describeTurnManagerSuite(
   (getBed) => {
     let testBed;
     let stopSpy;
-    let advanceTurnSpy; // General spy for advanceTurn
 
     beforeEach(() => {
       testBed = getBed();
       testBed.mocks.turnOrderService.isEmpty.mockReset();
       testBed.mocks.dispatcher.subscribe.mockReset().mockReturnValue(jest.fn());
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(null);
-
-      // Define the spy here for the actual advanceTurn method
-      advanceTurnSpy = testBed.spyOnAdvanceTurn();
 
       // Spy on stop with debug logging for verification
       stopSpy = testBed.setupDebugStopSpy();
@@ -53,49 +49,43 @@ describeTurnManagerSuite(
       expect(testBed.mocks.dispatcher.subscribe).not.toHaveBeenCalled(); // subscribe happens in start()
     });
 
-    test('No active actors found: logs error, dispatches message, and stops', async () => {
-      // Arrange
-      const nonActorEntity = createMockEntity('nonActor1', {
-        isActor: false,
-        isPlayer: false,
+    describe('No active actors found', () => {
+      beforeEach(async () => {
+        const nonActorEntity = createMockEntity('nonActor1', {
+          isActor: false,
+          isPlayer: false,
+        });
+        testBed.setActiveEntities(nonActorEntity);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+        await testBed.turnManager.start();
       });
-      testBed.setActiveEntities(nonActorEntity);
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty for TurnCycle.nextActor()
-      const expectedErrorMsg =
-        'Cannot start a new round: No active entities with an Actor component found.';
 
-      // Act: Start the manager, which will call advanceTurn once.
-      await testBed.turnManager.start(); // This calls advanceTurn.
+      test('logs initiation and checks the queue once', () => {
+        expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+          '▶️  TurnManager.advanceTurn() initiating...'
+        );
+        expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1);
+        expect(
+          testBed.mocks.turnOrderService.getNextEntity
+        ).not.toHaveBeenCalled();
+      });
 
-      // Assert (on the results of the advanceTurn call triggered by start)
-      expect(testBed.mocks.dispatcher.subscribe).toHaveBeenCalledTimes(1); // Ensure subscription happened in start()
-      expect(advanceTurnSpy).toHaveBeenCalledTimes(1); // The call from start()
+      test('dispatches system error when round cannot start', () => {
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+          SYSTEM_ERROR_OCCURRED_ID,
+          expect.objectContaining({
+            message: 'Critical error during turn advancement logic',
+            details: {
+              error:
+                'Cannot start a new round: No active entities with an Actor component found.',
+            },
+          })
+        );
+      });
 
-      // Check logs from the advanceTurn call triggered by start()
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-        '▶️  TurnManager.advanceTurn() initiating...'
-      );
-      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(1); // Called once by TurnCycle.nextActor()
-      expect(
-        testBed.mocks.turnOrderService.getNextEntity
-      ).toHaveBeenCalledTimes(0); // Not called when isEmpty returns true
-
-      // Check dispatch and stop from the advanceTurn call
-      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledTimes(2); // safeDispatchError + #dispatchSystemError
-      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-        SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({
-          message: 'Critical error during turn advancement logic',
-          details: {
-            error: expectedErrorMsg,
-          },
-        })
-      );
-
-      expect(stopSpy).toHaveBeenCalledTimes(1); // stop() called by the advanceTurn call
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-        'Mocked instance.stop() called.'
-      );
+      test('stops the manager when no actors are active', () => {
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
     test('No active actors found (empty map): logs error, dispatches message, and stops', async () => {
@@ -121,131 +111,146 @@ describeTurnManagerSuite(
       expect(stopSpy).toHaveBeenCalledTimes(1);
     });
 
-    test('Active actors found: starts new round and recursively calls advanceTurn', async () => {
-      // Arrange
-      const actor1 = createAiActor('actor1');
-      const actor2 = createAiActor('actor2');
-      testBed.setActiveEntities(actor1, actor2);
+    describe('Active actors found', () => {
+      let actor1;
+      let actor2;
+      let mockHandler;
 
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // Queue is empty for TurnCycle.nextActor()
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
-        actor1
-      ); // First actor in new round
+      beforeEach(async () => {
+        actor1 = createAiActor('actor1');
+        actor2 = createAiActor('actor2');
+        testBed.setActiveEntities(actor1, actor2);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+        testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
+          actor1
+        );
+        mockHandler = createMockTurnHandler({ actor: actor1 });
+        testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
+          mockHandler
+        );
+        await testBed.turnManager.start();
+      });
 
-      const mockHandler = createMockTurnHandler({ actor: actor1 });
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(
-        mockHandler
-      );
+      test('starts a new round and logs the action', () => {
+        expect(
+          testBed.mocks.turnOrderService.startNewRound
+        ).toHaveBeenCalledWith(
+          expect.arrayContaining([actor1, actor2]),
+          'round-robin'
+        );
+        expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
+          'New round started, recursively calling advanceTurn() to process the first turn.'
+        );
+      });
 
-      // Act: Start the manager, which will call advanceTurn and start a new round
-      await testBed.turnManager.start();
-
-      // Assert
-      expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(2); // Called once by TurnCycle.nextActor(), once by recursive advanceTurn
-      expect(
-        testBed.mocks.turnOrderService.getNextEntity
-      ).toHaveBeenCalledTimes(1); // Called by recursive advanceTurn
-      expect(testBed.mocks.turnOrderService.startNewRound).toHaveBeenCalledWith(
-        expect.arrayContaining([actor1, actor2]),
-        'round-robin'
-      );
-      expect(testBed.mocks.logger.debug).toHaveBeenCalledWith(
-        'New round started, recursively calling advanceTurn() to process the first turn.'
-      );
-
-      // Verify the recursive advanceTurn call
-      expect(
-        testBed.mocks.turnHandlerResolver.resolveHandler
-      ).toHaveBeenCalledWith(actor1);
-      expect(mockHandler.startTurn).toHaveBeenCalledWith(actor1);
-      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-        'core:turn_started',
-        {
-          entityId: actor1.id,
-          entityType: 'ai',
-        }
-      );
-      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-        TURN_PROCESSING_STARTED,
-        { entityId: actor1.id, actorType: 'ai' }
-      );
+      test('processes the first actor in the new round', () => {
+        expect(testBed.mocks.turnOrderService.isEmpty).toHaveBeenCalledTimes(2);
+        expect(
+          testBed.mocks.turnOrderService.getNextEntity
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          testBed.mocks.turnHandlerResolver.resolveHandler
+        ).toHaveBeenCalledWith(actor1);
+        expect(mockHandler.startTurn).toHaveBeenCalledWith(actor1);
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+          'core:turn_started',
+          {
+            entityId: actor1.id,
+            entityType: 'ai',
+          }
+        );
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+          TURN_PROCESSING_STARTED,
+          { entityId: actor1.id, actorType: 'ai' }
+        );
+      });
     });
 
-    test('startNewRound throws error: logs error, dispatches message, and stops', async () => {
-      // Arrange
-      const actor1 = createAiActor('actor1');
-      testBed.setActiveEntities(actor1);
+    describe('startNewRound throws error', () => {
+      let roundError;
 
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
-      const roundError = new Error('Round start failed');
-      testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(
-        roundError
-      );
+      beforeEach(async () => {
+        const actor1 = createAiActor('actor1');
+        testBed.setActiveEntities(actor1);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+        roundError = new Error('Round start failed');
+        testBed.mocks.turnOrderService.startNewRound.mockRejectedValue(
+          roundError
+        );
+        await testBed.turnManager.start();
+      });
 
-      // Act: Start the manager, which will call advanceTurn and fail to start a new round
-      await testBed.turnManager.start();
+      test('dispatches a system error', () => {
+        expectSystemErrorDispatch(
+          testBed.mocks.dispatcher.dispatch,
+          'System Error: No active actors found to start a round. Stopping game.',
+          roundError.message
+        );
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalled();
+      });
 
-      // Assert
-      expectSystemErrorDispatch(
-        testBed.mocks.dispatcher.dispatch,
-        'System Error: No active actors found to start a round. Stopping game.',
-        roundError.message
-      );
-      expect(stopSpy).toHaveBeenCalledTimes(1);
+      test('stops the manager', () => {
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
-    test('getNextEntity throws error after new round: logs error, dispatches message, and stops', async () => {
-      // Arrange
-      const actor1 = createAiActor('actor1');
-      testBed.setActiveEntities(actor1);
+    describe('getNextEntity fails after starting a new round', () => {
+      beforeEach(async () => {
+        const actor1 = createAiActor('actor1');
+        testBed.setActiveEntities(actor1);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(false);
+        testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(
+          new Error('Get next entity failed')
+        );
+        await testBed.turnManager.start();
+      });
 
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // First call by TurnCycle.nextActor()
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(false); // Second call by recursive advanceTurn
-      testBed.mocks.turnOrderService.getNextEntity.mockRejectedValue(
-        new Error('Get next entity failed')
-      ); // Called by recursive advanceTurn
+      test('dispatches a system error', () => {
+        expectSystemErrorDispatch(
+          testBed.mocks.dispatcher.dispatch,
+          'System Error during turn advancement. Stopping game.',
+          'Get next entity failed'
+        );
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalled();
+      });
 
-      // Act: Start the manager, which will call advanceTurn, start a new round, then fail
-      await testBed.turnManager.start();
-
-      // Assert
-      expectSystemErrorDispatch(
-        testBed.mocks.dispatcher.dispatch,
-        'System Error during turn advancement. Stopping game.',
-        'Get next entity failed'
-      );
-      expect(stopSpy).toHaveBeenCalledTimes(1);
+      test('stops the manager', () => {
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
-    test('Handler resolution fails after new round: logs error, dispatches message, and stops', async () => {
-      // Arrange
-      const actor1 = createAiActor('actor1');
-      testBed.setActiveEntities(actor1);
+    describe('handler resolution fails after a new round starts', () => {
+      let resolveError;
 
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true); // First call by TurnCycle.nextActor()
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(false); // Second call by recursive advanceTurn
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
-        actor1
-      ); // Called by recursive advanceTurn
-      const resolveError = new Error('Handler resolution failed');
-      testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
-        resolveError
-      );
+      beforeEach(async () => {
+        const actor1 = createAiActor('actor1');
+        testBed.setActiveEntities(actor1);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(true);
+        testBed.mocks.turnOrderService.isEmpty.mockResolvedValueOnce(false);
+        testBed.mocks.turnOrderService.getNextEntity.mockResolvedValueOnce(
+          actor1
+        );
+        resolveError = new Error('Handler resolution failed');
+        testBed.mocks.turnHandlerResolver.resolveHandler.mockRejectedValue(
+          resolveError
+        );
+        await testBed.turnManager.start();
+      });
 
-      // Act: Start the manager, which will call advanceTurn, start a new round, then fail
-      await testBed.turnManager.start();
+      test('dispatches a system error', () => {
+        expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+          SYSTEM_ERROR_OCCURRED_ID,
+          expect.objectContaining({
+            message: 'System Error during turn advancement',
+            details: { error: resolveError.message },
+          })
+        );
+      });
 
-      // Assert
-      expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
-        SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({
-          message: 'System Error during turn advancement',
-          details: {
-            error: resolveError.message,
-          },
-        })
-      );
-      expect(stopSpy).toHaveBeenCalledTimes(1);
+      test('stops the manager', () => {
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+      });
     });
   }
 );


### PR DESCRIPTION
Summary: Refactored round lifecycle specs so each test focuses on a single behavior. Split error-handling checks into separate cases and simplified round start verification logic.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint tests/unit/turns/turnManager.advanceTurn.roundStart.test.js tests/unit/turns/turnManager.roundLifecycle.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6859a4774944833189b76d2dd062dabb