### PR TITLE
[Fix] Prevent external mutation of list arrays

### DIFF
--- a/src/domUI/helpers/renderListCommon.js
+++ b/src/domUI/helpers/renderListCommon.js
@@ -89,7 +89,7 @@ export async function renderListCommon(
       }
     }
     logger.debug('[renderListCommon] Empty list message displayed.');
-    return Array.isArray(listData) ? listData : null;
+    return Array.isArray(listData) ? Array.from(listData) : null;
   }
 
   let rendered = 0;
@@ -116,7 +116,7 @@ export async function renderListCommon(
     `[renderListCommon] Rendered ${rendered} out of ${listData.length} items.`
   );
 
-  return listData;
+  return Array.from(listData);
 }
 
 export default renderListCommon;

--- a/src/domUI/selectableListDisplayComponent.js
+++ b/src/domUI/selectableListDisplayComponent.js
@@ -174,7 +174,7 @@ export class SelectableListDisplayComponent extends BaseListDisplayComponent {
    * @returns {void}
    */
   _onListRendered(listData, container) {
-    this.currentListData = Array.isArray(listData) ? listData : [];
+    this.currentListData = Array.isArray(listData) ? Array.from(listData) : [];
 
     // Create the handler for arrow key navigation. This is what the test expects on render.
     this._arrowKeyHandler = setupRadioListNavigation(


### PR DESCRIPTION
Summary: Ensure list data is copied when stored or returned to avoid unintended mutations.

Changes Made:
- Clone `listData` when assigning `currentListData` in `SelectableListDisplayComponent`.
- Return a new array from `renderListCommon`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint ...`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_685ad95123c88331baad6ad602d71706