### PR TITLE
[Agent] use const for required sections

### DIFF
--- a/src/persistence/saveValidationService.js
+++ b/src/persistence/saveValidationService.js
@@ -8,6 +8,13 @@ import {
   MSG_CHECKSUM_MISMATCH,
 } from './persistenceMessages.js';
 
+const REQUIRED_SECTIONS = [
+  'metadata',
+  'modManifest',
+  'gameState',
+  'integrityChecks',
+];
+
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./gameStateSerializer.js').default} GameStateSerializer */
 /** @typedef {import('../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
@@ -50,13 +57,7 @@ class SaveValidationService extends BaseService {
    * @returns {import('./persistenceTypes.js').PersistenceResult<null>} Result of validation.
    */
   validateStructure(obj, identifier) {
-    const requiredSections = [
-      'metadata',
-      'modManifest',
-      'gameState',
-      'integrityChecks',
-    ];
-    for (const section of requiredSections) {
+    for (const section of REQUIRED_SECTIONS) {
       if (
         !(section in obj) ||
         typeof obj[section] !== 'object' ||


### PR DESCRIPTION
## Summary
- define `REQUIRED_SECTIONS` constant
- use it when validating save structure

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 678 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685a10e9aac48331a8b6b6c03fff4b55