### PR TITLE
[Agent] centralize test messages

### DIFF
--- a/tests/common/constants.js
+++ b/tests/common/constants.js
@@ -25,3 +25,51 @@ export const DEFAULT_SAVE_NAME = 'MySaveFile';
  * @type {string}
  */
 export const DEFAULT_SAVE_ID = 'savegame-001.sav';
+//
+// Recurring test messages
+//
+/**
+ * Message displayed when the engine is ready.
+ *
+ * @type {string}
+ */
+export const ENGINE_READY_MESSAGE = 'Enter command...';
+
+/**
+ * Message dispatched when the engine stops.
+ *
+ * @type {string}
+ */
+export const ENGINE_STOPPED_MESSAGE = 'Game stopped. Engine is inactive.';
+
+/**
+ * Warning message used when an invalid note is encountered.
+ *
+ * @type {string}
+ */
+export const INVALID_NOTE_SKIPPED_MESSAGE =
+  'NotesPersistenceHook: Invalid note skipped';
+
+/**
+ * Error message for an unknown initialization failure.
+ *
+ * @type {string}
+ */
+export const UNKNOWN_INIT_ERROR_MESSAGE =
+  'Overall initialization failed. Error: Unknown error occurred';
+
+/**
+ * Error thrown when a logger lacks an "info" method.
+ *
+ * @type {string}
+ */
+export const LOGGER_INFO_METHOD_ERROR =
+  "Invalid or missing method 'info' on dependency 'logger'.";
+
+/**
+ * Message when a save operation completes successfully.
+ *
+ * @type {string}
+ */
+export const SAVE_OPERATION_FINISHED_MESSAGE =
+  'Save operation finished. Ready.';

--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -18,7 +18,12 @@ import {
   REQUEST_SHOW_SAVE_GAME_UI,
 } from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
-import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
+import {
+  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+  ENGINE_READY_MESSAGE,
+  ENGINE_STOPPED_MESSAGE,
+  SAVE_OPERATION_FINISHED_MESSAGE,
+} from '../constants.js';
 
 /**
  * Asserts that dispatch calls match the provided event sequence.
@@ -72,7 +77,7 @@ export function buildSaveDispatches(saveName, filePath) {
     ENGINE_READY_UI,
     {
       activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
-      message: 'Save operation finished. Ready.',
+      message: SAVE_OPERATION_FINISHED_MESSAGE,
     },
   ]);
 
@@ -86,10 +91,7 @@ export function buildSaveDispatches(saveName, filePath) {
  */
 export function buildStopDispatches() {
   return [
-    [
-      ENGINE_STOPPED_UI,
-      { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
-    ],
+    [ENGINE_STOPPED_UI, { inputDisabledMessage: ENGINE_STOPPED_MESSAGE }],
   ];
 }
 
@@ -102,7 +104,10 @@ export function buildStopDispatches() {
 export function buildStartDispatches(worldName) {
   return [
     [ENGINE_INITIALIZING_UI, { worldName }, { allowSchemaNotFound: true }],
-    [ENGINE_READY_UI, { activeWorld: worldName, message: 'Enter command...' }],
+    [
+      ENGINE_READY_UI,
+      { activeWorld: worldName, message: ENGINE_READY_MESSAGE },
+    ],
   ];
 }
 

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -15,7 +15,12 @@ import {
   expectComponentRemovedDispatch,
   expectNoDispatch,
 } from './dispatchTestUtils.js';
-import { DEFAULT_ACTIVE_WORLD_FOR_SAVE } from '../constants.js';
+import {
+  DEFAULT_ACTIVE_WORLD_FOR_SAVE,
+  ENGINE_READY_MESSAGE,
+  ENGINE_STOPPED_MESSAGE,
+  SAVE_OPERATION_FINISHED_MESSAGE,
+} from '../constants.js';
 import {
   ENGINE_OPERATION_IN_PROGRESS_UI,
   ENGINE_INITIALIZING_UI,
@@ -125,7 +130,7 @@ describe('dispatchTestUtils', () => {
           ENGINE_READY_UI,
           {
             activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
-            message: 'Save operation finished. Ready.',
+            message: SAVE_OPERATION_FINISHED_MESSAGE,
           },
         ],
       ]);
@@ -145,7 +150,7 @@ describe('dispatchTestUtils', () => {
           ENGINE_READY_UI,
           {
             activeWorld: DEFAULT_ACTIVE_WORLD_FOR_SAVE,
-            message: 'Save operation finished. Ready.',
+            message: SAVE_OPERATION_FINISHED_MESSAGE,
           },
         ],
       ]);
@@ -156,10 +161,7 @@ describe('dispatchTestUtils', () => {
     it('returns expected stop dispatch sequence', () => {
       const result = buildStopDispatches();
       expect(result).toEqual([
-        [
-          ENGINE_STOPPED_UI,
-          { inputDisabledMessage: 'Game stopped. Engine is inactive.' },
-        ],
+        [ENGINE_STOPPED_UI, { inputDisabledMessage: ENGINE_STOPPED_MESSAGE }],
       ]);
     });
   });
@@ -178,7 +180,7 @@ describe('dispatchTestUtils', () => {
       const result = buildStartDispatches('NewWorld');
       expect(result[1]).toEqual([
         ENGINE_READY_UI,
-        { activeWorld: 'NewWorld', message: 'Enter command...' },
+        { activeWorld: 'NewWorld', message: ENGINE_READY_MESSAGE },
       ]);
     });
   });

