### PR TITLE
[Agent] remove context utils internals export

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -7,12 +7,6 @@ import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
 
 // Re-export for backward compatibility
 export { resolveEntityNameFallback };
-
-// Expose internals for testing purposes
-export const _extractContextPath = PlaceholderResolver.extractContextPath;
-export const _resolvePlaceholderPath =
-  PlaceholderResolver.resolvePlaceholderPath;
-
 // PLACEHOLDER_FIND_REGEX and FULL_STRING_PLACEHOLDER_REGEX are imported from
 // placeholderResolverUtils.js to keep placeholder matching logic consistent.
 


### PR DESCRIPTION
## Summary
- stop exposing `_extractContextPath` and `_resolvePlaceholderPath`

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ac641ab708331a69acf4b2c719917