### PR TITLE
[Agent] log guard clearing failure

### DIFF
--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -145,8 +145,11 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
     if (ctx?.isAwaitingExternalEvent()) {
       try {
         ctx.setAwaitingExternalEvent(false, ctx.getActor().id);
-      } catch {
-        /* ignore */
+      } catch (err) {
+        getLogger(ctx, this._handler).warn(
+          `${this.getStateName()}: failed to clear awaitingExternalEvent flag – ${err.message}`,
+          err
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- improve cleanup in `AwaitingExternalTurnEndState`

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ac67571ac83318d515c9ab5cfd4bc