### PR TITLE
[Agent] Centralize filename and totals utilities

### DIFF
--- a/src/loaders/LoadResultAggregator.js
+++ b/src/loaders/LoadResultAggregator.js
@@ -5,6 +5,8 @@
  * per mod and across all mods.
  */
 
+import { cloneTotals } from '../utils/cloneTotals.js';
+
 /**
  * Structure to hold aggregated results per content type.
  *
@@ -44,23 +46,7 @@ export class LoadResultAggregator {
    */
   constructor(totalCounts) {
     // Clone the totals object to ensure immutability
-    this.#totalCounts = this.#cloneTotals(totalCounts);
-  }
-
-  /**
-   * Clones the totals object using structuredClone if available (Node ≥17),
-   * otherwise falls back to JSON.parse(JSON.stringify(...)).
-   *
-   * @private
-   * @param {TotalResultsSummary} totals - The totals object to clone.
-   * @returns {TotalResultsSummary} A deep clone of the totals object.
-   */
-  #cloneTotals(totals) {
-    if (typeof structuredClone !== 'undefined') {
-      return structuredClone(totals);
-    } else {
-      return JSON.parse(JSON.stringify(totals));
-    }
+    this.#totalCounts = cloneTotals(totalCounts);
   }
 
   /**
@@ -69,7 +55,7 @@ export class LoadResultAggregator {
    * @returns {TotalResultsSummary} A copy of the current total counts.
    */
   getTotalCounts() {
-    return this.#cloneTotals(this.#totalCounts);
+    return cloneTotals(this.#totalCounts);
   }
 
   /**

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -16,7 +16,7 @@ import { parseAndValidateId } from '../utils/idUtils.js';
 import { validateAgainstSchema } from '../utils/schemaValidationUtils.js';
 import { validateDependencies } from '../utils/validationUtils.js';
 import { storeItemInRegistry } from './helpers/registryStoreUtils.js';
-import { resolvePath } from '../utils/objectUtils.js';
+import { extractValidFilenames } from './helpers/filenameUtils.js';
 
 // --- Add LoadItemsResult typedef here for clarity ---
 /**
@@ -278,39 +278,7 @@ export class BaseManifestItemLoader extends AbstractLoader {
    * @returns {string[]} An array of valid, non-empty filenames. Returns empty array if key is missing, not an array, or contains no valid filenames.
    */
   _extractValidFilenames(manifest, contentKey, modId) {
-    const filenames = resolvePath(manifest?.content, contentKey);
-    if (filenames === null || filenames === undefined) {
-      this._logger.debug(
-        `Mod '${modId}': Content key '${contentKey}' not found or is null/undefined in manifest. Skipping.`
-      );
-      return [];
-    }
-    if (!Array.isArray(filenames)) {
-      this._logger.warn(
-        `Mod '${modId}': Expected an array for content key '${contentKey}' but found type '${typeof filenames}'. Skipping.`
-      );
-      return [];
-    }
-    const validFilenames = filenames
-      .filter((element) => {
-        if (typeof element !== 'string') {
-          this._logger.warn(
-            `Mod '${modId}': Invalid non-string entry found in '${contentKey}' list:`,
-            element
-          );
-          return false;
-        }
-        const trimmedElement = element.trim();
-        if (trimmedElement === '') {
-          this._logger.warn(
-            `Mod '${modId}': Empty string filename found in '${contentKey}' list after trimming. Skipping.`
-          );
-          return false;
-        }
-        return true;
-      })
-      .map((element) => element.trim());
-    return validFilenames;
+    return extractValidFilenames(manifest, contentKey, modId, this._logger);
   }
 
   /**

--- a/src/loaders/phases/contentPhase.js
+++ b/src/loaders/phases/contentPhase.js
@@ -6,6 +6,7 @@ import {
   ModsLoaderErrorCode,
 } from '../../errors/modsLoaderPhaseError.js';
 import { logPhaseStart } from '../../utils/logPhaseStart.js';
+import { cloneTotals } from '../../utils/cloneTotals.js';
 
 /**
  * @typedef {import('../LoadContext.js').LoadContext} LoadContext
@@ -50,7 +51,7 @@ export default class ContentPhase extends LoaderPhase {
       );
 
       // Create a new object reference for totals to ensure immutability downstream.
-      const totalsSnapshot = this.#cloneTotals(ctx.totals);
+      const totalsSnapshot = cloneTotals(ctx.totals);
 
       // Create new frozen context with modifications
       const next = {
@@ -66,22 +67,6 @@ export default class ContentPhase extends LoaderPhase {
         'ContentPhase',
         e
       );
-    }
-  }
-
-  /**
-   * Clones the totals object using structuredClone if available (Node ≥17),
-   * otherwise falls back to JSON.parse(JSON.stringify(...)).
-   *
-   * @private
-   * @param {import('../LoadContext.js').TotalResultsSummary} totals - The totals object to clone.
-   * @returns {import('../LoadContext.js').TotalResultsSummary} A deep clone of the totals object.
-   */
-  #cloneTotals(totals) {
-    if (typeof structuredClone !== 'undefined') {
-      return structuredClone(totals);
-    } else {
-      return JSON.parse(JSON.stringify(totals));
     }
   }
 }

--- a/src/utils/cloneTotals.js
+++ b/src/utils/cloneTotals.js
@@ -1,0 +1,21 @@
+// src/utils/cloneTotals.js
+
+/**
+ * @file Utility function to clone totals objects used during content loading.
+ */
+
+/**
+ * @template T
+ * @description Creates a deep clone of the provided totals object.
+ * Falls back to JSON methods when `structuredClone` is unavailable.
+ * @param {T} totals - Totals object to clone.
+ * @returns {T} A deep clone of the totals object.
+ */
+export function cloneTotals(totals) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(totals);
+  }
+  return JSON.parse(JSON.stringify(totals));
+}
+
+export default cloneTotals;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,3 +11,4 @@ export * from './loggerUtils.js';
 export * from './logHelpers.js';
 export * from './objectUtils.js';
 export * from './cloneUtils.js';
+export * from './cloneTotals.js';


### PR DESCRIPTION
Summary:
- expose `extractValidFilenames` helper and use it in BaseManifestItemLoader
- add reusable `cloneTotals` utility
- use `cloneTotals` in ContentPhase and LoadResultAggregator
- re-export new util from utils index

Testing Done:
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test` in llm-proxy-server

------
https://chatgpt.com/codex/tasks/task_e_685ae80771a0833195327927ab879c80