### PR TITLE
[Agent] centralize unavailable messages for engine tests

### DIFF
--- a/tests/common/engine/unavailableMessages.js
+++ b/tests/common/engine/unavailableMessages.js
@@ -1,0 +1,51 @@
+/**
+ * @file Contains shared error messages for service unavailability in engine tests.
+ */
+
+/**
+ * Error message when GamePersistenceService is missing for showLoadGameUI.
+ *
+ * @type {string}
+ */
+export const GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE =
+  'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.';
+
+/**
+ * Error message when GamePersistenceService is missing for showSaveGameUI.
+ *
+ * @type {string}
+ */
+export const GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE =
+  'GameEngine.showSaveGameUI: GamePersistenceService is unavailable. Cannot show Save Game UI.';
+
+/**
+ * Error message when GamePersistenceService is not available for loadGame.
+ *
+ * @type {string}
+ */
+export const GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE =
+  'GameEngine.loadGame: GamePersistenceService is not available. Cannot load game.';
+
+/**
+ * Error message when GamePersistenceService is not available for triggerManualSave.
+ *
+ * @type {string}
+ */
+export const GAME_PERSISTENCE_TRIGGER_SAVE_UNAVAILABLE =
+  'GameEngine.triggerManualSave: GamePersistenceService is not available. Cannot save game.';
+
+/**
+ * Failure message returned when GamePersistenceService is absent during manual save.
+ *
+ * @type {string}
+ */
+export const GAME_PERSISTENCE_SAVE_RESULT_UNAVAILABLE =
+  'GamePersistenceService is not available. Cannot save game.';
+
+/**
+ * Warning message when PlaytimeTracker is not available during engine stop.
+ *
+ * @type {string}
+ */
+export const PLAYTIME_TRACKER_STOP_UNAVAILABLE =
+  'GameEngine.stop: PlaytimeTracker service not available, cannot end session.';

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -11,6 +11,7 @@ import {
 } from '../../../common/engine/gameEngineHelpers.js';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 import * as bedModule from '../../../common/engine/gameEngineTestBed.js';
+import { GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE } from '../../../common/engine/unavailableMessages.js';
 
 describe('withGameEngineBed', () => {
   it('creates bed, resets mocks, runs callback and cleans up', async () => {
@@ -105,10 +106,7 @@ describe('withRunningGameEngineBed', () => {
 describe('runUnavailableServiceTest', () => {
   it('generates executable test functions', async () => {
     const cases = [
-      [
-        tokens.GamePersistenceService,
-        'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.',
-      ],
+      [tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE],
     ];
 
     const testCases = runUnavailableServiceTest(cases, (bed, engine) => {

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -15,6 +15,7 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import { DEFAULT_SAVE_ID } from '../../common/constants.js';
+import { GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('loadGame', () => {
@@ -182,14 +183,13 @@ describeEngineSuite('GameEngine', (ctx) => {
       [
         [
           tokens.GamePersistenceService,
-          'GameEngine.loadGame: GamePersistenceService is not available. Cannot load game.',
+          GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE,
           { preInit: true },
         ],
       ],
       async (bed, engine, expectedMsg) => {
         const result = await engine.loadGame(SAVE_ID);
 
-         
         expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
         // eslint-disable-next-line jest/no-standalone-expect
         expect(result).toEqual({

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -4,6 +4,7 @@ import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
 import { expectShowLoadGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
+import { GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('showLoadGameUI', () => {
@@ -17,12 +18,7 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     runUnavailableServiceSuite(
-      [
-        [
-          tokens.GamePersistenceService,
-          'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.',
-        ],
-      ],
+      [[tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE]],
       (bed, engine) => {
         engine.showLoadGameUI();
         return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -6,6 +6,7 @@ import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelper
 import { CANNOT_SAVE_GAME_INFO } from '../../../src/constants/eventIds.js';
 import { expectShowSaveGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
+import { GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeInitializedEngineSuite(
   'GameEngine',
@@ -49,12 +50,7 @@ describeInitializedEngineSuite(
       });
 
       runUnavailableServiceSuite(
-        [
-          [
-            tokens.GamePersistenceService,
-            'GameEngine.showSaveGameUI: GamePersistenceService is unavailable. Cannot show Save Game UI.',
-          ],
-        ],
+        [[tokens.GamePersistenceService, GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE]],
         (bed, engine) => {
           engine.showSaveGameUI();
           // eslint-disable-next-line jest/no-standalone-expect

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -22,6 +22,7 @@ import {
   expectEngineStopped,
 } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
+import { PLAYTIME_TRACKER_STOP_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('stop', () => {
@@ -41,7 +42,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           [
             [
               tokens.PlaytimeTracker,
-              'GameEngine.stop: PlaytimeTracker service not available, cannot end session.',
+              PLAYTIME_TRACKER_STOP_UNAVAILABLE,
               { preInit: true },
             ],
           ],

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -15,6 +15,10 @@ import {
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   DEFAULT_SAVE_NAME,
 } from '../../common/constants.js';
+import {
+  GAME_PERSISTENCE_TRIGGER_SAVE_UNAVAILABLE,
+  GAME_PERSISTENCE_SAVE_RESULT_UNAVAILABLE,
+} from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
   describe('triggerManualSave', () => {
@@ -40,20 +44,18 @@ describeEngineSuite('GameEngine', (ctx) => {
           [
             [
               tokens.GamePersistenceService,
-              'GameEngine.triggerManualSave: GamePersistenceService is not available. Cannot save game.',
+              GAME_PERSISTENCE_TRIGGER_SAVE_UNAVAILABLE,
               { preInit: true },
             ],
           ],
           async (bed, engine) => {
             const result = await engine.triggerManualSave(SAVE_NAME);
 
-             
             expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
             // eslint-disable-next-line jest/no-standalone-expect
             expect(result).toEqual({
               success: false,
-              error:
-                'GamePersistenceService is not available. Cannot save game.',
+              error: GAME_PERSISTENCE_SAVE_RESULT_UNAVAILABLE,
             });
             return [
               bed.mocks.logger.error,


### PR DESCRIPTION
Summary: Added `tests/common/engine/unavailableMessages.js` to hold shared service unavailability strings and updated all engine test suites to import these constants. Replaced literal messages in `runUnavailableServiceSuite` calls and related assertions. All tests pass after the update.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: existing repository issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859b57950e88331ab7e31921335e6c0