### PR TITLE
[Agent] export math helpers

### DIFF
--- a/tests/unit/logic/operationHandlers/mathHandler.helpers.test.js
+++ b/tests/unit/logic/operationHandlers/mathHandler.helpers.test.js
@@ -1,0 +1,56 @@
+/**
+ * @file Tests for mathHandler helper functions.
+ */
+
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import {
+  evaluateExpression,
+  resolveOperand,
+} from '../../../../src/logic/operationHandlers/mathHandler.js';
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('mathHandler helper functions', () => {
+  let logger;
+  let dispatcher;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    dispatcher = { dispatch: jest.fn() };
+    jest.clearAllMocks();
+  });
+
+  test('evaluateExpression correctly handles nested expressions', () => {
+    const expr = {
+      operator: 'multiply',
+      operands: [
+        { operator: 'add', operands: [1, 2] },
+        { operator: 'subtract', operands: [5, 3] },
+      ],
+    };
+    const result = evaluateExpression(expr, {}, logger, dispatcher);
+    expect(result).toBe(6);
+  });
+
+  test('evaluateExpression returns NaN and warns on division by zero', () => {
+    const expr = { operator: 'divide', operands: [10, 0] };
+    const result = evaluateExpression(expr, {}, logger, dispatcher);
+    expect(result).toBeNaN();
+    expect(logger.warn).toHaveBeenCalledWith('MATH: Division by zero.');
+  });
+
+  test('resolveOperand warns on invalid operand', () => {
+    const operand = { foo: 'bar' };
+    const result = resolveOperand(operand, {}, logger, dispatcher);
+    expect(result).toBeNaN();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'MATH: Invalid operand encountered.',
+      { operand }
+    );
+  });
+});


### PR DESCRIPTION
Summary: Exported evaluateExpression and resolveOperand from mathHandler for direct testing and added a helper test suite covering nested expressions, division by zero and invalid operands. MathHandler now uses these helpers.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685a19cc0ea083318872c3aac5326165