### PR TITLE
[Agent] add save file parser tests

### DIFF
--- a/tests/unit/persistence/saveFileParser.test.js
+++ b/tests/unit/persistence/saveFileParser.test.js
@@ -1,0 +1,137 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
+import {
+  manualSavePath,
+  getManualSavePath,
+} from '../../../src/utils/savePathUtils.js';
+import { createMockLogger } from '../testUtils.js';
+import * as readUtils from '../../../src/utils/saveFileReadUtils.js';
+
+jest.mock('../../../src/utils/saveFileReadUtils.js');
+
+/**
+ *
+ */
+function makeParser() {
+  const logger = createMockLogger();
+  const storageProvider = { readFile: jest.fn() };
+  const serializer = {};
+  const parser = new SaveFileParser({ logger, storageProvider, serializer });
+  return { parser, logger, storageProvider, serializer };
+}
+
+describe('SaveFileParser', () => {
+  let parser;
+  let logger;
+  let storageProvider;
+  let serializer;
+
+  beforeEach(() => {
+    ({ parser, logger, storageProvider, serializer } = makeParser());
+    readUtils.readAndDeserialize.mockReset();
+    logger.debug.mockReset();
+    logger.error.mockReset();
+    logger.warn.mockReset();
+  });
+
+  describe('readParsedSaveObject', () => {
+    it('delegates to readAndDeserialize', async () => {
+      readUtils.readAndDeserialize.mockResolvedValue({
+        success: true,
+        data: {},
+      });
+
+      const result = await parser.readParsedSaveObject('path.sav');
+
+      expect(readUtils.readAndDeserialize).toHaveBeenCalledWith(
+        storageProvider,
+        serializer,
+        expect.any(Object),
+        'path.sav'
+      );
+      expect(result).toEqual({ success: true, data: {} });
+    });
+  });
+
+  describe('parseManualSaveFile', () => {
+    it('returns parsed metadata on success', async () => {
+      const metadata = {
+        identifier: manualSavePath('manual_save_Name.sav'),
+        saveName: 'Name',
+        timestamp: 'now',
+        playtimeSeconds: 1,
+      };
+      readUtils.readAndDeserialize.mockResolvedValue({
+        success: true,
+        data: { metadata },
+      });
+
+      const result = await parser.parseManualSaveFile('manual_save_Name.sav');
+
+      expect(readUtils.readAndDeserialize).toHaveBeenCalledWith(
+        storageProvider,
+        serializer,
+        expect.any(Object),
+        getManualSavePath('Name')
+      );
+      expect(result).toEqual({ metadata, isCorrupted: false });
+      expect(logger.debug).toHaveBeenCalled();
+    });
+
+    it('marks invalid file names as corrupted', async () => {
+      const result = await parser.parseManualSaveFile('');
+
+      expect(result).toEqual({
+        metadata: {
+          identifier: manualSavePath(''),
+          saveName: ' (Invalid Name)',
+          timestamp: 'N/A',
+          playtimeSeconds: 0,
+        },
+        isCorrupted: true,
+      });
+      expect(logger.error).toHaveBeenCalled();
+      expect(readUtils.readAndDeserialize).not.toHaveBeenCalled();
+    });
+
+    it('flags corrupted files when deserialization fails', async () => {
+      readUtils.readAndDeserialize.mockResolvedValue({
+        success: false,
+        error: 'bad',
+      });
+
+      const result = await parser.parseManualSaveFile('manual_save_Bad.sav');
+
+      expect(result).toEqual({
+        metadata: {
+          identifier: manualSavePath('manual_save_Bad.sav'),
+          saveName: 'Bad (Corrupted)',
+          timestamp: 'N/A',
+          playtimeSeconds: 0,
+        },
+        isCorrupted: true,
+      });
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('flags missing metadata section', async () => {
+      readUtils.readAndDeserialize.mockResolvedValue({
+        success: true,
+        data: {},
+      });
+
+      const result = await parser.parseManualSaveFile('manual_save_NoMeta.sav');
+
+      expect(result).toEqual({
+        metadata: {
+          identifier: manualSavePath('manual_save_NoMeta.sav'),
+          saveName: 'NoMeta (No Metadata)',
+          timestamp: 'N/A',
+          playtimeSeconds: 0,
+        },
+        isCorrupted: true,
+      });
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/persistence/writeSaveFile.test.js
+++ b/tests/unit/persistence/writeSaveFile.test.js
@@ -47,4 +47,20 @@ describe('SaveFileRepository.writeSaveFile', () => {
     expect(res.error.message).toMatch(/Not enough disk space/);
     expect(logger.error).toHaveBeenCalled();
   });
+
+  it('passes path and data to the storage provider on disk full', async () => {
+    const data = new Uint8Array([1, 2]);
+    storageProvider.writeFileAtomically.mockResolvedValue({
+      success: false,
+      error: 'disk full',
+      code: StorageErrorCodes.DISK_FULL,
+    });
+
+    await repo.writeSaveFile('save.sav', data);
+
+    expect(storageProvider.writeFileAtomically).toHaveBeenCalledWith(
+      'save.sav',
+      data
+    );
+  });
 });

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -5,6 +5,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import GameStateRestorer from '../../../src/persistence/gameStateRestorer.js';
 import GamePersistenceService from '../../../src/persistence/gamePersistenceService.js';
+import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import { BaseService } from '../../../src/utils/serviceBase.js';
 import {
   createMockLogger,
@@ -103,5 +104,29 @@ describe('Persistence service constructor validation', () => {
       gameStateRestorer: { restoreGameState: jest.fn() },
     });
     expect(service).toBeInstanceOf(BaseService);
+  });
+
+  it('SaveFileParser extends BaseService', () => {
+    const parser = new SaveFileParser({
+      logger: createMockLogger(),
+      storageProvider: { readFile: jest.fn() },
+      serializer: {},
+    });
+    expect(parser).toBeInstanceOf(BaseService);
+  });
+
+  it('SaveFileRepository extends BaseService', () => {
+    const logger = createMockLogger();
+    const storageProvider = {
+      writeFileAtomically: jest.fn(),
+      listFiles: jest.fn(),
+      readFile: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      ensureDirectoryExists: jest.fn(),
+    };
+    const parser = new SaveFileParser({ logger, storageProvider, serializer });
+    const repo = new SaveFileRepository({ logger, storageProvider, parser });
+    expect(repo).toBeInstanceOf(BaseService);
   });
 });


### PR DESCRIPTION
Summary: add unit tests for SaveFileParser methods and extend repository disk-full handling tests. Also verify BaseService initialization for SaveFileParser and SaveFileRepository.

Changes Made:
- Created `saveFileParser.test.js` covering `readParsedSaveObject` and `parseManualSaveFile` flows.
- Added disk-full path assertion in `writeSaveFile.test.js`.
- Updated constructor validation suite with BaseService checks.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_6859b58c0e2c83319707b218c1c75ae2