### PR TITLE
[Agent] Update service unavailable tests API

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -130,15 +130,16 @@ export function runUnavailableServiceTest(cases, invokeFn) {
  *   [import('@jest/globals').Mock, import('@jest/globals').Mock]} invokeFn -
  *   Function invoked during each test case. It should perform the call under
  *   test and return the logger and dispatch mocks to validate.
- * @param {number} [extraAssertions] - Additional assertions performed inside
- *   {@code invokeFn}.
+ * @param {{ extraAssertions?: number }} [options] - Additional options.
+ *   Use `extraAssertions` to specify the number of assertions performed
+ *   inside {@code invokeFn}.
  * @returns {(title: string) => void} Callback that runs the generated `it.each`
  *   suite when provided a test title.
  */
 export function generateServiceUnavailableTests(
   cases,
   invokeFn,
-  extraAssertions = 0
+  { extraAssertions = 0 } = {}
 ) {
   const eachFn = it.each(runUnavailableServiceTest(cases, invokeFn));
   return (title) =>

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -217,7 +217,7 @@ describeEngineSuite('GameEngine', (context) => {
         });
         return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
       },
-      2
+      { extraAssertions: 2 }
     )(
       'should handle %s unavailability (guard clause) and dispatch UI event directly'
     );

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -24,7 +24,8 @@ describeEngineSuite('GameEngine', (context) => {
       (bed, engine) => {
         engine.showLoadGameUI();
         return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
-      }
+      },
+      {}
     )('should log error if %s is unavailable when showing load UI');
   });
 });

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -59,7 +59,7 @@ describeInitializedEngineSuite(
           ).not.toHaveBeenCalled();
           return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
         },
-        1
+        { extraAssertions: 1 }
       )('should log error if %s is unavailable when showing save UI');
     });
   },

--- a/tests/unit/engine/stop.test.js
+++ b/tests/unit/engine/stop.test.js
@@ -62,7 +62,7 @@ describeEngineSuite('GameEngine', (context) => {
             const dummyDispatch = jest.fn();
             return [bed.getLogger().warn, dummyDispatch];
           },
-          4
+          { extraAssertions: 4 }
         )(
           'should log warning for %s if it is not available during stop, after a successful start'
         );

--- a/tests/unit/engine/triggerManualSave.test.js
+++ b/tests/unit/engine/triggerManualSave.test.js
@@ -66,7 +66,7 @@ describeEngineSuite('GameEngine', (context) => {
               bed.getSafeEventDispatcher().dispatch,
             ];
           },
-          2
+          { extraAssertions: 2 }
         )('should dispatch error if %s is unavailable');
 
         it('should successfully save, dispatch all UI events in order, and return success result', async () => {


### PR DESCRIPTION
## Summary
- refactor `generateServiceUnavailableTests` to accept options object
- update unit tests to use the new signature

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many pre-existing warnings/errors)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ade9e6d748331b3a45fbcbf94a71b