### PR TITLE
[Agent] split mock factories

### DIFF
--- a/tests/common/mockFactories/dataFetcherMock.js
+++ b/tests/common/mockFactories/dataFetcherMock.js
@@ -1,0 +1,87 @@
+import { jest } from '@jest/globals';
+import { deepClone } from '../../../src/utils/cloneUtils.js';
+
+export const createMockDataFetcher = ({
+  fromDisk = false,
+  pathToResponse = {},
+  errorPaths = [],
+  overrides = {},
+} = {}) => {
+  if (fromDisk) {
+    const fs = require('fs');
+    return {
+      fetch: jest.fn().mockImplementation(async (identifier) => {
+        if (identifier.endsWith('.json')) {
+          const filePath = identifier.replace(/^\.\//, '');
+          return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        }
+        throw new Error('Unsupported identifier: ' + identifier);
+      }),
+      fetchJson: jest.fn(),
+      fetchText: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  let fetchErrorMessage = '';
+  const mockFetcher = {
+    fetch: jest.fn(),
+    fetchJson: jest.fn(),
+    fetchText: jest.fn(),
+    mockSuccess: function (path, responseData) {
+      pathToResponse[path] = deepClone(responseData);
+      if (errorPaths.includes(path)) {
+        errorPaths = errorPaths.filter((p) => p !== path);
+      }
+      setFetchImplementation();
+    },
+    mockFailure: function (
+      path,
+      errorMessage = `Mock Fetch Error: Failed to fetch ${path}`
+    ) {
+      if (!errorPaths.includes(path)) {
+        errorPaths.push(path);
+      }
+      if (Object.prototype.hasOwnProperty.call(pathToResponse, path)) {
+        delete pathToResponse[path];
+      }
+      fetchErrorMessage = errorMessage;
+      setFetchImplementation();
+    },
+    ...overrides,
+  };
+
+  /**
+   *
+   */
+  function setFetchImplementation() {
+    mockFetcher.fetch.mockImplementation(async (p) => {
+      if (errorPaths.includes(p)) {
+        const message =
+          fetchErrorMessage || `Mock Fetch Error: Failed to fetch ${p}`;
+        return Promise.reject(new Error(message));
+      }
+      if (Object.prototype.hasOwnProperty.call(pathToResponse, p)) {
+        try {
+          return Promise.resolve(deepClone(pathToResponse[p]));
+        } catch (e) {
+          return Promise.reject(
+            new Error(
+              `Mock Fetcher Error: Could not clone mock data for path ${p}. Is it valid JSON?`
+            )
+          );
+        }
+      }
+      if (overrides.defaultValue !== undefined) {
+        return Promise.resolve(deepClone(overrides.defaultValue));
+      }
+      return Promise.reject(
+        new Error(`Mock Fetch Error: 404 Not Found for path ${p}`)
+      );
+    });
+  }
+
+  setFetchImplementation();
+
+  return mockFetcher;
+};

--- a/tests/common/mockFactories/eventBusMocks.js
+++ b/tests/common/mockFactories/eventBusMocks.js
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+import { createSimpleMock } from './coreServices.js';
+
+export const createMockSafeEventDispatcher = () =>
+  createSimpleMock(['dispatch']);
+
+export const createMockValidatedEventDispatcher = () =>
+  createSimpleMock(['dispatch'], {
+    dispatch: jest.fn().mockResolvedValue(undefined),
+  });
+
+export const createEventBusMock = ({ captureEvents = false } = {}) => {
+  const handlers = {};
+  const events = [];
+
+  const bus = {
+    dispatch: jest.fn(async (eventType, payload) => {
+      if (captureEvents) {
+        events.push({ eventType, payload });
+      }
+      const listeners = [
+        ...(handlers[eventType] || []),
+        ...(handlers['*'] || []),
+      ];
+      await Promise.all(
+        listeners.map(async (h) => {
+          await h({ type: eventType, payload });
+        })
+      );
+    }),
+    subscribe: jest.fn((eventType, handler) => {
+      if (!handlers[eventType]) {
+        handlers[eventType] = new Set();
+      }
+      handlers[eventType].add(handler);
+      return jest.fn(() => {
+        handlers[eventType]?.delete(handler);
+      });
+    }),
+    unsubscribe: jest.fn((eventType, handler) => {
+      handlers[eventType]?.delete(handler);
+    }),
+    _triggerEvent(eventType, payload) {
+      (handlers[eventType] || new Set()).forEach((h) => h(payload));
+    },
+    _clearHandlers() {
+      Object.keys(handlers).forEach((k) => delete handlers[k]);
+    },
+  };
+
+  if (captureEvents) {
+    bus.events = events;
+  }
+
+  return bus;
+};
+
+export const createMockValidatedEventBus = () => createEventBusMock();
+
+export const createCapturingEventBus = () =>
+  createEventBusMock({ captureEvents: true });
+
+export const createMockValidatedEventDispatcherForIntegration = () => ({
+  dispatch: jest.fn().mockResolvedValue(true),
+  subscribe: jest.fn().mockReturnValue(() => {}),
+  unsubscribe: jest.fn(),
+});

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -1,4 +1,8 @@
 export * from './coreServices.js';
+export * from './loggerMocks.js';
+export * from './eventBusMocks.js';
+export * from './turnMocks.js';
+export * from './dataFetcherMock.js';
 export * from './loaders.js';
 export * from './entities.js';
 export * from './container.js';
@@ -6,11 +10,14 @@ export * from './container.js';
 // Explicit convenience exports
 export {
   createMockPathResolver,
-  createMockDataFetcher,
-  createMockValidatedEventDispatcherForIntegration,
-  createCapturingEventBus,
   createMockAIPromptPipeline,
 } from './coreServices.js';
+
+export { createMockDataFetcher } from './dataFetcherMock.js';
+export {
+  createMockValidatedEventDispatcherForIntegration,
+  createCapturingEventBus,
+} from './eventBusMocks.js';
 
 export { createLoaderMocks } from './loaders.js';
 

--- a/tests/common/mockFactories/loggerMocks.js
+++ b/tests/common/mockFactories/loggerMocks.js
@@ -1,0 +1,4 @@
+import { createSimpleMock } from './coreServices.js';
+
+export const createMockLogger = () =>
+  createSimpleMock(['info', 'warn', 'error', 'debug']);

--- a/tests/common/mockFactories/turnMocks.js
+++ b/tests/common/mockFactories/turnMocks.js
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals';
+import { createSimpleMock } from './coreServices.js';
+
+export const createMockTurnManager = () =>
+  createSimpleMock(['start', 'stop', 'nextTurn']);
+
+export const createMockTurnOrderService = () =>
+  createSimpleMock([
+    'startNewRound',
+    'getNextEntity',
+    'peekNextEntity',
+    'addEntity',
+    'removeEntity',
+    'isEmpty',
+    'getCurrentOrder',
+    'clearCurrentRound',
+  ]);
+
+export const createMockTurnHandlerResolver = () =>
+  createSimpleMock(['resolveHandler']);
+
+export const createMockTurnHandler = ({
+  actor = null,
+  failStart = false,
+  failDestroy = false,
+  includeSignalTermination = false,
+  name = 'MockTurnHandler',
+} = {}) => {
+  const handler = {
+    actor,
+    startTurn: jest.fn().mockImplementation((currentActor) => {
+      const promise = failStart
+        ? Promise.reject(
+            new Error(
+              `Simulated startTurn failure for ${currentActor?.id || 'unknown actor'}`
+            )
+          )
+        : Promise.resolve();
+      console.log(
+        'createMockTurnHandler.startTurn called, returns Promise:',
+        typeof promise.then === 'function'
+      );
+      return promise;
+    }),
+    destroy: jest.fn().mockImplementation(() => {
+      if (failDestroy) {
+        return Promise.reject(new Error('Simulated destroy failure'));
+      }
+      return Promise.resolve();
+    }),
+  };
+  const NamedConstructor = Function('return function ' + name + '(){}')();
+  handler.constructor = NamedConstructor;
+  if (includeSignalTermination) {
+    handler.signalNormalApparentTermination = jest.fn();
+  }
+  return handler;
+};


### PR DESCRIPTION
## Summary
- extract logger mock into dedicated file
- extract event bus mocks into dedicated file
- extract turn-related mocks into dedicated file
- extract data fetcher mock into dedicated file
- update mockFactories index exports
- trim removed factories from coreServices

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859ab6392f88331816b7d73d9aa85c1