### PR TITLE
[Agent] return error from safeResolvePath

### DIFF
--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -71,8 +71,9 @@ export function resolvePath(obj, propertyPath) {
  *   error reporting.
  * @param {string} [contextInfo] - Additional context included in log messages.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] - Dispatcher for system error events.
- * @returns {any | undefined} The resolved value or `undefined` when resolution
- *   fails.
+ * @returns {{ value: any | undefined, error: any | undefined }} Result object
+ *   containing the resolved value or `undefined` when resolution fails, and the
+ *   caught error if an exception occurred.
  */
 export function safeResolvePath(
   obj,
@@ -83,7 +84,8 @@ export function safeResolvePath(
 ) {
   const moduleLogger = ensureValidLogger(logger, 'ObjectUtils');
   try {
-    return resolvePath(obj, propertyPath);
+    const value = resolvePath(obj, propertyPath);
+    return { value, error: undefined };
   } catch (error) {
     const info = contextInfo ? ` (${contextInfo})` : '';
     const message = `Error resolving path "${propertyPath}"${info}`;
@@ -95,7 +97,7 @@ export function safeResolvePath(
     } else {
       moduleLogger.error(message, error);
     }
-    return undefined;
+    return { value: undefined, error };
   }
 }
 

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -125,13 +125,16 @@ export class PlaceholderResolver {
       return undefined;
     }
 
+    const { value, error } = safeResolvePath(
+      contextInfo.root,
+      contextInfo.path,
+      logger,
+      `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
+    );
+
     const resolvedValue =
-      safeResolvePath(
-        contextInfo.root,
-        contextInfo.path,
-        logger,
-        `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
-      ) ?? resolveEntityNameFallback(placeholderPath, executionContext, logger);
+      (error ? undefined : value) ??
+      resolveEntityNameFallback(placeholderPath, executionContext, logger);
 
     return resolvedValue;
   }
@@ -144,12 +147,13 @@ export class PlaceholderResolver {
    * @returns {any|undefined} Resolved value or undefined if not found.
    */
   resolvePath(obj, path) {
-    return safeResolvePath(
+    const { value } = safeResolvePath(
       obj,
       path,
       this.#logger,
       'PlaceholderResolver.resolvePath'
     );
+    return value;
   }
 
   /**

--- a/tests/unit/utils/contextUtils.private.test.js
+++ b/tests/unit/utils/contextUtils.private.test.js
@@ -65,7 +65,7 @@ describe('contextUtils private helpers', () => {
     });
 
     it('resolves path via safeResolvePath', () => {
-      safeResolvePath.mockReturnValue(42);
+      safeResolvePath.mockReturnValue({ value: 42, error: undefined });
       const exec = { actor: { id: 5 } };
       expect(_resolvePlaceholderPath('actor.id', exec, mockLogger)).toBe(42);
       expect(safeResolvePath).toHaveBeenCalledWith(
@@ -77,7 +77,10 @@ describe('contextUtils private helpers', () => {
     });
 
     it('uses resolveEntityNameFallback when safe resolution fails', () => {
-      safeResolvePath.mockReturnValue(undefined);
+      safeResolvePath.mockReturnValue({
+        value: undefined,
+        error: new Error('x'),
+      });
       resolveEntityNameFallback.mockReturnValue('Bob');
       const exec = { actor: { id: 'a1' } };
       expect(_resolvePlaceholderPath('actor.name', exec, mockLogger)).toBe(

--- a/tests/unit/utils/safeResolvePath.test.js
+++ b/tests/unit/utils/safeResolvePath.test.js
@@ -7,7 +7,8 @@ describe('safeResolvePath', () => {
     const logger = createMockLogger();
     const dispatcher = { dispatch: jest.fn() };
     const result = safeResolvePath({}, null, logger, 'unit-test', dispatcher);
-    expect(result).toBeUndefined();
+    expect(result.value).toBeUndefined();
+    expect(result.error).toBeInstanceOf(Error);
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ message: expect.stringContaining('unit-test') })
@@ -18,10 +19,18 @@ describe('safeResolvePath', () => {
   it('logs error when dispatcher not provided', () => {
     const logger = createMockLogger();
     const result = safeResolvePath({}, null, logger, 'unit-test');
-    expect(result).toBeUndefined();
+    expect(result.value).toBeUndefined();
+    expect(result.error).toBeInstanceOf(Error);
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('unit-test'),
       expect.any(Error)
     );
+  });
+
+  it('returns value when resolution succeeds', () => {
+    const logger = createMockLogger();
+    const obj = { a: { b: 1 } };
+    const result = safeResolvePath(obj, 'a.b', logger);
+    expect(result).toEqual({ value: 1, error: undefined });
   });
 });


### PR DESCRIPTION
## Summary
- return `{ value, error }` from `safeResolvePath`
- handle the new result object in `PlaceholderResolver`
- update tests for new API

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 671 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685afbbe96a88331947924e117a816d5