### PR TITLE
[Agent] Split placeholder resolver utilities

### DIFF
--- a/src/utils/contextUtils.js
+++ b/src/utils/contextUtils.js
@@ -1,5 +1,6 @@
 // src/utils/contextUtils.js
 import { PlaceholderResolver } from './placeholderResolverUtils.js';
+import { buildResolutionSources } from './placeholderSources.js';
 import { getEntityDisplayName } from './entityUtils.js';
 import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
 
@@ -36,8 +37,7 @@ export function resolvePlaceholders(
   skipKeys = []
 ) {
   const resolver = new PlaceholderResolver(logger);
-  const { sources, fallback } =
-    PlaceholderResolver.buildResolutionSources(executionContext);
+  const { sources, fallback } = buildResolutionSources(executionContext);
 
   return resolver.resolveStructure(input, sources, fallback, skipKeys);
 }

--- a/src/utils/placeholderParsing.js
+++ b/src/utils/placeholderParsing.js
@@ -1,0 +1,16 @@
+/**
+ * @module placeholderParsing
+ * @description Utilities for parsing placeholder syntax.
+ */
+
+/**
+ * Parses a placeholder key and determines whether it is optional.
+ *
+ * @param {string} key - Raw placeholder key.
+ * @returns {{ key: string, optional: boolean }} Parsed key and optional flag.
+ */
+export function parsePlaceholderKey(key) {
+  const trimmed = key.trim();
+  const optional = trimmed.endsWith('?');
+  return { key: optional ? trimmed.slice(0, -1) : trimmed, optional };
+}

--- a/src/utils/placeholderSources.js
+++ b/src/utils/placeholderSources.js
@@ -1,0 +1,46 @@
+/**
+ * @module placeholderSources
+ * @description Functions for assembling placeholder resolution sources.
+ */
+
+import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
+
+/**
+ * Builds the data sources for placeholder resolution.
+ *
+ * @param {object} executionContext - Execution context supplying actor, target,
+ *   and evaluationContext data.
+ * @returns {{sources: object[], fallback: object}} Sources array and fallback
+ *   object for use with PlaceholderResolver.
+ */
+export function buildResolutionSources(executionContext) {
+  const contextSource = {
+    context:
+      executionContext?.evaluationContext?.context &&
+      typeof executionContext.evaluationContext.context === 'object'
+        ? executionContext.evaluationContext.context
+        : {},
+  };
+
+  const fallback = {};
+  const actorName = resolveEntityNameFallback('actor.name', executionContext);
+  if (actorName !== undefined) {
+    fallback.actor = { name: actorName };
+  }
+  const targetName = resolveEntityNameFallback('target.name', executionContext);
+  if (targetName !== undefined) {
+    if (!fallback.target) fallback.target = {};
+    fallback.target.name = targetName;
+  }
+
+  const baseSource = { ...(executionContext ?? {}) };
+  delete baseSource.context;
+  const rootContextSource =
+    executionContext &&
+    Object.prototype.hasOwnProperty.call(executionContext, 'context')
+      ? { context: executionContext.context }
+      : {};
+  const sources = [rootContextSource, baseSource, contextSource];
+
+  return { sources, fallback };
+}

--- a/tests/unit/utils/contextUtils.test.js
+++ b/tests/unit/utils/contextUtils.test.js
@@ -12,11 +12,13 @@ import {
   resolvePlaceholders,
 } from '../../../src/utils/contextUtils.js';
 import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js';
+import { buildResolutionSources } from '../../../src/utils/placeholderSources.js';
 import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 import { NAME_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 
 // Mock dependencies
 jest.mock('../../../src/utils/placeholderResolverUtils.js');
+jest.mock('../../../src/utils/placeholderSources.js');
 jest.mock('../../../src/utils/entityUtils.js');
 
 const mockLogger = {
@@ -193,7 +195,7 @@ describe('contextUtils.js', () => {
         sources: [{ a: 1 }],
         fallback: { b: 2 },
       });
-      PlaceholderResolver.buildResolutionSources = mockBuildResolutionSources;
+      buildResolutionSources.mockImplementation(mockBuildResolutionSources);
     });
 
     test('should instantiate PlaceholderResolver with the provided logger', () => {

--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -8,10 +8,9 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
-import {
-  PlaceholderResolver,
-  parsePlaceholderKey,
-} from '../../../src/utils/placeholderResolverUtils.js'; // Adjust path as needed
+import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js';
+import { parsePlaceholderKey } from '../../../src/utils/placeholderParsing.js';
+import { buildResolutionSources } from '../../../src/utils/placeholderSources.js';
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed (assuming testUtils.js from previous adjustment)
 import * as loggerUtils from '../../../src/utils/loggerUtils.js';
 import { NAME_COMPONENT_ID } from '../../../src/constants/componentIds.js';
@@ -325,8 +324,7 @@ describe('PlaceholderResolver', () => {
         evaluationContext: { context: { val: 'foo' } },
         actor: { components: { [NAME_COMPONENT_ID]: { text: 'Hero' } } },
       };
-      const { sources, fallback } =
-        PlaceholderResolver.buildResolutionSources(executionContext);
+      const { sources, fallback } = buildResolutionSources(executionContext);
       const result = resolver.resolveStructure(
         '{context.val} {actor.name}',
         sources,


### PR DESCRIPTION
Summary:
- factor parsePlaceholderKey into placeholderParsing
- expose buildResolutionSources in placeholderSources
- update PlaceholderResolver to import new helper
- adjust contextUtils and tests to use new modules

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 671 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ae0f9cf248331a9a5be23a847d368