### PR TITLE
[Agent] Extract mixins for turn manager tests

### DIFF
--- a/tests/common/turns/entitySetupMixin.js
+++ b/tests/common/turns/entitySetupMixin.js
@@ -1,0 +1,76 @@
+/**
+ * @file Mixin providing helper methods for configuring entity data.
+ */
+
+import { createDefaultActors } from './testActors.js';
+
+/**
+ * @description Extends a base test bed with entity setup utilities.
+ * @param {typeof import('../baseTestBed.js').default} Base - Base class to extend.
+ * @returns {typeof import('../baseTestBed.js').default} Extended class with entity helpers.
+ */
+export function EntitySetupMixin(Base) {
+  return class EntitySetup extends Base {
+    /**
+     * Populates the mocked entity manager's activeEntities map.
+     *
+     * @param {...{ id: string }} entities - Entities to add.
+     * @returns {void}
+     */
+    setActiveEntities(...entities) {
+      const map = this.entityManager.activeEntities;
+      map.clear();
+      for (const e of entities) {
+        map.set(e.id, e);
+      }
+    }
+
+    /**
+     * Adds a set of default actors to the mocked entity manager.
+     *
+     * @returns {{ ai1: object, ai2: object, player: object }} Object containing the created actors.
+     */
+    addDefaultActors() {
+      const actors = createDefaultActors();
+      this.setActiveEntities(actors.ai1, actors.ai2, actors.player);
+      return actors;
+    }
+
+    /**
+     * Configures the turn order service to return the provided actor next.
+     *
+     * @param {object} actor - Actor entity to return.
+     * @returns {void}
+     */
+    mockNextActor(actor) {
+      this.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      this.mocks.turnOrderService.getNextEntity.mockResolvedValue(actor);
+    }
+
+    /**
+     * Configures the turn order service to return the provided actors sequentially.
+     *
+     * @param {...object} actors - Actor entities to return in order.
+     * @returns {void}
+     */
+    mockActorSequence(...actors) {
+      this.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
+      let index = 0;
+      this.mocks.turnOrderService.getNextEntity.mockImplementation(() =>
+        Promise.resolve(index < actors.length ? actors[index++] : null)
+      );
+    }
+
+    /**
+     * Configures the turn order service to represent an empty queue.
+     *
+     * @returns {void}
+     */
+    mockEmptyQueue() {
+      this.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
+      this.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
+    }
+  };
+}
+
+export default EntitySetupMixin;

--- a/tests/common/turns/eventCaptureMixin.js
+++ b/tests/common/turns/eventCaptureMixin.js
@@ -1,0 +1,80 @@
+/**
+ * @file Mixin providing event capture helpers for TurnManager tests.
+ */
+
+import { jest } from '@jest/globals';
+import { waitForCondition } from '../jestHelpers.js';
+
+/**
+ * @description Extends a base test bed with dispatcher event utilities.
+ * @param {typeof import('../baseTestBed.js').default} Base - Base class to extend.
+ * @returns {typeof import('../baseTestBed.js').default} Extended class with event helpers.
+ */
+export function EventCaptureMixin(Base) {
+  return class EventCapture extends Base {
+    /**
+     * Retrieves the subscribed callback for the given event id.
+     *
+     * @param {string} eventId - Event identifier.
+     * @returns {(Function|undefined)} Handler subscribed to the event.
+     */
+    captureHandler(eventId) {
+      const call = this.dispatcher.subscribe.mock.calls.find(
+        ([id]) => id === eventId
+      );
+      return call ? call[1] : undefined;
+    }
+
+    /**
+     * Sets up the dispatcher to capture subscriptions for the specified event.
+     *
+     * @param {string} eventId - Event identifier to capture.
+     * @returns {{ unsubscribe: import('@jest/globals').Mock, handler: (() => void)|null }}
+     *   Object exposing the unsubscribe spy and captured handler.
+     */
+    captureSubscription(eventId) {
+      let captured = null;
+      const unsubscribe = jest.fn();
+      this.dispatcher.subscribe.mockImplementation((id, handler) => {
+        if (id === eventId) {
+          captured = handler;
+        }
+        return unsubscribe;
+      });
+
+      return {
+        get handler() {
+          return captured;
+        },
+        unsubscribe,
+      };
+    }
+
+    /**
+     * Triggers an event on the internal dispatcher.
+     *
+     * @param {string} eventType - Event name.
+     * @param {object} payload - Event payload.
+     * @returns {void}
+     */
+    trigger(eventType, payload) {
+      this.dispatcher._triggerEvent(eventType, { type: eventType, payload });
+    }
+
+    /**
+     * Waits until the current actor matches the given id.
+     *
+     * @param {string} id - Expected actor id.
+     * @param {number} [maxTicks] - Maximum timer flush iterations.
+     * @returns {Promise<boolean>} Resolves true if actor found before timeout.
+     */
+    async waitForCurrentActor(id, maxTicks = 50) {
+      return waitForCondition(
+        () => this.turnManager.getCurrentActor()?.id === id,
+        maxTicks
+      );
+    }
+  };
+}
+
+export default EventCaptureMixin;

