### PR TITLE
[Agent] Inject time provider into SaveMetadataBuilder

### DIFF
--- a/src/persistence/saveMetadataBuilder.js
+++ b/src/persistence/saveMetadataBuilder.js
@@ -7,6 +7,7 @@ import { ENGINE_VERSION } from '../engine/engineVersion.js';
  * @property {import('../interfaces/coreServices.js').ILogger} logger - Logger for warnings.
  * @property {string} [engineVersion] - Default engine version to use if none provided.
  * @property {string} [saveFormatVersion] - Version for the save format.
+ * @property {() => Date} [timeProvider] - Function returning the current time.
  */
 
 /**
@@ -20,14 +21,19 @@ export default class SaveMetadataBuilder {
   #engineVersion;
   /** @type {string} */
   #saveFormatVersion;
+  /** @type {() => Date} */
+  #timeProvider;
 
   /**
-   * @param {SaveMetadataBuilderDeps} deps
+   * Create a new SaveMetadataBuilder.
+   *
+   * @param {SaveMetadataBuilderDeps} deps - Constructor dependencies.
    */
   constructor({
     logger,
     engineVersion = ENGINE_VERSION,
     saveFormatVersion = '1.0.0',
+    timeProvider = () => new Date(),
   }) {
     if (!logger) {
       throw new Error('SaveMetadataBuilder requires a logger.');
@@ -35,6 +41,7 @@ export default class SaveMetadataBuilder {
     this.#logger = logger;
     this.#engineVersion = engineVersion;
     this.#saveFormatVersion = saveFormatVersion;
+    this.#timeProvider = timeProvider;
   }
 
   /**
@@ -56,7 +63,7 @@ export default class SaveMetadataBuilder {
       saveFormatVersion: this.#saveFormatVersion,
       engineVersion,
       gameTitle: title,
-      timestamp: new Date().toISOString(),
+      timestamp: this.#timeProvider().toISOString(),
       playtimeSeconds,
       saveName: '',
     };

--- a/tests/unit/services/saveMetadataBuilder.test.js
+++ b/tests/unit/services/saveMetadataBuilder.test.js
@@ -5,6 +5,7 @@ import { ENGINE_VERSION } from '../../../src/engine/engineVersion.js';
 describe('SaveMetadataBuilder', () => {
   let logger;
   let builder;
+  let timeProvider;
 
   beforeEach(() => {
     logger = {
@@ -13,7 +14,8 @@ describe('SaveMetadataBuilder', () => {
       warn: jest.fn(),
       error: jest.fn(),
     };
-    builder = new SaveMetadataBuilder({ logger });
+    timeProvider = jest.fn(() => new Date('2023-01-01T00:00:00Z'));
+    builder = new SaveMetadataBuilder({ logger, timeProvider });
   });
 
   it('builds metadata with provided parameters', () => {
@@ -22,6 +24,7 @@ describe('SaveMetadataBuilder', () => {
     expect(meta.playtimeSeconds).toBe(12);
     expect(meta.engineVersion).toBe(ENGINE_VERSION);
     expect(meta.saveFormatVersion).toBe('1.0.0');
+    expect(meta.timestamp).toBe('2023-01-01T00:00:00.000Z');
     expect(logger.warn).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- add optional timeProvider dependency to SaveMetadataBuilder
- use timeProvider for timestamps
- update SaveMetadataBuilder unit tests to provide deterministic time

## Testing Done
- `npm run format`
- `npx eslint src/persistence/saveMetadataBuilder.js tests/unit/services/saveMetadataBuilder.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a195ea09083318e37ac399a01ca49