### PR TITLE
[Agent] rename unavailable service helper

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -109,21 +109,33 @@ export function runUnavailableServiceTest(cases, invokeFn) {
 }
 
 /**
- * Generates a Jest `it.each` suite for unavailable service scenarios.
+ * Creates a helper for asserting behavior when a required service token cannot
+ * be resolved.
  *
- * @param {Array<[string, string, { preInit?: boolean }]>} cases - Array of test
- *   case tuples forwarded to {@link runUnavailableServiceTest}.
+ * @description Each generated test temporarily overrides one of the provided
+ *   DI tokens to `null`. Optionally the engine can be started first by passing
+ *   the `preInit` flag on the case tuple. The supplied `invokeFn` performs the
+ *   operation under test and must return the logger and dispatch mocks used for
+ *   assertions. `generateServiceUnavailableTests` verifies the expected log
+ *   output and that no dispatches occurred, then delegates to the returned
+ *   function to run any extra assertions.
+ * @param {Array<[string, string, { preInit?: boolean }]>} cases - List of
+ *   `[token, expectedMessage, options]` tuples describing the service token to
+ *   null out, the message that should be logged, and whether the engine should
+ *   be initialized beforehand.
  * @param {(bed: GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default,
  *   expectedMessage: string) =>
  *   Promise<[import('@jest/globals').Mock, import('@jest/globals').Mock]> |
  *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
- *   Callback used by {@link runUnavailableServiceTest}.
- * @param {number} [extraAssertions] - Number of assertions performed inside
+ *   Function invoked during each test case. It should perform the call under
+ *   test and return the logger and dispatch mocks to validate.
+ * @param {number} [extraAssertions] - Additional assertions performed inside
  *   {@code invokeFn}.
- * @returns {(title: string) => void} Function executing the generated suite.
+ * @returns {(title: string) => void} Callback that runs the generated `it.each`
+ *   suite when provided a test title.
  */
