### PR TITLE
[Agent] capture storage read errors

### DIFF
--- a/src/utils/saveFileReadUtils.js
+++ b/src/utils/saveFileReadUtils.js
@@ -30,10 +30,12 @@ export async function readSaveFile(storageProvider, logger, filePath) {
     } catch (error) {
       const userMsg = MSG_FILE_READ_ERROR;
       logger.error(`Error reading file ${filePath}:`, error);
+      const details = error?.code || error?.message;
+      const errMsg = details ? `${userMsg} (${details})` : userMsg;
       return {
         ...createPersistenceFailure(
           PersistenceErrorCodes.FILE_READ_ERROR,
-          userMsg
+          errMsg
         ),
         userFriendlyError: userMsg,
       };

--- a/tests/unit/services/saveLoadService.privateHelpers.test.js
+++ b/tests/unit/services/saveLoadService.privateHelpers.test.js
@@ -17,6 +17,7 @@ import {
   MSG_DECOMPRESSION_FAILED,
   MSG_DESERIALIZATION_FAILED,
 } from '../../../src/persistence/persistenceMessages.js';
+import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
@@ -103,7 +104,8 @@ describe('SaveLoadService private helper error propagation', () => {
     /** @type {PersistenceResult<any>} */
     const res = await service.loadGameData('saves/manual_saves/test.sav');
     expect(res.success).toBe(false);
-    expect(res.error.message).toBe(MSG_FILE_READ_ERROR);
+    expect(res.error.message).toContain('read fail');
+    expect(res.error.code).toBe(PersistenceErrorCodes.FILE_READ_ERROR);
   });
 
   it('propagates empty file error', async () => {

--- a/tests/unit/utils/saveFileReadUtils.test.js
+++ b/tests/unit/utils/saveFileReadUtils.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { readSaveFile } from '../../../src/utils/saveFileReadUtils.js';
+import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
+import {
+  MSG_FILE_READ_ERROR,
+  MSG_EMPTY_FILE,
+} from '../../../src/persistence/persistenceMessages.js';
+
+/** @typedef {import('../../../src/persistence/persistenceTypes.js').PersistenceResult<any>} PersistenceResult */
+
+describe('readSaveFile', () => {
+  let storageProvider;
+  let logger;
+
+  beforeEach(() => {
+    logger = { error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+    storageProvider = { readFile: jest.fn() };
+  });
+
+  it('returns success when file content is present', async () => {
+    const buf = new Uint8Array([1, 2, 3]);
+    storageProvider.readFile.mockResolvedValue(buf);
+
+    /** @type {PersistenceResult<Uint8Array>} */
+    const result = await readSaveFile(storageProvider, logger, 'path.sav');
+
+    expect(result).toEqual({ success: true, data: buf });
+  });
+
+  it('includes error.message in PersistenceError when provided', async () => {
+    storageProvider.readFile.mockRejectedValue(new Error('boom'));
+
+    /** @type {PersistenceResult<Uint8Array>} */
+    const result = await readSaveFile(storageProvider, logger, 'bad.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.FILE_READ_ERROR);
+    expect(result.error.message).toContain('boom');
+    expect(result.userFriendlyError).toBe(MSG_FILE_READ_ERROR);
+  });
+
+  it('includes error.code in PersistenceError when message absent', async () => {
+    storageProvider.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+    /** @type {PersistenceResult<Uint8Array>} */
+    const result = await readSaveFile(storageProvider, logger, 'missing.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.FILE_READ_ERROR);
+    expect(result.error.message).toContain('ENOENT');
+    expect(result.userFriendlyError).toBe(MSG_FILE_READ_ERROR);
+  });
+
+  it('returns EMPTY_FILE error when file is empty', async () => {
+    storageProvider.readFile.mockResolvedValue(new Uint8Array());
+
+    /** @type {PersistenceResult<Uint8Array>} */
+    const result = await readSaveFile(storageProvider, logger, 'empty.sav');
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe(PersistenceErrorCodes.EMPTY_FILE);
+    expect(result.error.message).toBe(MSG_EMPTY_FILE);
+  });
+});


### PR DESCRIPTION
## Summary
- propagate storageProvider.readFile error details to PersistenceError
- add readSaveFile unit tests covering error detail handling
- update saveLoadService tests for new PersistenceError message

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ab78784788331b587b467caf0de53