### PR TITLE
[Agent] centralize input validation

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -13,6 +13,7 @@ import {
   buildActorContext,
   buildEntityTargetContext,
 } from './contextBuilders.js';
+import { validateActionInputs } from './inputValidators.js';
 
 /**
  * @class ActionValidationContextBuilder
@@ -106,35 +107,7 @@ export class ActionValidationContextBuilder extends BaseService {
    * @private
    */
   #assertValidInputs(actionDefinition, actor, targetContext) {
-    if (!actionDefinition?.id) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid actionDefinition provided (missing id).',
-        { actionDefinition }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid ActionDefinition.'
-      );
-    }
-
-    if (!actor?.id) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid actor entity provided (missing id).',
-        { actor }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid actor Entity.'
-      );
-    }
-
-    if (!targetContext?.type) {
-      this.#logger.error(
-        'ActionValidationContextBuilder: Invalid targetContext provided (missing type).',
-        { targetContext }
-      );
-      throw new Error(
-        'ActionValidationContextBuilder requires a valid ActionTargetContext.'
-      );
-    }
+    validateActionInputs(actionDefinition, actor, targetContext, this.#logger);
   }
 
   /**

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -7,9 +7,10 @@
 /** @typedef {import('../actionTypes.js').ActionAttemptPseudoEvent} ActionAttemptPseudoEvent */
 /** @typedef {import('./prerequisiteEvaluationService.js').PrerequisiteEvaluationService} PrerequisiteEvaluationService */
 
-import { ActionTargetContext } from '../../models/actionTargetContext.js';
+/** @typedef {import('../../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 import { PrerequisiteEvaluationService } from './prerequisiteEvaluationService.js';
 import { BaseService } from '../../utils/serviceBase.js';
+import { validateActionInputs } from './inputValidators.js';
 import {
   TARGET_DOMAIN_SELF,
   TARGET_DOMAIN_NONE,
@@ -113,17 +114,12 @@ export class ActionValidationService extends BaseService {
    * @throws {Error} If any input is structurally invalid according to basic requirements.
    */
   _checkStructuralSanity(actionDefinition, actorEntity, targetContext) {
-    // Extracted structural sanity checks
-    if (!actionDefinition?.id?.trim())
-      throw new Error(
-        'ActionValidationService.isValid: invalid actionDefinition'
-      );
-    if (!actorEntity?.id?.trim())
-      throw new Error('ActionValidationService.isValid: invalid actorEntity');
-    if (!(targetContext instanceof ActionTargetContext))
-      throw new Error(
-        'ActionValidationService.isValid: targetContext must be ActionTargetContext'
-      );
+    validateActionInputs(
+      actionDefinition,
+      actorEntity,
+      targetContext,
+      this.#logger
+    );
   }
 
   /**

--- a/src/actions/validation/inputValidators.js
+++ b/src/actions/validation/inputValidators.js
@@ -1,0 +1,49 @@
+/* type-only imports */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../entities/entity.js').default} Entity */
+/** @typedef {import('../../../data/schemas/action.schema.json').ActionDefinition} ActionDefinition */
+/** @typedef {import('../../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
+
+import { ActionTargetContext } from '../../models/actionTargetContext.js';
+
+/**
+ * @description Validate the core inputs required when processing an action.
+ * Ensures an action definition, actor entity, and target context are structurally sound.
+ * Any failures will be logged and an Error will be thrown.
+ * @param {ActionDefinition} actionDef - Definition describing the attempted action.
+ * @param {Entity} actor - The entity attempting the action.
+ * @param {ActionTargetContext} targetCtx - Context of the action's target.
+ * @param {ILogger} logger - Logger used for reporting validation issues.
+ * @throws {Error} If any input is missing required properties or has the wrong type.
+ * @returns {void}
+ */
+export function validateActionInputs(
+  actionDefinition,
+  actorEntity,
+  targetCtx,
+  logger
+) {
+  if (!actionDefinition?.id?.trim()) {
+    logger.error('Invalid actionDefinition provided (missing id).', {
+      actionDefinition,
+    });
+    throw new Error('Invalid actionDefinition');
+  }
+
+  if (!actorEntity?.id?.trim()) {
+    logger.error('Invalid actor entity provided (missing id).', {
+      actor: actorEntity,
+    });
+    throw new Error('Invalid actor entity');
+  }
+
+  if (!(targetCtx instanceof ActionTargetContext)) {
+    logger.error(
+      'Invalid targetContext provided (expected ActionTargetContext).',
+      {
+        targetContext: targetCtx,
+      }
+    );
+    throw new Error('Invalid ActionTargetContext');
+  }
+}

