### PR TITLE
[Agent] refactor GameConfigLoader using helpers

### DIFF
--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -76,6 +76,166 @@ class GameConfigLoader extends AbstractLoader {
   }
 
   /**
+   * Fetches and parses the game configuration file.
+   *
+   * @private
+   * @returns {Promise<{path: string, filename: string, config: any}>}
+   */
+  async #fetchConfig() {
+    const path = this.#pathResolver.resolveGameConfigPath();
+    const filename = this.#configuration.getGameConfigFilename();
+    this.#logger.debug(
+      `GameConfigLoader: Attempting to load game config '${filename}' from ${path}...`
+    );
+    try {
+      const config = await this.#dataFetcher.fetch(path);
+      this.#logger.debug(
+        `GameConfigLoader: Raw content fetched successfully from ${path}.`
+      );
+      return { path, filename, config };
+    } catch (fetchError) {
+      this.#logger.error(
+        `FATAL: Game configuration file '${filename}' not found or could not be fetched at ${path}. Details: ${fetchError.message}`,
+        fetchError
+      );
+      throw new Error(
+        `Failed to fetch game configuration '${filename}' from ${path}: ${fetchError.message}`
+      );
+    }
+  }
+
+  /**
+   * Validates the parsed configuration object and extracts the mods list.
+   *
+   * @private
+   * @param {any} configData - Parsed configuration data.
+   * @param {string} path - Source file path.
+   * @param {string} filename - Source file name.
+   * @returns {string[]} Array of mod IDs.
+   */
+  #validateConfig(configData, path, filename) {
+    const schemaId = this.#configuration.getContentTypeSchemaId('game');
+    if (!schemaId) {
+      this.#logger.error(
+        "FATAL: Schema ID for 'game' configuration type not found in IConfiguration."
+      );
+      throw new Error(
+        'Schema ID for \u2018game\u2019 configuration type not configured.'
+      );
+    }
+    this.#logger.debug(
+      `GameConfigLoader: Using schema ID '${schemaId}' for validation.`
+    );
+    validateAgainstSchema(
+      this.#schemaValidator,
+      schemaId,
+      configData,
+      this.#logger,
+      {
+        validationDebugMessage: `GameConfigLoader: Validating parsed config against schema '${schemaId}'...`,
+        notLoadedMessage: `FATAL: Game config schema ('${schemaId}') is not loaded in the validator. Ensure SchemaLoader ran first and '${filename}.schema.json' is configured.`,
+        notLoadedLogLevel: 'error',
+        notLoadedThrowMessage: `Required game config schema ('${schemaId}') not loaded.`,
+        noValidatorMessage: `FATAL: Could not retrieve validator function for game config schema '${schemaId}'. Schema might be invalid or compilation failed.`,
+        noValidatorThrowMessage: `Validator function unavailable for game config schema '${schemaId}'.`,
+        failureMessage: (errors) => {
+          const formattedErrors = formatAjvErrors(errors);
+          return `FATAL: Game configuration file '${filename}' failed schema validation. Path: ${path}. Schema ID: '${schemaId}'. Errors: ${formattedErrors}`;
+        },
+        failureThrowMessage: `Game configuration validation failed for '${filename}'.`,
+        appendErrorDetails: false,
+      }
+    );
+
+    this.#logger.debug(
+      `GameConfigLoader: Game config '${filename}' validation successful against schema '${schemaId}'.`
+    );
+
+    if (!configData || !Array.isArray(configData.mods)) {
+      this.#logger.error(
+        `FATAL: Validated game config '${filename}' is missing the required 'mods' array property or has incorrect type. Path: ${path}.`
+      );
+      throw new Error(
+        `Validated game config '${filename}' is missing the required 'mods' array.`
+      );
+    }
+    if (!configData.mods.every((m) => typeof m === 'string')) {
+      this.#logger.error(
+        `FATAL: Validated game config '${filename}' 'mods' array contains non-string elements. Path: ${path}.`
+      );
+      throw new Error(
+        `Validated game config '${filename}' 'mods' array contains non-string elements.`
+      );
+    }
+    return [...configData.mods];
+  }
+
+  /**
+   * Ensures {@link CORE_MOD_ID} is first in the mods list.
+   *
+   * @private
+   * @param {string[]} modList - Array of mod IDs.
+   * @returns {string[]} Updated list with CORE_MOD_ID first.
+   */
+  #ensureCoreModFirst(modList) {
+    if (!modList.length || modList[0] !== CORE_MOD_ID) {
+      if (modList.includes(CORE_MOD_ID)) {
+        modList = modList.filter((id) => id !== CORE_MOD_ID);
+        modList.unshift(CORE_MOD_ID);
+        this.#logger.debug(
+          'GameConfigLoader: CORE_MOD_ID mod found but was not first; moved to the beginning of the load order.'
+        );
+      } else {
+        modList.unshift(CORE_MOD_ID);
+        this.#logger.debug(
+          'GameConfigLoader: Auto-injected CORE_MOD_ID mod at the beginning of the load order.'
+        );
+      }
+    } else {
+      this.#logger.debug(
+        'GameConfigLoader: CORE_MOD_ID mod already present at the beginning of the load order.'
+      );
+    }
+    return modList;
+  }
+
+  // --- Testing Utilities ---
+
+  /**
+   * Exposes {@link GameConfigLoader.#fetchConfig} for tests.
+   *
+   * @public
+   * @returns {Promise<{path: string, filename: string, config: any}>}
+   */
+  fetchConfigForTest() {
+    return this.#fetchConfig();
+  }
+
+  /**
+   * Exposes {@link GameConfigLoader.#validateConfig} for tests.
+   *
+   * @public
+   * @param {any} data
+   * @param {string} path
+   * @param {string} filename
+   * @returns {string[]}
+   */
+  validateConfigForTest(data, path, filename) {
+    return this.#validateConfig(data, path, filename);
+  }
+
+  /**
+   * Exposes {@link GameConfigLoader.#ensureCoreModFirst} for tests.
+   *
+   * @public
+   * @param {string[]} mods
+   * @returns {string[]}
+   */
+  ensureCoreModFirstForTest(mods) {
+    return this.#ensureCoreModFirst([...mods]);
+  }
+
+  /**
    * Loads, parses, and validates the game configuration file (e.g., game.json).
    * If validation is successful, ensures CORE_MOD_ID is the first mod ID and returns the array of mod IDs.
    * Throws an error if any step fails (file not found, parse error, validation error),
@@ -88,144 +248,30 @@ class GameConfigLoader extends AbstractLoader {
    * @throws {Error} If the dependencyInjection file cannot be found, parsed, or validated.
    */
   async loadConfig() {
-    let configPath = '';
-    let parsedConfig = null;
-
+    let loadedPath = '';
     try {
-      // 1. Locate Config Path
-      configPath = this.#pathResolver.resolveGameConfigPath();
-      const configFilename = this.#configuration.getGameConfigFilename(); // Get filename for logging
-      this.#logger.debug(
-        `GameConfigLoader: Attempting to load game config '${configFilename}' from ${configPath}...`
-      );
+      const { path, filename, config } = await this.#fetchConfig();
+      loadedPath = path;
 
-      // 2. Fetch Config Content
-      try {
-        // --- MODIFIED TO EXPECT OBJECT DIRECTLY ---
-        parsedConfig = await this.#dataFetcher.fetch(configPath);
-        this.#logger.debug(
-          `GameConfigLoader: Raw content fetched successfully from ${configPath}.`
-        );
-        // --- END MODIFICATION ---
-      } catch (fetchError) {
-        // AC: File Not Found / Fetch Error Handling
-        this.#logger.error(
-          `FATAL: Game configuration file '${configFilename}' not found or could not be fetched at ${configPath}. Details: ${fetchError.message}`,
-          fetchError
-        );
-        // Re-throw the original error or a new summarizing one
-        throw new Error(
-          `Failed to fetch game configuration '${configFilename}' from ${configPath}: ${fetchError.message}`
-        );
-      }
-
-      // --- REMOVED RAW CONTENT CHECK AND JSON PARSE ---
-      // Assuming fetcher now returns parsed JSON or throws on invalid JSON
-
-      // 4. Schema Validation
-      const schemaId = this.#configuration.getContentTypeSchemaId('game');
-      if (!schemaId) {
-        this.#logger.error(
-          "FATAL: Schema ID for 'game' configuration type not found in IConfiguration."
-        );
-        throw new Error(
-          "Schema ID for 'game' configuration type not configured."
-        );
-      }
-      this.#logger.debug(
-        `GameConfigLoader: Using schema ID '${schemaId}' for validation.`
-      );
-
-      validateAgainstSchema(
-        this.#schemaValidator,
-        schemaId,
-        parsedConfig,
-        this.#logger,
-        {
-          validationDebugMessage: `GameConfigLoader: Validating parsed config against schema '${schemaId}'...`,
-          notLoadedMessage: `FATAL: Game config schema ('${schemaId}') is not loaded in the validator. Ensure SchemaLoader ran first and '${this.#configuration.getGameConfigFilename()}.schema.json' is configured.`,
-          notLoadedLogLevel: 'error',
-          notLoadedThrowMessage: `Required game config schema ('${schemaId}') not loaded.`,
-          noValidatorMessage: `FATAL: Could not retrieve validator function for game config schema '${schemaId}'. Schema might be invalid or compilation failed.`,
-          noValidatorThrowMessage: `Validator function unavailable for game config schema '${schemaId}'.`,
-          failureMessage: (errors) => {
-            const formattedErrors = formatAjvErrors(errors);
-            return `FATAL: Game configuration file '${configFilename}' failed schema validation. Path: ${configPath}. Schema ID: '${schemaId}'. Errors: ${formattedErrors}`;
-          },
-          failureThrowMessage: `Game configuration validation failed for '${configFilename}'.`,
-          appendErrorDetails: false,
-        }
-      );
-
-      // 5. Validation Success - Check 'mods' array
-      this.#logger.debug(
-        `GameConfigLoader: Game config '${configFilename}' validation successful against schema '${schemaId}'.`
-      );
-
-      // Final check for 'mods' array existence and type after successful validation
-      if (!parsedConfig || !Array.isArray(parsedConfig.mods)) {
-        this.#logger.error(
-          `FATAL: Validated game config '${configFilename}' is missing the required 'mods' array property or has incorrect type. Path: ${configPath}.`
-        );
-        throw new Error(
-          `Validated game config '${configFilename}' is missing the required 'mods' array.`
-        );
-      }
-      // Ensure all elements in mods are strings (basic check, schema should enforce this more strictly)
-      if (!parsedConfig.mods.every((mod) => typeof mod === 'string')) {
-        this.#logger.error(
-          `FATAL: Validated game config '${configFilename}' 'mods' array contains non-string elements. Path: ${configPath}.`
-        );
-        throw new Error(
-          `Validated game config '${configFilename}' 'mods' array contains non-string elements.`
-        );
-      }
-
-      // --- START: MODLOADER-XXX IMPLEMENTATION ---
-      // Ensure CORE_MOD_ID mod is always first in the list
-      if (!parsedConfig.mods.length || parsedConfig.mods[0] !== CORE_MOD_ID) {
-        if (parsedConfig.mods.includes(CORE_MOD_ID)) {
-          // If Core exists but not first, remove it and prepend
-          parsedConfig.mods = parsedConfig.mods.filter(
-            (modId) => modId !== CORE_MOD_ID
-          );
-          parsedConfig.mods.unshift(CORE_MOD_ID);
-          this.#logger.debug(
-            `GameConfigLoader: CORE_MOD_ID mod found but was not first; moved to the beginning of the load order.`
-          );
-        } else {
-          // If Core is missing entirely, prepend it
-          parsedConfig.mods.unshift(CORE_MOD_ID);
-          this.#logger.debug(
-            `GameConfigLoader: Auto-injected CORE_MOD_ID mod at the beginning of the load order.`
-          );
-        }
-      } else {
-        this.#logger.debug(
-          `GameConfigLoader: CORE_MOD_ID mod already present at the beginning of the load order.`
-        );
-      }
-      // --- END: MODLOADER-XXX IMPLEMENTATION ---
+      const mods = this.#validateConfig(config, path, filename);
+      const finalMods = this.#ensureCoreModFirst(mods);
 
       this.#logger.debug(
