### PR TITLE
[Agent] use extractModId in EntityDefinition

### DIFF
--- a/src/entities/entityDefinition.js
+++ b/src/entities/entityDefinition.js
@@ -1,4 +1,5 @@
 import { deepFreeze } from '../utils/cloneUtils.js'; // Import directly to avoid circular dependency
+import { extractModId } from '../utils/idUtils.js';
 
 /**
  * Represents the immutable template/definition of an entity.
@@ -76,8 +77,7 @@ class EntityDefinition {
    * @returns {string | undefined} The mod ID, or undefined if the ID format is unexpected.
    */
   get modId() {
-    const parts = this.id.split(':');
-    return parts.length > 1 ? parts[0] : undefined;
+    return extractModId(this.id);
   }
 
   /**

--- a/tests/unit/entities/EntityDefinition.test.js
+++ b/tests/unit/entities/EntityDefinition.test.js
@@ -1,5 +1,4 @@
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
-import { deepFreeze } from '../../../src/utils/cloneUtils.js'; // Used by the class, not directly tested here unless necessary
 
 describe('EntityDefinition', () => {
   const validDefinitionData = {
@@ -109,6 +108,18 @@ describe('EntityDefinition', () => {
 
     const definition3 = new EntityDefinition('noPrefix', validDefinitionData);
     expect(definition3.modId).toBeUndefined(); // Or potentially 'noPrefix' if that's the desired behavior for single-token IDs
+
+    const definition4 = new EntityDefinition(
+      'foo:bar:baz',
+      validDefinitionData
+    );
+    expect(definition4.modId).toBe('foo');
+
+    const definition5 = new EntityDefinition(
+      ':startsWithColon',
+      validDefinitionData
+    );
+    expect(definition5.modId).toBeUndefined();
   });
 
   describe('getComponentSchema', () => {


### PR DESCRIPTION
## Summary
- replace inline logic in `EntityDefinition.modId` with `extractModId`
- extend modId unit tests for edge cases

## Testing Done
- `npm run lint`
- `npx eslint src/entities/entityDefinition.js tests/unit/entities/EntityDefinition.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ab82bad8083319a27bfddfce6700f