### PR TITLE
[Agent] centralize validation error formatting

### DIFF
--- a/src/actions/validation/actionValidationContextBuilder.js
+++ b/src/actions/validation/actionValidationContextBuilder.js
@@ -12,6 +12,7 @@ import {
   buildEntityTargetContext,
 } from './contextBuilders.js';
 import { validateActionInputs } from './inputValidators.js';
+import { formatValidationError } from './validationErrorUtils.js';
 import { ENTITY as TARGET_TYPE_ENTITY } from '../../constants/actionTargetTypes.js';
 
 /**
@@ -112,19 +113,14 @@ export class ActionValidationContextBuilder extends BaseService {
         this.#logger
       );
     } catch (err) {
-      let idInfo = '';
-      if (err.message === 'Invalid actionDefinition') {
-        idInfo = `(id: ${actionDefinition?.id})`;
-      } else if (err.message === 'Invalid actor entity') {
-        idInfo = `(id: ${actor?.id})`;
-      } else if (err.message === 'Invalid ActionTargetContext') {
-        idInfo = `(type: ${targetContext?.type})`;
-      }
-      const msg = err.message
-        ? err.message.charAt(0).toLowerCase() + err.message.slice(1)
-        : 'invalid input';
-      throw new Error(
-        `ActionValidationContextBuilder.buildContext: ${msg} ${idInfo}`
+      throw formatValidationError(
+        err,
+        'ActionValidationContextBuilder.buildContext',
+        {
+          actionId: actionDefinition?.id,
+          actorId: actor?.id,
+          contextType: targetContext?.type,
+        }
       );
     }
   }

--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
 import { BaseService } from '../../utils/serviceBase.js';
 import { validateActionInputs } from './inputValidators.js';
+import { formatValidationError } from './validationErrorUtils.js';
 import {
   TARGET_DOMAIN_SELF,
   TARGET_DOMAIN_NONE,
@@ -110,18 +111,11 @@ export class ActionValidationService extends BaseService {
         this.#logger
       );
     } catch (err) {
-      let idInfo = '';
-      if (err.message === 'Invalid actionDefinition') {
-        idInfo = `(id: ${actionDefinition?.id})`;
-      } else if (err.message === 'Invalid actor entity') {
-        idInfo = `(id: ${actorEntity?.id})`;
-      } else if (err.message === 'Invalid ActionTargetContext') {
-        idInfo = `(type: ${targetContext?.type})`;
-      }
-      const msg = err.message
-        ? err.message.charAt(0).toLowerCase() + err.message.slice(1)
-        : 'invalid input';
-      throw new Error(`ActionValidationService.isValid: ${msg} ${idInfo}`);
+      throw formatValidationError(err, 'ActionValidationService.isValid', {
+        actionId: actionDefinition?.id,
+        actorId: actorEntity?.id,
+        contextType: targetContext?.type,
+      });
     }
   }
 

--- a/src/actions/validation/validationErrorUtils.js
+++ b/src/actions/validation/validationErrorUtils.js
@@ -1,0 +1,30 @@
+/**
+ * @module validationErrorUtils
+ * @description Helper utilities for formatting action validation errors.
+ */
+
+/**
+ * Formats an Error thrown by validateActionInputs for a consistent message.
+ *
+ * @param {Error} err - The original error.
+ * @param {string} source - Label for the calling function.
+ * @param {{actionId?: string, actorId?: string, contextType?: string}} ids
+ *  Identifier info used in the message.
+ * @returns {Error} A new Error instance with the formatted message.
+ */
+export function formatValidationError(err, source, ids) {
+  let idInfo = '';
+  if (err.message === 'Invalid actionDefinition') {
+    idInfo = `(id: ${ids.actionId})`;
+  } else if (err.message === 'Invalid actor entity') {
+    idInfo = `(id: ${ids.actorId})`;
+  } else if (err.message === 'Invalid ActionTargetContext') {
+    idInfo = `(type: ${ids.contextType})`;
+  }
+  const msg = err.message
+    ? err.message.charAt(0).toLowerCase() + err.message.slice(1)
+    : 'invalid input';
+  return new Error(`${source}: ${msg} ${idInfo}`.trim());
+}
+
+export default formatValidationError;

--- a/tests/unit/actions/validation/validationErrorUtils.test.js
+++ b/tests/unit/actions/validation/validationErrorUtils.test.js
@@ -1,0 +1,39 @@
+import { describe, test, expect } from '@jest/globals';
+import { formatValidationError } from '../../../../src/actions/validation/validationErrorUtils.js';
+
+/** Mock error cases used by validateActionInputs */
+const actionErr = new Error('Invalid actionDefinition');
+const actorErr = new Error('Invalid actor entity');
+const ctxErr = new Error('Invalid ActionTargetContext');
+const otherErr = new Error('Something else');
+
+describe('formatValidationError', () => {
+  test('formats invalid actionDefinition message', () => {
+    const err = formatValidationError(actionErr, 'Source.fn', {
+      actionId: 'a1',
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('Source.fn: invalid actionDefinition (id: a1)');
+  });
+
+  test('formats invalid actor entity message', () => {
+    const err = formatValidationError(actorErr, 'Source.fn', {
+      actorId: 'p1',
+    });
+    expect(err.message).toBe('Source.fn: invalid actor entity (id: p1)');
+  });
+
+  test('formats invalid ActionTargetContext message', () => {
+    const err = formatValidationError(ctxErr, 'Source.fn', {
+      contextType: 'none',
+    });
+    expect(err.message).toBe(
+      'Source.fn: invalid ActionTargetContext (type: none)'
+    );
+  });
+
+  test('handles unknown error message gracefully', () => {
+    const err = formatValidationError(otherErr, 'Source.fn', {});
+    expect(err.message).toBe('Source.fn: something else');
+  });
+});


### PR DESCRIPTION
## Summary
- add validationErrorUtils module for formatting input validation errors
- use formatValidationError in ActionValidationContextBuilder and ActionValidationService
- test new helper

## Testing Done
- `npx prettier --write src/actions/validation/actionValidationContextBuilder.js src/actions/validation/actionValidationService.js src/actions/validation/validationErrorUtils.js tests/unit/actions/validation/validationErrorUtils.test.js`
- `npx eslint src/actions/validation/actionValidationContextBuilder.js src/actions/validation/actionValidationService.js src/actions/validation/validationErrorUtils.js tests/unit/actions/validation/validationErrorUtils.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a0855035c8331a00c3ff0698252cb