### PR TITLE
[Agent] centralize slot item rendering

### DIFF
--- a/src/domUI/helpers/renderSlotItem.js
+++ b/src/domUI/helpers/renderSlotItem.js
@@ -71,3 +71,35 @@ export function renderSlotItem(
 
   return slotDiv;
 }
+
+/**
+ * Wrapper that also sets tabindex and delegates to {@link renderSlotItem}.
+ *
+ * @param {DomElementFactory} domFactory - Factory used to create elements.
+ * @param {string} datasetKey - Name of the dataset property for identification.
+ * @param {string|number} datasetValue - Value for the dataset property.
+ * @param {SlotItemMetadata} metadata - Display metadata for the slot.
+ * @param {number} itemIndex - Index of the slot in its list.
+ * @param {(Event) => void} [onClick] - Optional click handler for the slot.
+ * @returns {HTMLElement | null} The constructed slot element or null on failure.
+ */
+export function renderGenericSlotItem(
+  domFactory,
+  datasetKey,
+  datasetValue,
+  metadata,
+  itemIndex,
+  onClick
+) {
+  const slotDiv = renderSlotItem(
+    domFactory,
+    datasetKey,
+    datasetValue,
+    metadata,
+    onClick
+  );
+  if (!slotDiv) return null;
+
+  slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1');
+  return slotDiv;
+}

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -4,7 +4,10 @@ import { SlotModalBase } from './slotModalBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import { formatSaveFileMetadata } from './helpers/slotDataFormatter.js';
 import { fetchAndFormatLoadSlots } from '../utils/loadSlotUtils.js';
-import { renderSlotItem } from './helpers/renderSlotItem.js';
+import {
+  renderGenericSlotItem,
+  renderSlotItem,
+} from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 import createMessageElement from './helpers/createMessageElement.js';
 
@@ -252,11 +255,12 @@ class LoadGameUI extends SlotModalBase {
 
     const metadata = slotData.slotItemMeta || formatSaveFileMetadata(slotData);
 
-    const slotDiv = renderSlotItem(
+    return renderGenericSlotItem(
       this.domElementFactory,
       'slotIdentifier',
       slotData.identifier,
       metadata,
+      itemIndex,
       (evt) => {
         this._onItemSelected(
           /** @type {HTMLElement} */ (evt.currentTarget),
@@ -264,10 +268,6 @@ class LoadGameUI extends SlotModalBase {
         );
       }
     );
-    if (!slotDiv) return null;
-
-    slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1');
-    return slotDiv;
   }
 
   /**

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -6,7 +6,10 @@ import {
   formatSaveFileMetadata,
   formatEmptySlot,
 } from './helpers/slotDataFormatter.js';
-import { renderSlotItem } from './helpers/renderSlotItem.js';
+import {
+  renderGenericSlotItem,
+  renderSlotItem,
+} from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 import createMessageElement from './helpers/createMessageElement.js';
 
@@ -286,11 +289,12 @@ export class SaveGameUI extends SlotModalBase {
           )
         : formatSaveFileMetadata(slotData));
 
-    const slotDiv = renderSlotItem(
+    return renderGenericSlotItem(
       this.domElementFactory,
       'slotId',
       slotData.slotId,
       metadata,
+      itemIndex,
       (evt) => {
         this._onItemSelected(
           /** @type {HTMLElement} */ (evt.currentTarget),
@@ -298,10 +302,6 @@ export class SaveGameUI extends SlotModalBase {
         );
       }
     );
