### PR TITLE
[Agent] register LlmConfigLoader via DI

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -62,6 +62,7 @@ import { PerceptionLogFormatter } from '../../formatting/perceptionLogFormatter.
 import { GameStateValidationServiceForPrompting } from '../../validation/gameStateValidationServiceForPrompting.js';
 import { HttpConfigurationProvider } from '../../configuration/httpConfigurationProvider.js';
 import { LLMConfigService } from '../../llms/llmConfigService.js';
+import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { PlaceholderResolver } from '../../utils/placeholderResolverUtils.js';
 import { StandardElementAssembler } from '../../prompting/assembling/standardElementAssembler.js';
 import {
@@ -197,6 +198,17 @@ export function registerAI(container) {
       configSourceIdentifier: './config/llm-configs.json',
     });
   });
+
+  r.singletonFactory(
+    tokens.LlmConfigLoader,
+    (c) =>
+      new LlmConfigLoader({
+        logger: c.resolve(tokens.ILogger),
+        schemaValidator: c.resolve(tokens.ISchemaValidator),
+        configuration: c.resolve(tokens.IConfiguration),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+      })
+  );
 
   r.singletonFactory(
     tokens.PlaceholderResolver,

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -205,6 +205,7 @@ export const tokens = freeze({
   ScopeLoader: 'ScopeLoader',
   ModsLoader: 'ModsLoader',
   GameConfigLoader: 'GameConfigLoader',
+  LlmConfigLoader: 'LlmConfigLoader',
   PromptTextLoader: 'PromptTextLoader',
   ModManifestLoader: 'ModManifestLoader',
   ModDependencyValidator: 'ModDependencyValidator',

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -13,7 +13,6 @@
 /** @typedef {import('../../interfaces/IInitializationService.js').InitializationResult} InitializationResult */
 import { IInitializationService } from '../../interfaces/IInitializationService.js';
 import { tokens } from '../../dependencyInjection/tokens.js';
-import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
 import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
@@ -160,16 +159,11 @@ class InitializationService extends IInitializationService {
             'InitializationService: ConfigurableLLMAdapter already initialized. Skipping re-initialization.'
           );
         } else {
-          const llmConfigLoaderInstance = new LlmConfigLoader({
-            logger: this.#container.resolve(tokens.ILogger),
-            schemaValidator: this.#container.resolve(tokens.ISchemaValidator),
-            configuration: this.#container.resolve(tokens.IConfiguration),
-            safeEventDispatcher: this.#container.resolve(
-              tokens.ISafeEventDispatcher
-            ),
-          });
+          const llmConfigLoaderInstance = this.#container.resolve(
+            tokens.LlmConfigLoader
+          );
           this.#logger.debug(
-            'InitializationService: LlmConfigLoader instance created for adapter initialization.'
+            'InitializationService: LlmConfigLoader instance created for adapter initialization via DI.'
           );
 
           await llmAdapter.init({ llmConfigLoader: llmConfigLoaderInstance });

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -124,6 +124,9 @@ beforeEach(() => {
     unsubscribe: jest.fn(),
     dispatch: jest.fn(),
   });
+  container.register(tokens.LlmConfigLoader, {
+    loadConfigs: jest.fn(),
+  });
   container.register(tokens.IEntityManager, { getEntityInstance: jest.fn() });
 
   // Register the new mocks

--- a/tests/unit/initializers/services/initializationService.failureScenarios.test.js
+++ b/tests/unit/initializers/services/initializationService.failureScenarios.test.js
@@ -20,8 +20,6 @@ let mockSystemInitializer;
 let mockWorldInitializer;
 let mockDomUiFacade;
 let mockLlmAdapter;
-let mockSchemaValidator;
-let mockConfiguration;
 let mockDataRegistry;
 let mockScopeRegistry;
 
