### PR TITLE
[Agent] inject aggregator factory

### DIFF
--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -77,6 +77,7 @@ import SummaryPhase from '../../loaders/phases/summaryPhase.js';
 import ModManifestProcessor from '../../loaders/ModManifestProcessor.js';
 import ContentLoadManager from '../../loaders/ContentLoadManager.js';
 import WorldLoadSummaryLogger from '../../loaders/WorldLoadSummaryLogger.js';
+import LoadResultAggregator from '../../loaders/LoadResultAggregator.js';
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
@@ -159,7 +160,7 @@ export function registerLoaders(container) {
   registerLoader(tokens.EntityInstanceLoader, EntityInstanceLoader);
   registerLoader(tokens.WorldLoader, WorldLoader);
   registerLoader(tokens.GoalLoader, GoalLoader);
-  
+
   // Register ScopeLoader with TextDataFetcher instead of regular IDataFetcher
   registrar.singletonFactory(
     tokens.ScopeLoader,
@@ -173,7 +174,7 @@ export function registerLoaders(container) {
         c.resolve(tokens.ILogger)
       )
   );
-  
+
   registerLoader(tokens.ModManifestLoader, ModManifestLoader);
 
   registrar.singletonFactory(
@@ -302,6 +303,7 @@ export function registerLoaders(container) {
             phase: 'instances',
           },
         ],
+        aggregatorFactory: (counts) => new LoadResultAggregator(counts),
       })
   );
 

--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -20,17 +20,26 @@ export class ContentLoadManager {
   #logger;
   #validatedEventDispatcher;
   #contentLoadersConfig;
+  #aggregatorFactory;
 
   /**
    * @param {object} deps - Constructor dependencies.
    * @param {ILogger} deps.logger - Logging service.
    * @param {ValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher.
    * @param {Array<LoaderConfigEntry>} deps.contentLoadersConfig - Loader configuration.
+   * @param {(counts: TotalResultsSummary) => LoadResultAggregator} [deps.aggregatorFactory] -
+   * Factory for creating {@link LoadResultAggregator} instances.
    */
-  constructor({ logger, validatedEventDispatcher, contentLoadersConfig }) {
+  constructor({
+    logger,
+    validatedEventDispatcher,
+    contentLoadersConfig,
+    aggregatorFactory = (counts) => new LoadResultAggregator(counts),
+  }) {
     this.#logger = logger;
     this.#validatedEventDispatcher = validatedEventDispatcher;
     this.#contentLoadersConfig = contentLoadersConfig;
+    this.#aggregatorFactory = aggregatorFactory;
   }
 
   /**
@@ -166,7 +175,7 @@ export class ContentLoadManager {
     this.#logger.debug(
       `--- Loading content for mod: ${modId}, phase: ${phase} ---`
     );
-    const aggregator = new LoadResultAggregator(totalCounts);
+    const aggregator = this.#aggregatorFactory(totalCounts);
     let modDurationMs = 0;
     /** @type {'success' | 'skipped' | 'failed'} */
     let status = 'success'; // Assume success unless a loader fails or mod is skipped

--- a/tests/unit/loaders/contentLoadManager.processMod.test.js
+++ b/tests/unit/loaders/contentLoadManager.processMod.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import ContentLoadManager from '../../../src/loaders/ContentLoadManager.js';
+import LoadResultAggregator from '../../../src/loaders/LoadResultAggregator.js';
 
 /** @typedef {import('../../../src/loaders/LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
 
@@ -43,6 +44,7 @@ describe('ContentLoadManager.processMod', () => {
       logger,
       validatedEventDispatcher: dispatcher,
       contentLoadersConfig: phaseLoadersConfig,
+      aggregatorFactory: (counts) => new LoadResultAggregator(counts),
     });
     /** @type {TotalResultsSummary} */ const totals = {};
     const phase = 'definitions';
@@ -79,6 +81,7 @@ describe('ContentLoadManager.processMod', () => {
       logger,
       validatedEventDispatcher: dispatcher,
       contentLoadersConfig: phaseLoadersConfig,
+      aggregatorFactory: (counts) => new LoadResultAggregator(counts),
     });
     const manifest = { content: { items: ['a.json'] } };
     /** @type {TotalResultsSummary} */ const totals = {};
@@ -122,6 +125,7 @@ describe('ContentLoadManager.processMod', () => {
       logger,
       validatedEventDispatcher: dispatcher,
       contentLoadersConfig: phaseLoadersConfig,
+      aggregatorFactory: (counts) => new LoadResultAggregator(counts),
     });
     const manifest = { content: { items: ['a.json'] } };
     /** @type {TotalResultsSummary} */ const totals = {};

--- a/tests/unit/loaders/contentLoadManager.test.js
+++ b/tests/unit/loaders/contentLoadManager.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import ContentLoadManager from '../../../src/loaders/ContentLoadManager.js';
+import LoadResultAggregator from '../../../src/loaders/LoadResultAggregator.js';
 
 /** @typedef {import('../../../src/loaders/LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
 
@@ -89,6 +90,7 @@ describe('ContentLoadManager.loadContent', () => {
           phase: 'definitions',
         },
       ],
+      aggregatorFactory: (counts) => new LoadResultAggregator(counts),
     });
 
     const finalModOrder = ['modA', 'modB'];


### PR DESCRIPTION
Summary: added `aggregatorFactory` parameter to `ContentLoadManager` for customizable result aggregation and updated registrations and tests.

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859bc127bfc83318b2ec75c06f6ff5c