### PR TITLE
[Agent] Extract totals helper

### DIFF
--- a/src/loaders/WorldLoadSummaryLogger.js
+++ b/src/loaders/WorldLoadSummaryLogger.js
@@ -8,6 +8,22 @@
 /** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
 
 /**
+ * Computes summed totals across all registry keys.
+ *
+ * @param {TotalResultsSummary} totals - Map of content type totals.
+ * @returns {{count: number, overrides: number, errors: number}} Grand totals.
+ */
+export function computeTotalsSummary(totals) {
+  const summary = { count: 0, overrides: 0, errors: 0 };
+  for (const counts of Object.values(totals)) {
+    summary.count += counts.count;
+    summary.overrides += counts.overrides;
+    summary.errors += counts.errors;
+  }
+  return summary;
+}
+
+/**
  * @description Utility for printing a formatted summary of the world load.
  * @class
  */
@@ -48,21 +64,10 @@ export class WorldLoadSummaryLogger {
         const details = `${counts.count} loaded, ${counts.overrides} overrides, ${counts.errors} errors`;
         logger.info(`     - ${paddedRegistryKey}: ${details}`);
       }
-      const grandTotalCount = Object.values(totals).reduce(
-        (sum, tc) => sum + tc.count,
-        0
-      );
-      const grandTotalOverrides = Object.values(totals).reduce(
-        (sum, tc) => sum + tc.overrides,
-        0
-      );
-      const grandTotalErrors = Object.values(totals).reduce(
-        (sum, tc) => sum + tc.errors,
-        0
-      );
+      const grandTotals = computeTotalsSummary(totals);
       logger.info(`     - ${''.padEnd(20, '-')}--------------------------`);
       logger.info(
-        `     - ${'TOTAL'.padEnd(20, ' ')}: C:${grandTotalCount}, O:${grandTotalOverrides}, E:${grandTotalErrors}`
+        `     - ${'TOTAL'.padEnd(20, ' ')}: C:${grandTotals.count}, O:${grandTotals.overrides}, E:${grandTotals.errors}`
       );
     } else {
       logger.info(

--- a/tests/unit/loaders/worldLoadSummaryLogger.test.js
+++ b/tests/unit/loaders/worldLoadSummaryLogger.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+import WorldLoadSummaryLogger, {
+  computeTotalsSummary,
+} from '../../../src/loaders/WorldLoadSummaryLogger.js';
+import { createMockLogger } from '../../common/mockFactories.js';
+
+describe('computeTotalsSummary', () => {
+  it('returns correct totals without mutating input', () => {
+    const totals = {
+      items: { count: 2, overrides: 1, errors: 0 },
+      rules: { count: 1, overrides: 0, errors: 1 },
+    };
+    const original = JSON.parse(JSON.stringify(totals));
+
+    const result = computeTotalsSummary(totals);
+
+    expect(result).toEqual({ count: 3, overrides: 1, errors: 1 });
+    expect(totals).toEqual(original);
+  });
+});
+
+describe('WorldLoadSummaryLogger.logSummary', () => {
+  it('logs summary without mutating totals', () => {
+    const logger = createMockLogger();
+    const totals = { items: { count: 1, overrides: 0, errors: 0 } };
+    const original = JSON.parse(JSON.stringify(totals));
+
+    const summaryLogger = new WorldLoadSummaryLogger();
+    summaryLogger.logSummary(logger, 'World', ['modA'], ['modA'], 0, totals);
+
+    expect(logger.info).toHaveBeenCalled();
+    expect(totals).toEqual(original);
+  });
+});


### PR DESCRIPTION
Summary: Added pure `computeTotalsSummary` helper and updated `logSummary` to use it. Added unit tests confirming grand totals calculation and immutability.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (`npx eslint src/loaders/WorldLoadSummaryLogger.js tests/unit/loaders/worldLoadSummaryLogger.test.js`)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a19945a4483319c609c9066703a12