### PR TITLE
[Agent] Extract registry and filename helpers

### DIFF
--- a/src/loaders/helpers/filenameUtils.js
+++ b/src/loaders/helpers/filenameUtils.js
@@ -1,0 +1,56 @@
+/**
+ * @file Utility functions for working with filename lists in mod manifests.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+
+/**
+ * Safely extracts and validates filenames from the manifest for a given content key.
+ *
+ * @param {object | null | undefined} manifest - Parsed mod manifest object.
+ * @param {string} contentKey - Key within manifest.content.
+ * @param {string} modId - ID of the mod being processed.
+ * @param {ILogger} logger - Logger for warnings/debug messages.
+ * @returns {string[]} Array of valid, trimmed filenames.
+ */
+export function extractValidFilenames(manifest, contentKey, modId, logger) {
+  const getNested = (obj, path) =>
+    path
+      .split('.')
+      .reduce((o, k) => (o && o[k] !== undefined ? o[k] : undefined), obj);
+  const filenames = getNested(manifest?.content, contentKey);
+  if (filenames === null || filenames === undefined) {
+    logger.debug(
+      `Mod '${modId}': Content key '${contentKey}' not found or is null/undefined in manifest. Skipping.`
+    );
+    return [];
+  }
+  if (!Array.isArray(filenames)) {
+    logger.warn(
+      `Mod '${modId}': Expected an array for content key '${contentKey}' but found type '${typeof filenames}'. Skipping.`
+    );
+    return [];
+  }
+  const validFilenames = filenames
+    .filter((element) => {
+      if (typeof element !== 'string') {
+        logger.warn(
+          `Mod '${modId}': Invalid non-string entry found in '${contentKey}' list:`,
+          element
+        );
+        return false;
+      }
+      const trimmedElement = element.trim();
+      if (trimmedElement === '') {
+        logger.warn(
+          `Mod '${modId}': Empty string filename found in '${contentKey}' list after trimming. Skipping.`
+        );
+        return false;
+      }
+      return true;
+    })
+    .map((element) => element.trim());
+  return validFilenames;
+}
+
+export default extractValidFilenames;

--- a/src/loaders/helpers/registryStoreUtils.js
+++ b/src/loaders/helpers/registryStoreUtils.js
@@ -1,0 +1,104 @@
+/**
+ * @file Utility for storing items in the registry with standardized metadata and override checks.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+
+/**
+ * Stores an item in the registry, augmenting it with metadata and logging overrides.
+ *
+ * @param {ILogger} logger - Logger for output.
+ * @param {IDataRegistry} registry - Data registry instance.
+ * @param {string} loaderName - Name of the loader for logging.
+ * @param {string} category - Registry category.
+ * @param {string} modId - ID of the mod providing the item.
+ * @param {string} baseItemId - The item's unqualified ID.
+ * @param {object} dataToStore - Data object to store.
+ * @param {string} sourceFilename - Original filename for logging.
+ * @returns {{qualifiedId: string|null, didOverride: boolean, error?: boolean}} Result info.
+ */
+export function storeItemInRegistry(
+  logger,
+  registry,
+  loaderName,
+  category,
+  modId,
+  baseItemId,
+  dataToStore,
+  sourceFilename
+) {
+  if (!category || typeof category !== 'string') {
+    logger.error(
+      `${loaderName} [_storeItemInRegistry]: Category must be a non-empty string. Received: ${category}`
+    );
+    return { qualifiedId: null, didOverride: false, error: true };
+  }
+  if (!modId || typeof modId !== 'string') {
+    logger.error(
+      `${loaderName} [_storeItemInRegistry]: ModId must be a non-empty string for category '${category}'. Received: ${modId}`
+    );
+    return { qualifiedId: null, didOverride: false, error: true };
+  }
+  if (!baseItemId || typeof baseItemId !== 'string') {
+    logger.error(
+      `${loaderName} [_storeItemInRegistry]: BaseItemId must be a non-empty string for category '${category}', mod '${modId}'. Received: ${baseItemId}`
+    );
+    return { qualifiedId: null, didOverride: false, error: true };
+  }
+  if (!dataToStore || typeof dataToStore !== 'object') {
+    logger.error(
+      `${loaderName} [_storeItemInRegistry]: Data for '${modId}:${baseItemId}' (category: ${category}) must be an object. Received: ${typeof dataToStore}`
+    );
+    return { qualifiedId: null, didOverride: false, error: true };
+  }
+
+  const qualifiedId = `${modId}:${baseItemId}`;
+
+  const isClassInstance = dataToStore.constructor !== Object;
+  const isEntityDefinition = category === 'entityDefinitions';
+  const isEntityInstance = category === 'entityInstances';
+
+  let dataWithMetadata;
+  let finalId = baseItemId;
+  if (isEntityDefinition || isEntityInstance) {
+    finalId = qualifiedId;
+  }
+
+  if (isClassInstance) {
+    dataWithMetadata = dataToStore;
+    Object.defineProperties(dataWithMetadata, {
+      _modId: { value: modId, writable: false, enumerable: true },
+      _sourceFile: { value: sourceFilename, writable: false, enumerable: true },
+      _fullId: { value: qualifiedId, writable: false, enumerable: true },
+      id: { value: finalId, writable: false, enumerable: true },
+    });
+  } else {
+    dataWithMetadata = Object.assign({}, dataToStore, {
+      _modId: modId,
+      _sourceFile: sourceFilename,
+      _fullId: qualifiedId,
+      id: finalId,
+    });
+  }
+
+  logger.debug(
+    `${loaderName} [${modId}]: Storing item in registry. Category: '${category}', Qualified ID: '${qualifiedId}', Base ID: '${baseItemId}', Filename: '${sourceFilename}'`
+  );
+
+  const didOverride = registry.store(category, qualifiedId, dataWithMetadata);
+
+  if (didOverride) {
+    logger.warn(
+      `${loaderName} [${modId}]: Item '${qualifiedId}' (Base: '${baseItemId}') in category '${category}' from file '${sourceFilename}' overwrote an existing entry.`
+    );
+  } else {
+    logger.debug(
+      `${loaderName} [${modId}]: Item '${qualifiedId}' (Base: '${baseItemId}') stored successfully in category '${category}'.`
+    );
+  }
+
+  return { qualifiedId, didOverride };
+}
+
+export default storeItemInRegistry;

