### PR TITLE
[Agent] use dataset key constants

### DIFF
--- a/src/constants/datasetKeys.js
+++ b/src/constants/datasetKeys.js
@@ -1,0 +1,35 @@
+/**
+ * @file Defines dataset attribute keys used across DOM UI components.
+ */
+
+/**
+ * Dataset key storing the numeric ID for save slots.
+ * Used by save-related modals.
+ *
+ * @type {string}
+ */
+export const DATASET_SLOT_ID = 'slotId';
+
+/**
+ * Dataset key storing the unique identifier string for save slots.
+ * Used by load-related modals.
+ *
+ * @type {string}
+ */
+export const DATASET_SLOT_IDENTIFIER = 'slotIdentifier';
+
+/**
+ * Dataset key storing the ID of an LLM option.
+ * Used by the LLM selection modal.
+ *
+ * @type {string}
+ */
+export const DATASET_LLM_ID = 'llmId';
+
+/**
+ * Dataset key storing the index for an action button.
+ * Used by the action buttons renderer.
+ *
+ * @type {string}
+ */
+export const DATASET_ACTION_INDEX = 'actionIndex';

--- a/src/domUI/actionButtonsRenderer.js
+++ b/src/domUI/actionButtonsRenderer.js
@@ -6,6 +6,13 @@
 
 import { SelectableListDisplayComponent } from './selectableListDisplayComponent.js';
 import { PLAYER_TURN_SUBMITTED_ID } from '../constants/eventIds.js';
