### PR TITLE
[Agent] Fix GameStateRestorer dependency compatibility

### DIFF
--- a/src/entities/entityManagerAdapter.js
+++ b/src/entities/entityManagerAdapter.js
@@ -86,6 +86,16 @@ export class EntityManagerAdapter {
     return this.entityManager.findEntities(query);
   }
 
+  /**
+   * Clears all entities from the underlying EntityManager.
+   * Also clears any associated caches held by the EntityManager.
+   *
+   * @returns {void}
+   */
+  clearAll() {
+    this.entityManager.clearAll();
+  }
+
   get entities() {
     return this.entityManager.entities;
   }

--- a/tests/unit/entities/entityManagerAdapter.test.js
+++ b/tests/unit/entities/entityManagerAdapter.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { EntityManagerAdapter } from '../../../src/entities/entityManagerAdapter.js';
+import GameStateRestorer from '../../../src/persistence/gameStateRestorer.js';
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('EntityManagerAdapter', () => {
+  it('delegates clearAll to the wrapped entity manager', () => {
+    const entityManager = { clearAll: jest.fn() };
+    const locationQueryService = { getEntitiesInLocation: jest.fn() };
+    const adapter = new EntityManagerAdapter({
+      entityManager,
+      locationQueryService,
+    });
+
+    adapter.clearAll();
+
+    expect(entityManager.clearAll).toHaveBeenCalled();
+  });
+
+  it('is compatible with GameStateRestorer', () => {
+    const entityManager = {
+      clearAll: jest.fn(),
+      reconstructEntity: jest.fn(),
+    };
+    const locationQueryService = { getEntitiesInLocation: jest.fn() };
+    const adapter = new EntityManagerAdapter({
+      entityManager,
+      locationQueryService,
+    });
+    const playtimeTracker = { setAccumulatedPlaytime: jest.fn() };
+    const logger = makeLogger();
+
+    const restorer = new GameStateRestorer({
+      logger,
+      entityManager: adapter,
+      playtimeTracker,
+    });
+
+    expect(restorer).toBeInstanceOf(GameStateRestorer);
+  });
+});


### PR DESCRIPTION
## Summary
- delegate `clearAll` through EntityManagerAdapter
- test adapter delegation and GameStateRestorer compatibility

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3099 problems)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6859a9e05e94833194852fc07ac8ab63