### PR TITLE
[Agent] Centralize array modification modes

### DIFF
--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -15,7 +15,10 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
-import { advancedArrayModify } from '../utils/arrayModifyUtils.js';
+import {
+  advancedArrayModify,
+  ARRAY_MODIFICATION_MODES,
+} from '../utils/arrayModifyUtils.js';
 import { setByPath } from '../utils/objectPathUtils.js';
 
 /**
@@ -30,12 +33,13 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
   #dispatcher;
 
   /**
-   * @description Fetch the component and target array to modify.
-   * @param {string} entityId
-   * @param {string} componentType
-   * @param {string} field
-   * @param {ILogger} logger
-   * @returns {{data: object, array: Array}|null}
+   * Fetch the component and target array to modify.
+   *
+   * @param {string} entityId - The entity identifier.
+   * @param {string} componentType - Component type name.
+   * @param {string} field - Dot path to the array field.
+   * @param {ILogger} logger - Logger for warnings.
+   * @returns {{data: object, array: Array}|null} The cloned data and target array.
    * @private
    */
   #fetchTargetArray(entityId, componentType, field, logger) {
@@ -61,14 +65,15 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
   }
 
   /**
-   * @description Apply the requested modification to the array.
-   * @param {'push'|'push_unique'|'pop'|'remove_by_value'} mode
-   * @param {Array} targetArray
-   * @param {*} value
-   * @param {string} field
-   * @param {string} entityId
-   * @param {ILogger} logger
-   * @returns {{nextArray: Array, result: *, modified: boolean}|null}
+   * Apply the requested modification to the array.
+   *
+   * @param {'push'|'push_unique'|'pop'|'remove_by_value'} mode - Operation type.
+   * @param {Array} targetArray - The array to modify.
+   * @param {*} value - Value used for push-like modes.
+   * @param {string} field - Dot path to the array field.
+   * @param {string} entityId - The entity identifier.
+   * @param {ILogger} logger - Logger instance.
+   * @returns {{nextArray: Array, result: *, modified: boolean}|null} Modification outcome.
    * Returns a new array via `nextArray`; the original `targetArray` is never
    * mutated.
    * @private
@@ -78,8 +83,7 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
       `MODIFY_ARRAY_FIELD: Performing '${mode}' on field '${field}' for entity '${entityId}'.`
     );
 
-    const validModes = ['push', 'push_unique', 'pop', 'remove_by_value'];
-    if (!validModes.includes(mode)) {
+    if (!ARRAY_MODIFICATION_MODES.includes(mode)) {
       logger.warn(`MODIFY_ARRAY_FIELD: Unknown mode '${mode}'.`);
       return null;
     }
@@ -127,12 +131,13 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
   }
 
   /**
-   * @description Commit the modified component data back to the entity manager.
-   * @param {string} entityId
-   * @param {string} componentType
-   * @param {object} data
-   * @param {ILogger} logger
-   * @returns {boolean}
+   * Commit the modified component data back to the entity manager.
+   *
+   * @param {string} entityId - The entity identifier.
+   * @param {string} componentType - Component type name.
+   * @param {object} data - Modified component data.
+   * @param {ILogger} logger - Logger instance.
+   * @returns {boolean} True if commit succeeded.
    * @private
    */
   #commitChanges(entityId, componentType, data, logger) {
@@ -157,7 +162,9 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
   }
 
   /**
-   * @param {object} deps
+   * Create a new ModifyArrayFieldHandler.
+   *
+   * @param {object} deps - The handler dependencies.
    * @param {IEntityManager} deps.entityManager - The entity management service.
    * @param {ILogger} deps.logger - The logging service.
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for error events.

--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -11,7 +11,10 @@ import { resolvePath } from '../../utils/objectUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { cloneDeep } from 'lodash';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
-import { advancedArrayModify } from '../utils/arrayModifyUtils.js';
+import {
+  advancedArrayModify,
+  ARRAY_MODIFICATION_MODES,
+} from '../utils/arrayModifyUtils.js';
 import { setByPath } from '../utils/objectPathUtils.js';
 
 /**
@@ -26,7 +29,9 @@ class ModifyContextArrayHandler {
   #dispatcher;
 
   /**
-   * @param {object} deps
+   * Construct a new ModifyContextArrayHandler.
+   *
+   * @param {object} deps - The dependencies for the handler.
    * @param {ILogger} deps.logger - The logging service.
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for error events.
    */
@@ -111,14 +116,13 @@ class ModifyContextArrayHandler {
       try {
         // Attempt to stringify, but catch errors for complex objects or circular refs
         debugMessage += ` Value: ${JSON.stringify(value)}.`;
-      } catch (e) {
+      } catch {
         debugMessage += ` Value: [unable to stringify].`;
       }
     }
     log.debug(debugMessage);
 
-    const validModes = ['push', 'push_unique', 'pop', 'remove_by_value'];
-    if (!validModes.includes(mode)) {
+    if (!ARRAY_MODIFICATION_MODES.includes(mode)) {
       log.warn(`MODIFY_CONTEXT_ARRAY: Unknown mode '${mode}'.`);
       return;
     }

--- a/src/logic/utils/arrayModifyUtils.js
+++ b/src/logic/utils/arrayModifyUtils.js
@@ -1,4 +1,15 @@
 /**
+ * @description List of supported modification modes for array operations.
+ * @type {Array<'push'|'push_unique'|'pop'|'remove_by_value'>}
+ */
+export const ARRAY_MODIFICATION_MODES = [
+  'push',
+  'push_unique',
+  'pop',
+  'remove_by_value',
+];
+
+/**
  * Applies an array modification operation.
  *
  * @description Utility to mutate an array according to the given mode. It returns
@@ -30,11 +41,11 @@ export function applyArrayModification(mode, array, value, logger) {
 /**
  * Advanced modification with deep comparison and result return.
  *
- * @param {'push'|'push_unique'|'pop'|'remove_by_value'} mode
- * @param {any[]} array
- * @param {any} value
- * @param {import('../../interfaces/coreServices.js').ILogger} [logger]
- * @returns {{ nextArray: any[], result: any, modified: boolean }}
+ * @param {'push'|'push_unique'|'pop'|'remove_by_value'} mode - Operation type.
+ * @param {any[]} array - Array to operate on.
+ * @param {any} value - Value used for push-like operations.
+ * @param {import('../../interfaces/coreServices.js').ILogger} [logger] - Logger for errors.
+ * @returns {{ nextArray: any[], result: any, modified: boolean }} The next array, result, and modification flag.
  */
 export function advancedArrayModify(mode, array, value, logger) {
   if (!Array.isArray(array)) {


### PR DESCRIPTION
Summary: Extracted shared array modification modes constant and reused it across handlers for consistency.

Changes Made:
- Added `ARRAY_MODIFICATION_MODES` export in `arrayModifyUtils.js`.
- Replaced local arrays in `modifyArrayFieldHandler.js` and `modifyContextArrayHandler.js` with the new constant.
- Updated JSDoc comments and improved linting in touched files.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685ae86104708331a880f30be0156b2b