### PR TITLE
[Agent] Implement MockDataFetcher class

### DIFF
--- a/tests/common/mockFactories/coreServices.js
+++ b/tests/common/mockFactories/coreServices.js
@@ -4,7 +4,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { deepClone } from '../../../src/utils/cloneUtils.js';
+import { MockDataFetcher } from './dataFetcherMock.js';
 
 /**
  * Creates a simple mock object with jest.fn methods.
@@ -164,93 +164,8 @@ export const createMockPathResolver = (overrides = {}) => ({
  * @param {object} [options.overrides] - Optional overrides for mock methods.
  * @returns {object} Mock data fetcher with helper methods
  */
-export const createMockDataFetcher = ({
-  fromDisk = false,
-  pathToResponse = {},
-  errorPaths = [],
-  overrides = {},
-} = {}) => {
-  if (fromDisk) {
-    // eslint-disable-next-line no-undef
-    const fs = require('fs');
-    return {
-      fetch: jest.fn().mockImplementation(async (identifier) => {
-        if (identifier.endsWith('.json')) {
-          const filePath = identifier.replace(/^\.\//, '');
-          return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-        }
-        throw new Error('Unsupported identifier: ' + identifier);
-      }),
-      fetchJson: jest.fn(),
-      fetchText: jest.fn(),
-      ...overrides,
-    };
-  }
-
-  let fetchErrorMessage = '';
-  const mockFetcher = {
-    fetch: jest.fn(),
-    fetchJson: jest.fn(),
-    fetchText: jest.fn(),
-    mockSuccess: function (path, responseData) {
-      pathToResponse[path] = deepClone(responseData);
-      if (errorPaths.includes(path)) {
-        errorPaths = errorPaths.filter((p) => p !== path);
-      }
-      setFetchImplementation();
-    },
-    mockFailure: function (
-      path,
-      errorMessage = `Mock Fetch Error: Failed to fetch ${path}`
-    ) {
-      if (!errorPaths.includes(path)) {
-        errorPaths.push(path);
-      }
-      if (Object.prototype.hasOwnProperty.call(pathToResponse, path)) {
-        delete pathToResponse[path];
-      }
-      fetchErrorMessage = errorMessage;
-      setFetchImplementation();
-    },
-    ...overrides,
-  };
-
-  /**
-   * Updates the fetch mock implementation based on configured paths.
-   *
-   * @returns {void}
-   */
-  function setFetchImplementation() {
-    mockFetcher.fetch.mockImplementation(async (p) => {
-      if (errorPaths.includes(p)) {
-        const message =
-          fetchErrorMessage || `Mock Fetch Error: Failed to fetch ${p}`;
-        return Promise.reject(new Error(message));
-      }
-      if (Object.prototype.hasOwnProperty.call(pathToResponse, p)) {
-        try {
-          return Promise.resolve(deepClone(pathToResponse[p]));
-        } catch (e) {
-          return Promise.reject(
-            new Error(
-              `Mock Fetcher Error: Could not clone mock data for path ${p}. Is it valid JSON?`
-            )
-          );
-        }
-      }
-      if (overrides.defaultValue !== undefined) {
-        return Promise.resolve(deepClone(overrides.defaultValue));
-      }
-      return Promise.reject(
-        new Error(`Mock Fetch Error: 404 Not Found for path ${p}`)
-      );
-    });
-  }
-
-  setFetchImplementation();
-
-  return mockFetcher;
-};
+export const createMockDataFetcher = (options = {}) =>
+  new MockDataFetcher(options);
 
 /**
  * Creates a mock IScopeEngine.

--- a/tests/common/mockFactories/dataFetcherMock.js
+++ b/tests/common/mockFactories/dataFetcherMock.js
@@ -1,69 +1,100 @@
 import { jest } from '@jest/globals';
+import fs from 'fs';
 import { deepClone } from '../../../src/utils/cloneUtils.js';
 
-export const createMockDataFetcher = ({
-  fromDisk = false,
-  pathToResponse = {},
-  errorPaths = [],
-  overrides = {},
-} = {}) => {
-  if (fromDisk) {
-    const fs = require('fs');
-    return {
-      fetch: jest.fn().mockImplementation(async (identifier) => {
+/**
+ * @class
+ * @description Simple in-memory data fetcher used for tests. Supports
+ * mapping specific paths to responses, forcing failures, and optionally
+ * reading JSON from disk.
+ */
+export class MockDataFetcher {
+  /**
+   * @param {object} [options]
+   * @param {boolean} [options.fromDisk=false] Read data from disk instead.
+   * @param {Record<string, any>} [options.pathToResponse] Map of paths to data.
+   * @param {string[]} [options.errorPaths] Paths that should reject on fetch.
+   * @param {object} [options.overrides] Extra properties/mocks to assign.
+   */
+  constructor({
+    fromDisk = false,
+    pathToResponse = {},
+    errorPaths = [],
+    overrides = {},
+  } = {}) {
+    this.fromDisk = fromDisk;
+    this.pathToResponse = { ...pathToResponse };
+    this.errorPaths = [...errorPaths];
+    this.fetchErrorMessage = '';
+    /** @type {jest.Mock<any, [string]>} */
+    this.fetch = jest.fn();
+    this.fetchJson = jest.fn();
+    this.fetchText = jest.fn();
+    Object.assign(this, overrides);
+    this.#setFetchImplementation();
+  }
+
+  /**
+   * Maps a path to a successful response and removes any existing failure.
+   *
+   * @param {string} path Path identifier to resolve.
+   * @param {any} responseData Response that should be returned.
+   * @returns {void}
+   */
+  mockSuccess(path, responseData) {
+    this.pathToResponse[path] = deepClone(responseData);
+    this.errorPaths = this.errorPaths.filter((p) => p !== path);
+    this.#setFetchImplementation();
+  }
+
+  /**
+   * Forces the given path to reject with an optional message.
+   *
+   * @param {string} path Path identifier that should fail.
+   * @param {string} [errorMessage]
+   * @returns {void}
+   */
+  mockFailure(
+    path,
+    errorMessage = `Mock Fetch Error: Failed to fetch ${path}`
+  ) {
+    if (!this.errorPaths.includes(path)) {
+      this.errorPaths.push(path);
+    }
+    if (Object.prototype.hasOwnProperty.call(this.pathToResponse, path)) {
+      delete this.pathToResponse[path];
+    }
+    this.fetchErrorMessage = errorMessage;
+    this.#setFetchImplementation();
+  }
+
+  /**
+   * Internal helper to update the fetch mock implementation.
+   *
+   * @private
+   * @returns {void}
+   */
+  #setFetchImplementation() {
+    if (this.fromDisk) {
+      this.fetch.mockImplementation(async (identifier) => {
         if (identifier.endsWith('.json')) {
           const filePath = identifier.replace(/^\.\//, '');
           return JSON.parse(fs.readFileSync(filePath, 'utf8'));
         }
         throw new Error('Unsupported identifier: ' + identifier);
-      }),
-      fetchJson: jest.fn(),
-      fetchText: jest.fn(),
-      ...overrides,
-    };
-  }
+      });
+      return;
+    }
 
