### PR TITLE
[Agent] update action formatter result type

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -131,17 +131,18 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       return null;
     }
 
-    const formattedCommand = this.#formatActionCommandFn(
+    const formatResult = this.#formatActionCommandFn(
       actionDef,
       targetCtx,
       this.#entityManager,
       formatterOptions,
       this.#getEntityDisplayNameFn
     );
-
-    if (formattedCommand === null) {
+    if (!formatResult.ok) {
       return null;
     }
+
+    const formattedCommand = formatResult.value;
 
     return {
       id: actionDef.id,

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -22,7 +22,7 @@ describe('ActionDiscoveryService params exposure', () => {
     const actionValidationService = {
       isValid: () => true,
     };
-    const formatActionCommandFn = () => 'attack rat123';
+    const formatActionCommandFn = () => ({ ok: true, value: 'attack rat123' });
     const getEntityIdsForScopesFn = () => new Set(['rat123']);
     const logger = {
       debug: jest.fn(),

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -56,9 +56,9 @@ describe('ActionDiscoveryService – scoped discovery', () => {
 
   const formatActionCommandFn = (def, ctx) => {
     if (ctx.entityId) {
-      return `${def.commandVerb} ${ctx.entityId}`;
+      return { ok: true, value: `${def.commandVerb} ${ctx.entityId}` };
     }
-    return def.commandVerb;
+    return { ok: true, value: def.commandVerb };
   };
 
   const getEntityIdsForScopesFn = (scopes, context, logger) => {

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -38,7 +38,7 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
       getComponentData: jest.fn().mockReturnValue(null),
     };
     actionValidationService = { isValid: () => true };
-    formatActionCommandFn = jest.fn(() => 'doit');
+    formatActionCommandFn = jest.fn(() => ({ ok: true, value: 'doit' }));
     getEntityIdsForScopesFn = jest.fn(() => new Set());
     logger = {
       debug: jest.fn(),
@@ -102,7 +102,10 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
     };
     gameDataRepo.getAllActionDefinitions.mockReturnValue([def]);
     getEntityIdsForScopesFn.mockReturnValue(new Set(['monster1']));
-    formatActionCommandFn.mockReturnValue('attack monster1');
+    formatActionCommandFn.mockReturnValue({
+      ok: true,
+      value: 'attack monster1',
+    });
 
     const actor = { id: 'actor' };
     const context = {};

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -169,15 +169,20 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
 
     mockFormatActionCommandFn.mockImplementation(
       (actionDef, targetContext, entityManager) => {
-        if (actionDef.id === 'core:wait') return 'wait';
+        if (actionDef.id === 'core:wait') {
+          return { ok: true, value: 'wait' };
+        }
         if (actionDef.id === 'core:go' && targetContext.type === 'entity') {
           const targetEntity = entityManager.getEntityInstance(
             targetContext.entityId
           );
           const targetName = targetEntity.getComponentData('core:name').text;
-          return actionDef.template.replace('{target}', targetName);
+          return {
+            ok: true,
+            value: actionDef.template.replace('{target}', targetName),
+          };
         }
-        return null;
+        return { ok: false, error: 'invalid' };
       }
     );
 

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -124,9 +124,9 @@ describe('ActionDiscoveryService - Wait Action Tests', () => {
     );
     mockFormatActionCommandFn.mockImplementation((actionDef, targetContext) => {
       if (actionDef.id === 'core:wait' && targetContext.type === 'none') {
-        return actionDef.template;
+        return { ok: true, value: actionDef.template };
       }
-      return null;
+      return { ok: false, error: 'invalid' };
     });
     mockGetEntityIdsForScopesFn.mockReturnValue(new Set());
     mockEntityManager.getEntityInstance.mockImplementation((id) => {

--- a/tests/unit/actions/actionFormatter.additional.test.js
+++ b/tests/unit/actions/actionFormatter.additional.test.js
@@ -41,7 +41,7 @@ describe('formatActionCommand additional cases', () => {
     );
   });
 
-  it('returns null when entity context lacks entityId', () => {
+  it('returns error when entity context lacks entityId', () => {
     const actionDef = { id: 'core:use', template: 'use {target}' };
     const context = { type: TARGET_TYPE_ENTITY };
 
@@ -56,13 +56,13 @@ describe('formatActionCommand additional cases', () => {
       displayNameFn
     );
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('entityId is missing')
     );
   });
 
-  it('returns null when direction context lacks direction', () => {
+  it('returns error when direction context lacks direction', () => {
     const actionDef = { id: 'core:move', template: 'move {direction}' };
     const context = { type: TARGET_TYPE_DIRECTION };
 
@@ -77,7 +77,7 @@ describe('formatActionCommand additional cases', () => {
       displayNameFn
     );
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('direction string is missing')
     );
@@ -101,13 +101,13 @@ describe('formatActionCommand additional cases', () => {
       displayNameFn
     );
 
-    expect(result).toBe('wait {target} {direction}');
+    expect(result).toEqual({ ok: true, value: 'wait {target} {direction}' });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('contains placeholders')
     );
   });
 
-  it('returns null and logs error if placeholder substitution throws', () => {
+  it('returns error and logs event if placeholder substitution throws', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
     const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
     entityManager.getEntityInstance.mockImplementation(() => {
@@ -125,7 +125,7 @@ describe('formatActionCommand additional cases', () => {
       displayNameFn
     );
 
-    expect(result).toBeNull();
+    expect(result.ok).toBe(false);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
@@ -151,7 +151,7 @@ describe('formatActionCommand additional cases', () => {
       customMap
     );
 
-    expect(result).toBe('test-value');
+    expect(result).toEqual({ ok: true, value: 'test-value' });
     expect(customMap.entity).toHaveBeenCalled();
   });
 });

--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -41,7 +41,7 @@ describe('formatActionCommand', () => {
       displayNameFn
     );
 
-    expect(result).toBe('inspect The Entity');
+    expect(result).toEqual({ ok: true, value: 'inspect The Entity' });
     expect(displayNameFn).toHaveBeenCalledWith(mockEntity, 'e1', logger);
     expect(logger.debug).toHaveBeenCalled();
   });
@@ -62,7 +62,7 @@ describe('formatActionCommand', () => {
       displayNameFn
     );
 
-    expect(result).toBe('inspect e1');
+    expect(result).toEqual({ ok: true, value: 'inspect e1' });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Could not find entity instance for ID e1')
     );
@@ -83,7 +83,7 @@ describe('formatActionCommand', () => {
       displayNameFn
     );
 
-    expect(result).toBe('move north');
+    expect(result).toEqual({ ok: true, value: 'move north' });
   });
 
   it("returns template as-is for 'none' target type", () => {
@@ -98,10 +98,10 @@ describe('formatActionCommand', () => {
       displayNameFn
     );
 
-    expect(result).toBe('wait');
+    expect(result).toEqual({ ok: true, value: 'wait' });
   });
 
-  it('returns null for missing action template', () => {
+  it('returns error for missing action template', () => {
     const result = formatActionCommand(
       { id: 'bad' },
       { type: TARGET_TYPE_NONE },
@@ -109,7 +109,11 @@ describe('formatActionCommand', () => {
       { logger, safeEventDispatcher: dispatcher },
       displayNameFn
     );
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'formatActionCommand: Invalid or missing actionDefinition or template.',
+    });
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
@@ -146,7 +150,7 @@ describe('formatActionCommand', () => {
       },
       displayNameFn
     );
-    expect(result).toBe('do it');
+    expect(result).toEqual({ ok: true, value: 'do it' });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Unknown targetContext type')
     );


### PR DESCRIPTION
Summary: Introduces a result object for action command formatting and updates discovery logic and tests accordingly.

Changes Made:
- `formatActionCommand` now returns `{ok, value|error}` and internal helpers updated
- `ActionDiscoveryService` checks result objects when building discovered actions
- Updated unit tests and mocks for new return type

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_685a086832508331a39e7fe1cb1e464a