### PR TITLE
[Agent] Add placeholder key parser helper

### DIFF
--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -8,10 +8,26 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
-import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js'; // Adjust path as needed
+import {
+  PlaceholderResolver,
+  parsePlaceholderKey,
+} from '../../../src/utils/placeholderResolverUtils.js'; // Adjust path as needed
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed (assuming testUtils.js from previous adjustment)
 import * as loggerUtils from '../../../src/utils/loggerUtils.js';
 import { NAME_COMPONENT_ID } from '../../../src/constants/componentIds.js';
+
+describe('parsePlaceholderKey', () => {
+  it('strips trailing ? and marks optional', () => {
+    expect(parsePlaceholderKey('key?')).toEqual({ key: 'key', optional: true });
+  });
+
+  it('trims whitespace and handles non-optional', () => {
+    expect(parsePlaceholderKey('  path.to.val  ')).toEqual({
+      key: 'path.to.val',
+      optional: false,
+    });
+  });
+});
 
 describe('PlaceholderResolver', () => {
   let mockLogger;


### PR DESCRIPTION
## Summary
- add `parsePlaceholderKey` helper in placeholderResolverUtils
- refactor internal placeholder parsing to use new helper
- test `parsePlaceholderKey`

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a19222d448331aa004e507e98a024