### PR TITLE
Integrate scopeEngine into integration and unit tests

### DIFF
--- a/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
+++ b/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
@@ -157,6 +157,7 @@ describe('Scope Integration Tests', () => {
       getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
       safeEventDispatcher,
       scopeRegistry,
+      scopeEngine,
     });
   });
 

--- a/tests/integration/scopes/environmentScope.integration.test.js
+++ b/tests/integration/scopes/environmentScope.integration.test.js
@@ -115,6 +115,7 @@ describe('Scope Integration Tests', () => {
       getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
       safeEventDispatcher,
       scopeRegistry,
+      scopeEngine,
     });
   });
 

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -27,6 +27,7 @@ import {
   NAME_COMPONENT_ID,
   EXITS_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
+import { createMockScopeEngine } from '../../common/mockFactories/coreServices.js';
 import fs from 'fs';
 import path from 'path';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
@@ -149,6 +150,7 @@ describe('Scope Integration Tests', () => {
       getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
       safeEventDispatcher,
       scopeRegistry,
+      scopeEngine,
     });
   });
 
@@ -213,6 +215,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -271,6 +274,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -349,6 +353,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -415,6 +420,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -477,6 +483,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -554,6 +561,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -613,6 +621,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);
@@ -670,6 +679,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const context = {
@@ -716,6 +726,7 @@ describe('Scope Integration Tests', () => {
         getEntityIdsForScopesFn: getEntityIdsForScopesWithEngine,
         safeEventDispatcher,
         scopeRegistry,
+        scopeEngine,
       });
 
       const actorEntity = entityManager.getEntityInstance(actorId);

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -35,6 +35,10 @@ describe('ActionDiscoveryService params exposure', () => {
       getScope: jest.fn(),
       // Add other methods if they are called, for now a basic mock
     };
+    const mockScopeEngine = {
+      resolve: jest.fn(() => new Set(['rat123'])),
+      setMaxDepth: jest.fn(),
+    };
 
     service = new ActionDiscoveryService({
       gameDataRepository: gameDataRepo,
@@ -45,6 +49,7 @@ describe('ActionDiscoveryService params exposure', () => {
       logger,
       safeEventDispatcher,
       scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
     });
   });
 

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -77,6 +77,11 @@ describe('ActionDiscoveryService – scoped discovery', () => {
     getScope: jest.fn(),
   };
 
+  const mockScopeEngine = {
+    resolve: jest.fn(() => new Set(['loc-2', 'loc-3'])),
+    setMaxDepth: jest.fn(),
+  };
+
   const service = new ActionDiscoveryService({
     gameDataRepository,
     entityManager,
@@ -86,6 +91,7 @@ describe('ActionDiscoveryService – scoped discovery', () => {
     getEntityIdsForScopesFn,
     safeEventDispatcher,
     scopeRegistry,
+    scopeEngine: mockScopeEngine,
   });
 
   /** Bare-bones actor / context objects */

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -50,6 +50,10 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
     mockScopeRegistry = {
       getScope: jest.fn(),
     };
+    const mockScopeEngine = {
+      resolve: jest.fn(() => new Set()),
+      setMaxDepth: jest.fn(),
+    };
     service = new ActionDiscoveryService({
       gameDataRepository: gameDataRepo,
       entityManager,
@@ -59,6 +63,7 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
       logger,
       safeEventDispatcher,
       scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
     });
   });
 
@@ -125,7 +130,10 @@ describe('ActionDiscoveryService - processActionDefinition', () => {
         warn: expect.any(Function),
         error: expect.any(Function),
       }),
-      undefined,
+      expect.objectContaining({
+        resolve: expect.any(Function),
+        setMaxDepth: expect.any(Function),
+      }),
       expect.objectContaining({
         dispatch: expect.any(Function),
       })

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -194,6 +194,11 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       logger: mockLogger,
     };
 
+    const mockScopeEngine = {
+      resolve: jest.fn(() => new Set([TOWN_INSTANCE_ID])),
+      setMaxDepth: jest.fn(),
+    };
+
     actionDiscoveryService = new ActionDiscoveryService({
       gameDataRepository: mockGameDataRepo,
       entityManager: mockEntityManager,
@@ -203,6 +208,7 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
       getEntityIdsForScopesFn: mockGetEntityIdsForScopesFn,
       safeEventDispatcher: mockSafeEventDispatcher,
       scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
     });
   });
 
@@ -248,7 +254,10 @@ describe('ActionDiscoveryService - Go Action (Fixed State)', () => {
         warn: expect.any(Function),
         error: expect.any(Function),
       }),
-      undefined, // scopeEngine parameter
+      expect.objectContaining({
+        resolve: expect.any(Function),
+        setMaxDepth: expect.any(Function),
+      }), // scopeEngine parameter
       expect.objectContaining({
         dispatch: expect.any(Function),
       }) // dispatcher parameter

--- a/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
@@ -73,6 +73,8 @@ describe('registerCommandAndAction', () => {
       tokens.ISafeEventDispatcher,
       () => mockSafeEventDispatcher
     );
+    container.register(tokens.IScopeRegistry, () => mockScopeRegistry);
+    container.register(tokens.IScopeEngine, () => mockScopeEngine);
   });
 
   afterEach(() => {


### PR DESCRIPTION
- Added scopeEngine to various integration tests for action discovery and environment scopes.
- Updated unit tests for ActionDiscoveryService to include mock implementations of scopeEngine.
- Enhanced dependency injection registration to accommodate the new scopeEngine dependency.