### PR TITLE
[Feat] leverage resolvePath for content lookups

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -6,6 +6,7 @@
  */
 
 import LoadResultAggregator from './LoadResultAggregator.js';
+import { resolvePath } from '../utils/objectUtils.js';
 
 /** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -210,22 +211,14 @@ export class ContentLoadManager {
         // Iterate over phase-specific loaders
         const { loader, contentKey, diskFolder, registryKey } = config;
         const manifestContent = manifest.content || {};
-        // Support dot notation for nested content keys (e.g., 'entities.definitions')
-        const getNested = (obj, path) =>
-          path
-            .split('.')
-            .reduce(
-              (o, k) => (o && o[k] !== undefined ? o[k] : undefined),
-              obj
-            );
+        const contentList = resolvePath(manifestContent, contentKey);
         const hasContentForLoader =
-          Array.isArray(getNested(manifestContent, contentKey)) &&
-          getNested(manifestContent, contentKey).length > 0;
+          Array.isArray(contentList) && contentList.length > 0;
 
         if (hasContentForLoader) {
           hasContentInPhase = true;
           this.#logger.debug(
-            `ModsLoader [${modId}, ${phase}]: Processing ${contentKey} content with ${getNested(manifestContent, contentKey).length} files...`
+            `ModsLoader [${modId}, ${phase}]: Processing ${contentKey} content with ${contentList.length} files...`
           );
           this.#logger.debug(
             `ModsLoader [${modId}, ${phase}]: Found content for '${contentKey}'. Invoking loader '${loader.constructor.name}'.`

--- a/src/loaders/helpers/filenameUtils.js
+++ b/src/loaders/helpers/filenameUtils.js
@@ -3,6 +3,7 @@
  */
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+import { resolvePath } from '../../utils/objectUtils.js';
 
 /**
  * Safely extracts and validates filenames from the manifest for a given content key.
@@ -14,11 +15,7 @@
  * @returns {string[]} Array of valid, trimmed filenames.
  */
 export function extractValidFilenames(manifest, contentKey, modId, logger) {
-  const getNested = (obj, path) =>
-    path
-      .split('.')
-      .reduce((o, k) => (o && o[k] !== undefined ? o[k] : undefined), obj);
-  const filenames = getNested(manifest?.content, contentKey);
+  const filenames = resolvePath(manifest?.content, contentKey);
   if (filenames === null || filenames === undefined) {
     logger.debug(
       `Mod '${modId}': Content key '${contentKey}' not found or is null/undefined in manifest. Skipping.`

--- a/tests/unit/loaders/baseManifestItemLoader.extractValidFilenames.test.js
+++ b/tests/unit/loaders/baseManifestItemLoader.extractValidFilenames.test.js
@@ -154,6 +154,19 @@ describe('BaseManifestItemLoader _extractValidFilenames', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
+  it('handles nested content keys using dot notation', () => {
+    const manifest = {
+      id: modId,
+      content: { nested: { [contentKey]: ['file.json'] } },
+    };
+    const result = loader._extractValidFilenames(
+      manifest,
+      `nested.${contentKey}`,
+      modId
+    );
+    expect(result).toEqual(['file.json']);
+  });
+
   it('should return empty array and log debug if manifest is null', () => {
     const manifest = null;
     const expected = [];


### PR DESCRIPTION
Summary: Replaced custom nested path retrieval in loaders with shared `resolvePath` utility. Updated ContentLoadManager and BaseManifestItemLoader to import this helper and adjusted helper function accordingly. Added a unit test covering nested content keys.

Testing Done:
- [x] Code formatted (`npx prettier --write ...`)
- [x] Lint passes (`npm run lint`, `llm-proxy-server/npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6859ffa0ce5883319103c9d857120d1c