### PR TITLE
[Test] use accessor helpers in engine test bed

### DIFF
--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -24,6 +24,7 @@ export class BaseTestBed {
      * Collection of mocks used by the test bed.
      *
      * @type {Record<string, object>}
+     * @private
      */
     this.mocks = mocks;
 

--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -281,18 +281,18 @@ export const expectShowSaveGameUIDispatch = createDispatchAsserter(
  * @returns {void}
  */
 export function expectStartSuccess(bed, engine, world) {
-  expect(bed.mocks.entityManager.clearAll).toHaveBeenCalled();
-  expect(bed.mocks.playtimeTracker.reset).toHaveBeenCalled();
+  expect(bed.getEntityManager().clearAll).toHaveBeenCalled();
+  expect(bed.getPlaytimeTracker().reset).toHaveBeenCalled();
   expect(bed.env.mockContainer.resolve).toHaveBeenCalledWith(
     tokens.IInitializationService
   );
   expect(
-    bed.mocks.initializationService.runInitializationSequence
+    bed.getInitializationService().runInitializationSequence
   ).toHaveBeenCalledWith(world);
-  expect(bed.mocks.playtimeTracker.startSession).toHaveBeenCalled();
-  expect(bed.mocks.turnManager.start).toHaveBeenCalled();
+  expect(bed.getPlaytimeTracker().startSession).toHaveBeenCalled();
+  expect(bed.getTurnManager().start).toHaveBeenCalled();
   expectDispatchSequence(
-    bed.mocks.safeEventDispatcher.dispatch,
+    bed.getSafeEventDispatcher().dispatch,
     buildStartDispatches(world)
   );
   expectEngineRunning(engine, world);
@@ -307,14 +307,14 @@ export function expectStartSuccess(bed, engine, world) {
  * @returns {void}
  */
 export function expectStopSuccess(bed, engine) {
-  expect(bed.mocks.playtimeTracker.endSessionAndAccumulate).toHaveBeenCalled();
-  expect(bed.mocks.turnManager.stop).toHaveBeenCalled();
+  expect(bed.getPlaytimeTracker().endSessionAndAccumulate).toHaveBeenCalled();
+  expect(bed.getTurnManager().stop).toHaveBeenCalled();
   expectDispatchSequence(
-    bed.mocks.safeEventDispatcher.dispatch,
+    bed.getSafeEventDispatcher().dispatch,
     ...buildStopDispatches()
   );
   expectEngineStopped(engine);
-  expect(bed.mocks.logger.warn).not.toHaveBeenCalled();
+  expect(bed.getLogger().warn).not.toHaveBeenCalled();
 }
 
 /**

--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -177,7 +177,7 @@ export function setupLoadGameSpies(engine) {
  * @returns {void}
  */
 export function mockInitializationSuccess(bed) {
-  bed.mocks.initializationService.runInitializationSequence.mockResolvedValue({
+  bed.getInitializationService().runInitializationSequence.mockResolvedValue({
     success: true,
   });
 }

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -15,7 +15,9 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
- * environment and exposes helpers for common test operations.
+ * environment and exposes helpers for common test operations. Public getter
+ * methods expose commonly used service mocks while the underlying mock
+ * collection remains internal.
  * @class
  */
 const StoppableMixin = createStoppableMixin('engine');
@@ -56,6 +58,69 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
     const engine = env.instance || env.createInstance();
     this.env = env;
     this.engine = engine;
+  }
+
+  /**
+   * Returns the logger mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockLogger>} Logger mock.
+   */
+  getLogger() {
+    return this.logger;
+  }
+
+  /**
+   * Returns the entity manager mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockEntityManager>} Entity manager mock.
+   */
+  getEntityManager() {
+    return this.entityManager;
+  }
+
+  /**
+   * Returns the turn manager mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockTurnManager>} Turn manager mock.
+   */
+  getTurnManager() {
+    return this.turnManager;
+  }
+
+  /**
+   * Returns the game persistence service mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockGamePersistenceService>} Persistence service mock.
+   */
+  getGamePersistenceService() {
+    return this.gamePersistenceService;
+  }
+
+  /**
+   * Returns the playtime tracker mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockPlaytimeTracker>} Playtime tracker mock.
+   */
+  getPlaytimeTracker() {
+    return this.playtimeTracker;
+  }
+
+  /**
+   * Returns the validated event dispatcher mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockSafeEventDispatcher>} Dispatcher mock.
+   */
+  getSafeEventDispatcher() {
+    return this.safeEventDispatcher;
+  }
+
+  /**
+   * Returns the initialization service mock.
+   *
+   * @returns {ReturnType<import('../mockFactories').createMockInitializationService>} Initialization service mock.
+   */
+  getInitializationService() {
+    return this.initializationService;
   }
   /**
    * Initializes the engine using a default successful initialization result.

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -127,7 +127,7 @@ describe('runUnavailableServiceTest', () => {
 
     const testCases = runUnavailableServiceTest(cases, (bed, engine) => {
       engine.showLoadGameUI();
-      return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+      return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
     });
 
     expect(Array.isArray(testCases)).toBe(true);

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -60,8 +60,8 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
       container: testBed.env.mockContainer,
     });
     expect(testBed.engine).toBe(engine);
-    expect(testBed.logger).toBe(testBed.env.mocks.logger);
-    expect(testBed.turnManager).toBe(testBed.env.mocks.turnManager);
+    expect(testBed.getLogger()).toBe(testBed.env.mocks.logger);
+    expect(testBed.getTurnManager()).toBe(testBed.env.mocks.turnManager);
   });
 
   it('start presets initialization result and calls startNewGame', async () => {
@@ -166,7 +166,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     await testBed.cleanup();
 
     const restored = testBed.env.mockContainer.resolve(tokens.PlaytimeTracker);
-    expect(restored).toBe(testBed.playtimeTracker);
+    expect(restored).toBe(testBed.getPlaytimeTracker());
   });
 
   it('constructor overrides return specified value', async () => {
@@ -183,34 +183,34 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
   });
 
   it('resetMocks clears all spy call history', () => {
-    testBed.logger.info('log');
-    testBed.entityManager.clearAll();
-    testBed.turnManager.start();
-    testBed.gamePersistenceService.saveGame();
-    testBed.playtimeTracker.startSession();
-    testBed.safeEventDispatcher.dispatch();
-    testBed.initializationService.runInitializationSequence();
+    testBed.getLogger().info('log');
+    testBed.getEntityManager().clearAll();
+    testBed.getTurnManager().start();
+    testBed.getGamePersistenceService().saveGame();
+    testBed.getPlaytimeTracker().startSession();
+    testBed.getSafeEventDispatcher().dispatch();
+    testBed.getInitializationService().runInitializationSequence();
 
-    expect(testBed.logger.info).toHaveBeenCalled();
-    expect(testBed.entityManager.clearAll).toHaveBeenCalled();
-    expect(testBed.turnManager.start).toHaveBeenCalled();
-    expect(testBed.gamePersistenceService.saveGame).toHaveBeenCalled();
-    expect(testBed.playtimeTracker.startSession).toHaveBeenCalled();
-    expect(testBed.safeEventDispatcher.dispatch).toHaveBeenCalled();
+    expect(testBed.getLogger().info).toHaveBeenCalled();
+    expect(testBed.getEntityManager().clearAll).toHaveBeenCalled();
+    expect(testBed.getTurnManager().start).toHaveBeenCalled();
+    expect(testBed.getGamePersistenceService().saveGame).toHaveBeenCalled();
+    expect(testBed.getPlaytimeTracker().startSession).toHaveBeenCalled();
+    expect(testBed.getSafeEventDispatcher().dispatch).toHaveBeenCalled();
     expect(
-      testBed.initializationService.runInitializationSequence
+      testBed.getInitializationService().runInitializationSequence
     ).toHaveBeenCalled();
 
     testBed.resetMocks();
 
-    expect(testBed.logger.info).not.toHaveBeenCalled();
-    expect(testBed.entityManager.clearAll).not.toHaveBeenCalled();
-    expect(testBed.turnManager.start).not.toHaveBeenCalled();
-    expect(testBed.gamePersistenceService.saveGame).not.toHaveBeenCalled();
-    expect(testBed.playtimeTracker.startSession).not.toHaveBeenCalled();
-    expect(testBed.safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(testBed.getLogger().info).not.toHaveBeenCalled();
+    expect(testBed.getEntityManager().clearAll).not.toHaveBeenCalled();
+    expect(testBed.getTurnManager().start).not.toHaveBeenCalled();
+    expect(testBed.getGamePersistenceService().saveGame).not.toHaveBeenCalled();
+    expect(testBed.getPlaytimeTracker().startSession).not.toHaveBeenCalled();
+    expect(testBed.getSafeEventDispatcher().dispatch).not.toHaveBeenCalled();
     expect(
-      testBed.initializationService.runInitializationSequence
+      testBed.getInitializationService().runInitializationSequence
     ).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -64,7 +64,7 @@ describeEngineSuite('GameEngine', (context) => {
         `GameEngine: Failed to resolve core services. ${resolutionError.message}`
       );
 
-      expect(testBed.mocks.logger.error).toHaveBeenCalledWith(
+      expect(testBed.getLogger().error).toHaveBeenCalledWith(
         `GameEngine: CRITICAL - Failed to resolve one or more core services. Error: ${resolutionError.message}`,
         resolutionError
       );

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -31,22 +31,22 @@ describeEngineSuite('GameEngine', (context) => {
 
     beforeEach(() => {
       context.bed.resetMocks();
-      context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
-        {
+      context.bed
+        .getGamePersistenceService()
+        .loadAndRestoreGame.mockResolvedValue({
           success: true,
           data: typedMockSaveData,
-        }
-      );
+        });
     });
 
     it('should load and finalize a game successfully', async () => {
       const result = await context.engine.loadGame(SAVE_ID);
 
       expect(
-        context.bed.mocks.gamePersistenceService.loadAndRestoreGame
+        context.bed.getGamePersistenceService().loadAndRestoreGame
       ).toHaveBeenCalledWith(SAVE_ID);
       expectDispatchSequence(
-        context.bed.mocks.safeEventDispatcher.dispatch,
+        context.bed.getSafeEventDispatcher().dispatch,
         [
           ENGINE_OPERATION_IN_PROGRESS_UI,
           {
@@ -62,7 +62,7 @@ describeEngineSuite('GameEngine', (context) => {
           },
         ]
       );
-      expect(context.bed.mocks.turnManager.start).toHaveBeenCalled();
+      expect(context.bed.getTurnManager().start).toHaveBeenCalled();
       expect(result).toEqual({ success: true, data: typedMockSaveData });
       expectEngineRunning(context.engine, typedMockSaveData.metadata.gameTitle);
     });
@@ -71,23 +71,23 @@ describeEngineSuite('GameEngine', (context) => {
       const errorMsg = 'Restore operation failed';
 
       beforeEach(() => {
-        context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockResolvedValue(
-          {
+        context.bed
+          .getGamePersistenceService()
+          .loadAndRestoreGame.mockResolvedValue({
             success: false,
             error: errorMsg,
             data: null,
-          }
-        );
+          });
       });
 
       it('logs warning, dispatches failure UI and returns failure result', async () => {
         const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(context.bed.mocks.logger.warn).toHaveBeenCalledWith(
+        expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
           `GameEngine: Load/restore operation reported failure for "${SAVE_ID}".`
         );
         expectDispatchSequence(
-          context.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.getSafeEventDispatcher().dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -112,20 +112,20 @@ describeEngineSuite('GameEngine', (context) => {
       const errorObj = new Error('Execute failed');
 
       beforeEach(() => {
-        context.bed.mocks.gamePersistenceService.loadAndRestoreGame.mockRejectedValue(
-          errorObj
-        );
+        context.bed
+          .getGamePersistenceService()
+          .loadAndRestoreGame.mockRejectedValue(errorObj);
       });
 
       it('logs error, dispatches failure UI and returns failure result', async () => {
         const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(context.bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect(context.bed.getLogger().error).toHaveBeenCalledWith(
           `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${errorObj.message}`,
           errorObj
         );
         expectDispatchSequence(
-          context.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.getSafeEventDispatcher().dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -154,18 +154,18 @@ describeEngineSuite('GameEngine', (context) => {
       const errorObj = new Error('Finalize failed');
 
       beforeEach(() => {
-        context.bed.mocks.turnManager.start.mockRejectedValue(errorObj);
+        context.bed.getTurnManager().start.mockRejectedValue(errorObj);
       });
 
       it('logs error, dispatches failure UI and returns failure result', async () => {
         const result = await context.engine.loadGame(SAVE_ID);
 
-        expect(context.bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect(context.bed.getLogger().error).toHaveBeenCalledWith(
           `GameEngine: Overall catch in loadGame for identifier "${SAVE_ID}". Error: ${errorObj.message}`,
           errorObj
         );
         expectDispatchSequence(
-          context.bed.mocks.safeEventDispatcher.dispatch,
+          context.bed.getSafeEventDispatcher().dispatch,
           [
             ENGINE_OPERATION_IN_PROGRESS_UI,
             {
@@ -208,14 +208,14 @@ describeEngineSuite('GameEngine', (context) => {
       async (bed, engine, expectedMsg) => {
         const result = await engine.loadGame(SAVE_ID);
 
-        expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+        expectNoDispatch(bed.getSafeEventDispatcher().dispatch);
         // eslint-disable-next-line jest/no-standalone-expect
         expect(result).toEqual({
           success: false,
           error: expectedMsg,
           data: null,
         });
-        return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+        return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
       },
       2
     )(

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -11,11 +11,11 @@ describeEngineSuite('GameEngine', (context) => {
     it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
       context.engine.showLoadGameUI(); // Method is now sync
 
-      expect(context.bed.mocks.logger.debug).toHaveBeenCalledWith(
+      expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
       );
       expectShowLoadGameUIDispatch(
-        context.bed.mocks.safeEventDispatcher.dispatch
+        context.bed.getSafeEventDispatcher().dispatch
       );
     });
 
@@ -23,7 +23,7 @@ describeEngineSuite('GameEngine', (context) => {
       [[tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE]],
       (bed, engine) => {
         engine.showLoadGameUI();
-        return [bed.mocks.logger.error, bed.mocks.safeEventDispatcher.dispatch];
+        return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
       }
     )('should log error if %s is unavailable when showing load UI');
   });

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -13,39 +13,39 @@ describeInitializedEngineSuite(
   (context) => {
     describe('showSaveGameUI', () => {
       it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', () => {
-        context.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
-          true
-        );
+        context.bed
+          .getGamePersistenceService()
+          .isSavingAllowed.mockReturnValue(true);
         context.engine.showSaveGameUI(); // Method is now sync
 
-        expect(context.bed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
         );
         expect(
-          context.bed.mocks.gamePersistenceService.isSavingAllowed
+          context.bed.getGamePersistenceService().isSavingAllowed
         ).toHaveBeenCalledWith(true); // engine is initialized
         expectShowSaveGameUIDispatch(
-          context.bed.mocks.safeEventDispatcher.dispatch
+          context.bed.getSafeEventDispatcher().dispatch
         );
       });
 
       it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', () => {
-        context.bed.mocks.gamePersistenceService.isSavingAllowed.mockReturnValue(
-          false
-        );
+        context.bed
+          .getGamePersistenceService()
+          .isSavingAllowed.mockReturnValue(false);
         context.engine.showSaveGameUI(); // Method is now sync
 
-        expect(context.bed.mocks.logger.warn).toHaveBeenCalledWith(
+        expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Saving is not currently allowed.'
         );
         expect(
-          context.bed.mocks.gamePersistenceService.isSavingAllowed
+          context.bed.getGamePersistenceService().isSavingAllowed
         ).toHaveBeenCalledWith(true);
         expect(
-          context.bed.mocks.safeEventDispatcher.dispatch
+          context.bed.getSafeEventDispatcher().dispatch
         ).toHaveBeenCalledWith(CANNOT_SAVE_GAME_INFO);
         expect(
-          context.bed.mocks.safeEventDispatcher.dispatch
+          context.bed.getSafeEventDispatcher().dispatch
         ).toHaveBeenCalledTimes(1);
       });
 
@@ -55,12 +55,9 @@ describeInitializedEngineSuite(
           engine.showSaveGameUI();
           // eslint-disable-next-line jest/no-standalone-expect
           expect(
-            bed.mocks.gamePersistenceService.isSavingAllowed
+            bed.getGamePersistenceService().isSavingAllowed
           ).not.toHaveBeenCalled();
-          return [
-            bed.mocks.logger.error,
-            bed.mocks.safeEventDispatcher.dispatch,
-          ];
+          return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
         },
         1
       )('should log error if %s is unavailable when showing save UI');

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -52,15 +52,15 @@ describeEngineSuite('GameEngine', (context) => {
             await engine.stop();
 
             // eslint-disable-next-line jest/no-standalone-expect
-            expect(bed.mocks.logger.warn).toHaveBeenCalledWith(expectedMsg);
+            expect(bed.getLogger().warn).toHaveBeenCalledWith(expectedMsg);
             expectDispatchSequence(
-              bed.mocks.safeEventDispatcher.dispatch,
+              bed.getSafeEventDispatcher().dispatch,
               ...buildStopDispatches()
             );
             // eslint-disable-next-line jest/no-standalone-expect
-            expect(bed.mocks.turnManager.stop).toHaveBeenCalledTimes(1);
+            expect(bed.getTurnManager().stop).toHaveBeenCalledTimes(1);
             const dummyDispatch = jest.fn();
-            return [bed.mocks.logger.warn, dummyDispatch];
+            return [bed.getLogger().warn, dummyDispatch];
           },
           4
         )(
@@ -77,11 +77,11 @@ describeEngineSuite('GameEngine', (context) => {
       await context.engine.stop();
 
       expect(
-        context.bed.mocks.playtimeTracker.endSessionAndAccumulate
+        context.bed.getPlaytimeTracker().endSessionAndAccumulate
       ).not.toHaveBeenCalled();
-      expect(context.bed.mocks.turnManager.stop).not.toHaveBeenCalled();
+      expect(context.bed.getTurnManager().stop).not.toHaveBeenCalled();
       expect(
-        context.bed.mocks.safeEventDispatcher.dispatch
+        context.bed.getSafeEventDispatcher().dispatch
       ).not.toHaveBeenCalledWith(ENGINE_STOPPED_UI, expect.anything());
     });
   });

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -34,9 +34,9 @@ describeEngineSuite('GameEngine', (context) => {
       const expectedErrorMsg =
         'Game engine is not initialized. Cannot save game.';
 
-      expectNoDispatch(context.bed.mocks.safeEventDispatcher.dispatch);
+      expectNoDispatch(context.bed.getSafeEventDispatcher().dispatch);
       expect(
-        context.bed.mocks.gamePersistenceService.saveGame
+        context.bed.getGamePersistenceService().saveGame
       ).not.toHaveBeenCalled();
       expect(result).toEqual({ success: false, error: expectedErrorMsg });
     });
@@ -55,15 +55,15 @@ describeEngineSuite('GameEngine', (context) => {
           async (bed, engine) => {
             const result = await engine.triggerManualSave(SAVE_NAME);
 
-            expectNoDispatch(bed.mocks.safeEventDispatcher.dispatch);
+            expectNoDispatch(bed.getSafeEventDispatcher().dispatch);
             // eslint-disable-next-line jest/no-standalone-expect
             expect(result).toEqual({
               success: false,
               error: GAME_PERSISTENCE_SAVE_RESULT_UNAVAILABLE,
             });
             return [
-              bed.mocks.logger.error,
-              bed.mocks.safeEventDispatcher.dispatch,
+              bed.getLogger().error,
+              bed.getSafeEventDispatcher().dispatch,
             ];
           },
           2
@@ -71,19 +71,19 @@ describeEngineSuite('GameEngine', (context) => {
 
         it('should successfully save, dispatch all UI events in order, and return success result', async () => {
           const saveResultData = { success: true, filePath: 'path/to/my.sav' };
-          context.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
-            saveResultData
-          );
+          context.bed
+            .getGamePersistenceService()
+            .saveGame.mockResolvedValue(saveResultData);
 
           const result = await context.engine.triggerManualSave(SAVE_NAME);
 
           expectDispatchSequence(
-            context.bed.mocks.safeEventDispatcher.dispatch,
+            context.bed.getSafeEventDispatcher().dispatch,
             ...buildSaveDispatches(SAVE_NAME, saveResultData.filePath)
           );
 
           expect(
-            context.bed.mocks.gamePersistenceService.saveGame
+            context.bed.getGamePersistenceService().saveGame
           ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
           expect(result).toEqual(saveResultData);
         });
@@ -95,7 +95,7 @@ describeEngineSuite('GameEngine', (context) => {
             PersistenceErrorCodes.INVALID_SAVE_NAME,
             'Invalid save name provided. Please enter a valid name.'
           );
-          context.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue({
+          context.bed.getGamePersistenceService().saveGame.mockResolvedValue({
             success: false,
             error,
           });
@@ -103,12 +103,12 @@ describeEngineSuite('GameEngine', (context) => {
           const result = await context.engine.triggerManualSave('');
 
           expectDispatchSequence(
-            context.bed.mocks.safeEventDispatcher.dispatch,
+            context.bed.getSafeEventDispatcher().dispatch,
             ...buildSaveDispatches('')
           );
 
           expect(
-            context.bed.mocks.gamePersistenceService.saveGame
+            context.bed.getGamePersistenceService().saveGame
           ).toHaveBeenCalledWith('', true, MOCK_ACTIVE_WORLD_FOR_SAVE);
           expect(result.success).toBe(false);
           expect(result.error).toBe(error);
@@ -124,24 +124,24 @@ describeEngineSuite('GameEngine', (context) => {
           'should handle %s, dispatch UI events, and return failure result',
           async (_caseName, failureValue) => {
             if (failureValue instanceof Error) {
-              context.bed.mocks.gamePersistenceService.saveGame.mockRejectedValue(
-                failureValue
-              );
+              context.bed
+                .getGamePersistenceService()
+                .saveGame.mockRejectedValue(failureValue);
             } else {
-              context.bed.mocks.gamePersistenceService.saveGame.mockResolvedValue(
-                failureValue
-              );
+              context.bed
+                .getGamePersistenceService()
+                .saveGame.mockResolvedValue(failureValue);
             }
 
             const result = await context.engine.triggerManualSave(SAVE_NAME);
 
             expectDispatchSequence(
-              context.bed.mocks.safeEventDispatcher.dispatch,
+              context.bed.getSafeEventDispatcher().dispatch,
               ...buildSaveDispatches(SAVE_NAME)
             );
 
             expect(
-              context.bed.mocks.gamePersistenceService.saveGame
+              context.bed.getGamePersistenceService().saveGame
             ).toHaveBeenCalledWith(SAVE_NAME, true, MOCK_ACTIVE_WORLD_FOR_SAVE);
 
             const expectedResult =


### PR DESCRIPTION
Summary: Added getter methods to GameEngineTestBed to expose common service mocks and marked the internal mocks collection as private. Updated engine suite helpers and unit tests to use these accessors.

Changes Made:
- Added getLogger and related helpers in GameEngineTestBed
- Documented mocks property as private in BaseTestBed
- Updated dispatch helpers and engine tests to use accessor methods

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685ac6dc38048331abc7d213df3d3cb1