--- a/tests/unit/loaders/helpers/filenameUtils.test.js
+++ b/tests/unit/loaders/helpers/filenameUtils.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { extractValidFilenames } from '../../../../src/loaders/helpers/filenameUtils.js';
+
+describe('extractValidFilenames', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { warn: jest.fn(), debug: jest.fn() };
+  });
+
+  it('returns trimmed filenames', () => {
+    const manifest = { content: { actions: [' a.json ', 'b.json'] } };
+    const result = extractValidFilenames(manifest, 'actions', 'modA', logger);
+    expect(result).toEqual(['a.json', 'b.json']);
+  });
+
+  it('logs warning when value is not an array', () => {
+    const manifest = { content: { actions: 'bad' } };
+    const result = extractValidFilenames(manifest, 'actions', 'modA', logger);
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('filters invalid entries', () => {
+    const manifest = { content: { actions: [123, ' file.json ', null] } };
+    const result = extractValidFilenames(manifest, 'actions', 'modA', logger);
+    expect(result).toEqual(['file.json']);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/loaders/helpers/registryStoreUtils.test.js
+++ b/tests/unit/loaders/helpers/registryStoreUtils.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { storeItemInRegistry } from '../../../../src/loaders/helpers/registryStoreUtils.js';
+
+describe('storeItemInRegistry', () => {
+  let logger;
+  let registry;
+
+  beforeEach(() => {
+    logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    registry = { store: jest.fn().mockReturnValue(false) };
+  });
+
+  it('stores data and returns info when no override', () => {
+    const data = { value: 'x' };
+    const result = storeItemInRegistry(
+      logger,
+      registry,
+      'TestLoader',
+      'items',
+      'modA',
+      'item1',
+      data,
+      'item.json'
+    );
+    expect(registry.store).toHaveBeenCalledWith(
+      'items',
+      'modA:item1',
+      expect.objectContaining({
+        id: 'item1',
+        _fullId: 'modA:item1',
+        _modId: 'modA',
+        _sourceFile: 'item.json',
+      })
+    );
+    expect(result).toEqual({ qualifiedId: 'modA:item1', didOverride: false });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs warning when override occurs', () => {
+    registry.store.mockReturnValue(true);
+    const result = storeItemInRegistry(
+      logger,
+      registry,
+      'TestLoader',
+      'items',
+      'modA',
+      'item1',
+      {},
+      'file.json'
+    );
+    expect(result.didOverride).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('returns error flag when category invalid', () => {
+    const result = storeItemInRegistry(
+      logger,
+      registry,
+      'TestLoader',
+      '',
+      'modA',
+      'id',
+      {},
+      'file.json'
+    );
+    expect(result.error).toBe(true);
+    expect(registry.store).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create helpers for extracting filenames and storing in registry
- reuse helpers in BaseManifestItemLoader
- add unit tests for new helpers

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6859bc0714748331853465285b86e9d9