### PR TITLE
[Agent] Simplify initialized bed options

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -42,16 +42,15 @@ export function withGameEngineBed(overrides = {}, testFn) {
  * @description Creates a temporary test bed, initializes the underlying
  *   engine using {@link GameEngineTestBed.initAndReset}, then runs the provided
  *   callback. Cleanup always occurs after execution.
- * @param {Record<string, any>} [overrides] - Optional dependency overrides.
- * @param {string} [world] - Name of the world used for
- *   initialization.
+ * @param {{ overrides?: Record<string, any>, initArg?: string }} [options] -
+ *   Overrides and world used for initialization.
  * @param {(bed: GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default) =>
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export function withInitializedGameEngineBed(overrides, world, testFn) {
-  return withInitialized(overrides, world, testFn);
+export function withInitializedGameEngineBed(options, testFn) {
+  return withInitialized(options, testFn);
 }
 
 /**
@@ -60,15 +59,15 @@ export function withInitializedGameEngineBed(overrides, world, testFn) {
  * @description Creates a temporary test bed, starts the engine using
  *   {@link GameEngineTestBed.startAndReset}, then runs the provided callback.
  *   Cleanup always occurs after execution.
- * @param {Record<string, any>} [overrides] - Optional dependency overrides.
- * @param {string} [world] - Name of the world used for initialization.
+ * @param {{ overrides?: Record<string, any>, initArg?: string }} [options] -
+ *   Overrides and world used for initialization.
  * @param {(bed: GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default) =>
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export function withRunningGameEngineBed(overrides, world, testFn) {
-  return withRunning(overrides, world, testFn);
+export function withRunningGameEngineBed(options, testFn) {
+  return withRunning(options, testFn);
 }
 
 /**

--- a/tests/common/testBedHelpers.js
+++ b/tests/common/testBedHelpers.js
@@ -78,8 +78,8 @@ export function createWithBed(TestBedCtor, mapFn) {
  *   method.
  * @param {(bed: InstanceType<T>) => any[]} mapFn - Maps the bed to callback
  *   arguments.
- * @returns {(overrides?: ConstructorParameters<T>[0], arg?: any,
- *   callback?: (...args: any[]) => (Promise<void>|void)) => Promise<void>} Helper
+ * @returns {(options: { overrides?: ConstructorParameters<T>[0], initArg?: any },
+ *   callback: (...args: any[]) => (Promise<void>|void)) => Promise<void>} Helper
  *   invoking {@link withTestBed} with initialization.
  */
 export function createInitializedBed(
@@ -88,25 +88,13 @@ export function createInitializedBed(
   defaultArg,
   mapFn
 ) {
-  return async function withInitializedBed(overrides, arg, callback) {
-    if (typeof overrides === 'function') {
-      callback = overrides;
-      overrides = {};
-      arg = defaultArg;
-    } else if (typeof arg === 'function') {
-      callback = arg;
-      arg = defaultArg;
-      overrides = overrides || {};
-    } else {
-      overrides = overrides || {};
-      arg = arg !== undefined ? arg : defaultArg;
-    }
-
+  return async function withInitializedBed(options = {}, callback) {
+    const { overrides = {}, initArg = defaultArg } = options;
     await withTestBed(
       TestBedCtor,
       overrides,
       (bed) => callback(...mapFn(bed)),
-      (bed) => bed[initMethod](arg)
+      (bed) => bed[initMethod](initArg)
     );
   };
 }

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -34,27 +34,35 @@ describe('withGameEngineBed', () => {
 describe('withInitializedGameEngineBed', () => {
   it('initializes engine, runs callback and cleans up', async () => {
     const calls = [];
-    await withInitializedGameEngineBed({ b: 2 }, 'World', (bed, engine) => {
-      calls.push('cb');
-      expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
-      expect(engine).toBe(bed.engine);
-    });
+    await withInitializedGameEngineBed(
+      { overrides: { b: 2 }, initArg: 'World' },
+      (bed, engine) => {
+        calls.push('cb');
+        expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
+        expect(engine).toBe(bed.engine);
+      }
+    );
     expect(calls).toEqual(['cb']);
   });
 
   it('uses defaults and cleans up on error', async () => {
     const error = new Error('oops');
     const testFn = jest.fn().mockRejectedValue(error);
-    await expect(withInitializedGameEngineBed(testFn)).rejects.toThrow('oops');
+    await expect(withInitializedGameEngineBed({}, testFn)).rejects.toThrow(
+      'oops'
+    );
   });
 
   it('passes initialized bed and engine to callback', async () => {
     const calls = [];
-    await withInitializedGameEngineBed({ c: 3 }, 'World', (bed, engine) => {
-      calls.push('cb');
-      expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
-      expect(engine).toBe(bed.engine);
-    });
+    await withInitializedGameEngineBed(
+      { overrides: { c: 3 }, initArg: 'World' },
+      (bed, engine) => {
+        calls.push('cb');
+        expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
+        expect(engine).toBe(bed.engine);
+      }
+    );
     expect(calls).toEqual(['cb']);
   });
 
@@ -63,34 +71,42 @@ describe('withInitializedGameEngineBed', () => {
     const testFn = jest.fn(() => {
       throw error;
     });
-    await expect(withInitializedGameEngineBed(testFn)).rejects.toThrow('fail');
+    await expect(withInitializedGameEngineBed({}, testFn)).rejects.toThrow(
+      'fail'
+    );
   });
 });
 
 describe('withRunningGameEngineBed', () => {
   it('starts engine, runs callback and cleans up', async () => {
     const calls = [];
-    await withRunningGameEngineBed({ d: 4 }, 'World', (bed, engine) => {
-      calls.push('cb');
-      expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
-      expect(engine).toBe(bed.engine);
-    });
+    await withRunningGameEngineBed(
+      { overrides: { d: 4 }, initArg: 'World' },
+      (bed, engine) => {
+        calls.push('cb');
+        expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
+        expect(engine).toBe(bed.engine);
+      }
+    );
     expect(calls).toEqual(['cb']);
   });
 
   it('uses defaults and cleans up on error', async () => {
     const error = new Error('oops');
     const testFn = jest.fn().mockRejectedValue(error);
-    await expect(withRunningGameEngineBed(testFn)).rejects.toThrow('oops');
+    await expect(withRunningGameEngineBed({}, testFn)).rejects.toThrow('oops');
   });
 
   it('passes running bed and engine to callback', async () => {
     const calls = [];
-    await withRunningGameEngineBed({ e: 5 }, 'World', (bed, engine) => {
-      calls.push('cb');
-      expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
-      expect(engine).toBe(bed.engine);
-    });
+    await withRunningGameEngineBed(
+      { overrides: { e: 5 }, initArg: 'World' },
+      (bed, engine) => {
+        calls.push('cb');
+        expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
+        expect(engine).toBe(bed.engine);
+      }
+    );
     expect(calls).toEqual(['cb']);
   });
 
@@ -99,7 +115,7 @@ describe('withRunningGameEngineBed', () => {
     const testFn = jest.fn(() => {
       throw error;
     });
-    await expect(withRunningGameEngineBed(testFn)).rejects.toThrow('fail');
+    await expect(withRunningGameEngineBed({}, testFn)).rejects.toThrow('fail');
   });
 });
 


### PR DESCRIPTION
Summary: 
- refactor `createInitializedBed` to accept an options object `{overrides, initArg}`
- update game engine helpers and tests to use new options parameter

Testing Done:
- [x] Code formatted `npx prettier --write tests/common/testBedHelpers.js tests/common/engine/gameEngineHelpers.js tests/unit/common/engine/gameEngineHelpers.test.js`
- [x] Lint (selected files) `npx eslint tests/common/testBedHelpers.js tests/common/engine/gameEngineHelpers.js tests/unit/common/engine/gameEngineHelpers.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a01b056d083319aedaae21a16a45a