### PR TITLE
[Agent] Implement MockContainer class

### DIFF
--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -16,4 +16,4 @@ export { createLoaderMocks } from './loaders.js';
 
 export { createRuleTestDataRegistry } from './entities.js';
 
-export { createMockContainerWithRegistration } from './container.js';
+export { MockContainer } from './container.js';

--- a/tests/unit/config/registrations/initializerRegistrations.test.js
+++ b/tests/unit/config/registrations/initializerRegistrations.test.js
@@ -20,7 +20,7 @@ import { registerInitializers } from '../../../../src/dependencyInjection/regist
 // --- Dependencies ---
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import { INITIALIZABLE } from '../../../../src/dependencyInjection/tags.js';
-import { createMockContainerWithRegistration } from '../../../common/mockFactories/index.js';
+import { MockContainer } from '../../../common/mockFactories/index.js';
 
 // --- MOCK the Modules (Classes being registered) ---
 jest.mock('../../../../src/initializers/worldInitializer.js');
@@ -45,12 +45,12 @@ const mockSpatialIndexManager = { name: 'MockSpatialIndexManager' };
 const mockScopeRegistry = { name: 'MockScopeRegistry' };
 
 describe('registerInitializers', () => {
-  /** @type {ReturnType<typeof createMockContainerWithRegistration>} */
+  /** @type {MockContainer} */
   let mockContainer;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContainer = createMockContainerWithRegistration();
+    mockContainer = new MockContainer();
 
     // Register all base dependencies that the factories might try to resolve
     mockContainer.register(tokens.ILogger, mockLogger, {

--- a/tests/unit/config/registrations/interpreterRegistrations.test.js
+++ b/tests/unit/config/registrations/interpreterRegistrations.test.js
@@ -21,7 +21,7 @@ import { registerInterpreters } from '../../../../src/dependencyInjection/regist
 
 // --- Dependencies ---
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
-import { createMockContainerWithRegistration } from '../../../common/mockFactories/index.js';
+import { MockContainer } from '../../../common/mockFactories/index.js';
 
 // --- Mock Modules ---
 jest.mock('../../../../src/logic/operationRegistry.js');
@@ -75,12 +75,12 @@ const mockvalidatedEventDispatcher = {
 const mockSafeEventDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
 
 describe('registerInterpreters', () => {
-  /** @type {ReturnType<typeof createMockContainerWithRegistration>} */
+  /** @type {MockContainer} */
   let mockContainer;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContainer = createMockContainerWithRegistration();
+    mockContainer = new MockContainer();
 
     // Pre-register core dependencies NEEDED by the interpreter factories
     // These are the services the factories themselves will resolve.

--- a/tests/unit/config/registrations/loadersRegistrations.test.js
+++ b/tests/unit/config/registrations/loadersRegistrations.test.js
@@ -48,7 +48,7 @@ import DefaultPathResolver from '../../../../src/pathing/defaultPathResolver.js'
 import AjvSchemaValidator from '../../../../src/validation/ajvSchemaValidator.js';
 import InMemoryDataRegistry from '../../../../src/data/inMemoryDataRegistry.js';
 import WorkspaceDataFetcher from '../../../../src/data/workspaceDataFetcher.js';
-import { createMockContainerWithRegistration } from '../../../common/mockFactories/index.js';
+import { MockContainer } from '../../../common/mockFactories/index.js';
 
 // --- Mock Implementations (Core Services) ---
 const mockLogger = {
@@ -141,12 +141,12 @@ const mockDataRegistry = {
 
 // --- Mock Custom DI Container ---
 describe('registerLoaders (with Mock DI Container)', () => {
-  /** @type {ReturnType<typeof createMockContainerWithRegistration>} */
+  /** @type {MockContainer} */
   let mockContainer;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContainer = createMockContainerWithRegistration();
+    mockContainer = new MockContainer();
 
     // Register the logger BEFORE calling the function under test
     // Use internalOptions here for the mock's logic

--- a/tests/unit/config/registrations/promptBuilderRegistration.test.js
+++ b/tests/unit/config/registrations/promptBuilderRegistration.test.js
@@ -15,7 +15,7 @@ import { describe, beforeEach, it, expect, jest } from '@jest/globals';
 // --- Dependencies for Registration ---
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import { Registrar } from '../../../../src/dependencyInjection/registrarHelpers.js';
-import { createMockContainerWithRegistration } from '../../../common/mockFactories/index.js';
+import { MockContainer } from '../../../common/mockFactories/index.js';
 
 // --- Classes to be Mocked ---
 // Mock concrete implementations that will be instantiated by factories or resolved.
@@ -94,6 +94,7 @@ const mockLogger = {
 };
 
 describe('IPromptBuilder Registration and Resolution', () => {
+  /** @type {MockContainer} */
   let mockContainer;
   let registrar;
 
@@ -142,7 +143,7 @@ describe('IPromptBuilder Registration and Resolution', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContainer = createMockContainerWithRegistration();
+    mockContainer = new MockContainer();
     registrar = new Registrar(mockContainer);
 
     // Pre-register the mocked dependencies that IPromptBuilder's factory will resolve


### PR DESCRIPTION
## Summary
- add `MockContainer` class to encapsulate registration logic
- update mockFactories index to export `MockContainer`
- switch registration tests to instantiate `MockContainer`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: cannot meet lint rules)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859adb9d47c833198f5982fdaefa375