### PR TITLE
[Agent] extract action decision workflow

### DIFF
--- a/src/turns/states/workflows/actionDecisionWorkflow.js
+++ b/src/turns/states/workflows/actionDecisionWorkflow.js
@@ -1,0 +1,75 @@
+/**
+ * @file actionDecisionWorkflow.js
+ * @description Workflow logic for AwaitingActorDecisionState handling action decisions.
+ */
+
+export class ActionDecisionWorkflow {
+  /**
+   * @param {import('../awaitingActorDecisionState.js').AwaitingActorDecisionState} state - Owning state instance.
+   * @param {import('../interfaces/turnStateContextTypes.js').AwaitingActorDecisionStateContext} turnContext - Context for the turn.
+   * @param {import('../../../entities/entity.js').default} actor - Actor making the decision.
+   * @param {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} strategy - Strategy used to decide the action.
+   */
+  constructor(state, turnContext, actor, strategy) {
+    this._state = state;
+    this._turnContext = turnContext;
+    this._actor = actor;
+    this._strategy = strategy;
+  }
+
+  /**
+   * Runs the workflow.
+   *
+   * @returns {Promise<void>} Resolves when workflow completes.
+   */
+  async run() {
+    const logger = this._turnContext.getLogger();
+    try {
+      const { action, extractedData } = await this._state._decideAction(
+        this._strategy,
+        this._turnContext,
+        this._actor
+      );
+
+      if (!action || typeof action.actionDefinitionId !== 'string') {
+        const warnMsg = `${this._state.getStateName()}: Strategy for actor ${this._actor.id} returned an invalid or null ITurnAction (must have actionDefinitionId).`;
+        this._turnContext.getLogger().warn(warnMsg, { receivedAction: action });
+        await this._turnContext.endTurn(new Error(warnMsg));
+        return;
+      }
+
+      this._state._recordDecision(this._turnContext, action, extractedData);
+      await this._state._emitActionDecided(
+        this._turnContext,
+        this._actor,
+        extractedData
+      );
+
+      const cmdStr =
+        action.commandString && action.commandString.trim().length > 0
+          ? action.commandString
+          : action.actionDefinitionId;
+
+      logger.debug(
+        `${this._state.getStateName()}: Requesting transition to ProcessingCommandState for actor ${this._actor.id}.`
+      );
+      await this._turnContext.requestProcessingCommandStateTransition(
+        cmdStr,
+        action
+      );
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        logger.debug(
+          `${this._state.getStateName()}: Action decision for actor ${this._actor.id} was cancelled (aborted). Ending turn gracefully.`
+        );
+        await this._turnContext.endTurn(null);
+      } else {
+        const errMsg = `${this._state.getStateName()}: Error during action decision, storage, or transition for actor ${this._actor.id}: ${error.message}`;
+        logger.error(errMsg, { originalError: error });
+        await this._turnContext.endTurn(new Error(errMsg, { cause: error }));
+      }
+    }
+  }
+}
+
+export default ActionDecisionWorkflow;

--- a/tests/unit/turns/states/workflows/actionDecisionWorkflow.test.js
+++ b/tests/unit/turns/states/workflows/actionDecisionWorkflow.test.js
@@ -1,0 +1,75 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { ActionDecisionWorkflow } from '../../../../../src/turns/states/workflows/actionDecisionWorkflow.js';
+
+describe('ActionDecisionWorkflow.run', () => {
+  let logger;
+  let ctx;
+  let state;
+  let actor;
+  let strategy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    actor = { id: 'a1' };
+    ctx = {
+      getLogger: () => logger,
+      endTurn: jest.fn().mockResolvedValue(undefined),
+      requestProcessingCommandStateTransition: jest
+        .fn()
+        .mockResolvedValue(undefined),
+    };
+    strategy = { decideAction: jest.fn() };
+    state = {
+      getStateName: () => 'AwaitingActorDecisionState',
+      _decideAction: jest.fn(),
+      _recordDecision: jest.fn(),
+      _emitActionDecided: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  test('handles valid action decision', async () => {
+    const action = { actionDefinitionId: 'act', commandString: 'cmd' };
+    state._decideAction.mockResolvedValue({ action, extractedData: { n: 1 } });
+    const workflow = new ActionDecisionWorkflow(state, ctx, actor, strategy);
+    await workflow.run();
+    expect(state._decideAction).toHaveBeenCalledWith(strategy, ctx, actor);
+    expect(state._recordDecision).toHaveBeenCalledWith(ctx, action, { n: 1 });
+    expect(state._emitActionDecided).toHaveBeenCalledWith(ctx, actor, { n: 1 });
+    expect(ctx.requestProcessingCommandStateTransition).toHaveBeenCalledWith(
+      'cmd',
+      action
+    );
+  });
+
+  test('ends turn when action invalid', async () => {
+    state._decideAction.mockResolvedValue({
+      action: null,
+      extractedData: null,
+    });
+    const workflow = new ActionDecisionWorkflow(state, ctx, actor, strategy);
+    await workflow.run();
+    expect(ctx.endTurn).toHaveBeenCalledWith(expect.any(Error));
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('handles AbortError gracefully', async () => {
+    const abortErr = new Error('abort');
+    abortErr.name = 'AbortError';
+    state._decideAction.mockRejectedValue(abortErr);
+    const workflow = new ActionDecisionWorkflow(state, ctx, actor, strategy);
+    await workflow.run();
+    expect(ctx.endTurn).toHaveBeenCalledWith(null);
+  });
+
+  test('handles generic errors', async () => {
+    const err = new Error('boom');
+    state._decideAction.mockRejectedValue(err);
+    const workflow = new ActionDecisionWorkflow(state, ctx, actor, strategy);
+    await workflow.run();
+    expect(ctx.endTurn).toHaveBeenCalledWith(expect.any(Error));
+    const endErr = ctx.endTurn.mock.calls[0][0];
+    expect(endErr.message).toContain('boom');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add ActionDecisionWorkflow for deciding actor actions
- wire AwaitingActorDecisionState to use the workflow
- add unit tests for ActionDecisionWorkflow

## Testing Done
- `npm run lint` on modified files
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a09cb74848331958ca450636bc1ca