### PR TITLE
[Agent] reuse visited set in prerequisite resolution

### DIFF
--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -141,11 +141,13 @@ export class PrerequisiteEvaluationService extends BaseService {
         );
       }
 
-      return this.#resolveReferences(
+      const resolvedLogic = this.#resolveReferences(
         conditionDef.logic,
         actionId,
-        new Set(visited)
+        visited
       );
+      visited.delete(conditionId);
+      return resolvedLogic;
     }
 
     const resolved = {};

--- a/tests/unit/services/prerequisiteEvaluationService.cycle.test.js
+++ b/tests/unit/services/prerequisiteEvaluationService.cycle.test.js
@@ -68,4 +68,19 @@ describe('PrerequisiteEvaluationService Circular Reference Detection', () => {
       "Circular reference detected in prerequisites for action 'testAction'. Path: A -> B -> C -> A"
     );
   });
+
+  test('should resolve identical condition_refs in separate branches without errors', () => {
+    mockGameDataRepository.getConditionDefinition.mockImplementation((id) => {
+      if (id === 'X') return { logic: { condition_ref: 'A' } };
+      if (id === 'Y') return { logic: { condition_ref: 'A' } };
+      if (id === 'A') return { logic: { '==': [1, 1] } };
+      return null;
+    });
+
+    const input = [{ condition_ref: 'X' }, { condition_ref: 'Y' }];
+
+    const result = service._resolveConditionReferences(input, 'testAction');
+
+    expect(result).toEqual([{ '==': [1, 1] }, { '==': [1, 1] }]);
+  });
 });


### PR DESCRIPTION
Summary: Refactored `#resolveReferences` in `PrerequisiteEvaluationService` to reuse the `visited` set and added unit tests to verify circular reference detection and multi-branch resolution.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint run `npm run lint` *(fails: 678 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6859ff8375388331b00bc9f10fd68c3a