### PR TITLE
[Agent] deduplicate slot list population

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -292,18 +292,7 @@ class LoadGameUI extends SlotModalBase {
    */
   async _populateLoadSlotsList() {
     this.logger.debug(`${this._logPrefix} Populating load slots list...`);
-    if (!this.elements.listContainerElement) {
-      this.logger.error(
-        `${this._logPrefix} List container element not found in this.elements.`
-      );
-      this._displayStatusMessage(
-        'Error: UI component for slots missing.',
-        'error'
-      );
-      return;
-    }
-
-    await this._populateSlots(
+    await this.populateSlotsList(
       () => this._getLoadSlotsData(),
       (slotData, index) => this._renderLoadSlotItem(slotData, index),
       () => this._getEmptyLoadSlotsMessage(),

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -211,6 +211,14 @@ export class SlotModalBase extends BaseModalRenderer {
     emptyMessageProvider,
     loadingMessage
   ) {
+    if (!this.elements.listContainerElement) {
+      this.logger.error(`${this._logPrefix} List container element not found.`);
+      this._displayStatusMessage(
+        'Error: UI component for slots missing.',
+        'error'
+      );
+      return;
+    }
     this._setOperationInProgress(true);
     this._displayStatusMessage(loadingMessage, 'info');
 


### PR DESCRIPTION
## Summary
- centralize list container checks in SlotModalBase
- reuse populateSlotsList from LoadGameUI

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a193862d48331bcd3a8e4b034e945