--- a/tests/unit/services/actionValidationContextBuilder.test.js
+++ b/tests/unit/services/actionValidationContextBuilder.test.js
@@ -258,9 +258,7 @@ describe('ActionValidationContextBuilder', () => {
       it('should throw Error and log error for null actionDefinition', () => {
         const action = () =>
           builder.buildContext(null, mockActor, ActionTargetContext.noTarget());
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid ActionDefinition.'
-        );
+        expect(action).toThrow('Invalid actionDefinition');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: null }
@@ -275,9 +273,7 @@ describe('ActionValidationContextBuilder', () => {
             mockActor,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid ActionDefinition.'
-        );
+        expect(action).toThrow('Invalid actionDefinition');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: invalidActionDef }
@@ -291,9 +287,7 @@ describe('ActionValidationContextBuilder', () => {
             null,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid actor Entity.'
-        );
+        expect(action).toThrow('Invalid actor entity');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actor entity provided'),
           { actor: null }
@@ -308,9 +302,7 @@ describe('ActionValidationContextBuilder', () => {
             invalidActor,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid actor Entity.'
-        );
+        expect(action).toThrow('Invalid actor entity');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actor entity provided'),
           { actor: invalidActor }
@@ -320,9 +312,7 @@ describe('ActionValidationContextBuilder', () => {
       it('should throw Error and log error for null targetContext', () => {
         const action = () =>
           builder.buildContext(sampleActionDefinition, mockActor, null);
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid ActionTargetContext.'
-        );
+        expect(action).toThrow('Invalid ActionTargetContext');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid targetContext provided'),
           { targetContext: null }
@@ -337,9 +327,7 @@ describe('ActionValidationContextBuilder', () => {
             mockActor,
             invalidTargetContext
           );
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid ActionTargetContext.'
-        );
+        expect(action).toThrow('Invalid ActionTargetContext');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid targetContext provided'),
           { targetContext: invalidTargetContext }
@@ -348,9 +336,7 @@ describe('ActionValidationContextBuilder', () => {
 
       it('should prioritize actionDefinition validation when all inputs are missing', () => {
         const action = () => builder.buildContext(null, null, null);
-        expect(action).toThrow(
-          'ActionValidationContextBuilder requires a valid ActionDefinition.'
-        );
+        expect(action).toThrow('Invalid actionDefinition');
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: null }

--- a/tests/unit/services/actionValidationService.actorComponents.test.js
+++ b/tests/unit/services/actionValidationService.actorComponents.test.js
@@ -530,14 +530,12 @@ describe('ActionValidationService: Orchestration Logic', () => {
         actor,
         invalidTargetContext
       );
-    }).toThrow(
-      'ActionValidationService.isValid: targetContext must be ActionTargetContext'
-    );
+    }).toThrow('Invalid ActionTargetContext');
 
     // Assert logging indicates the structural failure before the throw
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Validation: STRUCTURAL ERROR: ActionValidationService.isValid: targetContext must be ActionTargetContext'
+        'Validation: STRUCTURAL ERROR: Invalid ActionTargetContext'
       ),
       expect.any(Object) // Check that some context object was logged
     );

--- a/tests/unit/services/actionValidationService.inputValidation.test.js
+++ b/tests/unit/services/actionValidationService.inputValidation.test.js
@@ -188,8 +188,7 @@ describe('ActionValidationService - Input Validation and Errors', () => {
   test('isValid throws Error if missing or invalid actionDefinition', () => {
     const context = ActionTargetContext.noTarget();
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg =
-      'ActionValidationService.isValid: invalid actionDefinition';
+    const expectedErrorMsg = 'Invalid actionDefinition';
 
     // Test cases for invalid actionDefinition
     expect(() => service.isValid(null, mockActor, context)).toThrow(
@@ -231,8 +230,7 @@ describe('ActionValidationService - Input Validation and Errors', () => {
     };
     const context = ActionTargetContext.noTarget();
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg =
-      'ActionValidationService.isValid: invalid actorEntity';
+    const expectedErrorMsg = 'Invalid actor entity';
 
     // Test cases for invalid actorEntity
     expect(() => service.isValid(actionDef, null, context)).toThrow(
@@ -277,8 +275,7 @@ describe('ActionValidationService - Input Validation and Errors', () => {
       template: 't',
     };
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg =
-      'ActionValidationService.isValid: targetContext must be ActionTargetContext';
+    const expectedErrorMsg = 'Invalid ActionTargetContext';
 
     // Test cases for invalid targetContext
     expect(() => service.isValid(actionDef, mockActor, null)).toThrow(


### PR DESCRIPTION
Summary: implement shared validator for action inputs and refactor services

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 685 errors, existing issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6859ba3681f88331867ec6af6e03702c