### PR TITLE
[Agent] Inject Proxy URL through DI

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -145,7 +145,7 @@ export function registerLlmInfrastructure(registrar, logger) {
       logger,
       executionEnvironment: 'client',
       projectRootPath: null,
-      proxyServerUrl: globalThis.process?.env?.PROXY_URL || undefined,
+      proxyServerUrl: c.resolve(tokens.ProxyUrl),
     });
     const apiKeyProvider = new ClientApiKeyProvider({
       logger,

--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -55,6 +55,7 @@ import GoalLoader from '../../loaders/goalLoader.js';
 import MacroLoader from '../../loaders/macroLoader.js';
 import ModManifestLoader from '../../modding/modManifestLoader.js';
 import ModsLoader from '../../loaders/modsLoader.js';
+import ModsLoadSession from '../../loaders/ModsLoadSession.js';
 import PromptTextLoader from '../../loaders/promptTextLoader.js';
 import RuleLoader from '../../loaders/ruleLoader.js';
 import SchemaLoader from '../../loaders/schemaLoader.js';
@@ -95,6 +96,9 @@ export function registerLoaders(container) {
   const registrar = new Registrar(container);
   const logger = container.resolve(tokens.ILogger);
   logger.debug('Loaders Registration: Starting...');
+
+  // Register proxy URL from environment variables (if provided)
+  registrar.value(tokens.ProxyUrl, globalThis.process?.env?.PROXY_URL);
 
   // === Core Infrastructure (unchanged) ===
   registrar.singletonFactory(
@@ -385,8 +389,7 @@ export function registerLoaders(container) {
       c.resolve(tokens.WorldPhase),
       c.resolve(tokens.SummaryPhase),
     ];
-    const ModsLoadSession = require('../../loaders/ModsLoadSession.js').default;
-    return new (require('../../loaders/modsLoader.js').default)({
+    return new ModsLoader({
       logger: c.resolve(tokens.ILogger),
       cache: c.resolve(tokens.ILoadCache),
       session: new ModsLoadSession({

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -26,6 +26,7 @@ import { freeze } from '../utils';
  * @property {DiToken} outputDiv - Token for the main output HTML element (legacy/direct access).
  * @property {DiToken} inputElement - Token for the command input HTML element (legacy/direct access).
  * @property {DiToken} titleElement - Token for the title HTML element (legacy/direct access).
+ * @property {DiToken} ProxyUrl - Token for the LLM proxy server URL.
  *
  * --- DOM UI Layer (Refactored) ---
  * @property {DiToken} IDocumentContext - Token for the DOM access abstraction service.
@@ -172,6 +173,7 @@ export const tokens = freeze({
   outputDiv: 'outputDiv', // Legacy/Direct access
   inputElement: 'inputElement', // Legacy/Direct access
   titleElement: 'titleElement', // Legacy/Direct access
+  ProxyUrl: 'ProxyUrl',
 
   // --- DOM UI Layer (Refactored) ---
   IDocumentContext: 'IDocumentContext',

--- a/tests/unit/config/registrations/loadersRegistrations.test.js
+++ b/tests/unit/config/registrations/loadersRegistrations.test.js
@@ -195,6 +195,7 @@ describe('registerLoaders (with Mock DI Container)', () => {
       tokens.IDataRegistry,
       tokens.IDataFetcher,
       tokens.ITextDataFetcher,
+      tokens.ProxyUrl,
       tokens.ILoadCache,
       // Specific Loaders
       tokens.SchemaLoader,
@@ -225,7 +226,7 @@ describe('registerLoaders (with Mock DI Container)', () => {
       tokens.WorldPhase,
       tokens.SummaryPhase,
     ];
-    const expectedRegistrationCount = expectedTokens.length; // This must be 33 now
+    const expectedRegistrationCount = expectedTokens.length; // Includes ProxyUrl
 
     // Expect 1 (ILogger from beforeEach) + all from registerLoaders
     expect(mockContainer.register).toHaveBeenCalledTimes(

--- a/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
@@ -71,6 +71,8 @@ describe('AI registration helpers', () => {
     container = new AppContainer();
     registrar = new Registrar(container);
 
+    container.register(tokens.ProxyUrl, 'http://proxy.test');
+
     // Reset all mocks and spies before each test
     jest.restoreAllMocks();
     jest.clearAllMocks();
@@ -141,6 +143,7 @@ describe('AI registration helpers', () => {
     it('should register IHttpClient using IValidatedEventDispatcher as fallback', () => {
       const fallbackContainer = new AppContainer();
       fallbackContainer.register(tokens.ILogger, logger);
+      fallbackContainer.register(tokens.ProxyUrl, 'http://proxy.test');
       fallbackContainer.register(tokens.IValidatedEventDispatcher, {
         dispatch: jest.fn(),
       });
@@ -258,7 +261,7 @@ describe('AI registration helpers', () => {
 
     test.each(services)(
       'should register $token correctly',
-      ({ token, Class }) => {
+      ({ token }) => {
         registerAIGameStateProviders(registrar, logger);
         expect(container.isRegistered(token)).toBe(true);
       }
@@ -295,7 +298,7 @@ describe('AI registration helpers', () => {
 
     test.each(pipelineSingletonServices)(
       'should register $token correctly',
-      ({ token, Class }) => {
+      ({ token }) => {
         registerAITurnPipeline(registrar, logger);
         expect(container.isRegistered(token)).toBe(true);
       }


### PR DESCRIPTION
Summary: Adds a new DI token for the LLM proxy URL and registers it during loader initialization. EnvironmentContext now resolves the proxy URL from the container. Tests supply a proxy URL when constructing containers.

Changes Made:
- defined `ProxyUrl` token and added to token registry
- registered proxy value via `registerLoaders`
- injected proxy URL into EnvironmentContext
- updated unit tests for container registrations

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint` on modified files)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685ae87d3a388331bdd8ef3753070e79