### PR TITLE
[Agent] waitForCurrentActor throws on timeout

### DIFF
--- a/tests/common/turns/eventCaptureMixin.js
+++ b/tests/common/turns/eventCaptureMixin.js
@@ -66,13 +66,17 @@ export function EventCaptureMixin(Base) {
      *
      * @param {string} id - Expected actor id.
      * @param {number} [maxTicks] - Maximum timer flush iterations.
-     * @returns {Promise<boolean>} Resolves true if actor found before timeout.
+     * @returns {Promise<void>} Resolves when actor found before timeout.
+     * @throws {Error} If the actor is not found before timeout.
      */
     async waitForCurrentActor(id, maxTicks = 50) {
-      return waitForCondition(
+      const found = await waitForCondition(
         () => this.turnManager.getCurrentActor()?.id === id,
         maxTicks
       );
+      if (!found) {
+        throw new Error(`Timed out waiting for actor ${id}`);
+      }
     }
   };
 }

--- a/tests/unit/turns/turnManager.roundLifecycle.test.js
+++ b/tests/unit/turns/turnManager.roundLifecycle.test.js
@@ -157,8 +157,7 @@ describeRunningTurnManagerSuite(
       test('advances through both actors', async () => {
         expect(testBed.turnManager.getCurrentActor()?.id).toBe(ai1.id);
         await triggerTurnEndedAndFlush(testBed, ai1.id);
-        const found = await testBed.waitForCurrentActor(ai2.id);
-        expect(found).toBe(true);
+        await testBed.waitForCurrentActor(ai2.id);
       });
     });
 


### PR DESCRIPTION
Summary: Implemented error throwing in `waitForCurrentActor` when the actor is not found before timeout. Updated round lifecycle test to await the helper directly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint tests/common/turns/eventCaptureMixin.js tests/unit/turns/turnManager.roundLifecycle.test.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685ab877dab48331b82a8bfb5d2ba266