### PR TITLE
[Agent] Extract memory storage provider helper

### DIFF
--- a/tests/common/mockFactories/container.js
+++ b/tests/common/mockFactories/container.js
@@ -168,30 +168,6 @@ export class MockContainer {
   }
 }
 
-/**
- * Creates a simple in-memory storage provider used by persistence tests.
- *
- * @returns {import('../../../src/interfaces/IStorageProvider.js').IStorageProvider} In-memory provider
- */
-export function createMemoryStorageProvider() {
-  const files = {};
-  return {
-    writeFileAtomically: jest.fn(async (path, data) => {
-      files[path] = data;
-      return { success: true };
-    }),
-    readFile: jest.fn(async (path) => files[path]),
-    listFiles: jest.fn(async () => Object.keys(files)),
-    deleteFile: jest.fn(async (path) => {
-      if (path in files) {
-        delete files[path];
-        return { success: true };
-      }
-      return { success: false, error: 'not found' };
-    }),
-    fileExists: jest.fn(async (path) => path in files),
-    ensureDirectoryExists: jest.fn(async () => {}),
-  };
-}
+export { default as createMemoryStorageProvider } from './memoryStorageProvider.js';
 
 export default createMockContainer;

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -7,6 +7,7 @@ export * from './dataFetcherMock.js';
 export * from './loaders.js';
 export * from './entities.js';
 export * from './container.js';
+export * from './memoryStorageProvider.js';
 
 // Explicit convenience exports
 export {

--- a/tests/common/mockFactories/memoryStorageProvider.js
+++ b/tests/common/mockFactories/memoryStorageProvider.js
@@ -1,0 +1,27 @@
+/**
+ * Creates a simple in-memory storage provider used by persistence tests.
+ *
+ * @returns {import('../../../src/interfaces/IStorageProvider.js').IStorageProvider} In-memory provider
+ */
+import { jest } from '@jest/globals';
+
+export default function createMemoryStorageProvider() {
+  const files = {};
+  return {
+    writeFileAtomically: jest.fn(async (path, data) => {
+      files[path] = data;
+      return { success: true };
+    }),
+    readFile: jest.fn(async (path) => files[path]),
+    listFiles: jest.fn(async () => Object.keys(files)),
+    deleteFile: jest.fn(async (path) => {
+      if (path in files) {
+        delete files[path];
+        return { success: true };
+      }
+      return { success: false, error: 'not found' };
+    }),
+    fileExists: jest.fn(async (path) => path in files),
+    ensureDirectoryExists: jest.fn(async () => {}),
+  };
+}


### PR DESCRIPTION
## Summary
- split memoryStorageProvider helper into its own file
- re-export memoryStorageProvider from container mock
- expose memoryStorageProvider via mockFactories index

## Testing
- `npm run lint` *(fails: 3188 problems)*
- `npm run test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af10bc0908331a0f3a223528bc6a1