### PR TITLE
[Agent] inject LlmConfigLoader via DI

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -62,6 +62,7 @@ import { PerceptionLogFormatter } from '../../formatting/perceptionLogFormatter.
 import { GameStateValidationServiceForPrompting } from '../../validation/gameStateValidationServiceForPrompting.js';
 import { HttpConfigurationProvider } from '../../configuration/httpConfigurationProvider.js';
 import { LLMConfigService } from '../../llms/llmConfigService.js';
+import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { PlaceholderResolver } from '../../utils/placeholderResolverUtils.js';
 import { StandardElementAssembler } from '../../prompting/assembling/standardElementAssembler.js';
 import {
@@ -123,6 +124,20 @@ export function registerLlmInfrastructure(registrar, logger) {
     });
   });
   logger.debug(`AI Systems Registration: Registered ${tokens.IHttpClient}.`);
+
+  registrar.singletonFactory(
+    tokens.LlmConfigLoader,
+    (c) =>
+      new LlmConfigLoader({
+        logger: c.resolve(tokens.ILogger),
+        schemaValidator: c.resolve(tokens.ISchemaValidator),
+        configuration: c.resolve(tokens.IConfiguration),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+      })
+  );
+  logger.debug(
+    `AI Systems Registration: Registered ${tokens.LlmConfigLoader}.`
+  );
 
   registrar.singletonFactory(tokens.LLMAdapter, (c) => {
     logger.debug('AI Systems Registration: Starting LLM Adapter setup...');

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -64,6 +64,7 @@ import { freeze } from '../utils';
  * @property {DiToken} ModsLoader - Token for orchestrating world data loading.
  * @property {DiToken} GameConfigLoader - Token for loading the main game configuration file.
  * @property {DiToken} PromptTextLoader - Token for loading the core prompt text used by the AI system.
+ * @property {DiToken} LlmConfigLoader - Token for loading LLM prompt configurations.
  * @property {DiToken} ModManifestLoader - Token for loading mod manifests.
  * @property {DiToken} ModDependencyValidator - Token for the mod dependency validator service.
  * @property {DiToken} ILoadCache - Token for the load cache service.
@@ -206,6 +207,7 @@ export const tokens = freeze({
   ModsLoader: 'ModsLoader',
   GameConfigLoader: 'GameConfigLoader',
   PromptTextLoader: 'PromptTextLoader',
+  LlmConfigLoader: 'LlmConfigLoader',
   ModManifestLoader: 'ModManifestLoader',
   ModDependencyValidator: 'ModDependencyValidator',
   ILoadCache: 'ILoadCache',

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -13,7 +13,6 @@
 /** @typedef {import('../../interfaces/IInitializationService.js').InitializationResult} InitializationResult */
 import { IInitializationService } from '../../interfaces/IInitializationService.js';
 import { tokens } from '../../dependencyInjection/tokens.js';
-import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
 import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
 import {
@@ -164,18 +163,13 @@ class InitializationService extends IInitializationService {
             'InitializationService: ConfigurableLLMAdapter already initialized. Skipping re-initialization.'
           );
         } else {
-          const llmConfigLoaderInstance = new LlmConfigLoader({
-            logger: this.#container.resolve(tokens.ILogger),
-            schemaValidator: this.#container.resolve(tokens.ISchemaValidator),
-            configuration: this.#container.resolve(tokens.IConfiguration),
-            safeEventDispatcher: this.#container.resolve(
-              tokens.ISafeEventDispatcher
-            ),
-          });
+          const llmConfigLoaderInstance =
+            /** @type {import('../../llms/services/llmConfigLoader.js').LlmConfigLoader} */ (
+              this.#container.resolve(tokens.LlmConfigLoader)
+            );
           this.#logger.debug(
-            'InitializationService: LlmConfigLoader instance created for adapter initialization.'
+            'InitializationService: LlmConfigLoader resolved from container for adapter initialization.'
           );
-
           await llmAdapter.init({ llmConfigLoader: llmConfigLoaderInstance });
 
           if (

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -129,6 +129,7 @@ beforeEach(() => {
   // Register the new mocks
   container.register(tokens.IDataRegistry, mockDataRegistry);
   container.register(tokens.IScopeRegistry, mockScopeRegistry);
+  container.register(tokens.LlmConfigLoader, { loadConfigs: jest.fn() });
 
   initializationService = new InitializationService({
     container,

--- a/tests/unit/initializers/services/initializationService.failureScenarios.test.js
+++ b/tests/unit/initializers/services/initializationService.failureScenarios.test.js
@@ -7,7 +7,6 @@ import {
   expect,
   it,
   jest,
-  test,
 } from '@jest/globals';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 
@@ -102,6 +101,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -153,6 +154,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -317,6 +320,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISchemaValidator:
               return mockSchemaValidator;
             case tokens.IConfiguration:
@@ -375,6 +380,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISchemaValidator:
               return mockSchemaValidator;
             case tokens.IConfiguration:
@@ -436,6 +443,8 @@ describe('InitializationService', () => {
               return mockDataRegistry;
             case tokens.LLMAdapter:
               return mockLlmAdapter;
+            case tokens.LlmConfigLoader:
+              return { loadConfigs: jest.fn() };
             case tokens.ISchemaValidator:
               return mockSchemaValidator;
             case tokens.IConfiguration:

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -4,7 +4,6 @@ import {
   beforeEach,
   describe,
   expect,
-  it,
   jest,
   test,
 } from '@jest/globals';
@@ -23,8 +22,6 @@ let mockSchemaValidator;
 let mockConfiguration;
 let mockDataRegistry;
 let mockScopeRegistry;
-
-const MOCK_WORLD_NAME = 'testWorld';
 
 describe('InitializationService', () => {
   beforeEach(() => {
@@ -99,6 +96,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -151,6 +150,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -7,7 +7,6 @@ import {
   expect,
   it,
   jest,
-  test,
 } from '@jest/globals';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
 
@@ -107,6 +106,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -162,6 +163,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator; // For LlmConfigLoader
           case tokens.IConfiguration:

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -5,7 +5,6 @@ import {
   beforeEach,
   describe,
   expect,
-  it,
   jest,
   test,
 } from '@jest/globals';
@@ -103,6 +102,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -153,6 +154,8 @@ describe('InitializationService', () => {
             return mockLogger;
           case tokens.LLMAdapter:
             return mockLlmAdapter;
+          case tokens.LlmConfigLoader:
+            return { loadConfigs: jest.fn() };
           case tokens.ISchemaValidator:
             return mockSchemaValidator;
           case tokens.IConfiguration:
@@ -208,9 +211,7 @@ describe('InitializationService', () => {
         tokens.IScopeRegistry,
         tokens.IDataRegistry, // For ScopeRegistry
         tokens.LLMAdapter,
-        tokens.ISchemaValidator, // by LlmConfigLoader
-        tokens.IConfiguration, // by LlmConfigLoader
-        tokens.ISafeEventDispatcher, // by LlmConfigLoader
+        tokens.LlmConfigLoader,
         tokens.SystemInitializer,
         tokens.WorldInitializer,
         tokens.ISafeEventDispatcher, // for AI Listeners


### PR DESCRIPTION
## Summary
- add LlmConfigLoader DI token
- register LlmConfigLoader in AI infrastructure
- resolve LlmConfigLoader from DI in InitializationService
- update unit tests for container-based LlmConfigLoader

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ac0cb918883318a4aabde85e7cf28