### PR TITLE
[Agent] extract movement lock helper

### DIFF
--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -10,7 +10,7 @@
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
-import { deepClone } from '../../utils/cloneUtils.js';
+import { updateMovementLock } from '../utils/movementUtils.js';
 
 /**
  * @class MergeClosenessCircleHandler
@@ -157,17 +157,7 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
   #lockMovement(memberIds) {
     for (const id of memberIds) {
       try {
-        const existing = this.#entityManager.getComponentData(
-          id,
-          'core:movement'
-        );
-        const move = existing
-          ? typeof structuredClone === 'function'
-            ? structuredClone(existing)
-            : deepClone(existing)
-          : {};
-        move.locked = true;
-        this.#entityManager.addComponent(id, 'core:movement', move);
+        updateMovementLock(this.#entityManager, id, true);
       } catch (err) {
         safeDispatchError(
           this.#dispatcher,

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -12,7 +12,7 @@ import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
-import { deepClone } from '../../utils/cloneUtils.js';
+import { updateMovementLock } from '../utils/movementUtils.js';
 
 class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
   /** @type {EntityManager} */
@@ -168,17 +168,7 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
    */
   #unlockMovement(ids) {
     for (const id of ids) {
-      const existing = this.#entityManager.getComponentData(
-        id,
-        'core:movement'
-      );
-      const move = existing
-        ? typeof structuredClone === 'function'
-          ? structuredClone(existing)
-          : deepClone(existing)
-        : {};
-      move.locked = false;
-      this.#entityManager.addComponent(id, 'core:movement', move);
+      updateMovementLock(this.#entityManager, id, false);
     }
   }
 }

--- a/src/logic/utils/movementUtils.js
+++ b/src/logic/utils/movementUtils.js
@@ -1,0 +1,22 @@
+// src/logic/utils/movementUtils.js
+
+import { deepClone } from '../../utils/cloneUtils.js';
+
+/**
+ * Update the locked state of an entity's movement component.
+ *
+ * @param {import('../../entities/entityManager.js').default} entityManager - Entity manager.
+ * @param {string} entityId - ID of the entity to update.
+ * @param {boolean} locked - Whether movement should be locked.
+ * @returns {void}
+ */
+export function updateMovementLock(entityManager, entityId, locked) {
+  const existing = entityManager.getComponentData(entityId, 'core:movement');
+  const move = existing
+    ? typeof structuredClone === 'function'
+      ? structuredClone(existing)
+      : deepClone(existing)
+    : {};
+  move.locked = locked;
+  entityManager.addComponent(entityId, 'core:movement', move);
+}


### PR DESCRIPTION
Summary: Refactored movement locking logic. Added `updateMovementLock` helper and used it in merge and remove closeness circle handlers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685ae8585ac0833189e4b30fff8667d0