### PR TITLE
[Agent] enforce TypeError on registry store errors

### DIFF
--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -480,6 +480,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
    * @param {object} dataToStore - The original data object fetched and validated for the item.
    * @param {string} sourceFilename - The original filename from which the data was loaded (for logging).
    * @returns {{qualifiedId: string, didOverride: boolean}} Object containing the fully qualified ID and override flag.
+   * @throws {TypeError} If arguments fail validation.
    * @throws {Error} Re-throws any error encountered during interaction with the data registry (`get` or `store`).
    */
   _storeItemInRegistry(

--- a/src/loaders/helpers/registryStoreUtils.js
+++ b/src/loaders/helpers/registryStoreUtils.js
@@ -16,7 +16,8 @@
  * @param {string} baseItemId - The item's unqualified ID.
  * @param {object} dataToStore - Data object to store.
  * @param {string} sourceFilename - Original filename for logging.
- * @returns {{qualifiedId: string|null, didOverride: boolean, error?: boolean}} Result info.
+ * @returns {{qualifiedId: string, didOverride: boolean}} Result info.
+ * @throws {TypeError} If any argument is of an unexpected type.
  */
 export function storeItemInRegistry(
   logger,
@@ -29,28 +30,24 @@ export function storeItemInRegistry(
   sourceFilename
 ) {
   if (!category || typeof category !== 'string') {
-    logger.error(
-      `${loaderName} [_storeItemInRegistry]: Category must be a non-empty string. Received: ${category}`
-    );
-    return { qualifiedId: null, didOverride: false, error: true };
+    const message = `${loaderName} [_storeItemInRegistry]: Category must be a non-empty string. Received: ${category}`;
+    logger.error(message);
+    throw new TypeError(message);
   }
   if (!modId || typeof modId !== 'string') {
-    logger.error(
-      `${loaderName} [_storeItemInRegistry]: ModId must be a non-empty string for category '${category}'. Received: ${modId}`
-    );
-    return { qualifiedId: null, didOverride: false, error: true };
+    const message = `${loaderName} [_storeItemInRegistry]: ModId must be a non-empty string for category '${category}'. Received: ${modId}`;
+    logger.error(message);
+    throw new TypeError(message);
   }
   if (!baseItemId || typeof baseItemId !== 'string') {
-    logger.error(
-      `${loaderName} [_storeItemInRegistry]: BaseItemId must be a non-empty string for category '${category}', mod '${modId}'. Received: ${baseItemId}`
-    );
-    return { qualifiedId: null, didOverride: false, error: true };
+    const message = `${loaderName} [_storeItemInRegistry]: BaseItemId must be a non-empty string for category '${category}', mod '${modId}'. Received: ${baseItemId}`;
+    logger.error(message);
+    throw new TypeError(message);
   }
   if (!dataToStore || typeof dataToStore !== 'object') {
-    logger.error(
-      `${loaderName} [_storeItemInRegistry]: Data for '${modId}:${baseItemId}' (category: ${category}) must be an object. Received: ${typeof dataToStore}`
-    );
-    return { qualifiedId: null, didOverride: false, error: true };
+    const message = `${loaderName} [_storeItemInRegistry]: Data for '${modId}:${baseItemId}' (category: ${category}) must be an object. Received: ${typeof dataToStore}`;
+    logger.error(message);
+    throw new TypeError(message);
   }
 
   const qualifiedId = `${modId}:${baseItemId}`;

--- a/tests/unit/loaders/baseManifestItemLoader._storeItemInRegistry.test.js
+++ b/tests/unit/loaders/baseManifestItemLoader._storeItemInRegistry.test.js
@@ -91,13 +91,7 @@ class TestableLoader extends BaseManifestItemLoader {
     );
   }
 
-  async _processFetchedItem(
-    _modId,
-    _filename,
-    _resolvedPath,
-    _fetchedData,
-    _registryKey
-  ) {
+  async _processFetchedItem(_modId, _filename, _resolvedPath, _fetchedData) {
     return {
       id: _fetchedData?.id || 'dummyId',
       didOverride: false,
@@ -422,7 +416,7 @@ describe('BaseManifestItemLoader._storeItemInRegistry', () => {
         "Data for 'testMod:validItem' (category: items) must be an object",
       ],
     ])(
-      'should log error and return error flag for invalid arguments: category="%s", modId="%s", baseItemId="%s", dataToStore="%s"',
+      'should log error and throw TypeError for invalid arguments: category="%s", modId="%s", baseItemId="%s", dataToStore="%s"',
       (
         category,
         modId,
@@ -431,23 +425,20 @@ describe('BaseManifestItemLoader._storeItemInRegistry', () => {
         filename,
         expectedLogPartial
       ) => {
-        const result = testLoader.publicStoreItemInRegistry(
-          category,
-          modId,
-          baseItemId,
-          dataToStore,
-          filename
-        );
+        expect(() =>
+          testLoader.publicStoreItemInRegistry(
+            category,
+            modId,
+            baseItemId,
+            dataToStore,
+            filename
+          )
+        ).toThrow(TypeError);
 
         expect(mockLogger.error).toHaveBeenCalledTimes(1);
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining(expectedLogPartial)
         );
-        expect(result).toEqual({
-          qualifiedId: null,
-          didOverride: false,
-          error: true,
-        });
         expect(mockRegistry.store).not.toHaveBeenCalled(); // Should not attempt to store
       }
     );

--- a/tests/unit/loaders/helpers/registryStoreUtils.test.js
+++ b/tests/unit/loaders/helpers/registryStoreUtils.test.js
@@ -52,18 +52,19 @@ describe('storeItemInRegistry', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  it('returns error flag when category invalid', () => {
-    const result = storeItemInRegistry(
-      logger,
-      registry,
-      'TestLoader',
-      '',
-      'modA',
-      'id',
-      {},
-      'file.json'
-    );
-    expect(result.error).toBe(true);
+  it('throws TypeError when category invalid', () => {
+    expect(() =>
+      storeItemInRegistry(
+        logger,
+        registry,
+        'TestLoader',
+        '',
+        'modA',
+        'id',
+        {},
+        'file.json'
+      )
+    ).toThrow(TypeError);
     expect(registry.store).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- throw `TypeError` when invalid args passed to `storeItemInRegistry`
- note `TypeError` in `_storeItemInRegistry` docs
- update helper and loader unit tests

## Testing Done
- `npx prettier -w src/loaders/helpers/registryStoreUtils.js src/loaders/baseManifestItemLoader.js tests/unit/loaders/helpers/registryStoreUtils.test.js tests/unit/loaders/baseManifestItemLoader._storeItemInRegistry.test.js`
- `npx eslint src/loaders/helpers/registryStoreUtils.js src/loaders/baseManifestItemLoader.js tests/unit/loaders/helpers/registryStoreUtils.test.js tests/unit/loaders/baseManifestItemLoader._storeItemInRegistry.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a114b2f448331a80407a4ffb3c228