### PR TITLE
[Agent] Introduce SaveLoadService factory

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -31,7 +31,7 @@ import GameStateRestorer from '../../persistence/gameStateRestorer.js';
 import SaveMetadataBuilder from '../../persistence/saveMetadataBuilder.js';
 import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuilder.js';
 // import ReferenceResolver from '../../initializers/services/referenceResolver.js'; // Removed - service is deprecated
-import SaveLoadService from '../../persistence/saveLoadService.js';
+import createSaveLoadService from '../../persistence/createSaveLoadService.js';
 import GameStateSerializer from '../../persistence/gameStateSerializer.js';
 import SaveFileRepository from '../../persistence/saveFileRepository.js';
 import SaveFileParser from '../../persistence/saveFileParser.js';
@@ -78,7 +78,7 @@ export function registerPersistence(container) {
   );
 
   r.singletonFactory(tokens.ISaveLoadService, (c) =>
-    SaveLoadService.createDefault({
+    createSaveLoadService({
       logger: c.resolve(tokens.ILogger),
       storageProvider: c.resolve(tokens.IStorageProvider),
     })

--- a/src/persistence/createSaveLoadService.js
+++ b/src/persistence/createSaveLoadService.js
@@ -1,0 +1,48 @@
+// src/persistence/createSaveLoadService.js
+
+import GameStateSerializer from './gameStateSerializer.js';
+import SaveFileParser from './saveFileParser.js';
+import SaveValidationService from './saveValidationService.js';
+import SaveFileRepository from './saveFileRepository.js';
+import SaveLoadService from './saveLoadService.js';
+
+/**
+ * @description Factory function to build a {@link SaveLoadService} instance
+ *   with default dependencies.
+ * @param {object} deps - Dependencies for the service.
+ * @param {import('../interfaces/coreServices.js').ILogger} deps.logger - Logger implementation.
+ * @param {import('../interfaces/IStorageProvider.js').IStorageProvider} deps.storageProvider - Storage provider for save files.
+ * @param {Crypto} [deps.crypto] - Optional Web Crypto implementation used by the serializer.
+ * @returns {SaveLoadService} Configured service instance.
+ */
+export function createSaveLoadService({
+  logger,
+  storageProvider,
+  crypto = globalThis.crypto,
+}) {
+  const serializer = new GameStateSerializer({ logger, crypto });
+  const parser = new SaveFileParser({
+    logger,
+    storageProvider,
+    serializer,
+  });
+  const validationService = new SaveValidationService({
+    logger,
+    gameStateSerializer: serializer,
+  });
+  const repository = new SaveFileRepository({
+    logger,
+    storageProvider,
+    serializer,
+    parser,
+  });
+
+  return new SaveLoadService({
+    logger,
+    saveFileRepository: repository,
+    gameStateSerializer: serializer,
+    saveValidationService: validationService,
+  });
+}
+
+export default createSaveLoadService;

--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -60,13 +60,6 @@ export default class SaveFileRepository extends BaseService {
   }
 
   /**
-   * Helper to wrap persistence operations with logging.
-   *
-   * @param {() => Promise<any>} operationFn - Operation to execute.
-   * @returns {Promise<any>} Result of the wrapped operation.
-   * @private
-   */
-  /**
    * Ensures the manual save directory exists if supported.
    *
    * @returns {Promise<import('./persistenceTypes.js').PersistenceResult<null>>} Result of directory creation.

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -288,44 +288,6 @@ class SaveLoadService extends BaseService {
 
     return this.#fileRepository.deleteSaveFile(saveIdentifier);
   }
-
-  /**
-   * Creates a SaveLoadService with default dependencies.
-   *
-   * @param {object} deps - Factory dependencies.
-   * @param {ILogger} deps.logger - Logger instance.
-   * @param {IStorageProvider} deps.storageProvider - Storage provider for files.
-   * @param {Crypto} [deps.crypto] - Optional Web Crypto implementation.
-   * @returns {SaveLoadService} Configured SaveLoadService instance.
-   */
-  static createDefault({
-    logger,
-    storageProvider,
-    crypto = globalThis.crypto,
-  }) {
-    const serializer = new GameStateSerializer({ logger, crypto });
-    const parser = new SaveFileParser({
-      logger,
-      storageProvider,
-      serializer,
-    });
-    const validationService = new SaveValidationService({
-      logger,
-      gameStateSerializer: serializer,
-    });
-    const repository = new SaveFileRepository({
-      logger,
-      storageProvider,
-      serializer,
-      parser,
-    });
-    return new SaveLoadService({
-      logger,
-      saveFileRepository: repository,
-      gameStateSerializer: serializer,
-      saveValidationService: validationService,
-    });
-  }
 }
 
 export default SaveLoadService;


### PR DESCRIPTION
## Summary
- add createSaveLoadService factory
- remove SaveLoadService.createDefault static factory
- register SaveLoadService via createSaveLoadService
- clean up stray JSDoc block in SaveFileRepository

## Testing Done
- `npm run lint` *(fails: 678 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a01dbfbe88331bef0f9cfa186cc9a