### PR TITLE
[Test] Add DOM UI instantiation tests

### DIFF
--- a/tests/domUI/loadGameUI.instantiate.test.js
+++ b/tests/domUI/loadGameUI.instantiate.test.js
@@ -1,0 +1,54 @@
+import { JSDOM } from 'jsdom';
+import LoadGameUI from '../../src/domUI/loadGameUI.js';
+import DocumentContext from '../../src/domUI/documentContext.js';
+import DomElementFactory from '../../src/domUI/domElementFactory.js';
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('LoadGameUI instantiation', () => {
+  it('can be created with mocked services and a custom DocumentContext', () => {
+    const html = `<!DOCTYPE html><body>
+      <div id="load-game-screen">
+        <div id="load-slots-container"></div>
+        <div id="load-game-status-message"></div>
+        <button id="confirm-load-button"></button>
+        <button id="delete-save-button"></button>
+        <button id="cancel-load-button"></button>
+      </div>
+    </body>`;
+    const dom = new JSDOM(html);
+    const document = dom.window.document;
+
+    const mockLogger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
+    const docContext = new DocumentContext(document, mockLogger);
+    const factory = new DomElementFactory(docContext);
+    const saveLoadService = {
+      listManualSaveSlots: jest.fn(),
+      deleteManualSave: jest.fn(),
+    };
+    const dispatcher = {
+      subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      dispatch: jest.fn(),
+    };
+    const userPrompt = { confirm: jest.fn(() => true) };
+
+    const ui = new LoadGameUI({
+      logger: mockLogger,
+      documentContext: docContext,
+      domElementFactory: factory,
+      saveLoadService,
+      validatedEventDispatcher: dispatcher,
+      userPrompt,
+    });
+
+    expect(ui).toBeInstanceOf(LoadGameUI);
+    expect(userPrompt.confirm).not.toHaveBeenCalled();
+    expect(typeof ui.show).toBe('function');
+    ui.show();
+    ui.hide();
+  });
+});

--- a/tests/domUI/saveGameUI.instantiate.test.js
+++ b/tests/domUI/saveGameUI.instantiate.test.js
@@ -1,0 +1,51 @@
+import { JSDOM } from 'jsdom';
+import SaveGameUI from '../../src/domUI/saveGameUI.js';
+import DocumentContext from '../../src/domUI/documentContext.js';
+import DomElementFactory from '../../src/domUI/domElementFactory.js';
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('SaveGameUI instantiation', () => {
+  it('can be created with mocked services and a custom DocumentContext', () => {
+    const html = `<!DOCTYPE html><body>
+      <div id="save-game-screen">
+        <button id="cancel-save-button"></button>
+        <div id="save-slots-container"></div>
+        <input id="save-name-input" />
+        <button id="confirm-save-button"></button>
+        <div id="save-game-status-message"></div>
+      </div>
+    </body>`;
+    const dom = new JSDOM(html);
+    const document = dom.window.document;
+
+    const mockLogger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
+    const docContext = new DocumentContext(document, mockLogger);
+    const factory = new DomElementFactory(docContext);
+    const saveLoadService = { listManualSaveSlots: jest.fn() };
+    const dispatcher = {
+      subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      dispatch: jest.fn(),
+    };
+    const userPrompt = { confirm: jest.fn(() => true) };
+
+    const ui = new SaveGameUI({
+      logger: mockLogger,
+      documentContext: docContext,
+      domElementFactory: factory,
+      saveLoadService,
+      validatedEventDispatcher: dispatcher,
+      userPrompt,
+    });
+
+    expect(ui).toBeInstanceOf(SaveGameUI);
+    expect(userPrompt.confirm).not.toHaveBeenCalled();
+    expect(typeof ui.show).toBe('function');
+    ui.show();
+    ui.hide();
+  });
+});


### PR DESCRIPTION
Summary: Add new Jest tests ensuring SaveGameUI and LoadGameUI can be created with mocked services using a custom DocumentContext.

Changes Made:
- Created tests/domUI/saveGameUI.instantiate.test.js
- Created tests/domUI/loadGameUI.instantiate.test.js

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and llm-proxy-server)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685aeea2d03c8331aaaa6f45ec10059f