-        `GameConfigLoader: Successfully loaded and validated ${parsedConfig.mods.length} mod IDs from game config. Final order: [${parsedConfig.mods.join(', ')}]`
+        `GameConfigLoader: Successfully loaded and validated ${finalMods.length} mod IDs from game config. Final order: [${finalMods.join(', ')}]`
       );
-      return parsedConfig.mods; // Return the validated (and potentially modified) mods array
+
+      return finalMods;
     } catch (error) {
-      // AC: Halting - Ensure any error caught up to this point propagates
-      // Log a general fatal error message if it wasn't caught by more specific handlers above
       if (
         !error.message.startsWith('Failed to fetch') &&
         !error.message.startsWith('Failed to parse') &&
         !error.message.startsWith('Game configuration validation failed')
       ) {
-        // Avoid redundant logging if already logged by specific handlers
         this.#logger.error(
-          `FATAL: An unexpected error occurred during game config loading process for path ${configPath || 'unknown'}. Error: ${error.message}`,
+          `FATAL: An unexpected error occurred during game config loading process for path ${loadedPath || 'unknown'}. Error: ${error.message}`,
           error
         );
       }
-      // Re-throw the caught error to halt the process
       throw error;
     }
   }

--- a/tests/unit/loaders/gameConfigLoader.helpers.test.js
+++ b/tests/unit/loaders/gameConfigLoader.helpers.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import GameConfigLoader from '../../../src/loaders/gameConfigLoader.js';
+import { CORE_MOD_ID } from '../../../src/constants/core.js';
+import { validateAgainstSchema } from '../../../src/utils/schemaValidationUtils.js';
+
+jest.mock('../../../src/utils/schemaValidationUtils.js', () => ({
+  validateAgainstSchema: jest.fn(),
+}));
+
+let configuration;
+let pathResolver;
+let dataFetcher;
+let schemaValidator;
+let logger;
+let loader;
+
+beforeEach(() => {
+  configuration = {
+    getGameConfigFilename: jest.fn().mockReturnValue('game.json'),
+    getContentTypeSchemaId: jest.fn().mockReturnValue('gameSchema'),
+  };
+  pathResolver = {
+    resolveGameConfigPath: jest.fn().mockReturnValue('/game.json'),
+  };
+  dataFetcher = { fetch: jest.fn() };
+  schemaValidator = {};
+  logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  loader = new GameConfigLoader({
+    configuration,
+    pathResolver,
+    dataFetcher,
+    schemaValidator,
+    logger,
+  });
+  jest.clearAllMocks();
+});
+
+describe('GameConfigLoader helper methods', () => {
+  describe('fetchConfigForTest', () => {
+    it('fetches config and returns parsed content', async () => {
+      dataFetcher.fetch.mockResolvedValue({ mods: ['a'] });
+
+      const result = await loader.fetchConfigForTest();
+
+      expect(result).toEqual({
+        path: '/game.json',
+        filename: 'game.json',
+        config: { mods: ['a'] },
+      });
+      expect(pathResolver.resolveGameConfigPath).toHaveBeenCalled();
+      expect(configuration.getGameConfigFilename).toHaveBeenCalled();
+      expect(dataFetcher.fetch).toHaveBeenCalledWith('/game.json');
+    });
+
+    it('logs and throws when fetch fails', async () => {
+      dataFetcher.fetch.mockRejectedValue(new Error('net'));
+
+      await expect(loader.fetchConfigForTest()).rejects.toThrow(
+        'Failed to fetch game configuration'
+      );
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateConfigForTest', () => {
+    it('validates config and returns mods array', () => {
+      const config = { mods: ['one', 'two'] };
+      validateAgainstSchema.mockReturnValue(undefined);
+
+      const mods = loader.validateConfigForTest(
+        config,
+        '/game.json',
+        'game.json'
+      );
+
+      expect(validateAgainstSchema).toHaveBeenCalled();
+      expect(mods).toEqual(['one', 'two']);
+    });
+
+    it('throws when mods array missing', () => {
+      const config = {};
+      validateAgainstSchema.mockReturnValue(undefined);
+
+      expect(() =>
+        loader.validateConfigForTest(config, '/game.json', 'game.json')
+      ).toThrow(/mods/);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('ensureCoreModFirstForTest', () => {
+    it('adds core mod when missing', () => {
+      const result = loader.ensureCoreModFirstForTest(['modA']);
+      expect(result).toEqual([CORE_MOD_ID, 'modA']);
+    });
+
+    it('moves core mod to front when not first', () => {
+      const result = loader.ensureCoreModFirstForTest([
+        'modA',
+        CORE_MOD_ID,
+        'modB',
+      ]);
+      expect(result).toEqual([CORE_MOD_ID, 'modA', 'modB']);
+    });
+
+    it('returns same list when core already first', () => {
+      const mods = [CORE_MOD_ID, 'modX'];
+      const result = loader.ensureCoreModFirstForTest([...mods]);
+      expect(result).toEqual(mods);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added private helper methods for fetching, validating, and ordering game configs. `loadConfig` now orchestrates these helpers. Provided test-only wrappers and new unit tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint src/loaders/gameConfigLoader.js tests/unit/loaders/gameConfigLoader.helpers.test.js --fix`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685a087e5ebc8331adef4d770e756e81