### PR TITLE
[Agent] record loader failures

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -261,6 +261,19 @@ export class ContentLoadManager {
             );
             if (result && typeof result.count === 'number') {
               aggregator.aggregate(result, registryKey);
+              if (
+                Array.isArray(result.failures) &&
+                result.failures.length > 0
+              ) {
+                for (const { file, error } of result.failures) {
+                  const msg = error?.message || String(error);
+                  this.#logger.error(
+                    `ModsLoader [${modId}, ${phase}]: ${registryKey} file '${file}' failed: ${msg}`,
+                    { modId, registryKey, phase, file, error: msg },
+                    error
+                  );
+                }
+              }
             } else {
               this.#logger.warn(
                 `ModsLoader [${modId}, ${phase}]: Loader for '${registryKey}' returned an unexpected result format. Assuming 0 counts.`,

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -412,7 +412,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
         `No valid ${contentKey} filenames found for mod ${modId}.`
       );
       // Return zero counts if no files to process
-      return { count: 0, overrides: 0, errors: 0 }; // <<< MODIFIED RETURN VALUE
+      return { count: 0, overrides: 0, errors: 0, failures: [] }; // <<< MODIFIED RETURN VALUE
     }
 
     this._logger.debug(
@@ -428,6 +428,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
     let processedCount = 0;
     let overrideCount = 0; // <<< ADDED override counter
     let failedCount = 0;
+    const failures = [];
 
     settledResults.forEach((result, index) => {
       const currentFilename = filenames[index]; // Get filename for logging context
@@ -441,6 +442,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
         // Debug log for success is already in _processFileWrapper
       } else {
         failedCount++;
+        failures.push({ file: currentFilename, error: result.reason });
         // Error logging is already handled comprehensively in _processFileWrapper
         // Only log a debug message here indicating which file failed in the batch
         this._logger.debug(
@@ -462,6 +464,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
       count: processedCount,
       overrides: overrideCount,
       errors: failedCount,
+      failures,
     }; // <<< MODIFIED RETURN VALUE
   }
 

--- a/tests/unit/loaders/baseManifestItemLoader.loadItemsForMod.test.js
+++ b/tests/unit/loaders/baseManifestItemLoader.loadItemsForMod.test.js
@@ -122,7 +122,12 @@ describe('BaseManifestItemLoader.loadItemsForMod', () => {
     },
   };
   // --- CORRECTED: Mock return value for successful load ---
-  const EXPECTED_LOAD_RESULT = { count: 5, overrides: 0, errors: 0 }; // Mock result object
+  const EXPECTED_LOAD_RESULT = {
+    count: 5,
+    overrides: 0,
+    errors: 0,
+    failures: [],
+  }; // Mock result object
 
   beforeEach(() => {
     // Create fresh mocks for each test
@@ -377,7 +382,7 @@ describe('BaseManifestItemLoader.loadItemsForMod', () => {
 
   // --- CORRECTED Return Value Test (Zero Case) ---
   it('should return { count: 0, ... } if _loadItemsInternal returns { count: 0, ... }', async () => {
-    const zeroResult = { count: 0, overrides: 0, errors: 0 };
+    const zeroResult = { count: 0, overrides: 0, errors: 0, failures: [] };
     loadItemsInternalSpy.mockResolvedValue(zeroResult); // Configure spy to return the zero object
     const result = await testLoader.loadItemsForMod(
       TEST_MOD_ID,

--- a/tests/unit/loaders/baseManifestItemLoader.loadItemsInternal.test.js
+++ b/tests/unit/loaders/baseManifestItemLoader.loadItemsInternal.test.js
@@ -165,7 +165,12 @@ describe('BaseManifestItemLoader _loadItemsInternal', () => {
     );
 
     // --- Assert ---
-    expect(result).toEqual({ count: 0, overrides: 0, errors: 0 }); // <<< CORRECTED: Expect the result object
+    expect(result).toEqual({
+      count: 0,
+      overrides: 0,
+      errors: 0,
+      failures: [],
+    }); // <<< CORRECTED: Expect the result object
     // Or check properties individually:
     // expect(result.count).toBe(0);
     // expect(result.overrides).toBe(0);
@@ -207,7 +212,12 @@ describe('BaseManifestItemLoader _loadItemsInternal', () => {
     );
 
     // --- Assert ---
-    expect(result).toEqual({ count: 2, overrides: 0, errors: 0 }); // <<< CORRECTED: Expect the result object
+    expect(result).toEqual({
+      count: 2,
+      overrides: 0,
+      errors: 0,
+      failures: [],
+    }); // <<< CORRECTED: Expect the result object
     // Or check properties individually:
     // expect(result.count).toBe(2);
     // expect(result.overrides).toBe(0);
@@ -267,7 +277,12 @@ describe('BaseManifestItemLoader _loadItemsInternal', () => {
     );
 
     // --- Assert ---
-    expect(result).toEqual({ count: 2, overrides: 1, errors: 1 }); // <<< CORRECTED: Expect the result object
+    expect(result).toEqual({
+      count: 2,
+      overrides: 1,
+      errors: 1,
+      failures: [{ file: 'file2.json', error: failureError }],
+    }); // <<< CORRECTED: Expect the result object
     // Or check properties individually:
     // expect(result.count).toBe(2); // file1 and file3 succeeded
     // expect(result.overrides).toBe(1); // file1 overwrote
@@ -330,7 +345,15 @@ describe('BaseManifestItemLoader _loadItemsInternal', () => {
     );
 
     // --- Assert ---
-    expect(result).toEqual({ count: 0, overrides: 0, errors: 2 }); // <<< CORRECTED: Expect the result object
+    expect(result).toEqual({
+      count: 0,
+      overrides: 0,
+      errors: 2,
+      failures: [
+        { file: 'file1.json', error: failureError1 },
+        { file: 'file2.json', error: failureError2 },
+      ],
+    }); // <<< CORRECTED: Expect the result object
     // Or check properties individually:
     // expect(result.count).toBe(0);
     // expect(result.overrides).toBe(0);

--- a/tests/unit/loaders/contentLoadManager.processMod.test.js
+++ b/tests/unit/loaders/contentLoadManager.processMod.test.js
@@ -31,7 +31,12 @@ describe('ContentLoadManager.processMod', () => {
   });
 
   it('returns "skipped" when manifest is missing and dispatches mod_load_failed', async () => {
-    const loader = new MockLoader({ count: 1, overrides: 0, errors: 0 });
+    const loader = new MockLoader({
+      count: 1,
+      overrides: 0,
+      errors: 0,
+      failures: [],
+    });
     const phaseLoadersConfig = [
       {
         loader,
@@ -111,7 +116,12 @@ describe('ContentLoadManager.processMod', () => {
   });
 
   it('returns "success" when all loaders succeed', async () => {
-    const loader = new MockLoader({ count: 1, overrides: 0, errors: 0 });
+    const loader = new MockLoader({
+      count: 1,
+      overrides: 0,
+      errors: 0,
+      failures: [],
+    });
     const phaseLoadersConfig = [
       {
         loader,

--- a/tests/unit/loaders/contentLoadManager.test.js
+++ b/tests/unit/loaders/contentLoadManager.test.js
@@ -25,7 +25,7 @@ class MockLoader {
           !manifest.content[this.contentKey] ||
           manifest.content[this.contentKey].length === 0
         ) {
-          return { count: 0, overrides: 0, errors: 0 };
+          return { count: 0, overrides: 0, errors: 0, failures: [] };
         }
 
         // It's the intended mod and has content for this loader
@@ -60,7 +60,7 @@ describe('ContentLoadManager.loadContent', () => {
 
   it('aggregates loader results across mods and dispatches on errors', async () => {
     const loaderA = new MockLoader(
-      { count: 1, overrides: 0, errors: 0 },
+      { count: 1, overrides: 0, errors: 0, failures: [] },
       'modA',
       'items'
     ); // Will succeed for modA

--- a/tests/unit/loaders/eventLoader.test.js
+++ b/tests/unit/loaders/eventLoader.test.js
@@ -113,7 +113,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   eventLoader._logger = mockLogger;
 
-  loadItemsInternalSpy.mockResolvedValue({ count: 0, overrides: 0, errors: 0 });
+  loadItemsInternalSpy.mockResolvedValue({
+    count: 0,
+    overrides: 0,
+    errors: 0,
+    failures: [],
+  });
   validatePrimarySchemaSpy.mockReturnValue({ isValid: true, errors: null });
   storeItemInRegistrySpy.mockImplementation((...args) =>
     realStoreItemInRegistry.apply(eventLoader, args)

--- a/tests/unit/loaders/goalLoader.fixes.test.js
+++ b/tests/unit/loaders/goalLoader.fixes.test.js
@@ -204,7 +204,12 @@ describe('GoalLoader', () => {
 
       // Assert
       // 1. Check final result summary
-      expect(result).toEqual({ count: 1, overrides: 0, errors: 0 });
+      expect(result).toEqual({
+        count: 1,
+        overrides: 0,
+        errors: 0,
+        failures: [],
+      });
 
       // 2. Verify dependencies were called correctly
       expect(mockPathResolver.resolveModContentPath).toHaveBeenCalledWith(

--- a/tests/unit/loaders/ruleLoader.fetchFailure.test.js
+++ b/tests/unit/loaders/ruleLoader.fetchFailure.test.js
@@ -288,6 +288,7 @@ describe('RuleLoader - Fetch Failure Handling (via loadItemsForMod)', () => {
         count: 1, // Only one rule was successfully processed
         errors: 1, // One file failed to fetch/process
         overrides: 0, // No existing rules were overridden
+        failures: [{ file: fileFail, error: fetchError }],
       });
       // *** REMOVED old assertion: expect(count).toBe(1); ***
 

--- a/tests/unit/loaders/ruleLoader.storeFailure.test.js
+++ b/tests/unit/loaders/ruleLoader.storeFailure.test.js
@@ -353,7 +353,12 @@ describe('RuleLoader - Storage Failure Handling (via loadItemsForMod)', () => {
       );
 
       // Verify the return value object
-      expect(result).toEqual({ count: 1, errors: 1, overrides: 0 });
+      expect(result).toEqual({
+        count: 1,
+        errors: 1,
+        overrides: 0,
+        failures: [{ file: ruleFileFailStore, error: storageError }],
+      });
 
       // Verify summary and debug logging
       expect(mockLogger.info).toHaveBeenCalledWith(

--- a/tests/unit/services/actionLoader.test.js
+++ b/tests/unit/services/actionLoader.test.js
@@ -165,7 +165,7 @@ beforeEach(() => {
 
     loadItemsInternalSpy = jest
       .spyOn(actionLoader, '_loadItemsInternal')
-      .mockResolvedValue({ count: 0, overrides: 0, errors: 0 });
+      .mockResolvedValue({ count: 0, overrides: 0, errors: 0, failures: [] });
     validatePrimarySchemaSpy = jest
       .spyOn(actionLoader, '_validatePrimarySchema')
       .mockReturnValue({ isValid: true, errors: null });
@@ -228,7 +228,12 @@ describe('ActionLoader', () => {
         );
         loadItemsInternalSpy = jest
           .spyOn(actionLoader, '_loadItemsInternal')
-          .mockResolvedValue({ count: 0, overrides: 0, errors: 0 });
+          .mockResolvedValue({
+            count: 0,
+            overrides: 0,
+            errors: 0,
+            failures: [],
+          });
         validatePrimarySchemaSpy = jest
           .spyOn(actionLoader, '_validatePrimarySchema')
           .mockReturnValue({ isValid: true, errors: null });

--- a/tests/unit/services/componentDefinitionLoader.internalError.test.js
+++ b/tests/unit/services/componentDefinitionLoader.internalError.test.js
@@ -195,7 +195,15 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
       'components'
     );
 
-    expect(result).toEqual({ count: 0, errors: 2, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 2,
+      overrides: 0,
+      failures: [
+        { file: filenameNullId, error: expect.any(Error) },
+        { file: filenameEmptyId, error: expect.any(Error) },
+      ],
+    });
     expect(mockRegistry.store).not.toHaveBeenCalled();
     expect(mockValidator.addSchema).not.toHaveBeenCalled();
     expect(mockLogger.error).toHaveBeenCalledTimes(2);
@@ -257,7 +265,15 @@ describe('ComponentLoader (Internal Definition Errors)', () => {
       'components'
     );
 
-    expect(result).toEqual({ count: 0, errors: 2, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 2,
+      overrides: 0,
+      failures: [
+        { file: filenameNullSchema, error: expect.any(Error) },
+        { file: filenameStringSchema, error: expect.any(Error) },
+      ],
+    });
     expect(mockRegistry.store).not.toHaveBeenCalled();
     expect(mockValidator.addSchema).not.toHaveBeenCalled();
     expect(mockLogger.error).toHaveBeenCalledTimes(2);

--- a/tests/unit/services/componentDefinitionLoader.ioErrors.test.js
+++ b/tests/unit/services/componentDefinitionLoader.ioErrors.test.js
@@ -312,7 +312,12 @@ describe('ComponentLoader (Sub-Ticket 6.7: Path/Fetch Errors)', () => {
     // --- Verify: Promise Resolves & Result Object ---
     await expect(loadPromise).resolves.not.toThrow();
     const result = await loadPromise;
-    expect(result).toEqual({ count: 0, errors: 1, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 1,
+      overrides: 0,
+      failures: [{ file: filename, error: pathError }],
+    });
 
     // --- Verify: No Fetch/Store/Schema Add ---
     expect(mockFetcher.fetch).not.toHaveBeenCalled();
@@ -392,7 +397,12 @@ describe('ComponentLoader (Sub-Ticket 6.7: Path/Fetch Errors)', () => {
     // --- Verify: Promise Resolves & Result Object ---
     await expect(loadPromise).resolves.not.toThrow();
     const result = await loadPromise;
-    expect(result).toEqual({ count: 0, errors: 1, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 1,
+      overrides: 0,
+      failures: [{ file: filename, error: fetchError }],
+    });
 
     // --- Verify: No Store/Schema Add ---
     expect(mockRegistry.store).not.toHaveBeenCalled();

--- a/tests/unit/services/componentDefinitionLoader.manifestErrors.test.js
+++ b/tests/unit/services/componentDefinitionLoader.manifestErrors.test.js
@@ -216,7 +216,12 @@ describe('ComponentLoader (Sub-Ticket 6.6: Manifest Handling Errors)', () => {
   // --- Shared Test Data ---
   const modId = 'manifestErrorMod';
   // <<< ADDED: Expected zero result object for cleaner tests >>>
-  const expectedZeroResult = { count: 0, errors: 0, overrides: 0 };
+  const expectedZeroResult = {
+    count: 0,
+    errors: 0,
+    overrides: 0,
+    failures: [],
+  };
 
   // --- Setup ---
   beforeEach(() => {

--- a/tests/unit/services/componentDefinitionLoader.registryStoreFailure.test.js
+++ b/tests/unit/services/componentDefinitionLoader.registryStoreFailure.test.js
@@ -391,6 +391,12 @@ describe('ComponentLoader (Sub-Ticket 6.9: Registry Storage Failure)', () => {
       count: 0, // 0 items successfully processed
       errors: 1, // 1 error occurred (storage failed)
       overrides: 0, // 0 overrides occurred
+      failures: [
+        {
+          file: filename,
+          error: storageError,
+        },
+      ],
     });
 
     // --- Verify: Pre-Storage Steps Succeeded ---

--- a/tests/unit/services/componentDefinitionLoader.schemaRegistrationFailure.test.js
+++ b/tests/unit/services/componentDefinitionLoader.schemaRegistrationFailure.test.js
@@ -296,7 +296,12 @@ describe('ComponentLoader (Sub-Ticket 6.8: Data Schema Registration Failure)', (
     // --- Verify: Promise Resolves & Result Object ---
     await expect(loadPromise).resolves.not.toThrow();
     const result = await loadPromise;
-    expect(result).toEqual({ count: 0, errors: 1, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 1,
+      overrides: 0,
+      failures: [{ file: filename, error: expect.any(Error) }],
+    });
 
     // --- Verify: Mock Calls ---
     expect(mockResolver.resolveModContentPath).toHaveBeenCalledWith(
@@ -392,7 +397,12 @@ describe('ComponentLoader (Sub-Ticket 6.8: Data Schema Registration Failure)', (
     // --- Verify: Promise Resolves & Result Object ---
     await expect(loadPromise).resolves.not.toThrow();
     const result = await loadPromise;
-    expect(result).toEqual({ count: 0, errors: 1, overrides: 0 });
+    expect(result).toEqual({
+      count: 0,
+      errors: 1,
+      overrides: 0,
+      failures: [{ file: filename, error: expect.any(Error) }],
+    });
 
     // --- Verify: Mock Calls ---
     expect(mockResolver.resolveModContentPath).toHaveBeenCalledWith(

--- a/tests/unit/services/macroLoader.happyPath.core.test.js
+++ b/tests/unit/services/macroLoader.happyPath.core.test.js
@@ -93,7 +93,12 @@ describe('MacroLoader (Happy Path - Core Mod)', () => {
       'macros'
     );
 
-    expect(result).toEqual({ count: 2, overrides: 0, errors: 0 });
+    expect(result).toEqual({
+      count: 2,
+      overrides: 0,
+      errors: 0,
+      failures: [],
+    });
 
     expect(mockRegistry.store).toHaveBeenCalledWith(
       'macros',


### PR DESCRIPTION
Summary: Updated base loader to collect failure details and return them. ContentLoadManager now logs per-file failure messages. Tests updated to verify new `failures` property.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 680 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ab86917a48331914edc51be8388e3