### PR TITLE
[Agent] Add constants for initialization errors

### DIFF
--- a/src/constants/eventIds.js
+++ b/src/constants/eventIds.js
@@ -161,6 +161,11 @@ export const REQUEST_SHOW_LOAD_GAME_UI = 'core:ui_request_show_load_game';
  */
 export const CANNOT_SAVE_GAME_INFO = 'core:ui_cannot_save_game_info';
 
+// --- Initialization & Error UI Event IDs ---
+export const INITIALIZATION_SERVICE_FAILED_ID =
+  'initialization:initialization_service:failed';
+export const UI_SHOW_FATAL_ERROR_ID = 'ui:show_fatal_error';
+
 // --- EntityManager Event IDs (Ticket 8) ---
 /** @typedef {import('../entities/entity.js').default} Entity */
 

--- a/src/domUI/titleRenderer.js
+++ b/src/domUI/titleRenderer.js
@@ -1,7 +1,10 @@
 // src/dom-ui/titleRenderer.js
 import { RendererBase } from './rendererBase.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
+import {
+  SYSTEM_ERROR_OCCURRED_ID,
+  INITIALIZATION_SERVICE_FAILED_ID,
+} from '../constants/eventIds.js';
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
@@ -80,7 +83,7 @@ export class TitleRenderer extends RendererBase {
       this.#handleInitializationCompleted.bind(this)
     );
     this._subscribe(
-      'initialization:initialization_service:failed',
+      INITIALIZATION_SERVICE_FAILED_ID,
       this.#handleInitializationFailed.bind(this)
     );
 

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -16,7 +16,11 @@ import { tokens } from '../../dependencyInjection/tokens.js';
 import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
 import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
-import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
+import {
+  ACTION_DECIDED_ID,
+  INITIALIZATION_SERVICE_FAILED_ID,
+  UI_SHOW_FATAL_ERROR_ID,
+} from '../../constants/eventIds.js';
 
 /**
  * Service responsible for orchestrating the entire game initialization sequence.
@@ -288,26 +292,24 @@ class InitializationService extends IInitializationService {
         stack: error instanceof Error ? error.stack : undefined,
       };
       this.#validatedEventDispatcher
-        .dispatch(
-          'initialization:initialization_service:failed',
-          failedPayload,
-          { allowSchemaNotFound: true }
-        )
+        .dispatch(INITIALIZATION_SERVICE_FAILED_ID, failedPayload, {
+          allowSchemaNotFound: true,
+        })
         .then(() =>
           this.#logger.debug(
-            "Dispatched 'initialization:initialization_service:failed' event.",
+            `Dispatched ${INITIALIZATION_SERVICE_FAILED_ID} event.`,
             failedPayload
           )
         )
         .catch((e) =>
           this.#logger.error(
-            "Failed to dispatch 'initialization:initialization_service:failed' event",
+            `Failed to dispatch ${INITIALIZATION_SERVICE_FAILED_ID} event`,
             e
           )
         );
 
       try {
-        await this.#validatedEventDispatcher.dispatch('ui:show_fatal_error', {
+        await this.#validatedEventDispatcher.dispatch(UI_SHOW_FATAL_ERROR_ID, {
           title: 'Fatal Initialization Error',
           message: `Initialization failed for world '${worldName}'. Reason: ${error.message}`,
           details: error instanceof Error ? error.stack : 'No stack available.',
@@ -316,7 +318,7 @@ class InitializationService extends IInitializationService {
           message: 'Fatal error during initialization. Cannot continue.',
         });
         this.#logger.debug(
-          'InitializationService: Dispatched ui:show_fatal_error and core:disable_input events.'
+          `InitializationService: Dispatched ${UI_SHOW_FATAL_ERROR_ID} and core:disable_input events.`
         );
       } catch (dispatchError) {
         this.#logger.error(


### PR DESCRIPTION
Summary: Add constants to centralize initialization error event ids and update files to use them.

Changes Made:
- Export `INITIALIZATION_SERVICE_FAILED_ID` and `UI_SHOW_FATAL_ERROR_ID` in `eventIds.js`.
- Refactor `initializationService.js` and `titleRenderer.js` to use the new constants.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint ...`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test (`npm run start`)

------
https://chatgpt.com/codex/tasks/task_e_685ab75903408331b636e5a1d0123484