### PR TITLE
[Agent] rename target existence check helper

### DIFF
--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -177,8 +177,8 @@ export class ActionValidationService {
    * @param {string} actionId - The ID of the action being validated (for logging).
    * @returns {void}
    */
-  _ensureTargetExists(targetContext, actionId) {
-    // Refactor-AVS-4.1 Decision: Keep EntityManager dependency for _ensureTargetExists.
+  warnIfTargetMissing(targetContext, actionId) {
+    // Refactor-AVS-4.1 Decision: Keep EntityManager dependency for warnIfTargetMissing.
     // Reason: This check provides an early warning if a target entity ID resolved for validation
     // does not correspond to an active entity instance in the EntityManager.
     // While the PrerequisiteEvaluation flow (via ActionValidationContextBuilder) already handles
@@ -202,7 +202,6 @@ export class ActionValidationService {
     this.#logger.debug(
       `Validation[${actionId}]: → STEP 2 PASSED (Entity Existence Checked).`
     );
-    return true;
   }
 
   /**
@@ -339,9 +338,7 @@ export class ActionValidationService {
       }
 
       // Step 2: Verify Target Entity Existence
-      if (!this._ensureTargetExists(targetContext, actionId)) {
-        return false;
-      }
+      this.warnIfTargetMissing(targetContext, actionId);
 
       // Steps 3 & 4: Process prerequisites
       const prerequisitesPassed = this._validatePrerequisites(

--- a/tests/unit/services/actionValidationService.actorComponents.test.js
+++ b/tests/unit/services/actionValidationService.actorComponents.test.js
@@ -614,9 +614,7 @@ describe('ActionValidationService: Orchestration Logic', () => {
     const step1 = jest
       .spyOn(actionValidationService, '_validateDomainAndContext')
       .mockReturnValue(true);
-    const step2 = jest
-      .spyOn(actionValidationService, '_ensureTargetExists')
-      .mockReturnValue(true);
+    const step2 = jest.spyOn(actionValidationService, 'warnIfTargetMissing');
     const step3 = jest
       .spyOn(actionValidationService, '_validatePrerequisites')
       .mockReturnValue(true);


### PR DESCRIPTION
Summary: Renamed the helper that verifies entity targets so it just logs warnings and doesn't return a value. Updated the orchestration logic and related test accordingly.

Testing Done:
- [x] Code formatted `npx prettier --write src/actions/validation/actionValidationService.js tests/unit/services/actionValidationService.actorComponents.test.js`
- [x] Lint executed `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859ad67f1d88331802c1637836dd1ad