### PR TITLE
[Agent] rename onComponentChanged method

### DIFF
--- a/src/entities/spatialIndexSynchronizer.js
+++ b/src/entities/spatialIndexSynchronizer.js
@@ -49,11 +49,11 @@ export class SpatialIndexSynchronizer {
     );
     safeEventDispatcher.subscribe(
       COMPONENT_ADDED_ID,
-      this.onComponentChanged.bind(this)
+      this.onPositionChanged.bind(this)
     );
     safeEventDispatcher.subscribe(
       COMPONENT_REMOVED_ID,
-      this.onComponentChanged.bind(this)
+      this.onPositionChanged.bind(this)
     );
 
     this.logger.debug(
@@ -115,7 +115,7 @@ export class SpatialIndexSynchronizer {
    *
    * @param {ComponentAddedPayload | ComponentRemovedPayload} payload
    */
-  onComponentChanged(payload) {
+  onPositionChanged(payload) {
     const { entity, componentTypeId, oldComponentData } = payload;
     // This handler only cares about the position component
     if (componentTypeId !== POSITION_COMPONENT_ID) {

--- a/tests/unit/entities/spatialIndexSynchronizer.test.js
+++ b/tests/unit/entities/spatialIndexSynchronizer.test.js
@@ -151,7 +151,7 @@ describe('SpatialIndexSynchronizer', () => {
     });
   });
 
-  describe('onComponentChanged (component:added/removed events)', () => {
+  describe('onPositionChanged (component:added/removed events)', () => {
     beforeEach(() => {
       synchronizer = initializeSynchronizer();
     });


### PR DESCRIPTION
Summary: Renamed the handler in SpatialIndexSynchronizer to `onPositionChanged` and updated event subscriptions and related tests accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (fails with existing repository issues)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run


------
https://chatgpt.com/codex/tasks/task_e_685ab8596ee4833194c751fcadb1df59