--- a/tests/common/turns/turnManagerTestUtils.js
+++ b/tests/common/turns/turnManagerTestUtils.js
@@ -10,7 +10,7 @@ import {
   TURN_STARTED_ID,
   TURN_PROCESSING_STARTED,
 } from '../../../src/constants/eventIds.js';
-import { flushPromisesAndTimers, waitForCondition } from '../jestHelpers.js';
+import { flushPromisesAndTimers } from '../jestHelpers.js';
 
 /**
  * Asserts that a SYSTEM_ERROR_OCCURRED dispatch was made with the standard
@@ -55,21 +55,6 @@ export function expectTurnStartedEvents(dispatchMock, actorId, actorType) {
     entityId: actorId,
     actorType,
   });
-}
-
-/**
- * Waits until the current actor matches the given id.
- *
- * @param {import('./turnManagerTestBed.js').TurnManagerTestBed} bed - Test bed instance.
- * @param {string} id - Expected actor id.
- * @param {number} [maxTicks] - Maximum timer flush iterations.
- * @returns {Promise<boolean>} Resolves true if actor found before timeout.
- */
-export async function waitForCurrentActor(bed, id, maxTicks = 50) {
-  return waitForCondition(
-    () => bed.turnManager.getCurrentActor()?.id === id,
-    maxTicks
-  );
 }
 
 /**

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -4,7 +4,6 @@
 import { describeRunningTurnManagerSuite } from '../../common/turns/turnManagerTestBed.js';
 import { flushPromisesAndTimers } from '../../common/jestHelpers.js';
 import {
-  waitForCurrentActor,
   expectSystemErrorDispatch,
   triggerTurnEndedAndFlush,
 } from '../../common/turns/turnManagerTestUtils.js';
@@ -158,7 +157,7 @@ describeRunningTurnManagerSuite(
       test('advances through both actors', async () => {
         expect(testBed.turnManager.getCurrentActor()?.id).toBe(ai1.id);
         await triggerTurnEndedAndFlush(testBed, ai1.id);
-        const found = await waitForCurrentActor(testBed, ai2.id);
+        const found = await testBed.waitForCurrentActor(ai2.id);
         expect(found).toBe(true);
       });
     });


### PR DESCRIPTION
## Summary
- add `EventCaptureMixin` for dispatcher utilities
- add `EntitySetupMixin` for entity helpers
- use new mixins inside `TurnManagerTestBed`
- update round lifecycle tests to use `waitForCurrentActor` method

## Testing Done
- `npx eslint tests/common/turns/eventCaptureMixin.js tests/common/turns/entitySetupMixin.js tests/common/turns/turnManagerTestBed.js tests/common/turns/turnManagerTestUtils.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1b2cd90c83318589767fc1b666b1