-export function runUnavailableServiceSuite(
+export function generateServiceUnavailableTests(
   cases,
   invokeFn,
   extraAssertions = 0

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -5,10 +5,10 @@ import GameEngine from '../../../src/engine/gameEngine.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('Constructor', () => {
     it('should instantiate and resolve all core services successfully', () => {
-      const testBed = ctx.bed;
+      const testBed = context.bed;
       new GameEngine({
         container: testBed.env.mockContainer,
       }); // Instantiation for this test
@@ -33,7 +33,7 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should throw an error if ILogger cannot be resolved', () => {
-      const testBed = ctx.bed;
+      const testBed = context.bed;
       testBed.withTokenOverride(tokens.ILogger, () => {
         throw new Error('Logger failed to resolve');
       });
@@ -54,7 +54,7 @@ describeEngineSuite('GameEngine', (ctx) => {
       ['PlaytimeTracker', tokens.PlaytimeTracker],
       ['ISafeEventDispatcher', tokens.ISafeEventDispatcher],
     ])('should throw an error if %s cannot be resolved', (_, failingToken) => {
-      const testBed = ctx.bed;
+      const testBed = context.bed;
       const resolutionError = new Error(`${String(failingToken)} failed`);
       testBed.withTokenOverride(failingToken, () => {
         throw resolutionError;

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -13,14 +13,14 @@ import {
 } from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
 import {
   DEFAULT_SAVE_ID,
   ENGINE_READY_MESSAGE,
 } from '../../common/constants.js';
 import { GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('loadGame', () => {
     const SAVE_ID = DEFAULT_SAVE_ID;
     const mockSaveData = {
@@ -30,8 +30,8 @@ describeEngineSuite('GameEngine', (ctx) => {
     const typedMockSaveData = /** @type {SaveGameStructure} */ (mockSaveData);
 
     beforeEach(() => {
-      ctx.bed.resetMocks();
-      ctx.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
+      context.bed.resetMocks();
+      context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
         {
           success: true,
           data: typedMockSaveData,
@@ -40,13 +40,13 @@ describeEngineSuite('GameEngine', (ctx) => {
     });
 
     it('should load and finalize a game successfully', async () => {
-      const result = await ctx.engine.loadGame(SAVE_ID);
+      const result = await context.engine.loadGame(SAVE_ID);
 
       expect(
-        ctx.bed.mocks.gamePersistenceService.loadAndRestoreGame
+        context.bed.mocks.gamePersistenceService.loadAndRestoreGame
       ).toHaveBeenCalledWith(SAVE_ID);
       expectDispatchSequence(
-        ctx.bed.mocks.safeEventDispatcher.dispatch,
+        context.bed.mocks.safeEventDispatcher.dispatch,
         [
           ENGINE_OPERATION_IN_PROGRESS_UI,
           {
@@ -62,16 +62,16 @@ describeEngineSuite('GameEngine', (ctx) => {
           },
         ]
       );
-      expect(ctx.bed.mocks.turnManager.start).toHaveBeenCalled();
+      expect(context.bed.mocks.turnManager.start).toHaveBeenCalled();
       expect(result).toEqual({ success: true, data: typedMockSaveData });
-      expectEngineRunning(ctx.engine, typedMockSaveData.metadata.gameTitle);
+      expectEngineRunning(context.engine, typedMockSaveData.metadata.gameTitle);
     });
 
     describe('when the persistence service reports failure', () => {
       const errorMsg = 'Restore operation failed';
 
       beforeEach(() => {
-        ctx.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
+        context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
           {
             success: false,
             error: errorMsg,
@@ -81,13 +81,13 @@ describeEngineSuite('GameEngine', (ctx) => {
       });
 
       it('logs warning, dispatches failure UI and returns failure result', async () => {
-        const result = await ctx.engine.loadGame(SAVE_ID);
+        const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
+        expect(context.bed.mocks.logger.warn).toHaveBeenCalledWith(
           `GameEngine: Load/restore operation reported failure for "${SAVE_ID}".`
         );
         expectDispatchSequence(
-          ctx.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.mocks.safeEventDispatcher.dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -104,7 +104,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           ]
         );
         expect(result).toEqual({ success: false, error: errorMsg, data: null });
-        expectEngineStopped(ctx.engine);
+        expectEngineStopped(context.engine);
       });
     });
 
@@ -112,20 +112,20 @@ describeEngineSuite('GameEngine', (ctx) => {
       const errorObj = new Error('Execute failed');
 
       beforeEach(() => {
-        ctx.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockRejectedValue(
+        context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockRejectedValue(
           errorObj
         );
       });
 
       it('logs error, dispatches failure UI and returns failure result', async () => {
-        const result = await ctx.engine.loadGame(SAVE_ID);
+        const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(ctx.bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect(context.bed.mocks.logger.error).toHaveBeenCalledWith(
           `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${errorObj.message}`,
           errorObj
         );
         expectDispatchSequence(
-          ctx.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.mocks.safeEventDispatcher.dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -146,7 +146,7 @@ describeEngineSuite('GameEngine', (ctx) => {
           error: errorObj.message,
           data: null,
         });
-        expectEngineStopped(ctx.engine);
+        expectEngineStopped(context.engine);
       });
     });
 
@@ -154,18 +154,18 @@ describeEngineSuite('GameEngine', (ctx) => {
       const errorObj = new Error('Finalize failed');
 
       beforeEach(() => {
-        ctx.bed.mocks.turnManager.start.mockRejectedValue(errorObj);
+        context.bed.mocks.turnManager.start.mockRejectedValue(errorObj);
       });
 
       it('logs error, dispatches failure UI and returns failure result', async () => {
-        const result = await ctx.engine.loadGame(SAVE_ID);
+        const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(ctx.bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect(context.bed.mocks.logger.error).toHaveBeenCalledWith(
           `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${errorObj.message}`,
           errorObj
         );
         expectDispatchSequence(
-          ctx.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.mocks.safeEventDispatcher.dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -193,11 +193,11 @@ describeEngineSuite('GameEngine', (ctx) => {
           error: errorObj.message,
           data: null,
         });
-        expectEngineStopped(ctx.engine);
+        expectEngineStopped(context.engine);
       });
     });
 
-    runUnavailableServiceSuite(
+    generateServiceUnavailableTests(
       [
         [
           tokens.GamePersistenceService,

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -2,22 +2,24 @@
 import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
 import { expectShowLoadGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('showLoadGameUI', () => {
     it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
-      ctx.engine.showLoadGameUI(); // Method is now sync
+      context.engine.showLoadGameUI(); // Method is now sync
 
-      expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
+      expect(context.bed.mocks.logger.debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
       );
-      expectShowLoadGameUIDispatch(ctx.bed.mocks.safeEventDispatcher.dispatch);
+      expectShowLoadGameUIDispatch(
+        context.bed.mocks.safeEventDispatcher.dispatch
+      );
     });
 
-    runUnavailableServiceSuite(
+    generateServiceUnavailableTests(
       [[tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE]],
       (bed, engine) => {
         engine.showLoadGameUI();

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -2,7 +2,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeInitializedEngineSuite } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
 import { CANNOT_SAVE_GAME_INFO } from '../../../src/constants/eventIds.js';
 import { expectShowSaveGameUIDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
@@ -10,46 +10,46 @@ import { GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE } from '../../common/engine/unavai
 
 describeInitializedEngineSuite(
   'GameEngine',
-  (ctx) => {
+  (context) => {
     describe('showSaveGameUI', () => {
       it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', () => {
-        ctx.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
+        context.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
           true
         );
-        ctx.engine.showSaveGameUI(); // Method is now sync
+        context.engine.showSaveGameUI(); // Method is now sync
 
-        expect(ctx.bed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect(context.bed.mocks.logger.debug).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
         );
         expect(
-          ctx.bed.mocks.gamePersistenceService.isSavingAllowed
+          context.bed.mocks.gamePersistenceService.isSavingAllowed
         ).toHaveBeenCalledWith(true); // engine is initialized
         expectShowSaveGameUIDispatch(
-          ctx.bed.mocks.safeEventDispatcher.dispatch
+          context.bed.mocks.safeEventDispatcher.dispatch
         );
       });
 
       it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', () => {
-        ctx.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
+        context.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
           false
         );
-        ctx.engine.showSaveGameUI(); // Method is now sync
+        context.engine.showSaveGameUI(); // Method is now sync
 
-        expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
+        expect(context.bed.mocks.logger.warn).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Saving is not currently allowed.'
         );
         expect(
-          ctx.bed.mocks.gamePersistenceService.isSavingAllowed
+          context.bed.mocks.gamePersistenceService.isSavingAllowed
         ).toHaveBeenCalledWith(true);
-        expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-          CANNOT_SAVE_GAME_INFO
-        );
         expect(
-          ctx.bed.mocks.safeEventDispatcher.dispatch
+          context.bed.mocks.safeEventDispatcher.dispatch
+        ).toHaveBeenCalledWith(CANNOT_SAVE_GAME_INFO);
+        expect(
+          context.bed.mocks.safeEventDispatcher.dispatch
         ).toHaveBeenCalledTimes(1);
       });
 
-      runUnavailableServiceSuite(
+      generateServiceUnavailableTests(
         [[tokens.GamePersistenceService, GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE]],
         (bed, engine) => {
           engine.showSaveGameUI();

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -21,76 +21,76 @@ import {
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 import { mockInitializationSuccess } from '../../common/engine/gameEngineHelpers.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('startNewGame', () => {
     beforeEach(() => {
-      mockInitializationSuccess(ctx.bed);
+      mockInitializationSuccess(context.bed);
     });
 
     it('should successfully start a new game', async () => {
-      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
-      expectStartSuccess(ctx.bed, ctx.engine, DEFAULT_TEST_WORLD);
+      await context.engine.startNewGame(DEFAULT_TEST_WORLD);
+      expectStartSuccess(context.bed, context.engine, DEFAULT_TEST_WORLD);
     });
 
     it('should stop an existing game if already initialized, with correct event payloads from stop()', async () => {
-      await ctx.bed.startAndReset('InitialWorld');
-      await ctx.engine.startNewGame(DEFAULT_TEST_WORLD);
+      await context.bed.startAndReset('InitialWorld');
+      await context.engine.startNewGame(DEFAULT_TEST_WORLD);
 
-      expect(ctx.bed.mocks.logger.warn).toHaveBeenCalledWith(
+      expect(context.bed.mocks.logger.warn).toHaveBeenCalledWith(
         'GameEngine._prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
       );
       expect(
-        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
+        context.bed.mocks.playtimeTracker.endSessionAndAccumulate
       ).toHaveBeenCalledTimes(1);
-      expect(ctx.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+      expect(context.bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
       expectDispatchSequence(
-        ctx.bed.mocks.safeEventDispatcher.dispatch,
+        context.bed.mocks.safeEventDispatcher.dispatch,
         ...buildStopDispatches(),
         ...buildStartDispatches(DEFAULT_TEST_WORLD)
       );
-      expectEngineRunning(ctx.engine, DEFAULT_TEST_WORLD);
+      expectEngineRunning(context.engine, DEFAULT_TEST_WORLD);
     });
 
     it('should handle InitializationService failure', async () => {
       const initError = new Error('Initialization failed via service');
-      ctx.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+      context.bed.mocks.initializationService.runInitializationSequence.mockResolvedValue(
         {
           success: false,
           error: initError,
         }
       );
 
-      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
-        initError
-      );
+      await expect(
+        context.engine.startNewGame(DEFAULT_TEST_WORLD)
+      ).rejects.toThrow(initError);
 
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENGINE_OPERATION_FAILED_UI,
-        {
-          errorMessage: `Failed to start new game: ${initError.message}`,
-          errorTitle: 'Initialization Error',
-        }
-      );
-      expectEngineStopped(ctx.engine);
+      expect(
+        context.bed.mocks.safeEventDispatcher.dispatch
+      ).toHaveBeenCalledWith(ENGINE_OPERATION_FAILED_UI, {
+        errorMessage: `Failed to start new game: ${initError.message}`,
+        errorTitle: 'Initialization Error',
+      });
+      expectEngineStopped(context.engine);
     });
 
     it('should handle general errors during start-up and dispatch failure event', async () => {
       const startupError = new Error('TurnManager failed to start');
-      ctx.bed.mocks.playtimeTracker.startSession.mockImplementation(() => {}); // Make sure this doesn't throw
-      ctx.bed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
+      context.bed.mocks.playtimeTracker.startSession.mockImplementation(
+        () => {}
+      ); // Make sure this doesn't throw
+      context.bed.mocks.turnManager.start.mockRejectedValue(startupError); // TurnManager fails to start
 
-      await expect(ctx.engine.startNewGame(DEFAULT_TEST_WORLD)).rejects.toThrow(
-        startupError
-      );
+      await expect(
+        context.engine.startNewGame(DEFAULT_TEST_WORLD)
+      ).rejects.toThrow(startupError);
 
-      expect(ctx.bed.mocks.safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        ENGINE_OPERATION_FAILED_UI,
-        {
-          errorMessage: `Failed to start new game: ${startupError.message}`, // Error from TurnManager
-          errorTitle: 'Initialization Error',
-        }
-      );
-      expectEngineStopped(ctx.engine);
+      expect(
+        context.bed.mocks.safeEventDispatcher.dispatch
+      ).toHaveBeenCalledWith(ENGINE_OPERATION_FAILED_UI, {
+        errorMessage: `Failed to start new game: ${startupError.message}`, // Error from TurnManager
+        errorTitle: 'Initialization Error',
+      });
+      expectEngineStopped(context.engine);
     });
   });
 });

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -12,7 +12,7 @@ import {
   describeEngineSuite,
   describeInitializedEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
 import { ENGINE_STOPPED_UI } from '../../../src/constants/eventIds.js';
 import {
   expectDispatchSequence,
@@ -24,7 +24,7 @@ import {
 import { DEFAULT_TEST_WORLD } from '../../common/constants.js';
 import { PLAYTIME_TRACKER_STOP_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('stop', () => {
     beforeEach(() => {
       // Ensure engine is fresh for each 'stop' test
@@ -32,13 +32,13 @@ describeEngineSuite('GameEngine', (ctx) => {
 
     describeInitializedEngineSuite(
       'when engine is initialized',
-      (ctx) => {
+      (context) => {
         it('should successfully stop a running game, with correct logging, events, and state changes', async () => {
-          await ctx.engine.stop();
-          expectStopSuccess(ctx.bed, ctx.engine);
+          await context.engine.stop();
+          expectStopSuccess(context.bed, context.engine);
         });
 
-        runUnavailableServiceSuite(
+        generateServiceUnavailableTests(
           [
             [
               tokens.PlaytimeTracker,
@@ -71,17 +71,17 @@ describeEngineSuite('GameEngine', (ctx) => {
     );
 
     it('should do nothing and log if engine is already stopped', async () => {
-      // ctx.engine is fresh, so not initialized
-      expectEngineStopped(ctx.engine);
+      // context.engine is fresh, so not initialized
+      expectEngineStopped(context.engine);
 
-      await ctx.engine.stop();
+      await context.engine.stop();
 
       expect(
-        ctx.bed.mocks.playtimeTracker.endSessionAndAccumulate
+        context.bed.mocks.playtimeTracker.endSessionAndAccumulate
       ).not.toHaveBeenCalled();
-      expect(ctx.bed.mocks.turnManager.stop).not.toHaveBeenCalled();
+      expect(context.bed.mocks.turnManager.stop).not.toHaveBeenCalled();
       expect(
-        ctx.bed.mocks.safeEventDispatcher.dispatch
+        context.bed.mocks.safeEventDispatcher.dispatch
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
   });

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -5,7 +5,7 @@ import {
   describeEngineSuite,
   describeInitializedEngineSuite,
 } from '../../common/engine/gameEngineTestBed.js';
-import { runUnavailableServiceSuite } from '../../common/engine/gameEngineHelpers.js';
+import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
 import {
   expectDispatchSequence,
   buildSaveDispatches,
@@ -20,27 +20,27 @@ import {
   GAME_PERSISTENCE_SAVE_RESULT_UNAVAILABLE,
 } from '../../common/engine/unavailableMessages.js';
 
-describeEngineSuite('GameEngine', (ctx) => {
+describeEngineSuite('GameEngine', (context) => {
   describe('triggerManualSave', () => {
     const SAVE_NAME = DEFAULT_SAVE_NAME;
     const MOCK_ACTIVE_WORLD_FOR_SAVE = DEFAULT_ACTIVE_WORLD_FOR_SAVE;
 
     it('should dispatch error and not attempt save if engine is not initialized', async () => {
-      const result = await ctx.engine.triggerManualSave(SAVE_NAME);
+      const result = await context.engine.triggerManualSave(SAVE_NAME);
       const expectedErrorMsg =
         'Game engine is not initialized. Cannot save game.';
 
-      expectNoDispatch(ctx.bed.mocks.safeEventDispatcher.dispatch);
+      expectNoDispatch(context.bed.mocks.safeEventDispatcher.dispatch);
       expect(
-        ctx.bed.mocks.gamePersistenceService.saveGame
+        context.bed.mocks.gamePersistenceService.saveGame
       ).not.toHaveBeenCalled();
       expect(result).toEqual({ success: false, error: expectedErrorMsg });
     });
 
     describeInitializedEngineSuite(
       'when engine is initialized',
-      (ctx) => {
-        runUnavailableServiceSuite(
+      (context) => {
+        generateServiceUnavailableTests(
           [
             [
               tokens.GamePersistenceService,
@@ -67,19 +67,19 @@ describeEngineSuite('GameEngine', (ctx) => {
 
         it('should successfully save, dispatch all UI events in order, and return success result', async () => {
           const saveResultData = { success: true, filePath: 'path/to/my.sav' };
-          ctx.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
+          context.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
             saveResultData
           );
 
-          const result = await ctx.engine.triggerManualSave(SAVE_NAME);
+          const result = await context.engine.triggerManualSave(SAVE_NAME);
 
           expectDispatchSequence(
-            ctx.bed.mocks.safeEventDispatcher.dispatch,
+            context.bed.mocks.safeEventDispatcher.dispatch,
             ...buildSaveDispatches(SAVE_NAME, saveResultData.filePath)
           );
 
           expect(
-            ctx.bed.mocks.gamePersistenceService.saveGame
+            context.bed.mocks.gamePersistenceService.saveGame
           ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
           expect(result).toEqual(saveResultData);
         });
@@ -94,24 +94,24 @@ describeEngineSuite('GameEngine', (ctx) => {
           'should handle %s, dispatch UI events, and return failure result',
           async (_caseName, failureValue) => {
             if (failureValue instanceof Error) {
-              ctx.bed.mocks.gamePersistenceService.saveGame.mockRejectedValue(
+              context.bed.mocks.gamePersistenceService.saveGame.mockRejectedValue(
                 failureValue
               );
             } else {
-              ctx.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
+              context.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
                 failureValue
               );
             }
 
-            const result = await ctx.engine.triggerManualSave(SAVE_NAME);
+            const result = await context.engine.triggerManualSave(SAVE_NAME);
 
             expectDispatchSequence(
-              ctx.bed.mocks.safeEventDispatcher.dispatch,
+              context.bed.mocks.safeEventDispatcher.dispatch,
               ...buildSaveDispatches(SAVE_NAME)
             );
 
             expect(
-              ctx.bed.mocks.gamePersistenceService.saveGame
+              context.bed.mocks.gamePersistenceService.saveGame
             ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
 
             const expectedResult =


### PR DESCRIPTION
## Summary
- rename `runUnavailableServiceSuite` to `generateServiceUnavailableTests`
- update helper JSDoc
- use `context` instead of `ctx` in engine tests

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a10980af0833198be527c589d2894