### PR TITLE
[Agent] Rename stop spy helpers

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -152,12 +152,12 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
    * confirmation that stop was triggered without affecting flow.
    *
    * @example
-   * const stopSpy = bed.setupDebugStopSpy();
+   * const stopSpy = bed.spyOnStopWithDebug();
    * await bed.turnManager.stop();
    * expect(stopSpy).toHaveBeenCalled();
    * @returns {import('@jest/globals').Mock} The spy instance.
    */
-  setupDebugStopSpy() {
+  spyOnStopWithDebug() {
     const spy = this.spyOnStop();
     spy.mockImplementation(() => {
       this.mocks.logger.debug('Mocked instance.stop() called.');
@@ -256,7 +256,7 @@ export class TurnManagerTestBed extends SpyTrackerMixin(
    *
    * @returns {import('@jest/globals').Mock} The spy instance.
    */
-  setupStopSpyNoOp() {
+  spyOnStopNoOp() {
     const spy = this.spyOnStop();
     spy.mockResolvedValue();
     return spy;

--- a/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.actorIdentification.test.js
@@ -29,7 +29,7 @@ describeRunningTurnManagerSuite(
       testBed = getBed();
       testBed.mockNextActor(createAiActor('initial-actor-for-start'));
       testBed.setupMockHandlerResolver();
-      stopSpy = testBed.setupStopSpyNoOp();
+      stopSpy = testBed.spyOnStopNoOp();
     });
 
     afterEach(async () => {

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -23,7 +23,7 @@ describeRunningTurnManagerSuite(
       testBed = getBed();
       testBed.mockNextActor(createAiActor('actor-next'));
       testBed.setupMockHandlerResolver();
-      stopSpy = testBed.setupStopSpyNoOp();
+      stopSpy = testBed.spyOnStopNoOp();
     });
 
     // --- Test Cases ---

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -25,7 +25,7 @@ describeTurnManagerSuite(
       testBed.mocks.turnHandlerResolver.resolveHandler.mockResolvedValue(null);
 
       // Spy on stop with debug logging for verification
-      stopSpy = testBed.setupDebugStopSpy();
+      stopSpy = testBed.spyOnStopWithDebug();
 
       // Clear constructor/setup logs AFTER instantiation and spy setup
       testBed.resetMocks();

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -53,7 +53,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     it('should handle subscription failure gracefully (invalid return value)', async () => {
       testBed.mocks.dispatcher.subscribe.mockReturnValue(null);
-      const stopSpy = testBed.setupStopSpyNoOp();
+      const stopSpy = testBed.spyOnStopNoOp();
       await testBed.turnManager.start();
       expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
@@ -88,7 +88,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
       testBed.mocks.dispatcher.subscribe.mockImplementation(() => {
         throw subscribeError;
       });
-      const stopSpy = testBed.setupStopSpyNoOp();
+      const stopSpy = testBed.spyOnStopNoOp();
       await testBed.turnManager.start();
       expect(testBed.mocks.dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -30,7 +30,7 @@ describeRunningTurnManagerSuite(
       testBed = getBed();
       ({ ai1, ai2, player } = testBed.addDefaultActors());
       testBed.setupHandlerForActor(ai1);
-      stopSpy = testBed.setupStopSpyNoOp();
+      stopSpy = testBed.spyOnStopNoOp();
       testBed.resetMocks();
     });
 


### PR DESCRIPTION
Summary: Renamed TurnManager test helpers for clarity and updated all usages.

Changes Made:
- `setupStopSpyNoOp` -> `spyOnStopNoOp`
- `setupDebugStopSpy` -> `spyOnStopWithDebug`
- Updated tests to reference new helper names.

Testing Done:
- [x] Code formatted (`npm run format` on changed files)
- [x] Lint passes (`npx eslint` on changed files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_685a08cb56408331959fdf14e62d9997