### PR TITLE
[Agent] add empty slot message helper

### DIFF
--- a/src/domUI/helpers/createEmptySlotMessage.js
+++ b/src/domUI/helpers/createEmptySlotMessage.js
@@ -1,0 +1,23 @@
+/**
+ * @file Helper to generate an empty slot message element.
+ */
+
+/** @typedef {import('../domElementFactory.js').default} DomElementFactory */
+
+/**
+ * Creates a DOM element or string representing an empty slots message.
+ *
+ * @param {DomElementFactory} [domFactory] - The DOM element factory.
+ * @param {string} message - Text content for the message.
+ * @returns {HTMLElement | string} The created <li> or <p> element, or the message string.
+ */
+export function createEmptySlotMessage(domFactory, message) {
+  const cls = 'empty-slot-message';
+  const li = domFactory?.li?.(cls, message) || null;
+  if (li) return li;
+  const p = domFactory?.p?.(cls, message) || null;
+  if (p) return p;
+  return message;
+}
+
+export default createEmptySlotMessage;

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -9,7 +9,7 @@ import {
   renderSlotItem,
 } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
-import createMessageElement from './helpers/createMessageElement.js';
+import createEmptySlotMessage from './helpers/createEmptySlotMessage.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -277,15 +277,10 @@ class LoadGameUI extends SlotModalBase {
    * @returns {string | HTMLElement} Element or text explaining no saves found.
    */
   _getEmptyLoadSlotsMessage() {
-    const message = 'No saved games found.';
-    if (this.domElementFactory) {
-      return createMessageElement(
-        this.domElementFactory,
-        'empty-slot-message',
-        message
-      );
-    }
-    return message;
+    return createEmptySlotMessage(
+      this.domElementFactory,
+      'No saved games found.'
+    );
   }
 
   /**

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -11,7 +11,7 @@ import {
   renderSlotItem,
 } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
-import createMessageElement from './helpers/createMessageElement.js';
+import createEmptySlotMessage from './helpers/createEmptySlotMessage.js';
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -311,14 +311,10 @@ export class SaveGameUI extends SlotModalBase {
    * @returns {string | HTMLElement}
    */
   _getEmptySaveSlotsMessage() {
-    if (this.domElementFactory) {
-      return createMessageElement(
-        this.domElementFactory,
-        'empty-slot-message',
-        'No save slots available to display.'
-      );
-    }
-    return 'No save slots available to display.';
+    return createEmptySlotMessage(
+      this.domElementFactory,
+      'No save slots available to display.'
+    );
   }
 
   /**

--- a/tests/unit/domUI/helpers/createEmptySlotMessage.test.js
+++ b/tests/unit/domUI/helpers/createEmptySlotMessage.test.js
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import DocumentContext from '../../../../src/domUI/documentContext.js';
+import DomElementFactory from '../../../../src/domUI/domElementFactory.js';
+import createEmptySlotMessage from '../../../../src/domUI/helpers/createEmptySlotMessage.js';
+
+describe('createEmptySlotMessage', () => {
+  let factory;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const ctx = new DocumentContext(document);
+    factory = new DomElementFactory(ctx);
+  });
+
+  it('creates <li> with message when possible', () => {
+    const el = createEmptySlotMessage(factory, 'msg');
+    expect(el).toBeInstanceOf(HTMLElement);
+    expect(el.tagName).toBe('LI');
+    expect(el.classList.contains('empty-slot-message')).toBe(true);
+    expect(el.textContent).toBe('msg');
+  });
+
+  it('falls back to <p> when li fails', () => {
+    jest.spyOn(factory, 'li').mockReturnValue(null);
+    const pSpy = jest.spyOn(factory, 'p');
+    const el = createEmptySlotMessage(factory, 'msg');
+    expect(el.tagName).toBe('P');
+    expect(pSpy).toHaveBeenCalledWith('empty-slot-message', 'msg');
+  });
+
+  it('returns string when factory missing', () => {
+    const result = createEmptySlotMessage(null, 'msg');
+    expect(result).toBe('msg');
+  });
+});

--- a/tests/unit/domUI/loadGameUI.coverage.test.js
+++ b/tests/unit/domUI/loadGameUI.coverage.test.js
@@ -18,7 +18,7 @@ import DomElementFactory from '../../../src/domUI/domElementFactory.js';
 import * as listNavigationUtils from '../../../src/utils/listNavigationUtils.js';
 import { SlotModalBase } from '../../../src/domUI/slotModalBase.js';
 import * as renderSlotItemModule from '../../../src/domUI/helpers/renderSlotItem.js';
-import * as createMessageElementModule from '../../../src/domUI/helpers/createMessageElement.js';
+import * as createEmptySlotMessageModule from '../../../src/domUI/helpers/createEmptySlotMessage.js';
 
 // Mock dependencies
 jest.mock('../../../src/utils/domUtils.js', () => ({
@@ -35,7 +35,7 @@ jest.mock('../../../src/domUI/helpers/renderSlotItem.js', () => ({
   renderGenericSlotItem: jest.fn(),
 }));
 
-jest.mock('../../../src/domUI/helpers/createMessageElement.js', () => ({
+jest.mock('../../../src/domUI/helpers/createEmptySlotMessage.js', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
@@ -271,18 +271,22 @@ describe('LoadGameUI', () => {
 
     it('_getEmptyLoadSlotsMessage should return a string if factory is missing', () => {
       instance.domElementFactory = null;
+      createEmptySlotMessageModule.default.mockImplementation((_f, msg) => msg);
       const message = instance._getEmptyLoadSlotsMessage();
       expect(message).toBe('No saved games found.');
+      expect(createEmptySlotMessageModule.default).toHaveBeenCalledWith(
+        null,
+        'No saved games found.'
+      );
     });
 
     it('_getEmptyLoadSlotsMessage should return an element if factory is present', () => {
-      const mockP = mockDocument.createElement('p');
-      createMessageElementModule.default.mockReturnValue(mockP);
+      const mockEl = mockDocument.createElement('p');
+      createEmptySlotMessageModule.default.mockReturnValue(mockEl);
       const messageElement = instance._getEmptyLoadSlotsMessage();
-      expect(messageElement).toBe(mockP);
-      expect(createMessageElementModule.default).toHaveBeenCalledWith(
+      expect(messageElement).toBe(mockEl);
+      expect(createEmptySlotMessageModule.default).toHaveBeenCalledWith(
         mockDomElementFactory,
-        'empty-slot-message',
         'No saved games found.'
       );
     });


### PR DESCRIPTION
Summary: Implemented `createEmptySlotMessage` helper to centralize creation of empty save/load slot messages. Both LoadGameUI and SaveGameUI now use this helper. Updated associated unit tests and added dedicated tests for the helper itself.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859b523ce7c8331a36b7cb6a4ccaff6