### PR TITLE
[Agent] Add test bed helper for running managers

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -307,6 +307,21 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
   }
 
   /**
+   * Prepares the manager for {@link TurnManager.start} by mocking the handler
+   * resolver and stubbing {@link TurnManager.advanceTurn}.
+   *
+   * @returns {import('@jest/globals').Mock} Spy on advanceTurn used during
+   *   preparation.
+   */
+  prepareRunningManager() {
+    this.setupMockHandlerResolver();
+    const spy = this.spyOnAdvanceTurn();
+    spy.mockResolvedValue(undefined);
+    this.resetMocks();
+    return spy;
+  }
+
+  /**
    * Retrieves the subscribed callback for the given event id.
    *
    * @param {string} eventId - Event identifier.

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -20,15 +20,8 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
   beforeEach(() => {
     // Timers reset via BaseTestBed cleanup
-
     testBed = getBed();
-
-    testBed.setupMockHandlerResolver();
-
-    advanceTurnSpy = testBed.spyOnAdvanceTurn();
-    advanceTurnSpy.mockResolvedValue(undefined);
-
-    testBed.resetMocks();
+    advanceTurnSpy = testBed.prepareRunningManager();
   });
 
   // --- start() Tests (Largely Unchanged) ---


### PR DESCRIPTION
Summary: Adds `prepareRunningManager()` in TurnManagerTestBed to consolidate common setup steps and updates lifecycle tests to use it.

Testing Done:
- [ ] Code formatted (`npx prettier --write tests/common/turns/turnManagerTestBed.js tests/unit/turns/turnManager.lifecycle.test.js`)
- [ ] Lint passes (`npm run lint`)
- [ ] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685a004924588331831a4d11fa79ac5c