### PR TITLE
[Agent] add missing actorId reporting utility

### DIFF
--- a/src/turns/states/helpers/errorReportingUtils.js
+++ b/src/turns/states/helpers/errorReportingUtils.js
@@ -1,0 +1,38 @@
+/**
+ * @file Utilities for reporting missing actor IDs.
+ */
+
+/**
+ * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {import('../../../interfaces/coreServices.js').ILogger|Console} ILogger
+ */
+
+import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
+
+/**
+ * @description Dispatches a system warning and logs when an actor ID is missing.
+ * @param {ISafeEventDispatcher|null} dispatcher - Dispatcher for system errors.
+ * @param {ILogger} logger - Logger instance for warnings.
+ * @param {string|null|undefined} providedId - Actor ID originally supplied.
+ * @param {string} fallbackId - Fallback ID that will be used.
+ * @returns {void}
+ */
+export function reportMissingActorId(
+  dispatcher,
+  logger,
+  providedId,
+  fallbackId
+) {
+  const message = 'Actor ID must be provided but was missing.';
+  if (dispatcher) {
+    safeDispatchError(
+      dispatcher,
+      message,
+      { providedActorId: providedId ?? null, fallbackActorId: fallbackId },
+      logger
+    );
+  }
+  logger.warn(`Actor ID was missing; fell back to '${fallbackId}'.`);
+}
+
+// --- FILE END ---

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -13,6 +13,7 @@
 import { AbstractTurnState } from './abstractTurnState.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { reportMissingActorId } from './helpers/errorReportingUtils.js';
 import { UNKNOWN_ACTOR_ID } from '../../constants/unknownIds.js';
 import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 
@@ -196,20 +197,6 @@ export class TurnEndingState extends AbstractTurnState {
    * @returns {void}
    */
   _notifyMissingActorId(dispatcher, log, providedId) {
-    const message =
-      'TurnEndingState Constructor: actorToEndId must be provided.';
-    if (dispatcher) {
-      safeDispatchError(
-        dispatcher,
-        message,
-        {
-          providedActorId: providedId ?? null,
-        },
-        log
-      );
-    }
-    log.warn(
-      `TurnEndingState Constructor: actorToEndId was missing, fell back to '${this.#actorToEndId}'.`
-    );
+    reportMissingActorId(dispatcher, log, providedId, this.#actorToEndId);
   }
 }

--- a/tests/unit/turns/states/helpers/errorReportingUtils.test.js
+++ b/tests/unit/turns/states/helpers/errorReportingUtils.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { reportMissingActorId } from '../../../../../src/turns/states/helpers/errorReportingUtils.js';
+import { safeDispatchError } from '../../../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../../../src/utils/safeDispatchErrorUtils.js');
+
+describe('errorReportingUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('reportMissingActorId dispatches and logs warning', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = { warn: jest.fn() };
+
+    reportMissingActorId(dispatcher, logger, undefined, 'fb');
+
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.any(String),
+      { providedActorId: null, fallbackActorId: 'fb' },
+      logger
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('fb'));
+  });
+});

--- a/tests/unit/turns/states/turnEndingState.helpers.test.js
+++ b/tests/unit/turns/states/turnEndingState.helpers.test.js
@@ -49,11 +49,11 @@ describe('TurnEndingState helper methods', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       expect.any(String),
-      { providedActorId: null },
+      { providedActorId: null, fallbackActorId: 'h-actor' },
       logger
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('actorToEndId was missing')
+      expect.stringContaining('Actor ID was missing')
     );
   });
 


### PR DESCRIPTION
## Summary
- add `reportMissingActorId` utility for consistent warnings
- use new utility in `TurnEndingState`
- cover new helper with unit tests
- adjust existing tests to match new helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 676 errors, 2516 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ae903dc088331b6a934ed781c4be2