### PR TITLE
[Agent] remove redundant prerequisite service import

### DIFF
--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -8,7 +8,6 @@
 /** @typedef {import('./prerequisiteEvaluationService.js').PrerequisiteEvaluationService} PrerequisiteEvaluationService */
 
 /** @typedef {import('../../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
-import { PrerequisiteEvaluationService } from './prerequisiteEvaluationService.js';
 import { BaseService } from '../../utils/serviceBase.js';
 import { validateActionInputs } from './inputValidators.js';
 import {


### PR DESCRIPTION
Summary: 
- remove unused `PrerequisiteEvaluationService` import from ActionValidationService

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859c347d70083318578c4ad019dffe5