### PR TITLE
[Agent] centralize action target type constants

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -15,6 +15,11 @@ import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { TARGET_DOMAIN_NONE } from '../constants/targetDomains.js';
+import {
+  ENTITY as TARGET_TYPE_ENTITY,
+  DIRECTION as TARGET_TYPE_DIRECTION,
+  NONE as TARGET_TYPE_NONE,
+} from '../constants/actionTargetTypes.js';
 
 /**
  * @description Helper for reporting argument validation errors.
@@ -53,7 +58,7 @@ function formatEntityTarget(
   const targetId = context.entityId;
   if (!targetId) {
     logger.warn(
-      `formatActionCommand: Target context type is 'entity' but entityId is missing for action ${actionId}. Template: "${command}"`
+      `formatActionCommand: Target context type is '${TARGET_TYPE_ENTITY}' but entityId is missing for action ${actionId}. Template: "${command}"`
     );
     return null;
   }
@@ -87,7 +92,7 @@ function formatDirectionTarget(command, context, { actionId, logger, debug }) {
   const direction = context.direction;
   if (!direction) {
     logger.warn(
-      `formatActionCommand: Target context type is 'direction' but direction string is missing for action ${actionId}. Template: "${command}"`
+      `formatActionCommand: Target context type is '${TARGET_TYPE_DIRECTION}' but direction string is missing for action ${actionId}. Template: "${command}"`
     );
     return null;
   }
@@ -121,9 +126,9 @@ function formatNoneTarget(command, _context, { actionId, logger, debug }) {
  * @type {TargetFormatterMap}
  */
 export const targetFormatterMap = {
-  entity: formatEntityTarget,
-  direction: formatDirectionTarget,
-  none: formatNoneTarget,
+  [TARGET_TYPE_ENTITY]: formatEntityTarget,
+  [TARGET_TYPE_DIRECTION]: formatDirectionTarget,
+  [TARGET_TYPE_NONE]: formatNoneTarget,
 };
 
 /**

--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -12,6 +12,7 @@ import {
   buildEntityTargetContext,
 } from './contextBuilders.js';
 import { validateActionInputs } from './inputValidators.js';
+import { ENTITY as TARGET_TYPE_ENTITY } from '../../constants/actionTargetTypes.js';
 
 /**
  * @class ActionValidationContextBuilder
@@ -69,7 +70,7 @@ export class ActionValidationContextBuilder extends BaseService {
     // --- 3. Build Target Context (handles different target types) ---
     let targetContextForEval = null;
 
-    if (targetContext.type === 'entity') {
+    if (targetContext.type === TARGET_TYPE_ENTITY) {
       targetContextForEval = this.#buildEntityTargetContextForEval(
         actionDefinition,
         targetContext

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -15,6 +15,7 @@ import {
   TARGET_DOMAIN_SELF,
   TARGET_DOMAIN_NONE,
 } from '../../constants/targetDomains.js';
+import { ENTITY as TARGET_TYPE_ENTITY } from '../../constants/actionTargetTypes.js';
 // --- Refactor-AVS-3.4: Remove dependency ---
 // REMOVED: import { ActionValidationContextBuilder } from './actionValidationContextBuilder.js';
 // --- End Refactor-AVS-3.4 ---
@@ -170,7 +171,7 @@ export class ActionValidationService extends BaseService {
     // Specific check for 'self' domain which requires the target ID to match the actor ID.
     if (
       expectedDomain === TARGET_DOMAIN_SELF &&
-      targetContext.type === 'entity' &&
+      targetContext.type === TARGET_TYPE_ENTITY &&
       targetContext.entityId !== actorId
     ) {
       this.#logger.debug(
@@ -207,7 +208,7 @@ export class ActionValidationService extends BaseService {
     // dependency there or increasing orchestration complexity.
     // Keeping it here is deemed the most pragmatic approach for now, accepting the minimal
     // dependency overhead for the benefit of the early warning log message.
-    if (targetContext.type === 'entity') {
+    if (targetContext.type === TARGET_TYPE_ENTITY) {
       const targetEntity = this.#entityManager.getEntityInstance(
         targetContext.entityId
       );

--- a/src/actions/validation/contextBuilders.js
+++ b/src/actions/validation/contextBuilders.js
@@ -3,10 +3,14 @@
 
 import { createComponentAccessor } from '../../logic/componentAccessor.js';
 import { createEntityContext } from '../../logic/contextAssembler.js';
+import {
+  ENTITY as TARGET_TYPE_ENTITY,
+  NONE as TARGET_TYPE_NONE,
+} from '../../constants/actionTargetTypes.js';
 
 /**
  * @description Create a base target context with default null fields.
- * @param {'entity' | 'none'} type - Target context type.
+ * @param {string} type - Target context type (use ActionTargetTypes constants).
  * @returns {{type: string, id: null, direction: null, components: null, blocker: null, exitDetails: null}}
  * Base target context object.
  */
