### PR TITLE
[Agent] categorize ui files and warn on unknown

### DIFF
--- a/docs/mods/loader.md
+++ b/docs/mods/loader.md
@@ -78,3 +78,4 @@ Reference them in the manifest using a `ui` content category:
 ```
 
 During loading, the UiLoader merges icon and label definitions from all mods. If multiple mods define the same key, the entry from the mod loaded last overrides earlier ones, following the same "last mod wins" rule used for other content.
+Files in the `ui/` folder that do not end with `icons.json` or `labels.json` are ignored and a warning is logged, allowing mods to ship extra files without breaking loading.

--- a/docs/mods/mod_manifest_format.md
+++ b/docs/mods/mod_manifest_format.md
@@ -82,7 +82,7 @@ The UiLoader validates these files against their schemas and merges the results 
 
 ### UiAssetsLoader Storage
 
-The `UiAssetsLoader` persists validated UI resources in the engine's data registry. Icon files are stored under the `ui_icons` key, while label files are stored under `ui_labels`. The loader chooses which schema to validate against based on the filename: include the word `"icon"` for files following `ui-icons.schema.json` and `"label"` for those following `ui-labels.schema.json`.
+The `UiAssetsLoader` persists validated UI resources in the engine's data registry. Icon files are stored under the `ui_icons` key, while label files are stored under `ui_labels`. Files ending in `icons.json` or `labels.json` are validated against the corresponding schema. Any other filenames are ignored and a warning is logged.
 
 ## Content Loading Order
 

--- a/tests/unit/loaders/uiAssetsLoader.test.js
+++ b/tests/unit/loaders/uiAssetsLoader.test.js
@@ -110,13 +110,23 @@ describe('UiAssetsLoader', () => {
     expect(result.errors).toBe(0);
   });
 
-  it('throws and warns on unknown filenames', async () => {
+  it('categorizes UI files correctly', () => {
+    const files = ['icons.json', 'labels.json', 'extra.txt'];
+    const result = loader.categorizeUiFilesForTest(files);
+
+    expect(result.iconFiles).toEqual(['icons.json']);
+    expect(result.labelFiles).toEqual(['labels.json']);
+    expect(result.unknownFiles).toEqual(['extra.txt']);
+  });
+
+  it('warns on unknown filenames without throwing', async () => {
     const manifest = { content: { ui: ['unknown.json'] } };
-    await expect(loader.loadUiAssetsForMod('ModX', manifest)).rejects.toThrow(
-      'Unknown UI asset file: unknown.json'
-    );
+    const result = await loader.loadUiAssetsForMod('ModX', manifest);
+
     expect(logger.warn).toHaveBeenCalledWith(
       'UiAssetsLoader [ModX]: Unknown file unknown.json'
     );
+    expect(result.count).toBe(0);
+    expect(result.errors).toBe(0);
   });
 });


### PR DESCRIPTION
Summary:
- add `#categorizeUiFiles` with a testing wrapper
- process categorized files in `loadUiAssetsForMod`
- warn and continue on unknown UI files
- document that unknown UI files are ignored with a warning
- update unit tests for `UiAssetsLoader`

Testing Done:
- `npm run format`
- `npm run lint`
- `npm test`
- `cd llm-proxy-server && npm run format && npm run lint && npm test`
- `npm run start` (manual smoke run)


------
https://chatgpt.com/codex/tasks/task_e_685ac69333ac83319ebad1b251211edc