--- a/tests/unit/ai/notesPersistenceHook.test.js
+++ b/tests/unit/ai/notesPersistenceHook.test.js
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { persistNotes } from '../../../src/ai/notesPersistenceHook.js';
 import { NOTES_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { INVALID_NOTE_SKIPPED_MESSAGE } from '../../common/constants.js';
 
 const makeLogger = () => ({
   error: jest.fn(),
@@ -107,21 +108,21 @@ describe('persistNotes', () => {
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: 'NotesPersistenceHook: Invalid note skipped',
+        message: INVALID_NOTE_SKIPPED_MESSAGE,
         details: { note: '' },
       })
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: 'NotesPersistenceHook: Invalid note skipped',
+        message: INVALID_NOTE_SKIPPED_MESSAGE,
         details: { note: 123 },
       })
     );
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: 'NotesPersistenceHook: Invalid note skipped',
+        message: INVALID_NOTE_SKIPPED_MESSAGE,
         details: { note: null },
       })
     );

--- a/tests/unit/domUI/titleRenderer.subscriptions.test.js
+++ b/tests/unit/domUI/titleRenderer.subscriptions.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { TitleRenderer } from '../../../src/domUI'; // Corrected import path if needed
 import { RendererBase } from '../../../src/domUI';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js'; // Needed for checking super.dispose
+import { UNKNOWN_INIT_ERROR_MESSAGE } from '../../common/constants.js';
 
 // --- Mock Dependencies ---
 
@@ -394,9 +395,7 @@ describe('TitleRenderer', () => {
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
-          message: expect.stringContaining(
-            'Overall initialization failed. Error: Unknown error occurred'
-          ),
+          message: expect.stringContaining(UNKNOWN_INIT_ERROR_MESSAGE),
         })
       );
     });
