### PR TITLE
[Agent] Add user prompt abstraction for save/load dialogs

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -28,6 +28,7 @@ import {
   ProcessingIndicatorController,
   ChatAlertRenderer,
   ActionResultRenderer,
+  WindowUserPrompt,
 } from '../../domUI/index.js';
 import SaveGameUI from '../../domUI/saveGameUI.js';
 import LoadGameUI from '../../domUI/loadGameUI.js';
@@ -89,6 +90,9 @@ export function registerUI(
     (c) => new DomElementFactory(c.resolve(tokens.IDocumentContext))
   );
   logger.debug(`UI Registrations: Registered ${tokens.DomElementFactory}.`);
+
+  registrar.singletonFactory(tokens.IUserPrompt, () => new WindowUserPrompt());
+  logger.debug(`UI Registrations: Registered ${tokens.IUserPrompt}.`);
 
   registrar.single(tokens.AlertRouter, AlertRouter, [
     tokens.ISafeEventDispatcher,

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -30,6 +30,7 @@ import { freeze } from '../utils';
  * --- DOM UI Layer (Refactored) ---
  * @property {DiToken} IDocumentContext - Token for the DOM access abstraction service.
  * @property {DiToken} DomElementFactory - Token for the utility creating DOM elements.
+ * @property {DiToken} IUserPrompt - Token for the user prompt abstraction.
  * @property {DiToken} SpeechBubbleRenderer - Token for the component rendering speech bubbles with portraits.
  * @property {DiToken} TitleRenderer - Token for the component rendering the main H1 title.
  * @property {DiToken} InputStateController - Token for the component controlling input field state.
@@ -174,6 +175,7 @@ export const tokens = freeze({
   // --- DOM UI Layer (Refactored) ---
   IDocumentContext: 'IDocumentContext',
   DomElementFactory: 'DomElementFactory',
+  IUserPrompt: 'IUserPrompt',
   SpeechBubbleRenderer: 'SpeechBubbleRenderer',
   TitleRenderer: 'TitleRenderer',
   InputStateController: 'InputStateController',

--- a/src/domUI/index.js
+++ b/src/domUI/index.js
@@ -28,6 +28,7 @@ export { ActionResultRenderer } from './actionResultRenderer.js';
 export { default as SaveGameUI } from './saveGameUI.js';
 export { default as LoadGameUI } from './loadGameUI.js';
 export { LlmSelectionModal } from './llmSelectionModal.js';
+export { default as WindowUserPrompt } from './windowUserPrompt.js';
 
 // Engine UI Management
 export * from './engineUIManager.js'; // Assuming this file exists and exports relevant items

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -48,6 +48,7 @@ class LoadGameUI extends SlotModalBase {
    * @param {DomElementFactory} deps.domElementFactory - Factory for DOM elements.
    * @param {ISaveLoadService} deps.saveLoadService - Service for loading/saving.
    * @param {IValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher instance.
+   * @param {IUserPrompt} deps.userPrompt - Utility for user confirmations.
    */
   constructor({
     logger,
@@ -55,6 +56,7 @@ class LoadGameUI extends SlotModalBase {
     domElementFactory,
     saveLoadService,
     validatedEventDispatcher,
+    userPrompt,
   }) {
     const elementsConfig = buildModalElementsConfig({
       modalElement: '#load-game-screen',
@@ -85,6 +87,13 @@ class LoadGameUI extends SlotModalBase {
     }
 
     this.saveLoadService = saveLoadService;
+
+    if (!userPrompt || typeof userPrompt.confirm !== 'function') {
+      throw new Error(
+        `${this._logPrefix} IUserPrompt dependency is missing or invalid.`
+      );
+    }
+    this.userPrompt = userPrompt;
 
     // _bindUiElements is handled by BoundDomRendererBase (via BaseModalRenderer)
 
@@ -489,7 +498,7 @@ class LoadGameUI extends SlotModalBase {
    */
   async _confirmDeletion(slotToDelete) {
     const confirmMsg = `Are you sure you want to delete the save "${slotToDelete.saveName}"? This action cannot be undone.`;
-    const confirmed = window.confirm(confirmMsg);
+    const confirmed = this.userPrompt.confirm(confirmMsg);
     if (!confirmed) {
       this.logger.debug(
         `${this._logPrefix} Delete operation cancelled by user for: ${slotToDelete.identifier}`

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -59,6 +59,7 @@ export class SaveGameUI extends SlotModalBase {
    * @param {DomElementFactory} deps.domElementFactory
    * @param {ISaveLoadService} deps.saveLoadService
    * @param {IValidatedEventDispatcher} deps.validatedEventDispatcher
+   * @param {IUserPrompt} deps.userPrompt
    */
   constructor({
     logger,
@@ -66,6 +67,7 @@ export class SaveGameUI extends SlotModalBase {
     domElementFactory,
     saveLoadService,
     validatedEventDispatcher,
+    userPrompt,
   }) {
     const elementsConfig = buildModalElementsConfig({
       modalElement: '#save-game-screen',
@@ -94,6 +96,13 @@ export class SaveGameUI extends SlotModalBase {
       );
     }
     this.saveLoadService = saveLoadService;
+
+    if (!userPrompt || typeof userPrompt.confirm !== 'function') {
+      throw new Error(
+        `${this._logPrefix} IUserPrompt dependency is missing or invalid.`
+      );
+    }
+    this.userPrompt = userPrompt;
 
     // Elements are now in this.elements, e.g., this.elements.saveNameInputEl
     // _bindUiElements is handled by BoundDomRendererBase
@@ -411,7 +420,7 @@ export class SaveGameUI extends SlotModalBase {
       `Slot ${this.selectedSlotData.slotId + 1}`;
 
     if (
-      !window.confirm(
+      !this.userPrompt.confirm(
         `Are you sure you want to overwrite the existing save "${originalSaveName}" with "${currentSaveName}"?`
       )
     ) {

--- a/src/domUI/windowUserPrompt.js
+++ b/src/domUI/windowUserPrompt.js
@@ -1,0 +1,26 @@
+// src/domUI/windowUserPrompt.js
+
+/**
+ * @file Default IUserPrompt implementation using the browser's window.confirm.
+ */
+
+/** @typedef {import('../interfaces/IUserPrompt.js').IUserPrompt} IUserPrompt */
+
+/**
+ * Wraps the global window.confirm for dependency injection.
+ *
+ * @implements {IUserPrompt}
+ */
+export class WindowUserPrompt {
+  /**
+   * Displays a confirmation dialog.
+   *
+   * @param {string} message - Text shown in the confirmation dialog.
+   * @returns {boolean} The user's choice.
+   */
+  confirm(message) {
+    return typeof window !== 'undefined' ? window.confirm(message) : false;
+  }
+}
+
+export default WindowUserPrompt;

--- a/src/interfaces/IUserPrompt.js
+++ b/src/interfaces/IUserPrompt.js
@@ -1,0 +1,17 @@
+// src/interfaces/IUserPrompt.js
+
+/**
+ * @interface IUserPrompt
+ * @description Provides user confirmation dialogs.
+ */
+export class IUserPrompt {
+  /**
+   * Requests user confirmation with a message.
+   *
+   * @param {string} message - Message to display to the user.
+   * @returns {boolean} Result of the confirmation.
+   */
+  confirm(message) {
+    throw new Error('IUserPrompt.confirm method not implemented.');
+  }
+}

--- a/tests/unit/domUI/loadGameUI.coverage.test.js
+++ b/tests/unit/domUI/loadGameUI.coverage.test.js
@@ -50,6 +50,7 @@ describe('LoadGameUI', () => {
   let mockSaveLoadService;
   let mockValidatedEventDispatcher;
   let mockGameEngine;
+  let mockUserPrompt;
   let instance;
 
   // DOM Elements
@@ -129,6 +130,7 @@ describe('LoadGameUI', () => {
     mockGameEngine = {
       loadGame: jest.fn().mockResolvedValue({ success: true }),
     };
+    mockUserPrompt = { confirm: jest.fn(() => true) };
   });
 
   afterEach(() => {
@@ -148,6 +150,7 @@ describe('LoadGameUI', () => {
       domElementFactory: mockDomElementFactory,
       saveLoadService: mockSaveLoadService,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      userPrompt: mockUserPrompt,
       ...depsOverrides,
     };
     return new LoadGameUI(deps);
@@ -380,8 +383,7 @@ describe('LoadGameUI', () => {
     beforeEach(() => {
       instance = createInstance();
       instance.init(mockGameEngine);
-      // Mock window.confirm using jest.spyOn for reliability
-      confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      confirmSpy = jest.spyOn(mockUserPrompt, 'confirm').mockReturnValue(true);
 
       // Mock the base class's populateSlotsList to simplify testing interactions
       jest
@@ -392,7 +394,6 @@ describe('LoadGameUI', () => {
     });
 
     afterEach(() => {
-      // Restore the original implementation of window.confirm
       confirmSpy.mockRestore();
     });
 

--- a/tests/unit/domUI/loadGameUI.test.js
+++ b/tests/unit/domUI/loadGameUI.test.js
@@ -21,6 +21,7 @@ let mockDocumentContext;
 let domElementFactory;
 let mockVED;
 let mockSaveLoadService;
+let mockUserPrompt;
 let loadGameUI;
 /** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderGenericSlotItem>} */
 let renderSlotItemSpy;
@@ -63,6 +64,7 @@ beforeEach(() => {
     listManualSaveSlots: jest.fn(),
     deleteManualSave: jest.fn(),
   };
+  mockUserPrompt = { confirm: jest.fn(() => true) };
 
   loadGameUI = new LoadGameUI({
     logger: mockLogger,
@@ -70,6 +72,7 @@ beforeEach(() => {
     domElementFactory,
     saveLoadService: mockSaveLoadService,
     validatedEventDispatcher: mockVED,
+    userPrompt: mockUserPrompt,
   });
   renderSlotItemSpy = jest.spyOn(renderSlotItemModule, 'renderGenericSlotItem');
 });

--- a/tests/unit/domUI/saveGameUI.test.js
+++ b/tests/unit/domUI/saveGameUI.test.js
@@ -37,6 +37,7 @@ describe('SaveGameUI', () => {
   let mockDomElementFactory;
   let mockValidatedEventDispatcher;
   let mockGameEngine;
+  let mockUserPrompt;
 
   /** @type {jest.SpiedFunction<typeof renderSlotItemModule.renderGenericSlotItem>} */
   let renderSlotItemSpy;
@@ -123,6 +124,7 @@ describe('SaveGameUI', () => {
 
     mockGameEngine = { triggerManualSave: jest.fn() };
     mockSaveLoadService = { listManualSaveSlots: jest.fn() };
+    mockUserPrompt = { confirm: jest.fn(() => true) };
 
     saveGameUI = new SaveGameUI({
       logger: mockLogger,
@@ -130,6 +132,7 @@ describe('SaveGameUI', () => {
       domElementFactory: mockDomElementFactory,
       saveLoadService: mockSaveLoadService,
       validatedEventDispatcher: mockValidatedEventDispatcher,
+      userPrompt: mockUserPrompt,
     });
     saveGameUI.init(mockGameEngine);
     renderSlotItemSpy = jest.spyOn(
@@ -400,7 +403,7 @@ describe('SaveGameUI', () => {
     });
 
     it('returns trimmed name when validation and confirmation pass', () => {
-      window.confirm = jest.fn(() => true);
+      mockUserPrompt.confirm.mockReturnValue(true);
       saveGameUI.selectedSlotData = {
         slotId: 0,
         isEmpty: false,
@@ -411,12 +414,12 @@ describe('SaveGameUI', () => {
 
       const result = saveGameUI._validateAndConfirmSave();
 
-      expect(window.confirm).toHaveBeenCalled();
+      expect(mockUserPrompt.confirm).toHaveBeenCalled();
       expect(result).toBe('New Name');
     });
 
     it('returns null if user cancels overwrite confirmation', () => {
-      window.confirm = jest.fn(() => false);
+      mockUserPrompt.confirm.mockReturnValue(false);
       saveGameUI.selectedSlotData = {
         slotId: 0,
         isEmpty: false,
@@ -427,7 +430,7 @@ describe('SaveGameUI', () => {
 
       const result = saveGameUI._validateAndConfirmSave();
 
-      expect(window.confirm).toHaveBeenCalled();
+      expect(mockUserPrompt.confirm).toHaveBeenCalled();
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
Summary: Implemented `IUserPrompt` interface to decouple confirmation dialogs from browser APIs and injected it into SaveGameUI and LoadGameUI. Added `WindowUserPrompt` as default implementation and updated dependency registrations and tests.

Changes Made:
- Created `IUserPrompt` interface and `WindowUserPrompt` implementation.
- Registered `IUserPrompt` in DI container and exported in domUI index.
- Updated SaveGameUI and LoadGameUI constructors and logic to use injected user prompt.
- Updated unit tests for new dependency.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`) *(fails: many existing warnings/errors)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_685ac0c0c9d88331bd8a5b3b0f3806ce