### PR TITLE
[Agent] add mockActorSequence helper

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -226,6 +226,21 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
   }
 
   /**
+   * Configures the turn order service to return the provided actors
+   * sequentially for successive calls.
+   *
+   * @param {...object} actors - Actor entities to return in order.
+   * @returns {void}
+   */
+  mockActorSequence(...actors) {
+    this.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+    let index = 0;
+    this.mocks.turnOrderService.getNextEntity.mockImplementation(() =>
+      Promise.resolve(index < actors.length ? actors[index++] : null)
+    );
+  }
+
+  /**
    * Configures the turn order service to represent an empty queue.
    *
    * @returns {void}

--- a/tests/unit/common/turns/turnManagerTestBed.test.js
+++ b/tests/unit/common/turns/turnManagerTestBed.test.js
@@ -166,4 +166,20 @@ describe('TurnManager Test Helpers: TurnManagerTestBed', () => {
     expect(jest.isMockFunction(bed.turnManager.stop)).toBe(false);
     expect(jest.isMockFunction(bed.turnManager.advanceTurn)).toBe(false);
   });
+
+  it('mockActorSequence returns actors in order then null', async () => {
+    const actor1 = { id: 'a1' };
+    const actor2 = { id: 'a2' };
+    testBed.mockActorSequence(actor1, actor2);
+
+    await expect(testBed.mocks.turnOrderService.getNextEntity()).resolves.toBe(
+      actor1
+    );
+    await expect(testBed.mocks.turnOrderService.getNextEntity()).resolves.toBe(
+      actor2
+    );
+    await expect(
+      testBed.mocks.turnOrderService.getNextEntity()
+    ).resolves.toBeNull();
+  });
 });

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -83,14 +83,7 @@ describeRunningTurnManagerSuite(
 
     test('Advances to next actor when current turn ends successfully', async () => {
       testBed.setActiveEntities(ai1, ai2);
-      testBed.mockNextActor(ai1);
-      testBed.mocks.turnOrderService.getNextEntity.mockImplementation(() => {
-        const result =
-          testBed.mocks.turnOrderService.getNextEntity.mock.calls.length === 1
-            ? ai1
-            : ai2;
-        return Promise.resolve(result);
-      });
+      testBed.mockActorSequence(ai1, ai2);
 
       await testBed.advanceAndFlush();
 
@@ -143,17 +136,11 @@ describeRunningTurnManagerSuite(
       beforeEach(async () => {
         testBed.setActiveEntities(ai1, ai2);
         let isEmptyCallCount = 0;
-        let getNextEntityCallCount = 0;
         testBed.mocks.turnOrderService.isEmpty.mockImplementation(() => {
           isEmptyCallCount++;
           return Promise.resolve(isEmptyCallCount >= 3);
         });
-        testBed.mocks.turnOrderService.getNextEntity.mockImplementation(() => {
-          getNextEntityCallCount++;
-          if (getNextEntityCallCount === 1) return Promise.resolve(ai1);
-          if (getNextEntityCallCount === 2) return Promise.resolve(ai2);
-          return Promise.resolve(null);
-        });
+        testBed.mockActorSequence(ai1, ai2, null);
         testBed.mocks.turnOrderService.clearCurrentRound.mockImplementation(
           () => {
             const newActor1 = createAiActor('actor1');


### PR DESCRIPTION
Summary: Implemented `mockActorSequence` in TurnManagerTestBed to streamline sequential actor mocking. Updated related tests to use this helper and added a unit test for it.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6859a9f335488331b8a884db123e3be9