### PR TITLE
[Agent] refactor DocumentContext detection

### DIFF
--- a/tests/unit/domUI/detectDocumentContext.node.test.js
+++ b/tests/unit/domUI/detectDocumentContext.node.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+import { describe, it, expect, jest } from '@jest/globals';
+import { detectDocumentContext } from '../../../src/domUI/documentContext.js';
+
+describe('detectDocumentContext (node environment)', () => {
+  it('returns null and logs an error when no document is available', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = detectDocumentContext();
+    expect(ctx).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not determine a valid document context')
+    );
+  });
+});

--- a/tests/unit/domUI/detectDocumentContext.test.js
+++ b/tests/unit/domUI/detectDocumentContext.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { detectDocumentContext } from '../../../src/domUI/documentContext.js';
+
+// Use the JSDOM environment provided by Jest
+
+describe('detectDocumentContext (JSDOM)', () => {
+  let window;
+  let document;
+
+  beforeEach(() => {
+    window = global.window;
+    document = global.document;
+    document.body.innerHTML = '<div id="root"><span class="foo"></span></div>';
+    global.HTMLElement = window.HTMLElement;
+    global.Document = window.Document;
+  });
+
+  it('returns the global document when no root is provided', () => {
+    const ctx = detectDocumentContext();
+    expect(ctx).toBe(document);
+  });
+
+  it("returns the root's ownerDocument when given an element", () => {
+    const rootEl = document.getElementById('root');
+    const ctx = detectDocumentContext(rootEl);
+    expect(ctx).toBe(document);
+  });
+
+  it('returns the provided document when passed directly', () => {
+    const ctx = detectDocumentContext(document);
+    expect(ctx).toBe(document);
+  });
+
+  it('uses duck-typed document-like objects', () => {
+    const fakeDoc = {
+      querySelector: () => null,
+      createElement: () => null,
+    };
+    const ctx = detectDocumentContext(fakeDoc);
+    expect(ctx).toBe(fakeDoc);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor document context detection into detectDocumentContext
- use detectDocumentContext in DocumentContext constructor
- expose the helper for tests
- test document context detection in both jsdom and node environments

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859ada47f5c8331a415c075d2f9b506