### PR TITLE
[Agent] introduce ITurnDirectiveResolver interface

### DIFF
--- a/src/turns/adapters/turnDirectiveResolverAdapter.js
+++ b/src/turns/adapters/turnDirectiveResolverAdapter.js
@@ -1,0 +1,25 @@
+// src/turns/adapters/turnDirectiveResolverAdapter.js
+
+import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js';
+import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
+
+/**
+ * @class TurnDirectiveResolverAdapter
+ * @implements {ITurnDirectiveResolver}
+ * @description Adapts the static {@link TurnDirectiveStrategyResolver}
+ * so it can be supplied where an {@link ITurnDirectiveResolver} instance
+ * is expected.
+ */
+export class TurnDirectiveResolverAdapter extends ITurnDirectiveResolver {
+  /**
+   * @override
+   * @param {string} directive
+   * @returns {import('../interfaces/ITurnDirectiveStrategy.js').ITurnDirectiveStrategy}
+   */
+  resolveStrategy(directive) {
+    return TurnDirectiveStrategyResolver.resolveStrategy(directive);
+  }
+}
+
+// Singleton instance, as the resolver is stateless
+export default new TurnDirectiveResolverAdapter();

--- a/src/turns/interfaces/ITurnDirectiveResolver.js
+++ b/src/turns/interfaces/ITurnDirectiveResolver.js
@@ -1,0 +1,23 @@
+// src/turns/interfaces/ITurnDirectiveResolver.js
+
+/** @typedef {import('./ITurnDirectiveStrategy.js').ITurnDirectiveStrategy} ITurnDirectiveStrategy */
+/** @typedef {import('../constants/turnDirectives.js').default} TurnDirectiveEnum */
+
+/**
+ * @interface ITurnDirectiveResolver
+ * @description Provides a method to resolve an {@link ITurnDirectiveStrategy}
+ * implementation for a given turn directive.
+ */
+export class ITurnDirectiveResolver {
+  /**
+   * Resolves the strategy for the supplied directive.
+   *
+   * @param {TurnDirectiveEnum|string} directive - Directive requesting a strategy.
+   * @returns {ITurnDirectiveStrategy} The resolved strategy implementation.
+   */
+  resolveStrategy(directive) {
+    throw new Error(
+      'ITurnDirectiveResolver.resolveStrategy method not implemented.'
+    );
+  }
+}

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -22,7 +22,8 @@ import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
 import { getLogger } from './helpers/contextUtils.js';
-import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
+import turnDirectiveResolverAdapter from '../adapters/turnDirectiveResolverAdapter.js';
+import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js';
 
 /**
  * @class ProcessingCommandState
@@ -31,7 +32,8 @@ import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyRe
 export class ProcessingCommandState extends AbstractTurnState {
   _isProcessing = false;
   _processingGuard;
-  _directiveResolver = TurnDirectiveStrategyResolver;
+  /** @type {ITurnDirectiveResolver} */
+  _directiveResolver = turnDirectiveResolverAdapter;
   _exceptionHandler;
   #turnActionToProcess = null;
   #commandStringForLog = null;
@@ -61,7 +63,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {BaseTurnHandler} handler - The turn handler managing this state.
    * @param {string} [commandString]
    * @param {ITurnAction} [turnAction]
-   * @param {{ resolveStrategy(directive: string): ITurnDirectiveStrategy }} [directiveResolver]
+   * @param {ITurnDirectiveResolver} [directiveResolver]
    * @param {ProcessingExceptionHandler} [exceptionHandler] - Preconstructed handler.
    * @param {new (state: ProcessingCommandState) => ProcessingGuard} [processingGuardFactory]
    *   - Factory for creating a ProcessingGuard instance.
@@ -72,7 +74,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     handler,
     commandString,
     turnAction = null,
-    directiveResolver = TurnDirectiveStrategyResolver,
+    directiveResolver = turnDirectiveResolverAdapter,
     exceptionHandler = undefined,
     processingGuardFactory = ProcessingGuard,
     exceptionHandlerFactory = ProcessingExceptionHandler


### PR DESCRIPTION
Summary: add new ITurnDirectiveResolver interface and adapter so ProcessingCommandState accepts it. Updated default resolver injection.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint src/turns/states/processingCommandState.js src/turns/adapters/turnDirectiveResolverAdapter.js src/turns/interfaces/ITurnDirectiveResolver.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685a194cd84c8331b8f2c8d3a012a480