### PR TITLE
[Agent] Simplify manual save flow and state compression

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -164,6 +164,19 @@ class GameStateSerializer extends BaseService {
   }
 
   /**
+   * Calculates the game state checksum and compresses the object.
+   *
+   * @param {object} obj - Save object to process.
+   * @returns {Promise<{compressedData: Uint8Array, finalSaveObject: object}>}
+   *   Compressed data and original object.
+   * @private
+   */
+  async #applyChecksumAndCompress(obj) {
+    await this.#applyChecksum(obj);
+    return this.#encodeAndCompress(obj);
+  }
+
+  /**
    * Serializes the game state to MessagePack and compresses it with Gzip.
    * Embeds a checksum of the gameState section.
    *
@@ -172,8 +185,7 @@ class GameStateSerializer extends BaseService {
    */
   async serializeAndCompress(gameStateObject) {
     const finalSaveObject = this.#cloneForSerialization(gameStateObject);
-    await this.#applyChecksum(finalSaveObject);
-    return this.#encodeAndCompress(finalSaveObject);
+    return this.#applyChecksumAndCompress(finalSaveObject);
   }
 
   /**
@@ -185,8 +197,7 @@ class GameStateSerializer extends BaseService {
    *   Compressed data and original object.
    */
   async compressPreparedState(saveObj) {
-    await this.#applyChecksum(saveObj);
-    return this.#encodeAndCompress(saveObj);
+    return this.#applyChecksumAndCompress(saveObj);
   }
 
   /**

--- a/src/persistence/manualSaveCoordinator.js
+++ b/src/persistence/manualSaveCoordinator.js
@@ -54,8 +54,6 @@ export default class ManualSaveCoordinator extends BaseService {
     this.#logger.debug(`ManualSaveCoordinator.saveGame: Saving "${saveName}".`);
     const state =
       this.#gameStateCaptureService.captureCurrentGameState(activeWorldName);
-    if (!state.metadata) state.metadata = {};
-    state.metadata.saveName = saveName;
     return this.#saveLoadService.saveManualGame(saveName, state);
   }
 }

--- a/tests/unit/services/manualSaveCoordinator.test.js
+++ b/tests/unit/services/manualSaveCoordinator.test.js
@@ -23,21 +23,23 @@ describe('ManualSaveCoordinator', () => {
     });
   });
 
-  it('saveGame adds metadata and delegates to saveLoadService', async () => {
-    captureService.captureCurrentGameState.mockReturnValueOnce({});
+  it('saveGame delegates to saveLoadService without mutating state', async () => {
+    const capturedState = {};
+    captureService.captureCurrentGameState.mockReturnValueOnce(capturedState);
     await coordinator.saveGame('Slot', 'World');
     expect(captureService.captureCurrentGameState).toHaveBeenCalledWith(
       'World'
     );
-    expect(saveLoadService.saveManualGame).toHaveBeenCalledWith('Slot', {
-      metadata: { saveName: 'Slot' },
-    });
+    expect(saveLoadService.saveManualGame).toHaveBeenCalledWith(
+      'Slot',
+      capturedState
+    );
   });
 
   it('saveGame preserves existing state fields', async () => {
     await coordinator.saveGame('Slot', 'World');
     expect(saveLoadService.saveManualGame).toHaveBeenCalledWith('Slot', {
-      metadata: { saveName: 'Slot' },
+      metadata: {},
       gameState: {},
     });
   });


### PR DESCRIPTION
Summary: Refactored persistence utilities to streamline checksum and compression. ManualSaveCoordinator now passes captured state untouched, while GameStateSerializer centralizes checksum+compression logic in `#applyChecksumAndCompress`. Updated associated unit test.

Testing Done:
- [x] Code formatted `npx prettier --write ...`
- [x] Lint run `npx eslint ... --fix`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a083966d883318cb5b0568153b554