+import { DATASET_ACTION_INDEX } from '../constants/datasetKeys.js';
+
+/**
+ * Dataset key storing the index for rendered action buttons.
+ *
+ * @constant {string}
+ */
 
 /**
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
@@ -126,7 +133,7 @@ export class ActionButtonsRenderer extends SelectableListDisplayComponent {
     };
 
     super({
-      datasetKey: 'actionIndex',
+      datasetKey: DATASET_ACTION_INDEX,
       logger,
       documentContext,
       validatedEventDispatcher,
@@ -225,7 +232,10 @@ export class ActionButtonsRenderer extends SelectableListDisplayComponent {
 
     button.title = buttonTooltip;
     button.setAttribute('role', 'radio');
-    button.setAttribute('data-action-index', String(actionIndex));
+    button.setAttribute(
+      `data-${DATASET_ACTION_INDEX.replace(/([A-Z])/g, '-$1').toLowerCase()}`,
+      String(actionIndex)
+    );
 
     button.addEventListener('click', () => {
       if (this.#isDisposed) return;
@@ -327,8 +337,12 @@ export class ActionButtonsRenderer extends SelectableListDisplayComponent {
     }
 
     if (this.selectedAction) {
+      const attrName = DATASET_ACTION_INDEX.replace(
+        /([A-Z])/g,
+        '-$1'
+      ).toLowerCase();
       const selectedButton = container.querySelector(
-        `button.action-button[data-action-index="${this.selectedAction.index}"]`
+        `button.action-button[data-${attrName}="${this.selectedAction.index}"]`
       );
       this._selectItem(selectedButton, this.selectedAction);
     } else {

--- a/src/domUI/llmSelectionModal.js
+++ b/src/domUI/llmSelectionModal.js
@@ -4,6 +4,13 @@
 import { SlotModalBase } from './slotModalBase.js';
 import { createSelectableItem } from './helpers/createSelectableItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
+import { DATASET_LLM_ID } from '../constants/datasetKeys.js';
+
+/**
+ * Dataset key storing the ID for LLM options.
+ *
+ * @constant {string}
+ */
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -76,7 +83,7 @@ export class LlmSelectionModal extends SlotModalBase {
       statusMessageElement: '#llm-selection-status-message',
     });
     super({
-      datasetKey: 'llmId',
+      datasetKey: DATASET_LLM_ID,
       logger,
       documentContext,
       validatedEventDispatcher,
@@ -351,7 +358,7 @@ export class LlmSelectionModal extends SlotModalBase {
    */
   async #handleLlmSelection(event) {
     const clickedItem = /** @type {HTMLElement} */ (event.currentTarget);
-    const selectedLlmId = clickedItem.dataset.llmId;
+    const selectedLlmId = clickedItem.dataset[DATASET_LLM_ID];
 
     if (!selectedLlmId) {
       this.logger.error(

--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -10,6 +10,13 @@ import {
 } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 import createEmptySlotMessage from './helpers/createEmptySlotMessage.js';
+import { DATASET_SLOT_IDENTIFIER } from '../constants/datasetKeys.js';
+
+/**
+ * Dataset key storing the unique string identifier on load slot elements.
+ *
+ * @constant {string}
+ */
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -70,7 +77,7 @@ class LoadGameUI extends SlotModalBase {
       validatedEventDispatcher,
       elementsConfig,
       domElementFactory,
-      datasetKey: 'slotIdentifier',
+      datasetKey: DATASET_SLOT_IDENTIFIER,
       confirmButtonKey: 'confirmLoadButtonEl',
       deleteButtonKey: 'deleteSaveButtonEl',
     });
@@ -257,7 +264,7 @@ class LoadGameUI extends SlotModalBase {
 
     return renderGenericSlotItem(
       this.domElementFactory,
-      'slotIdentifier',
+      DATASET_SLOT_IDENTIFIER,
       slotData.identifier,
       metadata,
       itemIndex,
@@ -558,7 +565,7 @@ class LoadGameUI extends SlotModalBase {
       if (firstSlot) {
         /** @type {HTMLElement} */ (firstSlot).focus();
         const firstSlotIdentifier = /** @type {HTMLElement} */ (firstSlot)
-          .dataset.slotIdentifier;
+          .dataset[DATASET_SLOT_IDENTIFIER];
         const firstSlotData = this.currentSlotsDisplayData.find(
           (s) => s.identifier === firstSlotIdentifier
         );

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -12,6 +12,13 @@ import {
 } from './helpers/renderSlotItem.js';
 import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js';
 import createEmptySlotMessage from './helpers/createEmptySlotMessage.js';
+import { DATASET_SLOT_ID } from '../constants/datasetKeys.js';
+
+/**
+ * Dataset key storing the numeric slot ID on save slot elements.
+ *
+ * @constant {string}
+ */
 
 /**
  * @typedef {import('../engine/gameEngine.js').default} GameEngine
@@ -81,7 +88,7 @@ export class SaveGameUI extends SlotModalBase {
       validatedEventDispatcher,
       elementsConfig,
       domElementFactory,
-      datasetKey: 'slotId',
+      datasetKey: DATASET_SLOT_ID,
       confirmButtonKey: 'confirmSaveButtonEl',
     });
 
@@ -291,7 +298,7 @@ export class SaveGameUI extends SlotModalBase {
 
     return renderGenericSlotItem(
       this.domElementFactory,
-      'slotId',
+      DATASET_SLOT_ID,
       slotData.slotId,
       metadata,
       itemIndex,

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -9,6 +9,13 @@ import { DomUtils } from '../utils/domUtils.js';
 import { setupRadioListNavigation } from '../utils/listNavigationUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
 import renderListCommon from './helpers/renderListCommon.js';
+import { DATASET_SLOT_ID } from '../constants/datasetKeys.js';
+
+/**
+ * Dataset key used to store the slot's numeric ID on DOM elements.
+ *
+ * @constant {string}
+ */
 
 /**
  * @class SlotModalBase
@@ -159,7 +166,7 @@ export class SlotModalBase extends BaseModalRenderer {
       this._datasetKey,
       (el, value) => {
         let slotData;
-        if (this._datasetKey === 'slotId') {
+        if (this._datasetKey === DATASET_SLOT_ID) {
           const slotId = parseInt(value || '-1', 10);
           slotData = this.currentSlotsDisplayData.find(
             (s) => s.slotId === slotId
@@ -180,7 +187,7 @@ export class SlotModalBase extends BaseModalRenderer {
       const target = /** @type {HTMLElement} */ (event.target);
       const value = target.dataset[this._datasetKey];
       let slotData;
-      if (this._datasetKey === 'slotId') {
+      if (this._datasetKey === DATASET_SLOT_ID) {
         const slotId = parseInt(value || '-1', 10);
         slotData = this.currentSlotsDisplayData.find(
           (s) => s.slotId === slotId


### PR DESCRIPTION
## Summary
- centralize dataset attribute names in `datasetKeys.js`
- use constants across UI components for readability
- document dataset keys via JSDoc

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3182 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `PORT=8081 npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685ac65589ec83319a042dd87fc7f988