### PR TITLE
[Agent] add mock helpers for TurnManager tests

### DIFF
--- a/tests/common/turns/turnManagerTestBed.js
+++ b/tests/common/turns/turnManagerTestBed.js
@@ -261,6 +261,21 @@ export class TurnManagerTestBed extends EventCaptureMixin(
   }
 
   /**
+   * Configures {@link TurnManager.start} to fail by rejecting from
+   * {@link TurnManager.advanceTurn}.
+   *
+   * @param {Error} [error] - Optional error to reject with.
+   * @returns {import('@jest/globals').Mock} Spy on advanceTurn that rejects.
+   */
+  mockStartFailure(error = new Error('Start failure')) {
+    this.setupMockHandlerResolver();
+    const spy = this.spyOnAdvanceTurn();
+    spy.mockRejectedValue(error);
+    this.resetMocks();
+    return spy;
+  }
+
+  /**
    * Calls advanceTurn then flushes timers/promises.
    *
    * @returns {Promise<void>} Resolves when all timers are flushed.

--- a/tests/unit/turns/turnManager.getCurrentActor.test.js
+++ b/tests/unit/turns/turnManager.getCurrentActor.test.js
@@ -140,8 +140,7 @@ describeTurnManagerSuite('TurnManager', (getBed) => {
       expect(testBed.turnManager.getCurrentActor()).toBe(mockActor);
 
       // Simulate queue becoming empty
-      testBed.mocks.turnOrderService.isEmpty.mockResolvedValue(true);
-      testBed.mocks.turnOrderService.getNextEntity.mockResolvedValue(null);
+      testBed.mockEmptyQueue();
       testBed.setActiveEntities();
 
       // Simulate turn ending

--- a/tests/unit/turns/turnManager.lifecycle.test.js
+++ b/tests/unit/turns/turnManager.lifecycle.test.js
@@ -116,7 +116,7 @@ describeTurnManagerSuite('TurnManager - Lifecycle (Start/Stop)', (getBed) => {
 
     it('should handle advanceTurn failure gracefully', async () => {
       const advanceError = new Error('Turn advancement failed');
-      advanceTurnSpy.mockRejectedValue(advanceError);
+      advanceTurnSpy = testBed.mockStartFailure(advanceError);
 
       await expect(testBed.turnManager.start()).rejects.toThrow(
         'Turn advancement failed'


### PR DESCRIPTION
## Summary
- provide mockStartFailure helper
- use mockStartFailure in lifecycle test
- replace manual queue clearing with mockEmptyQueue

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many unrelated errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ac6bba97483319c24692312e5cb94