### PR TITLE
[Agent] implement waitForCondition helper

### DIFF
--- a/tests/common/jestHelpers.js
+++ b/tests/common/jestHelpers.js
@@ -33,3 +33,23 @@ export function suppressConsoleError() {
 export async function flushPromisesAndTimers() {
   await jest.runAllTimersAsync();
 }
+
+/**
+ * Waits for the provided asynchronous condition function to return true,
+ * flushing timers between checks.
+ *
+ * @param {() => (boolean|Promise<boolean>)} asyncFn - Condition function.
+ * @param {number} [maxTicks=50] - Maximum iterations to attempt.
+ * @returns {Promise<boolean>} Resolves true if the condition is met.
+ */
+export async function waitForCondition(asyncFn, maxTicks = 50) {
+  for (let i = 0; i < maxTicks; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await asyncFn()) {
+      return true;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await flushPromisesAndTimers();
+  }
+  return false;
+}

--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -10,7 +10,7 @@ import {
   TURN_STARTED_ID,
   TURN_PROCESSING_STARTED,
 } from '../../../src/constants/eventIds.js';
-import { flushPromisesAndTimers } from './turnManagerTestBed.js';
+import { flushPromisesAndTimers, waitForCondition } from '../jestHelpers.js';
 
 /**
  * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
@@ -66,13 +66,10 @@ export function expectTurnStartedEvents(dispatchMock, actorId, actorType) {
  * @returns {Promise<boolean>} Resolves true if actor found before timeout.
  */
 export async function waitForCurrentActor(bed, id, maxTicks = 50) {
-  for (let i = 0; i < maxTicks; i++) {
-    if (bed.turnManager.getCurrentActor()?.id === id) {
-      return true;
-    }
-    await flushPromisesAndTimers();
-  }
-  return false;
+  return waitForCondition(
+    () => bed.turnManager.getCurrentActor()?.id === id,
+    maxTicks
+  );
 }
 
 /**


### PR DESCRIPTION
Summary: 
- add `waitForCondition` in jest helpers
- use new helper in TurnManager utilities

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes for changed files `npx eslint tests/common/jestHelpers.js tests/common/turns/turnManagerTestUtils.js`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b55233d083319cad34ea9e39c8d8