### PR TITLE
[Agent] Modularize location renderer

### DIFF
--- a/src/domUI/location/buildLocationDisplayPayload.js
+++ b/src/domUI/location/buildLocationDisplayPayload.js
@@ -1,0 +1,47 @@
+/**
+ * @module domUI/location/buildLocationDisplayPayload
+ * @description Helper to create a standardized payload for rendering a location.
+ */
+
+/**
+ * @typedef {import('../../entities/entityDisplayDataProvider.js').ProcessedExit} ProcessedExit
+ * @typedef {import('../../entities/entityDisplayDataProvider.js').CharacterDisplayInfo} CharacterDisplayData
+ */
+
+/**
+ * @typedef {object} LocationDisplayPayload
+ * @property {string} name - Display name for the location.
+ * @property {string} description - Narrative description of the location.
+ * @property {string|null} [portraitPath] - Image path for the location portrait.
+ * @property {string|null} [portraitAltText] - Alt text for the portrait image.
+ * @property {Array<ProcessedExit>} exits - Exits leading away from the location.
+ * @property {Array<CharacterDisplayData>} characters - Characters present in the location.
+ */
+
+/**
+ * Builds the payload used by {@link module:domUI/locationRenderer.LocationRenderer} to
+ * render a location.
+ *
+ * @param {object} locationDetails - Base location details from the provider.
+ * @param {{imagePath:string, altText?:string}|null} portraitData - Optional portrait info.
+ * @param {Array<CharacterDisplayData>} characters - Characters present at the location.
+ * @returns {LocationDisplayPayload} The structured display payload.
+ */
+export function buildLocationDisplayPayload(
+  locationDetails,
+  portraitData,
+  characters
+) {
+  return {
+    name: locationDetails.name,
+    description: locationDetails.description,
+    portraitPath: portraitData ? portraitData.imagePath : null,
+    portraitAltText: portraitData
+      ? portraitData.altText || `Image of ${locationDetails.name}`
+      : null,
+    exits: locationDetails.exits,
+    characters,
+  };
+}
+
+export default buildLocationDisplayPayload;

--- a/src/domUI/location/renderLocationLists.js
+++ b/src/domUI/location/renderLocationLists.js
@@ -1,0 +1,38 @@
+/**
+ * @module domUI/location/renderLocationLists
+ * @description Helper to render exits and characters lists of a location.
+ */
+
+/**
+ * @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger
+ * @typedef {import('./buildLocationDisplayPayload.js').LocationDisplayPayload} LocationDisplayPayload
+ * @typedef {import('../locationRenderer.js').LocationRenderer} LocationRenderer
+ */
+
+/**
+ * Uses the renderer's internal `_renderList` method to populate exits and
+ * characters list containers.
+ *
+ * @param {LocationRenderer} renderer - LocationRenderer instance.
+ * @param {LocationDisplayPayload} locationDto - Data for the location.
+ * @returns {void}
+ */
+export function renderLocationLists(renderer, locationDto) {
+  renderer._renderList(
+    locationDto.exits,
+    renderer.elements.exitsDisplay,
+    'Exits',
+    'description',
+    '(None visible)'
+  );
+
+  renderer._renderList(
+    locationDto.characters,
+    renderer.elements.charactersDisplay,
+    'Characters',
+    'name',
+    '(None else here)'
+  );
+}
+
+export default renderLocationLists;

--- a/src/domUI/location/renderPortraitElements.js
+++ b/src/domUI/location/renderPortraitElements.js
@@ -1,0 +1,52 @@
+/**
+ * @module domUI/location/renderPortraitElements
+ * @description Helper to render or hide location portrait elements.
+ */
+
+/**
+ * @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger
+ * @typedef {import('./buildLocationDisplayPayload.js').LocationDisplayPayload} LocationDisplayPayload
+ */
+
+/**
+ * Renders the portrait section for a location.
+ *
+ * @param {HTMLImageElement | null} imageElement - The image element to update.
+ * @param {HTMLElement | null} visualsElement - Container wrapping the image.
+ * @param {LocationDisplayPayload} locationDto - Data for the location.
+ * @param {ILogger} logger - Logger for debug messages.
+ * @returns {void}
+ */
+export function renderPortraitElements(
+  imageElement,
+  visualsElement,
+  locationDto,
+  logger
+) {
+  if (!imageElement || !visualsElement) {
+    logger.warn('[renderPortraitElements] portrait elements missing.');
+    return;
+  }
+
+  if (locationDto.portraitPath) {
+    logger.debug(
+      `[renderPortraitElements] Setting location portrait to ${locationDto.portraitPath}`
+    );
+    imageElement.src = locationDto.portraitPath;
+    imageElement.alt =
+      locationDto.portraitAltText ||
+      `Image of ${locationDto.name || 'location'}`;
+    imageElement.style.display = 'block';
+    visualsElement.style.display = 'flex';
+  } else {
+    logger.debug(
+      '[renderPortraitElements] No portrait path for location. Hiding portrait elements.'
+    );
+    visualsElement.style.display = 'none';
+    imageElement.style.display = 'none';
+    imageElement.src = '';
+    imageElement.alt = '';
+  }
+}
+
+export default renderPortraitElements;

