### PR TITLE
[Refactor] Standardize service base class

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -23,6 +23,11 @@ import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
+/**
+ * @class ActionDiscoveryService
+ * @augments IActionDiscoveryService
+ * @description Discovers valid actions for entities. Does not extend BaseService because it already inherits from IActionDiscoveryService.
+ */
 export class ActionDiscoveryService extends IActionDiscoveryService {
   #gameDataRepository;
   #entityManager;
@@ -49,17 +54,17 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
    * @param {Function}           deps.getEntityDisplayNameFn
    */
   constructor({
-                gameDataRepository,
-                entityManager,
-                actionValidationService,
-                logger,
-                formatActionCommandFn,
-                getEntityIdsForScopesFn,
-                safeEventDispatcher,
-                scopeRegistry,
-                getActorLocationFn = getActorLocation,
-                getEntityDisplayNameFn = getEntityDisplayName,
-              }) {
+    gameDataRepository,
+    entityManager,
+    actionValidationService,
+    logger,
+    formatActionCommandFn,
+    getEntityIdsForScopesFn,
+    safeEventDispatcher,
+    scopeRegistry,
+    getActorLocationFn = getActorLocation,
+    getEntityDisplayNameFn = getEntityDisplayName,
+  }) {
     super();
     this.#logger = setupService('ActionDiscoveryService', logger, {
       gameDataRepository: {

--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -7,7 +7,7 @@
 /** @typedef {import('../../logic/defs.js').JsonLogicEvaluationContext} JsonLogicEvaluationContext */
 
 // --- FIX: Import necessary functions and constants ---
-import { setupService } from '../../utils/serviceInitializerUtils.js';
+import { BaseService } from '../../utils/serviceBase.js';
 // FIX: Remove buildDirectionContext as it's obsolete
 import {
   buildActorContext,
@@ -16,10 +16,11 @@ import {
 
 /**
  * @class ActionValidationContextBuilder
+ * @augments BaseService
  * @description Service dedicated to constructing the data context object used
  * for evaluating JsonLogic rules within the action validation process.
  */
-export class ActionValidationContextBuilder {
+export class ActionValidationContextBuilder extends BaseService {
   #entityManager;
   #logger;
 
@@ -30,7 +31,8 @@ export class ActionValidationContextBuilder {
    * @throws {Error} If dependencies are missing or invalid.
    */
   constructor({ entityManager, logger }) {
-    this.#logger = setupService('ActionValidationContextBuilder', logger, {
+    super();
+    this.#logger = this._init('ActionValidationContextBuilder', logger, {
       entityManager: {
         value: entityManager,
         requiredMethods: ['getEntityInstance', 'getComponentData'],

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -9,7 +9,7 @@
 
 import { ActionTargetContext } from '../../models/actionTargetContext.js';
 import { PrerequisiteEvaluationService } from './prerequisiteEvaluationService.js';
-import { setupService } from '../../utils/serviceInitializerUtils.js';
+import { BaseService } from '../../utils/serviceBase.js';
 import {
   TARGET_DOMAIN_SELF,
   TARGET_DOMAIN_NONE,
@@ -18,7 +18,13 @@ import {
 // REMOVED: import { ActionValidationContextBuilder } from './actionValidationContextBuilder.js';
 // --- End Refactor-AVS-3.4 ---
 
-export class ActionValidationService {
+/**
+ * @class ActionValidationService
+ * @augments BaseService
+ * @description Validates whether actions can be executed by entities given the
+ * current game context and prerequisite rules.
+ */
+export class ActionValidationService extends BaseService {
   /** @type {EntityManager} */ #entityManager;
   /** @type {ILogger} */ #logger;
   /** @type {DomainContextCompatibilityChecker} */ #domainContextCompatibilityChecker;
@@ -52,7 +58,8 @@ export class ActionValidationService {
     // REMOVED: actionValidationContextBuilder, // AC1: Dependency removed from constructor destructuring
     // --- End Refactor-AVS-3.4 ---
   }) {
-    this.#logger = setupService('ActionValidationService', logger, {
+    super();
+    this.#logger = this._init('ActionValidationService', logger, {
       entityManager: {
         value: entityManager,
         requiredMethods: ['getEntityInstance'],

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -1,6 +1,6 @@
 // src/actions/validation/prerequisiteEvaluationService.js
 
-import { setupService } from '../../utils/serviceInitializerUtils.js';
+import { BaseService } from '../../utils/serviceBase.js';
 
 /* type-only imports */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -14,11 +14,12 @@ import { setupService } from '../../utils/serviceInitializerUtils.js';
 
 /**
  * @class PrerequisiteEvaluationService
+ * @augments BaseService
  * @description Service dedicated to evaluating prerequisite rules (typically JsonLogic) for actions.
  * It resolves any `condition_ref` instances within the rules, builds the necessary evaluation context,
  * and then uses the JsonLogicEvaluationService to evaluate the final, resolved rules.
  */
-export class PrerequisiteEvaluationService {
+export class PrerequisiteEvaluationService extends BaseService {
   #logger;
   #jsonLogicEvaluationService;
   #actionValidationContextBuilder;
@@ -40,7 +41,8 @@ export class PrerequisiteEvaluationService {
     actionValidationContextBuilder,
     gameDataRepository, // ADDED
   }) {
-    this.#logger = setupService('PrerequisiteEvaluationService', logger, {
+    super();
+    this.#logger = this._init('PrerequisiteEvaluationService', logger, {
       jsonLogicEvaluationService: {
         value: jsonLogicEvaluationService,
         requiredMethods: ['evaluate'],

--- a/src/persistence/activeModsManifestBuilder.js
+++ b/src/persistence/activeModsManifestBuilder.js
@@ -1,7 +1,7 @@
 // src/persistence/activeModsManifestBuilder.js
 
 import { CORE_MOD_ID } from '../constants/core.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -10,9 +10,10 @@ import { setupService } from '../utils/serviceInitializerUtils.js';
 
 /**
  * @class ActiveModsManifestBuilder
+ * @augments BaseService
  * @description Builds the active mods manifest for save files.
  */
-export default class ActiveModsManifestBuilder {
+export default class ActiveModsManifestBuilder extends BaseService {
   /** @type {ILogger} */
   #logger;
   /** @type {IDataRegistry} */
@@ -22,7 +23,8 @@ export default class ActiveModsManifestBuilder {
    * @param {{logger: ILogger, dataRegistry: IDataRegistry}} deps
    */
   constructor({ logger, dataRegistry }) {
-    this.#logger = setupService('ActiveModsManifestBuilder', logger, {
+    super();
+    this.#logger = this._init('ActiveModsManifestBuilder', logger, {
       dataRegistry: { value: dataRegistry, requiredMethods: ['getAll'] },
     });
     this.#dataRegistry = dataRegistry;

--- a/src/persistence/componentCleaningService.js
+++ b/src/persistence/componentCleaningService.js
@@ -1,7 +1,7 @@
 // src/persistence/componentCleaningService.js
 
 import { safeDeepClone } from '../utils/cloneUtils.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 /** @typedef {import('../interfaces/IComponentCleaningService.js').IComponentCleaningService} IComponentCleaningService */
 import {
   NOTES_COMPONENT_ID,
@@ -62,10 +62,11 @@ export function buildDefaultComponentCleaners(logger) {
 
 /**
  * @class ComponentCleaningService
+ * @augments BaseService
  * @implements {IComponentCleaningService}
  * @description Provides registration and execution of component data cleaners.
  */
-class ComponentCleaningService {
+class ComponentCleaningService extends BaseService {
   /** @type {Map<string, (data: any) => any>} */
   #cleaners;
 
@@ -83,7 +84,8 @@ class ComponentCleaningService {
    * @param dependencies.safeEventDispatcher
    */
   constructor({ logger, safeEventDispatcher, defaultCleaners } = {}) {
-    this.#logger = setupService('ComponentCleaningService', logger, {
+    super();
+    this.#logger = this._init('ComponentCleaningService', logger, {
       safeEventDispatcher: {
         value: safeEventDispatcher,
         requiredMethods: ['dispatch'],

--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -3,6 +3,7 @@
 import { encode, decode } from '@msgpack/msgpack';
 import pako from 'pako';
 import { cloneValidatedState } from '../utils/saveStateUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 import {
   PersistenceError,
   PersistenceErrorCodes,
@@ -15,11 +16,12 @@ import { wrapSyncPersistenceOperation } from '../utils/persistenceErrorUtils.js'
 
 /**
  * @class GameStateSerializer
+ * @augments BaseService
  * @description Utility for converting game state objects to and from a
  * MessagePack + Gzip representation. Handles checksum generation using
  * the Web Crypto API.
  */
-class GameStateSerializer {
+class GameStateSerializer extends BaseService {
   /** @type {import('../interfaces/coreServices.js').ILogger} */
   #logger;
 
@@ -34,10 +36,8 @@ class GameStateSerializer {
    * @param {Crypto} [dependencies.crypto] - Web Crypto implementation.
    */
   constructor({ logger, crypto = globalThis.crypto }) {
-    if (!logger) {
-      throw new Error('GameStateSerializer requires a logger.');
-    }
-    this.#logger = logger;
+    super();
+    this.#logger = this._init('GameStateSerializer', logger);
     this.#crypto = crypto;
   }
 

--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -2,7 +2,7 @@
 
 import { PersistenceErrorCodes } from './persistenceErrors.js';
 import { createPersistenceFailure } from '../utils/persistenceResultUtils.js';
-import { setupService } from '../utils/serviceInitializerUtils.js';
+import { BaseService } from '../utils/serviceBase.js';
 import {
   MSG_INTEGRITY_CALCULATION_ERROR,
   MSG_CHECKSUM_MISMATCH,
@@ -14,9 +14,10 @@ import {
 
 /**
  * @class SaveValidationService
+ * @augments BaseService
  * @description Provides validation utilities for loaded save data.
  */
-class SaveValidationService {
+class SaveValidationService extends BaseService {
   /** @type {ILogger} */
   #logger;
 
@@ -31,8 +32,9 @@ class SaveValidationService {
    * @param {GameStateSerializer} dependencies.gameStateSerializer - Serializer used for checksum generation.
    */
   constructor({ logger, gameStateSerializer }) {
+    super();
     this.#serializer = gameStateSerializer;
-    this.#logger = setupService('SaveValidationService', logger, {
+    this.#logger = this._init('SaveValidationService', logger, {
       gameStateSerializer: {
         value: gameStateSerializer,
         requiredMethods: ['calculateGameStateChecksum'],


### PR DESCRIPTION
Summary: Updated multiple services to extend BaseService and initialize via _init for consistent dependency validation.

Changes Made:
- Refactored GameStateSerializer, SaveValidationService, ComponentCleaningService and ActiveModsManifestBuilder to extend BaseService.
- Updated action validation services to inherit from BaseService.
- Documented ActionDiscoveryService inheritance choice.

Testing Done:
- [x] Code formatted (`npx prettier --write` on changed files)
- [ ] Lint passes (`npm run lint` in root) *(fails: 3091 problems)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6859b4deb1788331b03e4e41de03aa4e