### PR TITLE
[Agent] Remove deprecated clone wrapper

### DIFF
--- a/src/utils/saveStateUtils.js
+++ b/src/utils/saveStateUtils.js
@@ -38,16 +38,3 @@ export function cloneValidatedState(obj, logger) {
 
   return createPersistenceSuccess(cloned);
 }
-
-/**
- * Wrapper for {@link cloneValidatedState} to maintain backward compatibility.
- *
- * @param {object} obj - Raw save state object to clone.
- * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for
- *   error reporting.
- * @returns {import('../persistence/persistenceTypes.js').PersistenceResult<object>}
- *   Clone result with validation outcome.
- */
-export function cloneAndValidateSaveState(obj, logger) {
-  return cloneValidatedState(obj, logger);
-}

--- a/tests/unit/utils/saveStateUtils.test.js
+++ b/tests/unit/utils/saveStateUtils.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../src/utils/cloneUtils.js', () => ({
   safeDeepClone: jest.fn(),
 }));
 
-const { cloneValidatedState, cloneAndValidateSaveState } = saveStateUtils;
+const { cloneValidatedState } = saveStateUtils;
 
 describe('saveStateUtils', () => {
   let logger;
@@ -49,15 +49,5 @@ describe('saveStateUtils', () => {
     expect(logger.error).toHaveBeenCalled();
     expect(result.success).toBe(false);
     expect(result.error.code).toBe(PersistenceErrorCodes.INVALID_GAME_STATE);
-  });
-
-  it('cloneAndValidateSaveState returns same result as cloneValidatedState', () => {
-    const obj = { gameState: {} };
-    cloneUtils.safeDeepClone.mockReturnValue({ success: true, data: obj });
-
-    const viaWrapper = cloneAndValidateSaveState(obj, logger);
-
-    expect(viaWrapper).toEqual({ success: true, data: obj });
-    expect(cloneUtils.safeDeepClone).toHaveBeenCalledWith(obj, logger);
   });
 });


### PR DESCRIPTION
## Summary
- remove `cloneAndValidateSaveState`
- update saveState utils tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3182 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ac624427083318755b6f284861492