### PR TITLE
[Agent] rename warnIfTargetMissing method

### DIFF
--- a/src/actions/validation/actionValidationService.js
+++ b/src/actions/validation/actionValidationService.js
@@ -177,7 +177,7 @@ export class ActionValidationService extends BaseService {
    * @param {string} actionId - The ID of the action being validated (for logging).
    * @returns {void}
    */
-  warnIfTargetMissing(targetContext, actionId) {
+  #warnIfTargetMissing(targetContext, actionId) {
     if (targetContext.type === TARGET_TYPE_ENTITY) {
       const targetEntity = this.#entityManager.getEntityInstance(
         targetContext.entityId
@@ -327,7 +327,7 @@ export class ActionValidationService extends BaseService {
       }
 
       // Step 2: Verify Target Entity Existence
-      this.warnIfTargetMissing(targetContext, actionId);
+      this.#warnIfTargetMissing(targetContext, actionId);
 
       // Steps 3 & 4: Process prerequisites
       const prerequisitesPassed = this._validatePrerequisites(

--- a/tests/unit/services/actionValidationService.actorComponents.test.js
+++ b/tests/unit/services/actionValidationService.actorComponents.test.js
@@ -609,13 +609,12 @@ describe('ActionValidationService: Orchestration Logic', () => {
     };
     const ctx = ActionTargetContext.forEntity('target-order');
 
-    const step1 = jest
-      .spyOn(actionValidationService, '_validateDomainAndContext')
-      .mockReturnValue(true);
-    const step2 = jest.spyOn(actionValidationService, 'warnIfTargetMissing');
-    const step3 = jest
-      .spyOn(actionValidationService, '_validatePrerequisites')
-      .mockReturnValue(true);
+    const step1 = jest.spyOn(
+      actionValidationService,
+      '_validateDomainAndContext'
+    );
+    const step3 = jest.spyOn(actionValidationService, '_validatePrerequisites');
+    const debugSpy = jest.spyOn(mockLogger, 'debug');
 
     const result = actionValidationService.isValid(
       actionDefinition,
@@ -624,11 +623,15 @@ describe('ActionValidationService: Orchestration Logic', () => {
     );
 
     expect(result).toBe(true);
-    expect(step1).toHaveBeenCalledBefore(step2);
-    expect(step2).toHaveBeenCalledBefore(step3);
+    const debugCalls = debugSpy.mock.calls.map((call) => call[0]);
+    const step1Index = debugCalls.findIndex((m) => m.includes('STEP 1'));
+    const step2Index = debugCalls.findIndex((m) => m.includes('STEP 2'));
+    const step3Index = debugCalls.findIndex((m) => m.includes('STEP 3'));
+    expect(step1Index).toBeLessThan(step2Index);
+    expect(step2Index).toBeLessThan(step3Index);
 
     step1.mockRestore();
-    step2.mockRestore();
     step3.mockRestore();
+    debugSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- rename `warnIfTargetMissing` to `#warnIfTargetMissing`
- update internal calls
- observe validation step order via logger output in tests

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a126430f08331ac39d63bd221d35d