### PR TITLE
[Agent] add slot button key config

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -80,8 +80,10 @@ class LoadGameUI extends SlotModalBase {
       elementsConfig,
       domElementFactory,
       datasetKey: DATASET_SLOT_IDENTIFIER,
-      confirmButtonKey: 'confirmLoadButtonEl',
-      deleteButtonKey: 'deleteSaveButtonEl',
+      buttonKeys: {
+        confirmKey: 'confirmLoadButtonEl',
+        deleteKey: 'deleteSaveButtonEl',
+      },
     });
     if (
       !saveLoadService ||

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -91,7 +91,7 @@ export class SaveGameUI extends SlotModalBase {
       elementsConfig,
       domElementFactory,
       datasetKey: DATASET_SLOT_ID,
-      confirmButtonKey: 'confirmSaveButtonEl',
+      buttonKeys: { confirmKey: 'confirmSaveButtonEl' },
     });
 
     if (

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -18,6 +18,15 @@ import { DATASET_SLOT_ID } from '../constants/datasetKeys.js';
  */
 
 /**
+ * Configuration object specifying the element keys for confirm and delete buttons.
+ * Both properties are optional.
+ *
+ * @typedef {object} SlotActionButtonKeys
+ * @property {string} [confirmKey] - Key of the confirm button element.
+ * @property {string} [deleteKey] - Key of the delete button element.
+ */
+
+/**
  * @class SlotModalBase
  * @augments BaseModalRenderer
  * @abstract
@@ -69,15 +78,20 @@ export class SlotModalBase extends BaseModalRenderer {
    *
    * @param {object} deps - Constructor dependencies.
    * @param {string} deps.datasetKey - Dataset key storing slot identifiers.
-   * @param {string} [deps.confirmButtonKey] - Key for confirm button element.
-   * @param {string} [deps.deleteButtonKey] - Key for delete button element.
+   * @param {SlotActionButtonKeys} [deps.buttonKeys] - Optional configuration for action button element keys.
    * @param {...any} deps.rest - Remaining dependencies forwarded to BaseModalRenderer.
    */
-  constructor({ datasetKey, confirmButtonKey, deleteButtonKey, ...rest }) {
+  constructor({ datasetKey, buttonKeys = {}, ...rest }) {
     super(rest);
     this._datasetKey = datasetKey;
-    this._confirmButtonKey = confirmButtonKey;
-    this._deleteButtonKey = deleteButtonKey;
+    if (typeof buttonKeys !== 'object' || buttonKeys === null) {
+      throw new Error(
+        `${this._logPrefix} 'buttonKeys' must be an object when provided.`
+      );
+    }
+    const { confirmKey, deleteKey } = buttonKeys;
+    this._confirmButtonKey = confirmKey;
+    this._deleteButtonKey = deleteKey;
   }
 
   /**


### PR DESCRIPTION
Summary: Introduced `SlotActionButtonKeys` configuration to manage confirm/delete buttons in slot modals. SlotModalBase constructor now validates this object and subclasses pass it via `buttonKeys` to simplify setup.

Changes Made:
- Added `SlotActionButtonKeys` typedef and constructor validation in `slotModalBase.js`.
- Updated SaveGameUI and LoadGameUI to use the new `buttonKeys` configuration when calling the base constructor.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_685ae8ec55f48331803df605c257602e