### PR TITLE
[Agent] rename test helper for turn start

### DIFF
--- a/src/domUI/perceptionLogRenderer.js
+++ b/src/domUI/perceptionLogRenderer.js
@@ -342,9 +342,9 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
    * @param {CoreTurnStartedEvent} event - The event object from VED.
    * @returns {void}
    */
-  '#handleTurnStarted'(event) {
+  _handleTurnStartedForTest(event) {
     this.logger.debug(
-      `${this._logPrefix} #handleTurnStarted received '${event.type}' event. Payload:`,
+      `${this._logPrefix} _handleTurnStartedForTest received '${event.type}' event. Payload:`,
       event.payload
     );
 
@@ -366,7 +366,7 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
 
     this.refreshList().catch((error) => {
       this.logger.error(
-        `${this._logPrefix} Error during refreshList in #handleTurnStarted:`,
+        `${this._logPrefix} Error during refreshList in _handleTurnStartedForTest:`,
         error
       );
       if (this.elements.listContainerElement) {
@@ -389,7 +389,7 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
    * @returns {void}
    */
   #handleTurnStarted(event) {
-    return this['#handleTurnStarted'](event);
+    return this._handleTurnStartedForTest(event);
   }
 
   /**

--- a/tests/unit/domUI/perceptionLogRenderer.test.js
+++ b/tests/unit/domUI/perceptionLogRenderer.test.js
@@ -369,7 +369,7 @@ describe('PerceptionLogRenderer', () => {
     });
   });
 
-  describe('#handleTurnStarted', () => {
+  describe('_handleTurnStartedForTest', () => {
     let renderer;
     const actorId = 'player:hero';
 
@@ -415,14 +415,14 @@ describe('PerceptionLogRenderer', () => {
       // However, turnStartedHandler is captured globally from the last `createRenderer` in `beforeEach`.
       // For this test, it's better to call the method directly or re-capture the handler.
       // Let's call the method directly on errorRenderer for clarity.
-      await errorRenderer['#handleTurnStarted']({
+      await errorRenderer._handleTurnStartedForTest({
         type: TURN_STARTED_ID,
         payload: { entityId: actorId },
       });
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `${CLASS_PREFIX} Error during refreshList in #handleTurnStarted`
+          `${CLASS_PREFIX} Error during refreshList in _handleTurnStartedForTest`
         ),
         expect.objectContaining({ message: 'Simulated refreshList failure' })
       );


### PR DESCRIPTION
## Summary
- rename the `'#handleTurnStarted'` method to `_handleTurnStartedForTest`
- call the renamed method from the private wrapper
- update unit tests for the new method name

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 692 errors, 2407 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859aa3378f08331bff9e32c32ee453a