### PR TITLE
[Feat] Refactor SaveGameUI save flow

### DIFF
--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -611,18 +611,43 @@ export class SaveGameUI extends SlotModalBase {
    * @async
    */
   async _handleSave() {
+    const currentSaveName = this._validateAndConfirmSave();
+    if (!currentSaveName) return;
+    await this._executeAndFinalizeSave(currentSaveName);
+  }
+
+  /**
+   * Validates preconditions and confirms overwrite if necessary.
+   *
+   * @private
+   * @returns {string | null} Cleaned save name or null if validation fails
+   * or user cancels.
+   */
+  _validateAndConfirmSave() {
     const validationError = this.#validatePreconditions();
     if (validationError) {
       this._displayStatusMessage(validationError, 'error');
-      return;
+      return null;
     }
 
     const currentSaveName = this.elements.saveNameInputEl.value.trim();
 
     if (!this.#confirmOverwrite(currentSaveName)) {
-      return;
+      return null;
     }
 
+    return currentSaveName;
+  }
+
+  /**
+   * Executes the save and finalizes UI updates.
+   *
+   * @private
+   * @async
+   * @param {string} currentSaveName - The validated save name.
+   * @returns {Promise<void>} Resolves when the operation completes.
+   */
+  async _executeAndFinalizeSave(currentSaveName) {
     this._setOperationInProgress(true);
     this._displayStatusMessage(
       `Saving game as "${currentSaveName}"...`,


### PR DESCRIPTION
Summary: Introduced helper methods for SaveGameUI to simplify save orchestration.

Changes Made:
- Added `_validateAndConfirmSave` for input checks and overwrite confirmation.
- Added `_executeAndFinalizeSave` to wrap save execution and finalize UI updates.
- Updated `_handleSave` to use new helpers.
- Added unit tests covering each helper independently.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on touched files (`npx eslint src/domUI/saveGameUI.js tests/unit/domUI/saveGameUI.test.js`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685a01b958688331801091441164ed30