-  let fetchErrorMessage = '';
-  const mockFetcher = {
-    fetch: jest.fn(),
-    fetchJson: jest.fn(),
-    fetchText: jest.fn(),
-    mockSuccess: function (path, responseData) {
-      pathToResponse[path] = deepClone(responseData);
-      if (errorPaths.includes(path)) {
-        errorPaths = errorPaths.filter((p) => p !== path);
-      }
-      setFetchImplementation();
-    },
-    mockFailure: function (
-      path,
-      errorMessage = `Mock Fetch Error: Failed to fetch ${path}`
-    ) {
-      if (!errorPaths.includes(path)) {
-        errorPaths.push(path);
-      }
-      if (Object.prototype.hasOwnProperty.call(pathToResponse, path)) {
-        delete pathToResponse[path];
-      }
-      fetchErrorMessage = errorMessage;
-      setFetchImplementation();
-    },
-    ...overrides,
-  };
-
-  /**
-   *
-   */
-  function setFetchImplementation() {
-    mockFetcher.fetch.mockImplementation(async (p) => {
-      if (errorPaths.includes(p)) {
+    this.fetch.mockImplementation(async (p) => {
+      if (this.errorPaths.includes(p)) {
         const message =
-          fetchErrorMessage || `Mock Fetch Error: Failed to fetch ${p}`;
+          this.fetchErrorMessage || `Mock Fetch Error: Failed to fetch ${p}`;
         return Promise.reject(new Error(message));
       }
-      if (Object.prototype.hasOwnProperty.call(pathToResponse, p)) {
+      if (Object.prototype.hasOwnProperty.call(this.pathToResponse, p)) {
         try {
-          return Promise.resolve(deepClone(pathToResponse[p]));
+          return Promise.resolve(deepClone(this.pathToResponse[p]));
         } catch (e) {
           return Promise.reject(
             new Error(
@@ -72,16 +103,21 @@ export const createMockDataFetcher = ({
           );
         }
       }
-      if (overrides.defaultValue !== undefined) {
-        return Promise.resolve(deepClone(overrides.defaultValue));
+      if (this.defaultValue !== undefined) {
+        return Promise.resolve(deepClone(this.defaultValue));
       }
       return Promise.reject(
         new Error(`Mock Fetch Error: 404 Not Found for path ${p}`)
       );
     });
   }
+}
 
-  setFetchImplementation();
-
-  return mockFetcher;
-};
+/**
+ * Factory helper returning a new {@link MockDataFetcher} instance.
+ *
+ * @param {object} [options] Constructor options passed through.
+ * @returns {MockDataFetcher}
+ */
+export const createMockDataFetcher = (options = {}) =>
+  new MockDataFetcher(options);

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -14,7 +14,7 @@ export {
   createMockScopeEngine,
 } from './coreServices.js';
 
-export { createMockDataFetcher } from './dataFetcherMock.js';
+export { createMockDataFetcher, MockDataFetcher } from './dataFetcherMock.js';
 export {
   createMockValidatedEventDispatcherForIntegration,
   createCapturingEventBus,

--- a/tests/unit/mockFactories/createMockDataFetcher.test.js
+++ b/tests/unit/mockFactories/createMockDataFetcher.test.js
@@ -1,7 +1,10 @@
 /** @jest-environment node */
 
 import { describe, it, expect } from '@jest/globals';
-import { createMockDataFetcher } from '../../common/mockFactories/index.js';
+import {
+  createMockDataFetcher,
+  MockDataFetcher,
+} from '../../common/mockFactories/index.js';
 import fs from 'fs';
 
 describe('createMockDataFetcher (in-memory)', () => {
@@ -10,6 +13,7 @@ describe('createMockDataFetcher (in-memory)', () => {
     const fetcher = createMockDataFetcher({
       pathToResponse: { '/test/path': data },
     });
+    expect(fetcher).toBeInstanceOf(MockDataFetcher);
 
     const result1 = await fetcher.fetch('/test/path');
     expect(result1).toEqual(data);


### PR DESCRIPTION
## Summary
- add `MockDataFetcher` class with success/failure helpers
- export `MockDataFetcher` via mockFactories index
- create simple factory in `coreServices`
- update unit test for new class

## Testing Done
- `npx prettier --write tests/common/mockFactories/dataFetcherMock.js tests/common/mockFactories/coreServices.js tests/common/mockFactories/index.js tests/unit/mockFactories/createMockDataFetcher.test.js`
- `npx eslint tests/common/mockFactories/dataFetcherMock.js tests/common/mockFactories/coreServices.js tests/common/mockFactories/index.js tests/unit/mockFactories/createMockDataFetcher.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a1154aa4c8331a1f2abbd7e574044