### PR TITLE
[Agent] move placeholder path helpers

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -1,5 +1,4 @@
 // src/utils/contextUtils.js
-import { safeResolvePath } from './objectUtils.js';
 import { PlaceholderResolver } from './placeholderResolverUtils.js';
 import { getEntityDisplayName } from './entityUtils.js';
 import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
@@ -10,98 +9,12 @@ import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
 export { resolveEntityNameFallback };
 
 // Expose internals for testing purposes
-export const _extractContextPath = extractContextPath;
-export const _resolvePlaceholderPath = resolvePlaceholderPath;
+export const _extractContextPath = PlaceholderResolver.extractContextPath;
+export const _resolvePlaceholderPath =
+  PlaceholderResolver.resolvePlaceholderPath;
 
 // PLACEHOLDER_FIND_REGEX and FULL_STRING_PLACEHOLDER_REGEX are imported from
 // placeholderResolverUtils.js to keep placeholder matching logic consistent.
-
-/**
- * Extracts the effective root and path when handling `context.` placeholders.
- *
- * @description Returns an object containing the trimmed path and the root
- * context object. When the prefix is used but `executionContext.evaluationContext.context`
- * is missing, `null` is returned.
- * @param {string} placeholderPath - Original placeholder path.
- * @param {object} executionContext - The current execution context.
- * @returns {{ path: string, root: object } | null} Extracted info or `null` on
- *   invalid context.
- */
-function extractContextPath(placeholderPath, executionContext) {
-  if (!placeholderPath.startsWith('context.')) {
-    return { path: placeholderPath, root: executionContext };
-  }
-
-  const ctx = executionContext?.evaluationContext?.context;
-  if (ctx && typeof ctx === 'object') {
-    return { path: placeholderPath.substring('context.'.length), root: ctx };
-  }
-
-  return null;
-}
-
-/**
- * Resolves a placeholder path against the provided execution context.
- *
- * @description Handles the `context.` prefix, uses {@link safeResolvePath}, and
- * falls back to {@link resolveEntityNameFallback} when direct resolution fails.
- * @param {string} placeholderPath - Path from the placeholder (e.g.,
- *   `context.varA`).
- * @param {object} executionContext - The execution context root object.
- * @param {ILogger} [logger] - Optional logger for warnings and errors.
- * @param {string} [logPath] - String used in log messages to indicate the
- *   source of the resolution attempt.
- * @returns {any|undefined} The resolved value, or `undefined` when resolution
- *   fails.
- */
-function resolvePlaceholderPath(
-  placeholderPath,
-  executionContext,
-  logger,
-  logPath = ''
-) {
-  if (!placeholderPath) {
-    logger?.warn(`Failed to extract path from placeholder at ${logPath}`);
-    return undefined;
-  }
-
-  if (!executionContext || typeof executionContext !== 'object') {
-    logger?.warn(
-      `Cannot resolve placeholder path "${placeholderPath}" at ${logPath}: executionContext is not a valid object.`
-    );
-    return undefined;
-  }
-
-  const contextInfo = extractContextPath(placeholderPath, executionContext);
-  if (contextInfo === null) {
-    logger?.warn(
-      `Placeholder "${placeholderPath}" uses "context." prefix, but executionContext.evaluationContext.context is missing or invalid. Path: ${logPath}`
-    );
-    return undefined;
-  }
-
-  const resolvedValue =
-    safeResolvePath(
-      contextInfo.root,
-      contextInfo.path,
-      logger,
-      `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
-    ) ?? resolveEntityNameFallback(placeholderPath, executionContext, logger);
-
-  return resolvedValue;
-}
-
-/**
- * Resolves placeholders within a structure using a provided resolver.
- *
- * @private
- * @param {*} value - Value potentially containing placeholders.
- * @param {PlaceholderResolver} resolver - Resolver instance.
- * @param {object[]} sources - Primary data sources for resolution.
- * @param {object} fallback - Fallback source for resolution.
- * @param {Iterable<string>} [skipKeys] - Keys to skip when processing objects.
- * @returns {*} Resolved value or the original input when unchanged.
- */
 
 /**
  * Recursively resolves placeholder strings (e.g., "{actor.id}", "{context.variableName}") within an input structure

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -92,6 +92,84 @@ export class PlaceholderResolver {
   }
 
   /**
+   * Extracts the effective root and path when handling `context.` placeholders.
+   *
+   * @description Returns an object containing the trimmed path and the root
+   * context object. When the prefix is used but `executionContext.evaluationContext.context`
+   * is missing, `null` is returned.
+   * @param {string} placeholderPath - Original placeholder path.
+   * @param {object} executionContext - The current execution context.
+   * @returns {{ path: string, root: object } | null} Extracted info or `null` on
+   *   invalid context.
+   */
+  static extractContextPath(placeholderPath, executionContext) {
+    if (!placeholderPath.startsWith('context.')) {
+      return { path: placeholderPath, root: executionContext };
+    }
+
+    const ctx = executionContext?.evaluationContext?.context;
+    if (ctx && typeof ctx === 'object') {
+      return { path: placeholderPath.substring('context.'.length), root: ctx };
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolves a placeholder path against the provided execution context.
+   *
+   * @description Handles the `context.` prefix, uses {@link safeResolvePath}, and
+   * falls back to {@link resolveEntityNameFallback} when direct resolution fails.
+   * @param {string} placeholderPath - Path from the placeholder (e.g.,
+   *   `context.varA`).
+   * @param {object} executionContext - The execution context root object.
+   * @param {ILogger} [logger] - Optional logger for warnings and errors.
+   * @param {string} [logPath] - String used in log messages to indicate the
+   *   source of the resolution attempt.
+   * @returns {any|undefined} The resolved value, or `undefined` when resolution
+   *   fails.
+   */
+  static resolvePlaceholderPath(
+    placeholderPath,
+    executionContext,
+    logger,
+    logPath = ''
+  ) {
+    if (!placeholderPath) {
+      logger?.warn(`Failed to extract path from placeholder at ${logPath}`);
+      return undefined;
+    }
+
+    if (!executionContext || typeof executionContext !== 'object') {
+      logger?.warn(
+        `Cannot resolve placeholder path "${placeholderPath}" at ${logPath}: executionContext is not a valid object.`
+      );
+      return undefined;
+    }
+
+    const contextInfo = this.extractContextPath(
+      placeholderPath,
+      executionContext
+    );
+    if (contextInfo === null) {
+      logger?.warn(
+        `Placeholder "${placeholderPath}" uses "context." prefix, but executionContext.evaluationContext.context is missing or invalid. Path: ${logPath}`
+      );
+      return undefined;
+    }
+
+    const resolvedValue =
+      safeResolvePath(
+        contextInfo.root,
+        contextInfo.path,
+        logger,
+        `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
+      ) ?? resolveEntityNameFallback(placeholderPath, executionContext, logger);
+
+    return resolvedValue;
+  }
+
+  /**
    * Resolves a dotted path against a given object.
    *
    * @param {object} obj - Root object to resolve against.

--- a/tests/unit/utils/contextUtils.private.test.js
+++ b/tests/unit/utils/contextUtils.private.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import {
-  _extractContextPath,
-  _resolvePlaceholderPath,
-} from '../../../src/utils/contextUtils.js';
+import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js';
+const _extractContextPath =
+  PlaceholderResolver.extractContextPath.bind(PlaceholderResolver);
+const _resolvePlaceholderPath =
+  PlaceholderResolver.resolvePlaceholderPath.bind(PlaceholderResolver);
 import { safeResolvePath } from '../../../src/utils/objectUtils.js';
 import { resolveEntityNameFallback } from '../../../src/utils/entityNameFallbackUtils.js';
 


### PR DESCRIPTION
## Summary
- move internal helper functions to `PlaceholderResolver`
- expose new static methods from `contextUtils`
- update private tests to use static helpers

## Testing Done
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a10ad748883319b8eb0a4b3061c4a