### PR TITLE
Update action schema and refactor imports in tests

### DIFF
--- a/data/schemas/action.schema.json
+++ b/data/schemas/action.schema.json
@@ -20,7 +20,15 @@
       "description": "Required. The single, canonical command verb associated with this action (e.g., 'go', 'take', 'look', 'use'). Used for UI generation and potentially mapping. Hyphenated and camelCase verbs are allowed, but spaces are not.",
       "minLength": 1,
       "pattern": "^[A-Za-z-]+$",
-      "examples": ["go", "take", "look", "inventory", "wait", "attack"]
+      "examples": [
+        "go",
+        "take",
+        "look",
+        "inventory",
+        "wait",
+        "attack",
+        "take-off"
+      ]
     },
     "name": {
       "type": "string",
@@ -28,36 +36,42 @@
     },
     "scope": {
       "type": "string",
-      "description": "Required. DSL scope expression or scope name that defines where to look for potential targets for this action. Examples: 'actor.inventory.items[]', 'location.entities(core:item)[]', 'actor.followers[]', or a predefined scope name like 'nearby_items'.",
+      "description": "Required. The namescaped DSL scope that defines where to look for potential targets for this action. Notes: inline scopes in the DSL are not supported.",
       "examples": [
-        "actor.inventory.items[]",
-        "location.entities(core:item)[]",
-        "actor.followers[]",
-        "location.entities(core:npc)[][{\"!=\": [{\"var\": \"faction\"}, \"enemy\"]}]",
-        "nearby_items"
+        "core:followers",
+        "core:environment",
+        "core:directions"
       ]
     },
