### PR TITLE
[Agent] clone movement components before update

### DIFF
--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -10,6 +10,7 @@
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { deepClone } from '../../utils/cloneUtils.js';
 
 /**
  * @class MergeClosenessCircleHandler
@@ -156,12 +157,17 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
   #lockMovement(memberIds) {
     for (const id of memberIds) {
       try {
-        const move =
-          this.#entityManager.getComponentData(id, 'core:movement') || {};
-        this.#entityManager.addComponent(id, 'core:movement', {
-          ...move,
-          locked: true,
-        });
+        const existing = this.#entityManager.getComponentData(
+          id,
+          'core:movement'
+        );
+        const move = existing
+          ? typeof structuredClone === 'function'
+            ? structuredClone(existing)
+            : deepClone(existing)
+          : {};
+        move.locked = true;
+        this.#entityManager.addComponent(id, 'core:movement', move);
       } catch (err) {
         safeDispatchError(
           this.#dispatcher,

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -12,6 +12,7 @@ import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { deepClone } from '../../utils/cloneUtils.js';
 
 class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
   /** @type {EntityManager} */
@@ -167,12 +168,17 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
    */
   #unlockMovement(ids) {
     for (const id of ids) {
-      const move =
-        this.#entityManager.getComponentData(id, 'core:movement') || {};
-      this.#entityManager.addComponent(id, 'core:movement', {
-        ...move,
-        locked: false,
-      });
+      const existing = this.#entityManager.getComponentData(
+        id,
+        'core:movement'
+      );
+      const move = existing
+        ? typeof structuredClone === 'function'
+          ? structuredClone(existing)
+          : deepClone(existing)
+        : {};
+      move.locked = false;
+      this.#entityManager.addComponent(id, 'core:movement', move);
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure movement data is cloned before modification
- fall back to deepClone when structuredClone isn't available

## Testing Done
- `npm run format`
- `npm run lint`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a00a1d9948331a4c953f8a3ad1be1