@@ -39,11 +43,11 @@ export function buildActorContext(entityId, entityManager, logger) {
  * @param {string} entityId - ID of the target entity.
  * @param {EntityManager} entityManager - Manager to access components.
  * @param {ILogger} logger - Logger instance.
- * @returns {{type: 'entity', id: string, direction: null, components: object, blocker: null, exitDetails: null}}
+ * @returns {{type: string, id: string, direction: null, components: object, blocker: null, exitDetails: null}}
  * Target context for an entity.
  */
 export function buildEntityTargetContext(entityId, entityManager, logger) {
-  const ctx = createBaseTargetContext('entity');
+  const ctx = createBaseTargetContext(TARGET_TYPE_ENTITY);
   ctx.id = entityId;
   ctx.components = createComponentAccessor(entityId, entityManager, logger);
   return ctx;

--- a/src/constants/actionTargetTypes.js
+++ b/src/constants/actionTargetTypes.js
@@ -1,0 +1,10 @@
+/**
+ * Defines identifiers for action target types.
+ * @module ActionTargetTypes
+ */
+
+export const ENTITY = 'entity';
+export const NONE = 'none';
+export const DIRECTION = 'direction';
+
+export default { ENTITY, NONE, DIRECTION };

--- a/tests/unit/actions/actionFormatter.additional.test.js
+++ b/tests/unit/actions/actionFormatter.additional.test.js
@@ -4,6 +4,11 @@ import {
   targetFormatterMap,
 } from '../../../src/actions/actionFormatter.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import {
+  ENTITY as TARGET_TYPE_ENTITY,
+  DIRECTION as TARGET_TYPE_DIRECTION,
+  NONE as TARGET_TYPE_NONE,
+} from '../../../src/constants/actionTargetTypes.js';
 
 const createMockLogger = () => ({
   debug: jest.fn(),
@@ -38,7 +43,7 @@ describe('formatActionCommand additional cases', () => {
 
   it('returns null when entity context lacks entityId', () => {
     const actionDef = { id: 'core:use', template: 'use {target}' };
-    const context = { type: 'entity' };
+    const context = { type: TARGET_TYPE_ENTITY };
 
     const result = formatActionCommand(
       actionDef,
@@ -59,7 +64,7 @@ describe('formatActionCommand additional cases', () => {
 
   it('returns null when direction context lacks direction', () => {
     const actionDef = { id: 'core:move', template: 'move {direction}' };
-    const context = { type: 'direction' };
+    const context = { type: TARGET_TYPE_DIRECTION };
 
     const result = formatActionCommand(
       actionDef,
@@ -83,7 +88,7 @@ describe('formatActionCommand additional cases', () => {
       id: 'core:wait',
       template: 'wait {target} {direction}',
     };
-    const context = { type: 'none' };
+    const context = { type: TARGET_TYPE_NONE };
 
     const result = formatActionCommand(
       actionDef,
@@ -104,7 +109,7 @@ describe('formatActionCommand additional cases', () => {
 
   it('returns null and logs error if placeholder substitution throws', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
-    const context = { type: 'entity', entityId: 'e1' };
+    const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
     entityManager.getEntityInstance.mockImplementation(() => {
       throw new Error('boom');
     });
@@ -131,7 +136,7 @@ describe('formatActionCommand additional cases', () => {
 
   it('allows overriding the target formatter map', () => {
     const actionDef = { id: 'core:test', template: 'test {target}' };
-    const context = { type: 'entity', entityId: 'e1' };
+    const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
     const customMap = {
       ...targetFormatterMap,
       entity: jest.fn(() => 'test-value'),

--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import {
+  ENTITY as TARGET_TYPE_ENTITY,
+  DIRECTION as TARGET_TYPE_DIRECTION,
+  NONE as TARGET_TYPE_NONE,
+} from '../../../src/constants/actionTargetTypes.js';
 import { createMockLogger } from '../../common/mockFactories/index.js';
 
 describe('formatActionCommand', () => {
@@ -19,7 +24,7 @@ describe('formatActionCommand', () => {
 
   it('formats an entity target using the entity display name', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
-    const context = { type: 'entity', entityId: 'e1' };
+    const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
     const mockEntity = { id: 'e1' };
     entityManager.getEntityInstance.mockReturnValue(mockEntity);
     displayNameFn.mockReturnValue('The Entity');
@@ -43,7 +48,7 @@ describe('formatActionCommand', () => {
 
   it('falls back to entity id when instance is missing', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
-    const context = { type: 'entity', entityId: 'e1' };
+    const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
     entityManager.getEntityInstance.mockReturnValue(null);
 
     const result = formatActionCommand(
@@ -65,7 +70,7 @@ describe('formatActionCommand', () => {
 
   it('formats a direction target', () => {
     const actionDef = { id: 'core:move', template: 'move {direction}' };
-    const context = { type: 'direction', direction: 'north' };
+    const context = { type: TARGET_TYPE_DIRECTION, direction: 'north' };
 
     const result = formatActionCommand(
       actionDef,
@@ -83,7 +88,7 @@ describe('formatActionCommand', () => {
 
   it("returns template as-is for 'none' target type", () => {
     const actionDef = { id: 'core:wait', template: 'wait' };
-    const context = { type: 'none' };
+    const context = { type: TARGET_TYPE_NONE };
 
     const result = formatActionCommand(
       actionDef,
@@ -99,7 +104,7 @@ describe('formatActionCommand', () => {
   it('returns null for missing action template', () => {
     const result = formatActionCommand(
       { id: 'bad' },
-      { type: 'none' },
+      { type: TARGET_TYPE_NONE },
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
       displayNameFn
@@ -118,7 +123,7 @@ describe('formatActionCommand', () => {
     expect(() =>
       formatActionCommand(
         { id: 'core:use', template: 'use {target}' },
-        { type: 'entity', entityId: 'e1' },
+        { type: TARGET_TYPE_ENTITY, entityId: 'e1' },
         {},
         { logger, safeEventDispatcher: dispatcher },
         displayNameFn

--- a/tests/unit/actions/contextBuilders.test.js
+++ b/tests/unit/actions/contextBuilders.test.js
@@ -1,10 +1,9 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import {
   buildActorContext,
-  buildDirectionContext,
   buildEntityTargetContext,
-  resolveDirectionExit,
 } from '../../../src/actions/validation/contextBuilders.js';
+import { ENTITY as TARGET_TYPE_ENTITY } from '../../../src/constants/actionTargetTypes.js';
 
 jest.mock('../../../src/logic/componentAccessor.js', () => ({
   createComponentAccessor: jest.fn((id) => ({ accessorFor: id })),
@@ -45,7 +44,7 @@ describe('contextBuilders', () => {
         mockLogger
       );
       expect(result).toEqual({
-        type: 'entity',
+        type: TARGET_TYPE_ENTITY,
         id: 'target1',
         direction: null,
         components: { accessorFor: 'target1' },

--- a/tests/unit/services/actionValidationService.inputValidation.test.js
+++ b/tests/unit/services/actionValidationService.inputValidation.test.js
@@ -5,6 +5,7 @@
  */
 import { ActionValidationService } from '../../../src/actions/validation/actionValidationService.js';
 import { ActionTargetContext } from '../../../src/models/actionTargetContext.js';
+import { ENTITY as TARGET_TYPE_ENTITY } from '../../../src/constants/actionTargetTypes.js';
 import {
   afterAll,
   beforeAll,
@@ -289,7 +290,10 @@ describe('ActionValidationService - Input Validation and Errors', () => {
     );
 
     // Check invalid targetContext structure (plain object, not an instance of ActionTargetContext)
-    const invalidContextObject = { type: 'entity', entityId: 'some-id' };
+    const invalidContextObject = {
+      type: TARGET_TYPE_ENTITY,
+      entityId: 'some-id',
+    };
     expect(() =>
       service.isValid(actionDef, mockActor, invalidContextObject)
     ).toThrow(expectedErrorMsg);


### PR DESCRIPTION
## Summary
- add `actionTargetTypes.js` for action target constants
- refactor actions to use constants
- update validation services and builders
- adjust tests to import constants

## Testing Done
- `npx eslint src/constants/actionTargetTypes.js src/actions/actionFormatter.js src/actions/validation/contextBuilders.js src/actions/validation/actionValidationContextBuilder.js src/actions/validation/actionValidationService.js tests/unit/actions/actionFormatter.test.js tests/unit/actions/actionFormatter.additional.test.js tests/unit/actions/contextBuilders.test.js tests/unit/services/actionValidationService.inputValidation.test.js`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859c3674c908331bd99bd57ffe28d29