### PR TITLE
[Agent] Support dispatcher factories

### DIFF
--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -7,23 +7,26 @@ import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
  *
  * @description
  * Instantiates and returns a dispatcher when the execution context contains a
- * validatedEventDispatcher. A custom dispatcher class can be provided for
+ * validatedEventDispatcher. A custom dispatcher factory can be provided for
  * testing. Construction failures result in `null`.
  * @param {import('../logic/defs.js').ExecutionContext} executionContext - Execution context.
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger passed to the dispatcher.
- * @param {typeof SafeEventDispatcher} [DispatcherClass] -
- *   Class used to instantiate the dispatcher when needed.
+ * @param {(opts: {
+ * validatedEventDispatcher: import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher,
+ * logger: import('../interfaces/coreServices.js').ILogger
+ * }) => import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcherFactory]
+ *   Factory used to instantiate the dispatcher when needed.
  * @returns {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher | null}
  *   The resolved dispatcher or `null` when unavailable.
  */
 export function resolveSafeDispatcher(
   executionContext,
   logger,
-  DispatcherClass = SafeEventDispatcher
+  dispatcherFactory = (opts) => new SafeEventDispatcher(opts)
 ) {
   if (executionContext?.validatedEventDispatcher) {
     try {
-      return new DispatcherClass({
+      return dispatcherFactory({
         validatedEventDispatcher: executionContext.validatedEventDispatcher,
         logger,
       });

--- a/tests/unit/utils/dispatcherUtils.test.js
+++ b/tests/unit/utils/dispatcherUtils.test.js
@@ -32,7 +32,7 @@ describe('resolveSafeDispatcher', () => {
     expect(result).toBeNull();
   });
 
-  test('uses injected DispatcherClass', () => {
+  test('uses injected dispatcher factory', () => {
     const validated = {
       dispatch: jest.fn(),
       subscribe: jest.fn(),
@@ -46,17 +46,17 @@ describe('resolveSafeDispatcher', () => {
       debug: jest.fn(),
     };
     const spy = jest.fn();
-    class DummyDispatcher {
-      constructor({ validatedEventDispatcher, logger }) {
-        spy(validatedEventDispatcher, logger);
-        this.validatedEventDispatcher = validatedEventDispatcher;
-        this.logger = logger;
-      }
-    }
+    const factory = ({ validatedEventDispatcher, logger }) => {
+      spy(validatedEventDispatcher, logger);
+      return {
+        validatedEventDispatcher,
+        logger,
+      };
+    };
 
-    const result = resolveSafeDispatcher(execCtx, logger, DummyDispatcher);
+    const result = resolveSafeDispatcher(execCtx, logger, factory);
 
-    expect(result).toBeInstanceOf(DummyDispatcher);
+    expect(result).toEqual({ validatedEventDispatcher: validated, logger });
     expect(spy).toHaveBeenCalledWith(validated, logger);
   });
 });


### PR DESCRIPTION
## Summary
- allow `resolveSafeDispatcher` to accept a factory function
- default to creating `SafeEventDispatcher`
- adjust unit tests for custom dispatcher factory

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format && npm run lint && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ae03623788331b0d002b8b859e735