### PR TITLE
[Agent] allow injection of processing dependencies

### DIFF
--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -35,6 +35,7 @@ export class ServiceLookupError extends Error {
  * @param {string} contextMethod - Method name on ITurnContext used to retrieve the service.
  * @param {string} serviceLabel - Label for logging when retrieval fails.
  * @param {string} actorIdForLog - Actor ID for logging context.
+ * @param {ProcessingExceptionHandler} [exceptionHandler] - Handler for errors.
  * @returns {Promise<*>} The requested service instance.
  * @throws {ServiceLookupError} When the service cannot be retrieved.
  */
@@ -43,7 +44,8 @@ export async function getServiceFromContext(
   turnCtx,
   contextMethod,
   serviceLabel,
-  actorIdForLog
+  actorIdForLog,
+  exceptionHandler = state._exceptionHandler
 ) {
   const logger = getLogger(turnCtx, state._handler);
   const dispatcher = getSafeEventDispatcher(turnCtx, state._handler);
@@ -100,8 +102,8 @@ export async function getServiceFromContext(
       );
     }
     const serviceError = new Error(errorMsg);
-    const exceptionHandler = new ProcessingExceptionHandler(state);
-    await exceptionHandler.handle(turnCtx, serviceError, actorIdForLog);
+    const handler = exceptionHandler || new ProcessingExceptionHandler(state);
+    await handler.handle(turnCtx, serviceError, actorIdForLog);
     throw new ServiceLookupError(errorMsg);
   }
 }

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -62,20 +62,26 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {string} [commandString]
    * @param {ITurnAction} [turnAction]
    * @param {{ resolveStrategy(directive: string): ITurnDirectiveStrategy }} [directiveResolver]
-   * @param exceptionHandler
+   * @param {ProcessingExceptionHandler} [exceptionHandler] - Preconstructed handler.
+   * @param {new (state: ProcessingCommandState) => ProcessingGuard} [processingGuardFactory]
+   *   - Factory for creating a ProcessingGuard instance.
+   * @param {new (state: ProcessingCommandState) => ProcessingExceptionHandler} [exceptionHandlerFactory]
+   *   - Factory for creating a ProcessingExceptionHandler instance when one is not supplied.
    */
   constructor(
     handler,
     commandString,
     turnAction = null,
     directiveResolver = TurnDirectiveStrategyResolver,
-    exceptionHandler = undefined
+    exceptionHandler = undefined,
+    processingGuardFactory = ProcessingGuard,
+    exceptionHandlerFactory = ProcessingExceptionHandler
   ) {
     super(handler);
-    this._processingGuard = new ProcessingGuard(this);
+    this._processingGuard = new processingGuardFactory(this);
     this._directiveResolver = directiveResolver;
     this._exceptionHandler =
-      exceptionHandler || new ProcessingExceptionHandler(this);
+      exceptionHandler || new exceptionHandlerFactory(this);
     finishProcessing(this);
     this.#turnActionToProcess = turnAction;
     this.#commandStringForLog =
@@ -184,7 +190,8 @@ export class ProcessingCommandState extends AbstractTurnState {
       turnCtx,
       contextMethod,
       serviceLabel,
-      actorIdForLog
+      actorIdForLog,
+      this._exceptionHandler
     );
   }
 


### PR DESCRIPTION
## Summary
- support injectable ProcessingGuard and ProcessingExceptionHandler factories
- use injected instances throughout ProcessingCommandState
- adjust getServiceFromContext to honor injected exception handler
- test injected factories in ProcessingCommandState.enterState

## Testing Done
- `npx eslint src/turns/states/processingCommandState.js src/turns/states/helpers/getServiceFromContext.js tests/unit/turns/states/processingCommandState.enterState.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a10dd13248331915be0a1ef64a8dd