@@ -414,9 +413,7 @@ describe('TitleRenderer', () => {
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
-          message: expect.stringContaining(
-            'Overall initialization failed. Error: Unknown error occurred'
-          ),
+          message: expect.stringContaining(UNKNOWN_INIT_ERROR_MESSAGE),
         })
       );
     });

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -14,7 +14,10 @@ import {
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
-import { DEFAULT_SAVE_ID } from '../../common/constants.js';
+import {
+  DEFAULT_SAVE_ID,
+  ENGINE_READY_MESSAGE,
+} from '../../common/constants.js';
 import { GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (ctx) => {
@@ -55,7 +58,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           ENGINE_READY_UI,
           {
             activeWorld: typedMockSaveData.metadata.gameTitle,
-            message: 'Enter command...',
+            message: ENGINE_READY_MESSAGE,
           },
         ]
       );
@@ -160,7 +163,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           ENGINE_READY_UI,
           {
             activeWorld: typedMockSaveData.metadata.gameTitle,
-            message: 'Enter command...',
+            message: ENGINE_READY_MESSAGE,
           },
         ],
         [

--- a/tests/unit/llms/LLMStrategyFactory.test.js
+++ b/tests/unit/llms/LLMStrategyFactory.test.js
@@ -4,6 +4,7 @@ import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { LLMStrategyFactory } from '../../../src/llms/LLMStrategyFactory.js';
 import { ConfigurationError } from '../../../src/errors/configurationError';
 import { LLMStrategyFactoryError } from '../../../src/llms/errors/LLMStrategyFactoryError.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 // Import concrete strategies to check instanceof and to mock their modules
 import { OpenRouterJsonSchemaStrategy } from '../../../src/llms/strategies/openRouterJsonSchemaStrategy.js';
@@ -93,7 +94,7 @@ describe('LLMStrategyFactory', () => {
         () => new LLMStrategyFactory({ httpClient, logger: undefined })
       ).toThrow('Missing required dependency: logger.');
       expect(() => new LLMStrategyFactory({ httpClient, logger: {} })).toThrow(
-        "Invalid or missing method 'info' on dependency 'logger'."
+        LOGGER_INFO_METHOD_ERROR
       );
       expect(
         () =>
@@ -101,7 +102,7 @@ describe('LLMStrategyFactory', () => {
             httpClient,
             logger: { info: 'not a function' },
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
 
     test('should throw error if httpClient is invalid or missing', () => {

--- a/tests/unit/llms/clientApiKeyProvider.test.js
+++ b/tests/unit/llms/clientApiKeyProvider.test.js
@@ -6,6 +6,7 @@ import { ClientApiKeyProvider } from '../../../src/llms/clientApiKeyProvider.js'
 import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
 const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 /**
  * @typedef {import('../../src/llms/interfaces/ILogger.js').ILogger} ILogger
@@ -70,7 +71,7 @@ describe('ClientApiKeyProvider', () => {
         'Missing required dependency: logger.'
       );
       expect(() => new ClientApiKeyProvider({ logger: {} })).toThrow(
-        "Invalid or missing method 'info' on dependency 'logger'."
+        LOGGER_INFO_METHOD_ERROR
       );
     });
   });

--- a/tests/unit/llms/environmentContext.test.js
+++ b/tests/unit/llms/environmentContext.test.js
@@ -3,6 +3,7 @@
 
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { EnvironmentContext } from '../../../src/llms/environmentContext.js'; // Adjust path as needed
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 const DEFAULT_PROXY_SERVER_URL = 'http://localhost:3001/api/llm-request';
 
@@ -44,7 +45,7 @@ describe('EnvironmentContext', () => {
               logger: {},
               executionEnvironment: 'client',
             })
-        ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+        ).toThrow(LOGGER_INFO_METHOD_ERROR);
       });
 
       ['warn', 'error', 'debug'].forEach((method) => {

--- a/tests/unit/logic/contextAssembler.more.test.js
+++ b/tests/unit/logic/contextAssembler.more.test.js
@@ -9,6 +9,7 @@
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 // Import ONLY createJsonLogicContext
 import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js'; // Adjust path if necessary
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 // Import Entity type for creating mock entity structure
 import Entity from '../../../src/entities/entity.js'; // Adjust path if necessary
 
@@ -771,7 +772,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
             error: jest.fn(),
           }
         )
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
       expect(() =>
         createJsonLogicContext(
           baseEvent,
@@ -784,7 +785,7 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
             error: jest.fn(),
           }
         )
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
   });
 });

--- a/tests/unit/logic/contextAssembler.test.js
+++ b/tests/unit/logic/contextAssembler.test.js
@@ -13,6 +13,7 @@ import {
 } from '@jest/globals';
 // Import ONLY createJsonLogicContext
 import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js'; // Import the function under test
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -579,7 +580,7 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
           mockEntityManager,
           { warn: jest.fn() }
         )
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
   });
 });

--- a/tests/unit/logic/operationHandlers/checkFollowCycleHandler.test.js
+++ b/tests/unit/logic/operationHandlers/checkFollowCycleHandler.test.js
@@ -15,6 +15,7 @@ import CheckFollowCycleHandler from '../../../../src/logic/operationHandlers/che
 // Assuming the constant is exported from a known path
 import { FOLLOWING_COMPONENT_ID } from '../../../../src/constants/componentIds.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../../common/constants.js';
 
 /**
  * Creates a mock ILogger.
@@ -89,7 +90,7 @@ describe('CheckFollowCycleHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: mockDispatcher,
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
       expect(
         () =>
           new CheckFollowCycleHandler({
@@ -97,7 +98,7 @@ describe('CheckFollowCycleHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: mockDispatcher,
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
 
     test('should throw an error if the entity manager dependency is missing or invalid', () => {

--- a/tests/unit/logic/operationHandlers/getTimestampHandler.test.js
+++ b/tests/unit/logic/operationHandlers/getTimestampHandler.test.js
@@ -12,6 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import GetTimestampHandler from '../../../../src/logic/operationHandlers/getTimestampHandler.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../../common/constants.js';
 
 /**
  * Creates a mock ILogger.
@@ -53,11 +54,11 @@ describe('GetTimestampHandler', () => {
     test('should throw an error if the logger dependency is missing or invalid', () => {
       // Test with no logger
       expect(() => new GetTimestampHandler({})).toThrow(
-        "Invalid or missing method 'info' on dependency 'logger'."
+        LOGGER_INFO_METHOD_ERROR
       );
       // Test with a logger that doesn't have the required methods
       expect(() => new GetTimestampHandler({ logger: {} })).toThrow(
-        "Invalid or missing method 'info' on dependency 'logger'."
+        LOGGER_INFO_METHOD_ERROR
       );
     });
 

--- a/tests/unit/logic/operationHandlers/logHandler.test.js
+++ b/tests/unit/logic/operationHandlers/logHandler.test.js
@@ -8,6 +8,7 @@ import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 // import LogHandler, { INTERPOLATION_FALLBACK } from '../../../logic/operationHandlers/logHandler.js';
 import LogHandler from '../../../../src/logic/operationHandlers/logHandler.js'; // Adjust path if needed
 const INTERPOLATION_FALLBACK = 'N/A'; // Define fallback if not exported from handler
+import { LOGGER_INFO_METHOD_ERROR } from '../../../common/constants.js';
 
 // --- JSDoc Imports ---
 /** @typedef {import('../../core/interfaces/coreServices.js').ILogger} ILogger */
@@ -53,16 +54,14 @@ describe('LogHandler', () => {
 
   // --- Constructor Tests --- (Updated for BaseOperationHandler)
   test('constructor should throw if logger is missing', () => {
-    expect(() => new LogHandler({})).toThrow(
-      "Invalid or missing method 'info' on dependency 'logger'."
-    );
+    expect(() => new LogHandler({})).toThrow(LOGGER_INFO_METHOD_ERROR);
   });
   test('constructor should throw if logger is invalid (missing methods)', () => {
     expect(() => new LogHandler({ logger: { info: jest.fn() } })).toThrow(
       "Invalid or missing method 'warn' on dependency 'logger'."
     );
     expect(() => new LogHandler({ logger: 'not a logger' })).toThrow(
-      "Invalid or missing method 'info' on dependency 'logger'."
+      LOGGER_INFO_METHOD_ERROR
     );
   });
   test('constructor should initialize successfully with valid logger', () => {

--- a/tests/unit/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
+++ b/tests/unit/logic/operationHandlers/rebuildLeaderListCacheHandler.test.js
@@ -13,6 +13,7 @@ import {
 } from '@jest/globals';
 import RebuildLeaderListCacheHandler from '../../../../src/logic/operationHandlers/rebuildLeaderListCacheHandler.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../../common/constants.js';
 
 // --- Constants ---
 const FOLLOWING_COMPONENT_ID = 'core:following';
@@ -96,7 +97,7 @@ describe('RebuildLeaderListCacheHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: makeMockDispatcher(),
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
       expect(
         () =>
           new RebuildLeaderListCacheHandler({
@@ -104,7 +105,7 @@ describe('RebuildLeaderListCacheHandler', () => {
             entityManager: mockEntityManager,
             safeEventDispatcher: makeMockDispatcher(),
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
 
     test('should throw a TypeError if the entity manager dependency is missing or invalid', () => {

--- a/tests/unit/logic/operationInterpreter.test.js
+++ b/tests/unit/logic/operationInterpreter.test.js
@@ -5,6 +5,7 @@
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 /**
  * -----------------------------------------------------------------------
@@ -131,7 +132,7 @@ describe('OperationInterpreter', () => {
           logger: {},
           operationRegistry: mockRegistry,
         })
-    ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+    ).toThrow(LOGGER_INFO_METHOD_ERROR);
   });
 
   test('constructor should throw if registry is missing or invalid', () => {

--- a/tests/unit/services/entityDisplayDataProvider.test.js
+++ b/tests/unit/services/entityDisplayDataProvider.test.js
@@ -10,6 +10,7 @@ import {
   EXITS_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
 import { CORE_MOD_ID } from '../../../src/constants/core';
+import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 describe('EntityDisplayDataProvider', () => {
   let mockEntityManager;
@@ -74,7 +75,7 @@ describe('EntityDisplayDataProvider', () => {
             logger: {},
             safeEventDispatcher: mockSafeEventDispatcher,
           })
-      ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
 
     it('should throw an error if safeEventDispatcher is missing or invalid', () => {


### PR DESCRIPTION
## Summary
- consolidate recurring messages in tests/common/constants.js
- use these constants across unit tests

## Testing
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b54b28f08331afb2fad3b2f55ece