### PR TITLE
[Agent] fix componentAccessUtils logging

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -135,7 +135,9 @@ export function resolveEntityInstance(entityOrId, entityManager, logger) {
   }
 
   if (entityOrId !== null && entityOrId !== undefined) {
-    log.debug('resolveEntityInstance: provided value is not a valid entity.');
+    moduleLogger.debug(
+      'resolveEntityInstance: provided value is not a valid entity.'
+    );
   }
 
   return null;

--- a/tests/unit/utils/componentAccessUtils.test.js
+++ b/tests/unit/utils/componentAccessUtils.test.js
@@ -165,4 +165,12 @@ describe('resolveEntityInstance', () => {
     };
     expect(resolveEntityInstance('missing', mgr)).toBeNull();
   });
+
+  it('logs debug for invalid value', () => {
+    const logger = createMockLogger();
+    expect(resolveEntityInstance(123, null, logger)).toBeNull();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[componentAccessUtils] resolveEntityInstance: provided value is not a valid entity.'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- update resolveEntityInstance to use moduleLogger
- add regression test for invalid value handling

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ae8219eac8331941faa62951fa1f1