-    if (!slotDiv) return null;
-
-    slotDiv.setAttribute('tabindex', itemIndex === 0 ? '0' : '-1');
-    return slotDiv;
   }
 
   /**

--- a/tests/unit/domUI/helpers/renderSlotItem.test.js
+++ b/tests/unit/domUI/helpers/renderSlotItem.test.js
@@ -4,7 +4,10 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import DocumentContext from '../../../../src/domUI/documentContext.js';
 import DomElementFactory from '../../../../src/domUI/domElementFactory.js';
-import { renderSlotItem } from '../../../../src/domUI/helpers/renderSlotItem.js';
+import {
+  renderGenericSlotItem,
+  renderSlotItem,
+} from '../../../../src/domUI/helpers/renderSlotItem.js';
 
 describe('renderSlotItem', () => {
   let factory;
@@ -44,5 +47,17 @@ describe('renderSlotItem', () => {
   it('returns null when factory is missing', () => {
     const res = renderSlotItem(null, 'id', '1', {}, undefined);
     expect(res).toBeNull();
+  });
+
+  it('sets tabindex correctly via renderGenericSlotItem', () => {
+    const slot = renderGenericSlotItem(
+      factory,
+      'slotId',
+      '1',
+      { name: 'Save1' },
+      0,
+      undefined
+    );
+    expect(slot?.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/tests/unit/domUI/loadGameUI.coverage.test.js
+++ b/tests/unit/domUI/loadGameUI.coverage.test.js
@@ -32,7 +32,7 @@ jest.mock('../../../src/utils/listNavigationUtils.js', () => ({
 }));
 
 jest.mock('../../../src/domUI/helpers/renderSlotItem.js', () => ({
-  renderSlotItem: jest.fn(),
+  renderGenericSlotItem: jest.fn(),
 }));
 
 jest.mock('../../../src/domUI/helpers/createMessageElement.js', () => ({
@@ -337,16 +337,18 @@ describe('LoadGameUI', () => {
 
     it('_renderLoadSlotItem should call renderSlotItem helper with correct params', () => {
       const mockDiv = mockDocument.createElement('div');
-      renderSlotItemModule.renderSlotItem.mockReturnValue(mockDiv);
+      mockDiv.setAttribute('tabindex', '0');
+      renderSlotItemModule.renderGenericSlotItem.mockReturnValue(mockDiv);
       instance = createInstance();
 
       const result = instance._renderLoadSlotItem(aGoodSlot, 0);
 
-      expect(renderSlotItemModule.renderSlotItem).toHaveBeenCalledWith(
+      expect(renderSlotItemModule.renderGenericSlotItem).toHaveBeenCalledWith(
         mockDomElementFactory,
         'slotIdentifier',
         aGoodSlot.identifier,
         expect.any(Object),
+        0,
         expect.any(Function)
       );
       expect(result).toBe(mockDiv);

--- a/tests/unit/domUI/loadGameUI.test.js
+++ b/tests/unit/domUI/loadGameUI.test.js
@@ -22,7 +22,7 @@ let domElementFactory;
 let mockVED;
 let mockSaveLoadService;
 let loadGameUI;
-/** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderSlotItem>} */
+/** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderGenericSlotItem>} */
 let renderSlotItemSpy;
 
 beforeEach(() => {
@@ -71,7 +71,7 @@ beforeEach(() => {
     saveLoadService: mockSaveLoadService,
     validatedEventDispatcher: mockVED,
   });
-  renderSlotItemSpy = jest.spyOn(renderSlotItemModule, 'renderSlotItem');
+  renderSlotItemSpy = jest.spyOn(renderSlotItemModule, 'renderGenericSlotItem');
 });
 
 afterEach(() => {

--- a/tests/unit/domUI/saveGameUI.test.js
+++ b/tests/unit/domUI/saveGameUI.test.js
@@ -38,7 +38,7 @@ describe('SaveGameUI', () => {
   let mockValidatedEventDispatcher;
   let mockGameEngine;
 
-  /** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderSlotItem>} */
+  /** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderGenericSlotItem>} */
   let renderSlotItemSpy;
 
   let mockSaveLoadService;
@@ -132,7 +132,10 @@ describe('SaveGameUI', () => {
       validatedEventDispatcher: mockValidatedEventDispatcher,
     });
     saveGameUI.init(mockGameEngine);
-    renderSlotItemSpy = jest.spyOn(renderSlotItemModule, 'renderSlotItem');
+    renderSlotItemSpy = jest.spyOn(
+      renderSlotItemModule,
+      'renderGenericSlotItem'
+    );
 
     jest.useFakeTimers();
   });


### PR DESCRIPTION
## Summary
- add `renderGenericSlotItem` helper
- wrap slot item rendering in SaveGameUI and LoadGameUI
- update unit tests for new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3101 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859adac8e2c8331b801a8808109bffc