### PR TITLE
[Agent] refactor placeholder resolution helpers

### DIFF
--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -335,5 +335,40 @@ describe('PlaceholderResolver', () => {
       expect(result).toBe('foo Hero');
     });
   });
+
+  describe('_handleFullString and _replaceEmbedded', () => {
+    it('resolves a full placeholder and logs debug', () => {
+      const res = resolver._handleFullString('{name}', [{ name: 'Alice' }]);
+      expect(res).toEqual({ changed: true, value: 'Alice' });
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Resolved full string placeholder {name} to: Alice'
+        )
+      );
+    });
+
+    it('returns undefined and logs warning when full placeholder missing', () => {
+      const res = resolver._handleFullString('{missing}', [{}]);
+      expect(res).toEqual({ changed: true, value: undefined });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'PlaceholderResolver: Placeholder "{missing}" not found in provided data sources. Replacing with empty string.'
+      );
+    });
+
+    it('replaces embedded placeholders in a string', () => {
+      const res = resolver._replaceEmbedded('Hello {name}', [{ name: 'Bob' }]);
+      expect(res).toEqual({ changed: true, value: 'Hello Bob' });
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Replaced embedded placeholder {name} with string: "Bob"'
+        )
+      );
+    });
+
+    it('returns unchanged when no placeholders present', () => {
+      const res = resolver._replaceEmbedded('Nothing here', [{}]);
+      expect(res).toEqual({ changed: false, value: 'Nothing here' });
+    });
+  });
 });
 // --- FILE END ---


### PR DESCRIPTION
## Summary
- split `PlaceholderResolver` string logic into `_handleFullString` and `_replaceEmbedded`
- update `_resolveString` to delegate to the new helpers
- add unit tests for the helper functions

## Testing Done
- `npm run format`
- `ESLINT_USE_FLAT_CONFIG=true npm run lint` *(fails: 3184 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ab76f43b88331b602bed78ed57e33