### PR TITLE
[Agent] throw ServiceLookupError for failed service lookup

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -13,6 +13,21 @@ import { getLogger, getSafeEventDispatcher } from './contextUtils.js';
 import { finishProcessing } from './processingErrorUtils.js';
 
 /**
+ * @class ServiceLookupError
+ * @augments Error
+ * @description Error thrown when a service cannot be retrieved from the turn context.
+ */
+export class ServiceLookupError extends Error {
+  /**
+   * @param {string} message - Error message describing the lookup failure.
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'ServiceLookupError';
+  }
+}
+
+/**
  * Safely obtains a service from the turn context.
  *
  * @param {ProcessingCommandStateLike} state - Owning state instance.
@@ -20,7 +35,8 @@ import { finishProcessing } from './processingErrorUtils.js';
  * @param {string} contextMethod - Method name on ITurnContext used to retrieve the service.
  * @param {string} serviceLabel - Label for logging when retrieval fails.
  * @param {string} actorIdForLog - Actor ID for logging context.
- * @returns {Promise<*>} The requested service instance or `null` if unavailable.
+ * @returns {Promise<*>} The requested service instance.
+ * @throws {ServiceLookupError} When the service cannot be retrieved.
  */
 export async function getServiceFromContext(
   state,
@@ -51,7 +67,7 @@ export async function getServiceFromContext(
     if (state._isProcessing) {
       finishProcessing(state);
     }
-    return null;
+    throw new ServiceLookupError(errorMsg);
   }
   try {
     if (typeof turnCtx[contextMethod] !== 'function') {
@@ -86,7 +102,7 @@ export async function getServiceFromContext(
     const serviceError = new Error(errorMsg);
     const exceptionHandler = new ProcessingExceptionHandler(state);
     await exceptionHandler.handle(turnCtx, serviceError, actorIdForLog);
-    return null;
+    throw new ServiceLookupError(errorMsg);
   }
 }
 

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -15,6 +15,7 @@ import {
 } from '../../../../src/constants/eventIds.js';
 import TurnDirective from '../../../../src/turns/constants/turnDirectives.js';
 import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+import { ServiceLookupError } from '../../../../src/turns/states/helpers/getServiceFromContext.js';
 
 class MockActor {
   constructor(id = 'actorXYZ') {
@@ -399,15 +400,16 @@ describe('ProcessingCommandState.enterState – error branches', () => {
 });
 
 describe('ProcessingCommandState._getServiceFromContext – error branches', () => {
-  test('should return null and clear _isProcessing when turnCtx is null', async () => {
+  test('should throw ServiceLookupError and clear _isProcessing when turnCtx is null', async () => {
     processingState['_isProcessing'] = true;
-    const result = await processingState['_getServiceFromContext'](
-      null,
-      'getCommandProcessor',
-      'ICommandProcessor',
-      'actorZ'
-    );
-    expect(result).toBeNull();
+    await expect(
+      processingState['_getServiceFromContext'](
+        null,
+        'getCommandProcessor',
+        'ICommandProcessor',
+        'actorZ'
+      )
+    ).rejects.toThrow(ServiceLookupError);
     expect(processingState['_isProcessing']).toBe(false);
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Invalid turnCtx in _getServiceFromContext')
@@ -425,14 +427,14 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     processingState['_isProcessing'] = true;
     const dummyCtx = {};
 
-    const result = await processingState['_getServiceFromContext'](
-      dummyCtx,
-      'getCommandProcessor',
-      'ICommandProcessor',
-      'actorMissingLogger'
-    );
-
-    expect(result).toBeNull();
+    await expect(
+      processingState['_getServiceFromContext'](
+        dummyCtx,
+        'getCommandProcessor',
+        'ICommandProcessor',
+        'actorMissingLogger'
+      )
+    ).rejects.toThrow(ServiceLookupError);
     expect(processingState['_isProcessing']).toBe(false);
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Invalid turnCtx in _getServiceFromContext')
@@ -445,7 +447,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     );
   });
 
-  test('should catch missing method on turnCtx and dispatch SYSTEM_ERROR_OCCURRED_ID, then return null', async () => {
+  test('should catch missing method on turnCtx and dispatch SYSTEM_ERROR_OCCURRED_ID', async () => {
     processingState['_isProcessing'] = true;
     const actor = new MockActor('actorF');
     const mockTurnContext = {
@@ -456,13 +458,14 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     const spyDispatch = mockHandler.safeEventDispatcher.dispatch;
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
-    const result = await processingState['_getServiceFromContext'](
-      mockTurnContext,
-      'getCommandProcessor',
-      'ICommandProcessor',
-      actor.id
-    );
-    expect(result).toBeNull();
+    await expect(
+      processingState['_getServiceFromContext'](
+        mockTurnContext,
+        'getCommandProcessor',
+        'ICommandProcessor',
+        actor.id
+      )
+    ).rejects.toThrow(ServiceLookupError);
     // _isProcessing should be set to false
     expect(processingState['_isProcessing']).toBe(false);
     // SYSTEM_ERROR_OCCURRED_ID dispatched via handler.safeEventDispatcher
@@ -493,13 +496,14 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     };
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
-    const result = await processingState['_getServiceFromContext'](
-      mockTurnContext,
-      'getCommandProcessor',
-      'ICommandProcessor',
-      actor.id
-    );
-    expect(result).toBeNull();
+    await expect(
+      processingState['_getServiceFromContext'](
+        mockTurnContext,
+        'getCommandProcessor',
+        'ICommandProcessor',
+        actor.id
+      )
+    ).rejects.toThrow(ServiceLookupError);
     expect(processingState['_isProcessing']).toBe(false);
     const spyDispatch = mockEventDispatcher.dispatch;
     expect(spyDispatch).toHaveBeenCalledWith(


### PR DESCRIPTION
Summary: Introduced ServiceLookupError class and updated service retrieval to throw it so callers can handle failures. Updated processing flow to catch this new error and route through error handling. Adjusted tests for new behavior.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 3101 problems)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6859aae2218c8331b0a4b4aeea676af4