### PR TITLE
[Feat] Add context method validator helper

### DIFF
--- a/tests/unit/turns/states/awaitingActorDecisionState.ensureContext.test.js
+++ b/tests/unit/turns/states/awaitingActorDecisionState.ensureContext.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { AwaitingActorDecisionState } from '../../../../src/turns/states/awaitingActorDecisionState.js';
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('AwaitingActorDecisionState._ensureContext', () => {
+  let logger;
+  let ctx;
+  let handler;
+  let state;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    ctx = {
+      getLogger: () => logger,
+      getActor: jest.fn(() => ({ id: 'a1' })),
+      requestProcessingCommandStateTransition: jest.fn(),
+      endTurn: jest.fn().mockResolvedValue(undefined),
+    };
+    handler = {
+      getLogger: jest.fn(() => logger),
+      getTurnContext: jest.fn(() => ctx),
+      resetStateAndResources: jest.fn(),
+      requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
+    };
+    state = new AwaitingActorDecisionState(handler);
+  });
+
+  test('calls endTurn when required methods are missing', async () => {
+    const result = await state._ensureContext('missing');
+    expect(result).toBeNull();
+    const expectedMsg =
+      'AwaitingActorDecisionState: ITurnContext missing required methods: getStrategy';
+    expect(logger.error).toHaveBeenCalledWith(expectedMsg);
+    expect(ctx.endTurn).toHaveBeenCalledWith(expect.any(Error));
+    expect(handler.resetStateAndResources).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/turns/states/processingCommandState.ensureContext.test.js
+++ b/tests/unit/turns/states/processingCommandState.ensureContext.test.js
@@ -1,0 +1,43 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { ProcessingCommandState } from '../../../../src/turns/states/processingCommandState.js';
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('ProcessingCommandState._ensureContext', () => {
+  let logger;
+  let ctx;
+  let handler;
+  let state;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    ctx = {
+      getLogger: () => logger,
+      getActor: jest.fn(() => ({ id: 'a1' })),
+      getSafeEventDispatcher: jest.fn(() => ({ dispatch: jest.fn() })),
+    };
+    handler = {
+      getLogger: jest.fn(() => logger),
+      getTurnContext: jest.fn(() => ctx),
+      resetStateAndResources: jest.fn(),
+      requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
+    };
+    state = new ProcessingCommandState(handler, null, null);
+  });
+
+  test('resets to idle when required methods are missing', async () => {
+    const result = await state._ensureContext('missing');
+    expect(result).toBeNull();
+    const expectedMsg =
+      'ProcessingCommandState: ITurnContext missing required methods: getChosenAction';
+    expect(logger.error).toHaveBeenCalledWith(expectedMsg);
+    expect(handler.resetStateAndResources).toHaveBeenCalledWith(
+      'missing-methods-ProcessingCommandState'
+    );
+    expect(handler.requestIdleStateTransition).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Implemented helper `_ensureContextWithMethods` in AbstractTurnState to validate required context APIs. Updated AwaitingActorDecisionState and ProcessingCommandState to use this helper. Added unit tests for each state covering missing methods handling.

Changes Made:
- Added `_ensureContextWithMethods` to abstract state and imported `validateContextMethods`.
- Refactored AwaitingActorDecisionState and ProcessingCommandState to delegate context checks to new helper.
- Created new tests verifying endTurn/reset behavior when required context methods are absent.

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes (`npx eslint` on changed files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6859c0482b188331a7832182919d8291