### PR TITLE
[Agent] Refactor engine tests to avoid private APIs

### DIFF
--- a/tests/unit/engine/playtimeTracker.test.js
+++ b/tests/unit/engine/playtimeTracker.test.js
@@ -33,7 +33,8 @@ describe('PlaytimeTracker', () => {
       safeEventDispatcher: mockDispatcher,
     });
     tracker.startSession();
-    expect(tracker._getSessionStartTime()).toBe(BASE_TIME);
+    jest.setSystemTime(BASE_TIME + 3000);
+    expect(tracker.getTotalPlaytime()).toBe(3);
     expect(mockLogger.debug).toHaveBeenCalledWith(
       `PlaytimeTracker: Session started at ${BASE_TIME}`
     );
@@ -47,10 +48,11 @@ describe('PlaytimeTracker', () => {
     tracker.startSession();
     jest.setSystemTime(BASE_TIME + 1000);
     tracker.startSession();
+    jest.setSystemTime(BASE_TIME + 2000);
     expect(mockLogger.warn).toHaveBeenCalledWith(
       `PlaytimeTracker: startSession called while a session was already active (started at ${BASE_TIME}). Restarting session timer.`
     );
-    expect(tracker._getSessionStartTime()).toBe(BASE_TIME + 1000);
+    expect(tracker.getTotalPlaytime()).toBe(1);
   });
 
   test('endSessionAndAccumulate adds playtime when session active', () => {
@@ -61,8 +63,7 @@ describe('PlaytimeTracker', () => {
     tracker.startSession();
     jest.setSystemTime(BASE_TIME + 5000);
     tracker.endSessionAndAccumulate();
-    expect(tracker._getAccumulatedPlaytimeSeconds()).toBe(5);
-    expect(tracker._getSessionStartTime()).toBe(0);
+    expect(tracker.getTotalPlaytime()).toBe(5);
   });
 
   test('endSessionAndAccumulate with no session logs debug', () => {
@@ -81,7 +82,7 @@ describe('PlaytimeTracker', () => {
       logger: mockLogger,
       safeEventDispatcher: mockDispatcher,
     });
-    tracker._setAccumulatedPlaytimeSeconds(10);
+    tracker.setAccumulatedPlaytime(10);
     tracker.startSession();
     jest.setSystemTime(BASE_TIME + 3000);
     expect(tracker.getTotalPlaytime()).toBe(13);
@@ -101,11 +102,10 @@ describe('PlaytimeTracker', () => {
       logger: mockLogger,
       safeEventDispatcher: mockDispatcher,
     });
-    tracker._setAccumulatedPlaytimeSeconds(20);
+    tracker.setAccumulatedPlaytime(20);
     tracker.startSession();
     tracker.reset();
-    expect(tracker._getAccumulatedPlaytimeSeconds()).toBe(0);
-    expect(tracker._getSessionStartTime()).toBe(0);
+    expect(tracker.getTotalPlaytime()).toBe(0);
     expect(mockLogger.debug).toHaveBeenLastCalledWith(
       'PlaytimeTracker: Playtime reset.'
     );

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -37,7 +37,9 @@ describeEngineSuite('GameEngine', (context) => {
       await context.engine.startNewGame(DEFAULT_TEST_WORLD);
 
       expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
-        'GameEngine._prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
+        expect.stringContaining(
+          'Engine already initialized. Stopping existing game before starting new.'
+        )
       );
       expect(
         context.bed.getPlaytimeTracker().endSessionAndAccumulate


### PR DESCRIPTION
## Summary
- refactor PlaytimeTracker tests to use public API
- relax logger message check in startNewGame test

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`
- [x] `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685ad9948b448331bdba9a146d7a194b