### PR TITLE
[Agent] validate handler execute method

### DIFF
--- a/tests/common/engine/systemLogicTestEnv.js
+++ b/tests/common/engine/systemLogicTestEnv.js
@@ -74,6 +74,11 @@ export function createRuleTestEnvironment({
     operationRegistry = new OperationRegistry({ logger: testLogger });
     const handlers = createHandlers(entityManager, bus, testLogger);
     for (const [type, handler] of Object.entries(handlers)) {
+      if (!handler || typeof handler.execute !== 'function') {
+        throw new Error(
+          `Handler for ${type} must be an object with an execute() method`
+        );
+      }
       operationRegistry.register(type, handler.execute.bind(handler));
     }
     operationInterpreter = new OperationInterpreter({

--- a/tests/integration/rules/waitRule.integration.test.js
+++ b/tests/integration/rules/waitRule.integration.test.js
@@ -83,4 +83,21 @@ describe('core_handle_wait rule integration', () => {
     const types = testEnv.events.map((e) => e.eventType);
     expect(types).toEqual(expect.arrayContaining(['core:turn_ended']));
   });
+
+  it('throws when a handler lacks an execute method', () => {
+    /**
+     *
+     */
+    function badHandlers() {
+      return { BAD_HANDLER: {} };
+    }
+
+    expect(() =>
+      createRuleTestEnvironment({
+        createHandlers: badHandlers,
+      })
+    ).toThrow(
+      'Handler for BAD_HANDLER must be an object with an execute() method'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- validate that operation handlers from `createHandlers` have an `execute` function
- add failing handler test for wait rule integration

## Testing
- `npm run lint` *(fails: 678 errors)*
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a08aab1fc83319ed95e15fe777b4d