### PR TITLE
[Agent] inject timers into AwaitingExternalTurnEndState

### DIFF
--- a/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -144,7 +144,12 @@ describe('AwaitingExternalTurnEndState', () => {
       return mockUnsubscribeFn;
     });
 
-    state = new AwaitingExternalTurnEndState(mockHandler, TIMEOUT_MS);
+    state = new AwaitingExternalTurnEndState(
+      mockHandler,
+      TIMEOUT_MS,
+      global.setTimeout,
+      global.clearTimeout
+    );
   });
 
   afterEach(() => {

--- a/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
@@ -68,7 +68,12 @@ describe('AwaitingExternalTurnEndState – action propagation', () => {
     };
 
     /* ── state under test ──────────────────────────────────────────────── */
-    state = new AwaitingExternalTurnEndState(mockHandler, TIMEOUT_MS);
+    state = new AwaitingExternalTurnEndState(
+      mockHandler,
+      TIMEOUT_MS,
+      global.setTimeout,
+      global.clearTimeout
+    );
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add injectable timers to `AwaitingExternalTurnEndState`
- use injected timers
- update tests to provide timers

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3184 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ad95d96c48331b80ede6d34520d7b