### PR TITLE
[Agent] refactor environment helpers

### DIFF
--- a/tests/common/engine/gameEngineEnvironment.js
+++ b/tests/common/engine/gameEngineEnvironment.js
@@ -58,12 +58,11 @@ const tokenMap = {
  *   Test environment utilities and mocks.
  */
 export function createEnvironment(overrides = {}) {
-  const env = createServiceTestEnvironment(
+  const env = createServiceTestEnvironment({
     factoryMap,
     tokenMap,
-    (container) => new GameEngine({ container }),
-    undefined,
-    overrides
-  );
+    build: (container) => new GameEngine({ container }),
+    overrides,
+  });
   return env;
 }

--- a/tests/common/loaders/modsLoader.test-setup.js
+++ b/tests/common/loaders/modsLoader.test-setup.js
@@ -83,12 +83,12 @@ export function createTestEnvironment() {
   /* ── Content-loader mocks ───────────────────────────────────────────── */
   const loaders = createLoaderMocks(loaderTypes);
 
-  const env = createServiceTestEnvironment(
+  const env = createServiceTestEnvironment({
     factoryMap,
-    {},
-    serviceFactory,
-    adjustMocks
-  );
+    tokenMap: {},
+    build: serviceFactory,
+    setupMocks: adjustMocks,
+  });
 
   /* ── Return the assembled environment ──────────────────────────────── */
   return {


### PR DESCRIPTION
## Summary
- consolidate test environment helper logic
- wrap exported helpers around the new shared implementation
- update GameEngine and ModsLoader test helpers

## Testing Done
- `npm run format`
- `npm run lint`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b539251c8331ac993827f475b559