-    "target_domain": {
-      "type": "string",
-      "description": "Deprecated. Specifies where to look for potential targets for this action. Replaced by 'scope' property.",
-      "deprecated": true,
-      "enum": [
-        "none",
-        "self",
-        "inventory",
-        "equipment",
-        "environment",
-        "direction",
-        "followers"
-      ]
+    "required_components": {
+      "type": "object",
+      "description": "HIGH-LEVEL PRE-FILTERING. Specifies component IDs required on the actor or target for this action to be considered for discovery. This is the primary mechanism used by the ActionIndex service for performance optimization.",
+      "properties": {
+        "actor": {
+          "type": "array",
+          "description": "A list of component IDs that the actor must possess for this action to be a candidate.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target": {
+          "type": "array",
+          "description": "A list of component IDs that a potential target must possess. Used by the indexer to further refine action candidates.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "prerequisites": {
       "type": "array",
-      "description": "Optional. Defines all conditional requirements beyond basic target domain checks. It is an array of objects, each containing a 'logic' property (a standard JSON Logic object) and an optional 'failure_message'. These are evaluated by JsonLogicEvaluationService. The evaluation context includes 'actor' and 'target'. This field replaces the removed component requirement fields (actor_required_components, etc.).",
-      "$comment": "This 'prerequisites' array, using objects with a 'logic' key for JSON Logic, replaces the deprecated actor_required_components, actor_forbidden_components, target_required_components, and target_forbidden_components fields.",
+      "description": "ACTOR/WORLD STATE VALIDATION. Checks conditions on the actor (e.g., has enough mana, not rooted) or the global game state. Target-specific filtering and validation should be handled exclusively by the 'scope' property's DSL expression.",
       "items": {
         "type": "object",
-        "required": ["logic"],
+        "required": [
+          "logic"
+        ],
         "properties": {
           "logic": {
             "$ref": "./condition-container.schema.json#",
@@ -74,10 +88,17 @@
     },
     "template": {
       "type": "string",
-      "description": "Required. Text template for generating the command string output, using placeholders like {target} or {direction} (e.g., 'eat {target}', 'go {direction}', 'wait')."
+      "description": "Required. Text template for generating the command string output, using placeholders like {target} (e.g., 'eat {target}', 'wait')."
     }
   },
-  "required": ["id", "description", "commandVerb", "name", "scope", "template"],
+  "required": [
+    "id",
+    "description",
+    "commandVerb",
+    "name",
+    "scope",
+    "template"
+  ],
   "additionalProperties": true,
-  "$comment": "Allows additional properties for future extensions like action costs or effects definitions. The 'dispatch_event' property has been removed."
+  "$comment": "Allows additional properties for future extensions like action costs or effects definitions."
 }

--- a/tests/common/index.js
+++ b/tests/common/index.js
@@ -1,0 +1,1 @@
+export { default as createTestAjv } from './validation/createTestAjv.js'; 

--- a/tests/common/validation/createTestAjv.js
+++ b/tests/common/validation/createTestAjv.js
@@ -1,0 +1,30 @@
+import Ajv from 'ajv';
+import loadOperationSchemas from '../../unit/helpers/loadOperationSchemas.js';
+import loadConditionSchemas from '../../unit/helpers/loadConditionSchemas.js';
+import commonSchema from '../../../data/schemas/common.schema.json';
+import operationSchema from '../../../data/schemas/operation.schema.json';
+import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
+import ruleSchema from '../../../data/schemas/rule.schema.json';
+
+/**
+ * Creates a pre-configured AJV instance with all common schemas loaded.
+ * This reduces duplication across test files that need schema validation.
+ *
+ * @returns {Ajv} Configured AJV instance with all schemas loaded
+ */
+export default function createTestAjv() {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+
+  // Add core schemas
+  ajv.addSchema(commonSchema, 'http://example.com/schemas/common.schema.json');
+  ajv.addSchema(operationSchema, 'http://example.com/schemas/operation.schema.json');
+  ajv.addSchema(jsonLogicSchema, 'http://example.com/schemas/json-logic.schema.json');
+  ajv.addSchema(ruleSchema, 'http://example.com/schemas/rule.schema.json');
+  
+  // Load operation and condition schemas using existing helpers
+  // Note: loadConditionSchemas already adds condition.schema.json and condition-container.schema.json
+  loadOperationSchemas(ajv);
+  loadConditionSchemas(ajv);
+
+  return ajv;
+} 

--- a/tests/integration/coreHandlers.integration.test.js
+++ b/tests/integration/coreHandlers.integration.test.js
@@ -27,7 +27,7 @@ import OperationRegistry from '../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
 import ModifyComponentHandler from '../../src/logic/operationHandlers/modifyComponentHandler.js';
 import { createSimpleMockDataRegistry } from '../common/mockFactories.js';
-import SimpleEntityManager from '../common/entities/simpleEntityManager.js';
+import { SimpleEntityManager } from '../common/entities/index.js';
 
 // -----------------------------------------------------------------------------
 //  The Test -------------------------------------------------------------------

--- a/tests/integration/nestedPlaceholderResolution.integration.test.js
+++ b/tests/integration/nestedPlaceholderResolution.integration.test.js
@@ -11,7 +11,7 @@ import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
 import OperationInterpreter from '../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationService.js';
-import SimpleEntityManager from '../common/entities/simpleEntityManager.js';
+import { SimpleEntityManager } from '../common/entities/index.js';
 
 const TEST_TIMESTAMP = '2099-01-01T00:00:00.000Z';
 

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -4,14 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import Ajv from 'ajv';
 import ruleSchema from '../../../data/schemas/rule.schema.json';
-import commonSchema from '../../../data/schemas/common.schema.json';
-import operationSchema from '../../../data/schemas/operation.schema.json';
-import jsonLogicSchema from '../../../data/schemas/json-logic.schema.json';
-import conditionSchema from '../../../data/schemas/condition.schema.json';
-import conditionContainerSchema from '../../../data/schemas/condition-container.schema.json';
-import loadOperationSchemas from '../../unit/helpers/loadOperationSchemas.js';
 import followRule from '../../../data/mods/core/rules/follow.rule.json';
 import eventIsActionFollow from '../../../data/mods/core/conditions/event-is-action-follow.condition.json';
 import SystemLogicInterpreter from '../../../src/logic/systemLogicInterpreter.js';
@@ -350,28 +343,8 @@ describe('core_handle_follow rule integration', () => {
   });
 
   it('validates follow.rule.json against schema', () => {
-    const ajv = new Ajv({ allErrors: true });
-    ajv.addSchema(
-      commonSchema,
-      'http://example.com/schemas/common.schema.json'
-    );
-    ajv.addSchema(
-      operationSchema,
-      'http://example.com/schemas/operation.schema.json'
-    );
-    loadOperationSchemas(ajv);
-    ajv.addSchema(
-      jsonLogicSchema,
-      'http://example.com/schemas/json-logic.schema.json'
-    );
-    ajv.addSchema(
-      conditionContainerSchema,
-      'http://example.com/schemas/condition-container.schema.json'
-    );
-    ajv.addSchema(
-      conditionSchema,
-      'http://example.com/schemas/condition.schema.json'
-    );
+    const { createTestAjv } = require('../../common/index.js');
+    const ajv = createTestAjv();
     const valid = ajv.validate(ruleSchema, followRule);
     if (!valid) console.error(ajv.errors);
     expect(valid).toBe(true);

--- a/tests/integration/sequentialActionExecution.integration.test.js
+++ b/tests/integration/sequentialActionExecution.integration.test.js
@@ -34,7 +34,7 @@ import {
   createMockLogger,
 } from '../common/mockFactories.js';
 import { buildExecContext } from '../common/entities/index.js';
-import SimpleEntityManager from '../common/entities/simpleEntityManager.js';
+import { SimpleEntityManager } from '../common/entities/index.js';
 import {
   afterEach,
   beforeEach,

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -27,7 +27,7 @@ import {
   createMockLogger,
 } from '../common/mockFactories.js';
 import { buildExecContext } from '../common/entities/index.js';
-import SimpleEntityManager from '../common/entities/simpleEntityManager.js';
+import { SimpleEntityManager } from '../common/entities/index.js';
 import {
   afterEach,
   beforeEach,


### PR DESCRIPTION
- Added "take-off" to the examples of the commandVerb in action.schema.json.
- Updated the description of the scope property for clarity.
- Introduced a new required_components property to specify component IDs needed for action discovery.
- Refactored imports in multiple test files to use a centralized index for SimpleEntityManager.