### PR TITLE
[Agent] include IDs in validation error messages

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -107,7 +107,29 @@ export class ActionValidationContextBuilder extends BaseService {
    * @private
    */
   #assertValidInputs(actionDefinition, actor, targetContext) {
-    validateActionInputs(actionDefinition, actor, targetContext, this.#logger);
+    try {
+      validateActionInputs(
+        actionDefinition,
+        actor,
+        targetContext,
+        this.#logger
+      );
+    } catch (err) {
+      let idInfo = '';
+      if (err.message === 'Invalid actionDefinition') {
+        idInfo = `(id: ${actionDefinition?.id})`;
+      } else if (err.message === 'Invalid actor entity') {
+        idInfo = `(id: ${actor?.id})`;
+      } else if (err.message === 'Invalid ActionTargetContext') {
+        idInfo = `(type: ${targetContext?.type})`;
+      }
+      const msg = err.message
+        ? err.message.charAt(0).toLowerCase() + err.message.slice(1)
+        : 'invalid input';
+      throw new Error(
+        `ActionValidationContextBuilder.buildContext: ${msg} ${idInfo}`
+      );
+    }
   }
 
   /**

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -114,12 +114,27 @@ export class ActionValidationService extends BaseService {
    * @throws {Error} If any input is structurally invalid according to basic requirements.
    */
   _checkStructuralSanity(actionDefinition, actorEntity, targetContext) {
-    validateActionInputs(
-      actionDefinition,
-      actorEntity,
-      targetContext,
-      this.#logger
-    );
+    try {
+      validateActionInputs(
+        actionDefinition,
+        actorEntity,
+        targetContext,
+        this.#logger
+      );
+    } catch (err) {
+      let idInfo = '';
+      if (err.message === 'Invalid actionDefinition') {
+        idInfo = `(id: ${actionDefinition?.id})`;
+      } else if (err.message === 'Invalid actor entity') {
+        idInfo = `(id: ${actorEntity?.id})`;
+      } else if (err.message === 'Invalid ActionTargetContext') {
+        idInfo = `(type: ${targetContext?.type})`;
+      }
+      const msg = err.message
+        ? err.message.charAt(0).toLowerCase() + err.message.slice(1)
+        : 'invalid input';
+      throw new Error(`ActionValidationService.isValid: ${msg} ${idInfo}`);
+    }
   }
 
   /**

--- a/tests/unit/services/actionValidationContextBuilder.test.js
+++ b/tests/unit/services/actionValidationContextBuilder.test.js
@@ -258,7 +258,9 @@ describe('ActionValidationContextBuilder', () => {
       it('should throw Error and log error for null actionDefinition', () => {
         const action = () =>
           builder.buildContext(null, mockActor, ActionTargetContext.noTarget());
-        expect(action).toThrow('Invalid actionDefinition');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid actionDefinition'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: null }
@@ -273,7 +275,9 @@ describe('ActionValidationContextBuilder', () => {
             mockActor,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow('Invalid actionDefinition');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid actionDefinition'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: invalidActionDef }
@@ -287,7 +291,9 @@ describe('ActionValidationContextBuilder', () => {
             null,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow('Invalid actor entity');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid actor entity'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actor entity provided'),
           { actor: null }
@@ -302,7 +308,9 @@ describe('ActionValidationContextBuilder', () => {
             invalidActor,
             ActionTargetContext.noTarget()
           );
-        expect(action).toThrow('Invalid actor entity');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid actor entity'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actor entity provided'),
           { actor: invalidActor }
@@ -312,7 +320,9 @@ describe('ActionValidationContextBuilder', () => {
       it('should throw Error and log error for null targetContext', () => {
         const action = () =>
           builder.buildContext(sampleActionDefinition, mockActor, null);
-        expect(action).toThrow('Invalid ActionTargetContext');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid ActionTargetContext'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid targetContext provided'),
           { targetContext: null }
@@ -327,7 +337,9 @@ describe('ActionValidationContextBuilder', () => {
             mockActor,
             invalidTargetContext
           );
-        expect(action).toThrow('Invalid ActionTargetContext');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid ActionTargetContext'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid targetContext provided'),
           { targetContext: invalidTargetContext }
@@ -336,7 +348,9 @@ describe('ActionValidationContextBuilder', () => {
 
       it('should prioritize actionDefinition validation when all inputs are missing', () => {
         const action = () => builder.buildContext(null, null, null);
-        expect(action).toThrow('Invalid actionDefinition');
+        expect(action).toThrow(
+          'ActionValidationContextBuilder.buildContext: invalid actionDefinition'
+        );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Invalid actionDefinition provided'),
           { actionDefinition: null }

--- a/tests/unit/services/actionValidationService.actorComponents.test.js
+++ b/tests/unit/services/actionValidationService.actorComponents.test.js
@@ -530,12 +530,12 @@ describe('ActionValidationService: Orchestration Logic', () => {
         actor,
         invalidTargetContext
       );
-    }).toThrow('Invalid ActionTargetContext');
+    }).toThrow('ActionValidationService.isValid: invalid ActionTargetContext');
 
     // Assert logging indicates the structural failure before the throw
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Validation: STRUCTURAL ERROR: Invalid ActionTargetContext'
+        'Validation: STRUCTURAL ERROR: ActionValidationService.isValid: invalid ActionTargetContext'
       ),
       expect.any(Object) // Check that some context object was logged
     );

--- a/tests/unit/services/actionValidationService.inputValidation.test.js
+++ b/tests/unit/services/actionValidationService.inputValidation.test.js
@@ -188,7 +188,8 @@ describe('ActionValidationService - Input Validation and Errors', () => {
   test('isValid throws Error if missing or invalid actionDefinition', () => {
     const context = ActionTargetContext.noTarget();
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg = 'Invalid actionDefinition';
+    const expectedErrorMsg =
+      'ActionValidationService.isValid: invalid actionDefinition';
 
     // Test cases for invalid actionDefinition
     expect(() => service.isValid(null, mockActor, context)).toThrow(
@@ -230,7 +231,8 @@ describe('ActionValidationService - Input Validation and Errors', () => {
     };
     const context = ActionTargetContext.noTarget();
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg = 'Invalid actor entity';
+    const expectedErrorMsg =
+      'ActionValidationService.isValid: invalid actor entity';
 
     // Test cases for invalid actorEntity
     expect(() => service.isValid(actionDef, null, context)).toThrow(
@@ -275,7 +277,8 @@ describe('ActionValidationService - Input Validation and Errors', () => {
       template: 't',
     };
     // Error message comes from _checkStructuralSanity
-    const expectedErrorMsg = 'Invalid ActionTargetContext';
+    const expectedErrorMsg =
+      'ActionValidationService.isValid: invalid ActionTargetContext';
 
     // Test cases for invalid targetContext
     expect(() => service.isValid(actionDef, mockActor, null)).toThrow(


### PR DESCRIPTION
## Summary
- improve error messages in ActionValidationService and ActionValidationContextBuilder
- update unit tests for new validation messages

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3120 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859c05cf9188331bfeab3a9ad409787