### PR TITLE
[Agent] remove interface imports

### DIFF
--- a/src/persistence/gamePersistenceService.js
+++ b/src/persistence/gamePersistenceService.js
@@ -1,5 +1,6 @@
-import { IGamePersistenceService } from '../interfaces/IGamePersistenceService.js';
 import { BaseService } from '../utils/serviceBase.js';
+
+/** @typedef {import('../interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */

--- a/src/persistence/saveLoadService.js
+++ b/src/persistence/saveLoadService.js
@@ -1,11 +1,12 @@
-import { ISaveLoadService } from '../interfaces/ISaveLoadService.js';
 import GameStateSerializer from './gameStateSerializer.js';
 import SaveValidationService from './saveValidationService.js';
 import { getManualSavePath } from '../utils/savePathUtils.js';
 import SaveFileRepository from './saveFileRepository.js';
 import SaveFileParser from './saveFileParser.js';
-import { ISaveFileRepository } from '../interfaces/ISaveFileRepository.js';
 import { BaseService } from '../utils/serviceBase.js';
+
+/** @typedef {import('../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService */
+/** @typedef {import('../interfaces/ISaveFileRepository.js').ISaveFileRepository} ISaveFileRepository */
 import { prepareState } from './savePreparation.js';
 import { PersistenceErrorCodes } from './persistenceErrors.js';
 import {
@@ -22,8 +23,6 @@ import { isValidSaveString } from './saveInputValidators.js';
 /** @typedef {import('../interfaces/ISaveLoadService.js').LoadGameResult} LoadGameResult */
 /** @typedef {import('../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */
-/** @typedef {import('../interfaces/ISaveFileRepository.js').ISaveFileRepository} ISaveFileRepository */
-
 // --- Constants ---
 // const MAX_MANUAL_SAVES = 10; // Not directly enforced by list/load, but by save UI/logic
 // Constants defining the manual save directory live in savePathUtils


### PR DESCRIPTION
Summary: replace unused interface imports with JSDoc typedefs in persistence services.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (`npx eslint` on changed files)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a0816505c83318f3d9ca83db0ade4