@@ -63,20 +61,6 @@ describe('InitializationService', () => {
       isInitialized: jest.fn().mockReturnValue(false),
       isOperational: jest.fn().mockReturnValue(false),
     };
-    mockSchemaValidator = {
-      validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
-      addSchema: jest.fn(),
-      isSchemaLoaded: jest.fn().mockReturnValue(true),
-      getValidator: jest.fn(),
-    };
-    mockConfiguration = {
-      getContentTypeSchemaId: jest.fn((registryKey) => {
-        if (registryKey === 'llm-configs') {
-          return 'http://example.com/schemas/llm-configs.schema.json';
-        }
-        return `http://example.com/schemas/${registryKey}.schema.json`;
-      }),
-    };
     mockDataRegistry = {
       get: jest.fn().mockReturnValue({}),
       getAll: jest.fn().mockReturnValue([]), // Return empty array for scopes
@@ -102,10 +86,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),
@@ -153,10 +135,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),
@@ -317,10 +297,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
-            case tokens.ISchemaValidator:
-              return mockSchemaValidator;
-            case tokens.IConfiguration:
-              return mockConfiguration;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISafeEventDispatcher:
               return {
                 subscribe: jest.fn(),
@@ -375,10 +353,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
-            case tokens.ISchemaValidator:
-              return mockSchemaValidator;
-            case tokens.IConfiguration:
-              return mockConfiguration;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISafeEventDispatcher:
               return {
                 subscribe: jest.fn(),
@@ -436,10 +412,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
-            case tokens.ISchemaValidator:
-              return mockSchemaValidator;
-            case tokens.IConfiguration:
-              return mockConfiguration;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISafeEventDispatcher:
               return {
                 subscribe: jest.fn(),

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -19,8 +19,6 @@ let mockSystemInitializer;
 let mockWorldInitializer;
 let mockDomUiFacade;
 let mockLlmAdapter;
-let mockSchemaValidator;
-let mockConfiguration;
 let mockDataRegistry;
 let mockScopeRegistry;
 
@@ -62,20 +60,6 @@ describe('InitializationService', () => {
       isInitialized: jest.fn().mockReturnValue(false),
       isOperational: jest.fn().mockReturnValue(false),
     };
-    mockSchemaValidator = {
-      validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
-      addSchema: jest.fn(),
-      isSchemaLoaded: jest.fn().mockReturnValue(true),
-      getValidator: jest.fn(),
-    };
-    mockConfiguration = {
-      getContentTypeSchemaId: jest.fn((registryKey) => {
-        if (registryKey === 'llm-configs') {
-          return 'http://example.com/schemas/llm-configs.schema.json';
-        }
-        return `http://example.com/schemas/${registryKey}.schema.json`;
-      }),
-    };
     mockDataRegistry = {
       get: jest.fn().mockReturnValue({}),
     };
@@ -99,10 +83,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),
@@ -151,10 +133,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -20,8 +20,6 @@ let mockSystemInitializer;
 let mockWorldInitializer;
 let mockDomUiFacade;
 let mockLlmAdapter;
-let mockSchemaValidator;
-let mockConfiguration;
 let mockDataRegistry;
 let mockScopeRegistry;
 
@@ -64,23 +62,6 @@ describe('InitializationService', () => {
       isInitialized: jest.fn().mockReturnValue(false), // Start as not initialized
       isOperational: jest.fn().mockReturnValue(false), // Start as not operational
     };
-    mockSchemaValidator = {
-      validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
-      addSchema: jest.fn(),
-      isSchemaLoaded: jest.fn().mockReturnValue(true),
-      getValidator: jest.fn(),
-    };
-    mockConfiguration = {
-      getContentTypeSchemaId: jest.fn((registryKey) => {
-        if (registryKey === 'llm-configs') {
-          return 'http://example.com/schemas/llm-configs.schema.json';
-        }
-        return `http://example.com/schemas/${registryKey}.schema.json`;
-      }),
-      // Provide a basic mock for `get` if LlmConfigLoader or other parts need it directly
-      get: jest.fn(),
-      getWorldSetting: jest.fn(),
-    };
     mockDataRegistry = {
       get: jest.fn().mockReturnValue({}),
       getAll: jest.fn().mockReturnValue([]), // Return empty array for scopes
@@ -107,10 +88,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),
@@ -162,10 +141,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator; // For LlmConfigLoader
-          case tokens.IConfiguration:
-            return mockConfiguration; // For LlmConfigLoader
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() }; // For LlmConfigLoader
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -20,8 +20,6 @@ let mockSystemInitializer;
 let mockWorldInitializer;
 let mockDomUiFacade;
 let mockLlmAdapter;
-let mockSchemaValidator;
-let mockConfiguration;
 let mockDataRegistry;
 let mockScopeRegistry;
 
@@ -63,20 +61,6 @@ describe('InitializationService', () => {
       isInitialized: jest.fn().mockReturnValue(false),
       isOperational: jest.fn().mockReturnValue(false),
     };
-    mockSchemaValidator = {
-      validate: jest.fn().mockReturnValue({ isValid: true, errors: null }),
-      addSchema: jest.fn(),
-      isSchemaLoaded: jest.fn().mockReturnValue(true),
-      getValidator: jest.fn(),
-    };
-    mockConfiguration = {
-      getContentTypeSchemaId: jest.fn((registryKey) => {
-        if (registryKey === 'llm-configs') {
-          return 'http://example.com/schemas/llm-configs.schema.json';
-        }
-        return `http://example.com/schemas/${registryKey}.schema.json`;
-      }),
-    };
     mockDataRegistry = {
       get: jest.fn().mockReturnValue({}), // Default to empty object, specific tests can override
       getAll: jest.fn().mockReturnValue([]), // Return empty array for scopes
@@ -103,15 +87,9 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
-          case tokens.ISafeEventDispatcher:
+          case tokens.LlmConfigLoader:
             return {
-              subscribe: jest.fn(),
-              unsubscribe: jest.fn(),
-              dispatch: jest.fn(),
+              loadConfigs: jest.fn(),
             };
           case tokens.IEntityManager:
             return { getEntityInstance: jest.fn() };
@@ -153,10 +131,10 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
-          case tokens.ISchemaValidator:
-            return mockSchemaValidator;
-          case tokens.IConfiguration:
-            return mockConfiguration;
+          case tokens.LlmConfigLoader:
+            return {
+              loadConfigs: jest.fn(),
+            };
           case tokens.ISafeEventDispatcher:
             return {
               subscribe: jest.fn(),
@@ -208,9 +186,7 @@ describe('InitializationService', () => {
         tokens.IScopeRegistry,
         tokens.IDataRegistry, // For ScopeRegistry
         tokens.LLMAdapter,
-        tokens.ISchemaValidator, // by LlmConfigLoader
-        tokens.IConfiguration, // by LlmConfigLoader
-        tokens.ISafeEventDispatcher, // by LlmConfigLoader
+        tokens.LlmConfigLoader,
         tokens.SystemInitializer,
         tokens.WorldInitializer,
         tokens.ISafeEventDispatcher, // for AI Listeners


### PR DESCRIPTION
## Summary
- introduce a `LlmConfigLoader` token
- register the loader in AI registrations
- use the DI container to obtain `LlmConfigLoader` during initialization
- update initialization service tests for the new token resolution

## Testing Done
- `npm run lint` *(fails: many existing lint issues)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test` *(inside llm-proxy-server)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5738c9483318c176a95aa6a22eb