### PR TITLE
[Agent] handle missing save directory

### DIFF
--- a/src/persistence/saveFileRepository.js
+++ b/src/persistence/saveFileRepository.js
@@ -137,10 +137,7 @@ export default class SaveFileRepository extends BaseService {
       );
       return { success: true, data: files };
     } catch (listError) {
-      if (
-        listError.message &&
-        listError.message.toLowerCase().includes('not found')
-      ) {
+      if (listError.code === StorageErrorCodes.FILE_NOT_FOUND) {
         this.#logger.debug(
           `${FULL_MANUAL_SAVE_DIRECTORY_PATH} not found. Assuming no manual saves yet.`
         );

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -2,6 +2,7 @@
 import { IStorageProvider } from '../interfaces/IStorageProvider.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { StorageErrorCodes } from './storageErrors.js';
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
@@ -328,9 +329,11 @@ export class BrowserStorageProvider extends IStorageProvider {
     } catch (error) {
       if (error.name === 'NotFoundError') {
         this.#logger.warn(
-          `BrowserStorageProvider: Directory not found for listing: "${directoryPath}". Returning empty list.`
+          `BrowserStorageProvider: Directory not found for listing: "${directoryPath}".`
         );
-        return [];
+        const err = new Error(`Directory not found: ${directoryPath}`);
+        err.code = StorageErrorCodes.FILE_NOT_FOUND;
+        throw err;
       }
       if (
         error.message &&

--- a/tests/unit/services/saveLoadService.additional.test.js
+++ b/tests/unit/services/saveLoadService.additional.test.js
@@ -8,6 +8,7 @@ import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
 import { encode, decode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
+import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -84,7 +85,9 @@ describe('SaveLoadService additional coverage', () => {
   });
 
   it('returns empty list when directory missing', async () => {
-    storageProvider.listFiles.mockRejectedValue(new Error('not found'));
+    const err = new Error('not found');
+    err.code = StorageErrorCodes.FILE_NOT_FOUND;
+    storageProvider.listFiles.mockRejectedValue(err);
     const result = await service.listManualSaveSlots();
     expect(result).toEqual({ success: true, data: [] });
     expect(logger.debug).toHaveBeenCalled();


### PR DESCRIPTION
Summary: Fixes manual save listing when the directory is absent. The browser storage provider now throws a FILE_NOT_FOUND code if the directory is missing, and SaveFileRepository detects this via the error code. Updated unit tests to expect the new behavior.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on edited files
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685a1968b698833198f44ebf5dc4f1d5