--- a/tests/unit/domUI/location/buildLocationDisplayPayload.test.js
+++ b/tests/unit/domUI/location/buildLocationDisplayPayload.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildLocationDisplayPayload } from '../../../../src/domUI/location/buildLocationDisplayPayload.js';
+
+describe('buildLocationDisplayPayload', () => {
+  it('creates payload with portrait data', () => {
+    const details = { name: 'Town', description: 'A nice place', exits: [] };
+    const portrait = { imagePath: '/img/town.png', altText: 'Town view' };
+    const chars = [{ id: 'npc:1', name: 'Bob' }];
+    const result = buildLocationDisplayPayload(details, portrait, chars);
+    expect(result).toEqual({
+      name: 'Town',
+      description: 'A nice place',
+      portraitPath: '/img/town.png',
+      portraitAltText: 'Town view',
+      exits: [],
+      characters: chars,
+    });
+  });
+
+  it('handles null portrait data', () => {
+    const details = { name: 'Field', description: 'Open area', exits: [] };
+    const result = buildLocationDisplayPayload(details, null, []);
+    expect(result).toEqual({
+      name: 'Field',
+      description: 'Open area',
+      portraitPath: null,
+      portraitAltText: null,
+      exits: [],
+      characters: [],
+    });
+  });
+});

--- a/tests/unit/domUI/location/renderLocationLists.test.js
+++ b/tests/unit/domUI/location/renderLocationLists.test.js
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import { renderLocationLists } from '../../../../src/domUI/location/renderLocationLists.js';
+
+describe('renderLocationLists', () => {
+  it('calls renderer._renderList with exits and characters', () => {
+    const renderer = {
+      _renderList: jest.fn(),
+      elements: {
+        exitsDisplay: document.createElement('div'),
+        charactersDisplay: document.createElement('div'),
+      },
+    };
+
+    const dto = {
+      name: 'Loc',
+      description: '',
+      portraitPath: null,
+      portraitAltText: null,
+      exits: [{ description: 'North' }],
+      characters: [{ name: 'Bob' }],
+    };
+
+    renderLocationLists(renderer, dto);
+
+    expect(renderer._renderList).toHaveBeenCalledTimes(2);
+    expect(renderer._renderList).toHaveBeenNthCalledWith(
+      1,
+      dto.exits,
+      renderer.elements.exitsDisplay,
+      'Exits',
+      'description',
+      '(None visible)'
+    );
+    expect(renderer._renderList).toHaveBeenNthCalledWith(
+      2,
+      dto.characters,
+      renderer.elements.charactersDisplay,
+      'Characters',
+      'name',
+      '(None else here)'
+    );
+  });
+});

--- a/tests/unit/domUI/location/renderPortraitElements.test.js
+++ b/tests/unit/domUI/location/renderPortraitElements.test.js
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { renderPortraitElements } from '../../../../src/domUI/location/renderPortraitElements.js';
+
+const logger = {
+  debug: jest.fn(),
+  warn: jest.fn(),
+};
+
+describe('renderPortraitElements', () => {
+  let img;
+  let container;
+
+  beforeEach(() => {
+    img = document.createElement('img');
+    container = document.createElement('div');
+  });
+
+  it('shows image when portraitPath is provided', () => {
+    const dto = {
+      name: 'Town',
+      description: '',
+      portraitPath: '/p.png',
+      portraitAltText: 'alt',
+      exits: [],
+      characters: [],
+    };
+    renderPortraitElements(img, container, dto, logger);
+    expect(img.src).toContain('/p.png');
+    expect(img.alt).toBe('alt');
+    expect(img.style.display).toBe('block');
+    expect(container.style.display).toBe('flex');
+  });
+
+  it('hides image when no portraitPath', () => {
+    const dto = {
+      name: 'Field',
+      description: '',
+      portraitPath: null,
+      portraitAltText: null,
+      exits: [],
+      characters: [],
+    };
+    renderPortraitElements(img, container, dto, logger);
+    expect(container.style.display).toBe('none');
+    expect(img.style.display).toBe('none');
+    expect(img.getAttribute('src')).toBe('');
+  });
+});


### PR DESCRIPTION
Summary: Adds helper modules for location display payloads, portrait rendering, and list rendering. LocationRenderer now delegates to these helpers, keeping orchestration logic focused.

Changes Made:
- Added `buildLocationDisplayPayload`, `renderPortraitElements`, and `renderLocationLists` helpers.
- Refactored LocationRenderer to use new helpers.
- Added unit tests for helper modules.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685a09ed014883319a8ef7ad2b006160