### PR TITLE
[Agent] Add validation for component override data

### DIFF
--- a/src/entities/entityInstanceData.js
+++ b/src/entities/entityInstanceData.js
@@ -108,6 +108,9 @@ class EntityInstanceData {
     if (typeof componentTypeId !== 'string' || !componentTypeId.trim()) {
       throw new Error('Invalid componentTypeId for setComponentOverride.');
     }
+    if (typeof componentData !== 'object' || componentData === null) {
+      throw new TypeError('componentData must be a non-null object.');
+    }
     // Storing a clone to prevent external mutations of the provided data from affecting the instance.
     this.overrides[componentTypeId] = cloneDeep(componentData);
   }

--- a/tests/unit/entities/EntityInstanceData.test.js
+++ b/tests/unit/entities/EntityInstanceData.test.js
@@ -103,10 +103,11 @@ describe('EntityInstanceData', () => {
       expect(instanceData.getComponentData('non:existent')).toBeUndefined();
     });
 
-    it('should return null if override is explicitly null, even if component exists in definition', () => {
+    it('should throw a TypeError if override data is null', () => {
       const instanceData = new EntityInstanceData(validInstanceId, entityDef);
-      instanceData.setComponentOverride('core:health', null);
-      expect(instanceData.getComponentData('core:health')).toBeNull();
+      expect(() =>
+        instanceData.setComponentOverride('core:health', null)
+      ).toThrow(TypeError);
     });
 
     it('should return a clone, not the original override object, when override is an object', () => {
@@ -160,6 +161,13 @@ describe('EntityInstanceData', () => {
         'Invalid componentTypeId for setComponentOverride.'
       );
     });
+
+    it('should throw a TypeError if componentData is not an object', () => {
+      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      expect(() =>
+        instanceData.setComponentOverride('core:health', 42)
+      ).toThrow(TypeError);
+    });
   });
 
   describe('removeComponentOverride', () => {
@@ -204,10 +212,11 @@ describe('EntityInstanceData', () => {
       expect(instanceData.hasComponent('non:existent')).toBe(false);
     });
 
-    it('should return true even if override is null (component is considered present but nullified)', () => {
+    it('should throw a TypeError when attempting to set a null override', () => {
       const instanceData = new EntityInstanceData(validInstanceId, entityDef);
-      instanceData.setComponentOverride('core:health', null);
-      expect(instanceData.hasComponent('core:health')).toBe(true);
+      expect(() =>
+        instanceData.setComponentOverride('core:health', null)
+      ).toThrow(TypeError);
     });
   });
 

--- a/tests/unit/entities/entity.test.js
+++ b/tests/unit/entities/entity.test.js
@@ -132,9 +132,10 @@ describe('Entity Class', () => {
       expect(entity.getComponentData('non:existent')).toBeUndefined();
     });
 
-    it('should return null if the override is explicitly null', () => {
-      mockInstanceData.setComponentOverride('core:health', null);
-      expect(entity.getComponentData('core:health')).toBeNull();
+    it('should throw a TypeError if the override data is null', () => {
+      expect(() =>
+        mockInstanceData.setComponentOverride('core:health', null)
+      ).toThrow(TypeError);
     });
   });
 
@@ -263,19 +264,10 @@ describe('Entity Class', () => {
       expect(collectedData.length).toBe(3);
     });
 
-    it('should not yield data for components overridden to null', () => {
-      mockInstanceData.setComponentOverride('core:health', null); // Nullify
-      const collectedData = entity.allComponentData;
-
-      // Expected: 'core:name'
-      // 'core:health' should be absent from values, even if its key might appear in allComponentTypeIds
-      expect(
-        collectedData.some((data) => data && data.hasOwnProperty('current'))
-      ).toBe(false); // No health data
-      expect(
-        collectedData.find((data) => data && data.name === 'DefaultName')
-      ).toEqual({ name: 'DefaultName' });
-      expect(collectedData.length).toBe(1); // Only core:name
+    it('should throw a TypeError when setting a null override', () => {
+      expect(() =>
+        mockInstanceData.setComponentOverride('core:health', null)
+      ).toThrow(TypeError);
     });
   });
 
@@ -310,18 +302,10 @@ describe('Entity Class', () => {
       expect(collectedEntries.length).toBe(3);
     });
 
-    it('should not yield entries for components overridden to null', () => {
-      mockInstanceData.setComponentOverride('core:name', null);
-      const collectedEntries = entity.componentEntries;
-
-      expect(
-        collectedEntries.find(([id, _]) => id === 'core:name')
-      ).toBeUndefined();
-      expect(collectedEntries.length).toBe(1); // Only core:health
-      expect(collectedEntries[0]).toEqual([
-        'core:health',
-        { current: 100, max: 100 },
-      ]);
+    it('should throw a TypeError when overriding with null', () => {
+      expect(() =>
+        mockInstanceData.setComponentOverride('core:name', null)
+      ).toThrow(TypeError);
     });
   });
 


### PR DESCRIPTION
## Summary
- enforce that setComponentOverride only accepts non-null objects
- test that null and primitive values throw TypeError
- update Entity tests accordingly

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3180 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ac68839748331818fb5a59c4b6ccb