### PR TITLE
[Agent] Rename registrar variables

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -478,16 +478,16 @@ export function registerAITurnHandler(registrar, logger) {
  * @param {AppContainer} container - The DI container.
  */
 export function registerAI(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   /** @type {ILogger} */
   const logger = container.resolve(tokens.ILogger);
   logger.debug('AI Systems Registration: Starting...');
 
-  registerLlmInfrastructure(r, logger);
-  registerPromptingEngine(r, logger);
-  registerAIGameStateProviders(r, logger);
-  registerAITurnPipeline(r, logger);
+  registerLlmInfrastructure(registrar, logger);
+  registerPromptingEngine(registrar, logger);
+  registerAIGameStateProviders(registrar, logger);
+  registerAITurnPipeline(registrar, logger);
   registerActorAwareStrategy(container);
-  registerAITurnHandler(r, logger);
+  registerAITurnHandler(registrar, logger);
   logger.debug('AI Systems Registration: All registrations complete.');
 }

--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -45,14 +45,14 @@ import ScopeCache, { LRUCache } from '../../scopeDsl/cache.js';
  * @param container
  */
 export function registerInfrastructure(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   /** @type {ILogger} */
   const log = container.resolve(tokens.ILogger);
 
   log.debug('Infrastructure Registration: starting…');
 
   // ─── Shared ActionIndexingService ─────────────────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ActionIndexingService,
     // ActionIndexingService needs { logger }
     (c) =>
@@ -64,7 +64,7 @@ export function registerInfrastructure(container) {
     `Infrastructure Registration: Registered ${String(tokens.ActionIndexingService)}.`
   );
 
-  r.single(tokens.EventBus, EventBus);
+  registrar.single(tokens.EventBus, EventBus);
   log.debug(
     `Infrastructure Registration: Registered ${String(tokens.EventBus)}.`
   );
@@ -115,7 +115,7 @@ export function registerInfrastructure(container) {
     `Infrastructure Registration: Registered ${String(tokens.IValidatedEventDispatcher)}.`
   );
 
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ISafeEventDispatcher,
     (c) =>
       new SafeEventDispatcher({
@@ -130,13 +130,13 @@ export function registerInfrastructure(container) {
   );
 
   // Scope DSL Engine
-  r.single(tokens.ScopeEngine, ScopeEngine);
+  registrar.single(tokens.ScopeEngine, ScopeEngine);
   log.debug(
     `Infrastructure Registration: Registered ${String(tokens.ScopeEngine)}.`
   );
 
   // Scope DSL Cache (wraps ScopeEngine with caching)
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ScopeCache,
     (c) =>
       new ScopeCache({

--- a/src/dependencyInjection/registrations/initializerRegistrations.js
+++ b/src/dependencyInjection/registrations/initializerRegistrations.js
@@ -13,12 +13,12 @@ import { INITIALIZABLE } from '../tags.js';
  * @param container
  */
 export function registerInitializers(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   const log = container.resolve(tokens.ILogger); // For logging within this function
 
   // --- WorldInitializer (Ticket 15 & Current Ticket) ---
   // Updated to use factory for object dependency constructor
-  r.singletonFactory(tokens.WorldInitializer, (c) => {
+  registrar.singletonFactory(tokens.WorldInitializer, (c) => {
     const dependencies = {
       entityManager: c.resolve(tokens.IEntityManager),
       worldContext: c.resolve(tokens.IWorldContext),
@@ -35,7 +35,7 @@ export function registerInitializers(container) {
 
   // --- SystemInitializer (Ticket 15) ---
   // Updated to use factory for object dependency constructor
-  r.singletonFactory(tokens.SystemInitializer, (c) => {
+  registrar.singletonFactory(tokens.SystemInitializer, (c) => {
     const dependencies = {
       resolver: c, // Pass the container (AppContainer) as the resolver
       logger: c.resolve(tokens.ILogger),

--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -43,12 +43,12 @@ import { BrowserStorageProvider } from '../../storage/browserStorageProvider.js'
  * @param {AppContainer} container - The DI container.
  */
 export function registerPersistence(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   /** @type {ILogger} */
   const logger = container.resolve(tokens.ILogger);
   logger.debug('Persistence Registration: Starting...');
 
-  r.single(tokens.IStorageProvider, BrowserStorageProvider, [
+  registrar.single(tokens.IStorageProvider, BrowserStorageProvider, [
     tokens.ILogger,
     tokens.ISafeEventDispatcher,
   ]);
@@ -56,7 +56,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.IStorageProvider)}.`
   );
 
-  r.singletonFactory(tokens.ISaveFileRepository, (c) => {
+  registrar.singletonFactory(tokens.ISaveFileRepository, (c) => {
     const logger = c.resolve(tokens.ILogger);
     const storageProvider = c.resolve(tokens.IStorageProvider);
     const serializer = new GameStateSerializer({
@@ -77,7 +77,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.ISaveFileRepository)}.`
   );
 
-  r.singletonFactory(tokens.ISaveLoadService, (c) =>
+  registrar.singletonFactory(tokens.ISaveLoadService, (c) =>
     createSaveLoadService({
       logger: c.resolve(tokens.ILogger),
       storageProvider: c.resolve(tokens.IStorageProvider),
@@ -87,7 +87,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.ISaveLoadService)}.`
   );
 
-  r.single(tokens.PlaytimeTracker, PlaytimeTracker, [
+  registrar.single(tokens.PlaytimeTracker, PlaytimeTracker, [
     tokens.ILogger,
     tokens.ISafeEventDispatcher,
   ]);
@@ -95,7 +95,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.PlaytimeTracker)}.`
   );
 
-  r.singletonFactory(tokens.ComponentCleaningService, (c) => {
+  registrar.singletonFactory(tokens.ComponentCleaningService, (c) => {
     const logger = c.resolve(tokens.ILogger);
     return new ComponentCleaningService({
       logger,
@@ -107,20 +107,23 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.ComponentCleaningService)}.`
   );
 
-  r.single(tokens.SaveMetadataBuilder, SaveMetadataBuilder, [tokens.ILogger]);
+  registrar.single(tokens.SaveMetadataBuilder, SaveMetadataBuilder, [
+    tokens.ILogger,
+  ]);
   logger.debug(
     `Persistence Registration: Registered ${String(tokens.SaveMetadataBuilder)}.`
   );
 
-  r.single(tokens.ActiveModsManifestBuilder, ActiveModsManifestBuilder, [
-    tokens.ILogger,
-    tokens.IDataRegistry,
-  ]);
+  registrar.single(
+    tokens.ActiveModsManifestBuilder,
+    ActiveModsManifestBuilder,
+    [tokens.ILogger, tokens.IDataRegistry]
+  );
   logger.debug(
     `Persistence Registration: Registered ${String(tokens.ActiveModsManifestBuilder)}.`
   );
 
-  r.singletonFactory(tokens.GameStateCaptureService, (c) => {
+  registrar.singletonFactory(tokens.GameStateCaptureService, (c) => {
     return new GameStateCaptureService({
       logger: c.resolve(tokens.ILogger),
       entityManager: c.resolve(tokens.IEntityManager),
@@ -134,7 +137,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.GameStateCaptureService)}.`
   );
 
-  r.singletonFactory(tokens.ManualSaveCoordinator, (c) => {
+  registrar.singletonFactory(tokens.ManualSaveCoordinator, (c) => {
     return new ManualSaveCoordinator({
       logger: c.resolve(tokens.ILogger),
       gameStateCaptureService: c.resolve(tokens.GameStateCaptureService),
@@ -145,7 +148,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.ManualSaveCoordinator)}.`
   );
 
-  r.singletonFactory(tokens.GamePersistenceService, (c) => {
+  registrar.singletonFactory(tokens.GamePersistenceService, (c) => {
     return new GamePersistenceService({
       logger: c.resolve(tokens.ILogger),
       saveLoadService: c.resolve(tokens.ISaveLoadService),
@@ -164,7 +167,7 @@ export function registerPersistence(container) {
     `Persistence Registration: Registered ${String(tokens.GamePersistenceService)}.`
   );
 
-  // r.singletonFactory(tokens.IReferenceResolver, (c) => { // Removed - service is deprecated
+  // registrar.singletonFactory(tokens.IReferenceResolver, (c) => { // Removed - service is deprecated
   //   return new ReferenceResolver({
   //     entityManager: c.resolve(tokens.IEntityManager),
   //     logger: c.resolve(tokens.ILogger),

--- a/src/dependencyInjection/registrations/registerActorAwareStrategy.js
+++ b/src/dependencyInjection/registrations/registerActorAwareStrategy.js
@@ -17,12 +17,12 @@ import { ActorAwareStrategyFactory } from '../../turns/factories/actorAwareStrat
  * @param {AppContainer} container - The DI container.
  */
 export function registerActorAwareStrategy(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   const logger = container.resolve(tokens.ILogger);
   logger.debug('[registerActorAwareStrategy] Starting...');
 
   if (!container.isRegistered(tokens.TurnActionChoicePipeline)) {
-    r.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
+    registrar.singletonFactory(tokens.TurnActionChoicePipeline, (c) => {
       return new TurnActionChoicePipeline({
         availableActionsProvider: c.resolve(tokens.IAvailableActionsProvider),
         logger: c.resolve(tokens.ILogger),
@@ -34,7 +34,7 @@ export function registerActorAwareStrategy(container) {
   }
 
   if (!container.isRegistered(tokens.ITurnActionFactory)) {
-    r.singletonFactory(
+    registrar.singletonFactory(
       tokens.ITurnActionFactory,
       () => new TurnActionFactory()
     );
@@ -44,7 +44,7 @@ export function registerActorAwareStrategy(container) {
   }
 
   if (!container.isRegistered(tokens.TurnStrategyFactory)) {
-    r.singletonFactory(tokens.TurnStrategyFactory, (c) => {
+    registrar.singletonFactory(tokens.TurnStrategyFactory, (c) => {
       const opts = {
         providers: {
           human: c.resolve(tokens.IHumanDecisionProvider),

--- a/src/dependencyInjection/registrations/runtimeRegistrations.js
+++ b/src/dependencyInjection/registrations/runtimeRegistrations.js
@@ -28,7 +28,7 @@ import { Registrar } from '../registrarHelpers.js';
  * @param {AppContainer} container - The application's DI container.
  */
 export function registerRuntime(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   /** @type {ILogger} */
   const log = container.resolve(tokens.ILogger); // Use explicit type
   log.debug('Runtime Registration: Starting...'); // <<< Moved log up
@@ -39,7 +39,7 @@ export function registerRuntime(container) {
   // elsewhere, likely within the main application bootstrapping process
   // or initialization service, *after* the container is configured.
   // ====================================================================
-  // r.singletonFactory(tokens.GameLoop, c => { ... }); // <<< ENTIRE BLOCK REMOVED
+  // registrar.singletonFactory(tokens.GameLoop, c => { ... }); // <<< ENTIRE BLOCK REMOVED
   // log.info(`Runtime Registration: Registered ${tokens.GameLoop} (Singleton).`); // <<< REMOVED
 
   // Note: Other runtime services like TurnManager, TurnHandlerResolver etc.

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -29,19 +29,19 @@ import { assertValidEntity } from '../../utils/entityAssertionsUtils.js';
  * @param {import('../appContainer.js').default} container
  */
 export function registerTurnLifecycle(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   const logger = container.resolve(tokens.ILogger);
   logger.debug('Turn Lifecycle Registration: Starting...');
 
   // ───────────────────── Core singletons ─────────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ITurnOrderService,
     (c) => new TurnOrderService({ logger: c.resolve(tokens.ILogger) })
   );
-  r.single(tokens.ITurnStateFactory, ConcreteTurnStateFactory);
+  registrar.single(tokens.ITurnStateFactory, ConcreteTurnStateFactory);
 
   // ─────────────────── Turn-context factory ──────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ITurnContextFactory,
     (c) =>
       new ConcreteTurnContextFactory({
@@ -57,7 +57,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ────────────────── Prompt-layer services ──────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.ActionContextBuilder,
     (c) =>
       new ActionContextBuilder({
@@ -68,7 +68,7 @@ export function registerTurnLifecycle(container) {
       })
   );
 
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.IPlayerTurnEvents,
     (c) =>
       new ValidatedEventDispatcherAdapter({
@@ -76,7 +76,7 @@ export function registerTurnLifecycle(container) {
       })
   );
 
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.IPromptCoordinator,
     (c) =>
       new PromptCoordinator({
@@ -90,7 +90,7 @@ export function registerTurnLifecycle(container) {
     'Turn Lifecycle Registration: Registered Turn services and factories.'
   );
 
-  r.transientFactory(
+  registrar.transientFactory(
     tokens.IHumanDecisionProvider,
     (c) =>
       new HumanDecisionProvider({
@@ -101,7 +101,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ──────────────────── Validation Utils ─────────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.assertValidEntity,
     (c) => (entity, logger, contextName) =>
       assertValidEntity(
@@ -113,7 +113,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ───────────────── Turn Context Builder ────────────────────
-  r.transientFactory(
+  registrar.transientFactory(
     tokens.TurnContextBuilder,
     (c) =>
       new TurnContextBuilder({
@@ -124,7 +124,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ────────────────── Resolver & manager ──────────────────
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.TurnHandlerResolver,
     (c) =>
       new TurnHandlerResolver({
@@ -147,7 +147,7 @@ export function registerTurnLifecycle(container) {
     `Turn Lifecycle Registration: Registered ${tokens.TurnHandlerResolver} with singleton resolution.`
   );
 
-  r.tagged(INITIALIZABLE).singletonFactory(
+  registrar.tagged(INITIALIZABLE).singletonFactory(
     tokens.ITurnManager,
     (c) =>
       new TurnManager({
@@ -165,7 +165,7 @@ export function registerTurnLifecycle(container) {
   );
 
   // ─────────────── ITurnContext façade (read-only) ───────────────
-  r.transientFactory(tokens.ITurnContext, (c) => {
+  registrar.transientFactory(tokens.ITurnContext, (c) => {
     const tm = c.resolve(tokens.ITurnManager);
     return tm?.getActiveTurnHandler?.()?.getTurnContext?.() ?? null;
   });

--- a/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
+++ b/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
@@ -35,13 +35,13 @@ import { LocationQueryService } from '../../entities/locationQueryService.js';
  * @param {AppContainer} container - The DI container.
  */
 export function registerWorldAndEntity(container) {
-  const r = new Registrar(container);
+  const registrar = new Registrar(container);
   /** @type {ILogger} */
   const logger = container.resolve(tokens.ILogger);
   logger.debug('World and Entity Registration: Starting...');
 
   // --- IEntityManager (EntityManager implementation) ---
-  r.singletonFactory(tokens.IEntityManager, (c) => {
+  registrar.singletonFactory(tokens.IEntityManager, (c) => {
     const entityManager = new EntityManager({
       registry: /** @type {IDataRegistry} */ (c.resolve(tokens.IDataRegistry)),
       validator: /** @type {ISchemaValidator} */ (
@@ -66,7 +66,7 @@ export function registerWorldAndEntity(container) {
     `World and Entity Registration: Registered ${String(tokens.IEntityManager)}.`
   );
 
-  r.singletonFactory(
+  registrar.singletonFactory(
     tokens.IWorldContext,
     (c) =>
       new WorldContext(
@@ -81,24 +81,25 @@ export function registerWorldAndEntity(container) {
     `World and Entity Registration: Registered ${String(tokens.IWorldContext)}.`
   );
 
-  r.single(tokens.JsonLogicEvaluationService, JsonLogicEvaluationService, [
-    tokens.ILogger,
-    tokens.IGameDataRepository,
-  ]);
+  registrar.single(
+    tokens.JsonLogicEvaluationService,
+    JsonLogicEvaluationService,
+    [tokens.ILogger, tokens.IGameDataRepository]
+  );
   logger.debug(
     `World and Entity Registration: Registered ${String(
       tokens.JsonLogicEvaluationService
     )}.`
   );
 
-  r.single(tokens.ClosenessCircleService, closenessCircleService, []);
+  registrar.single(tokens.ClosenessCircleService, closenessCircleService, []);
   logger.debug(
     `World and Entity Registration: Registered ${String(
       tokens.ClosenessCircleService
     )}.`
   );
 
-  r.singletonFactory(tokens.EntityDisplayDataProvider, (c) => {
+  registrar.singletonFactory(tokens.EntityDisplayDataProvider, (c) => {
     return new EntityDisplayDataProvider({
       entityManager: /** @type {IEntityManager} */ (
         c.resolve(tokens.IEntityManager)
@@ -116,16 +117,15 @@ export function registerWorldAndEntity(container) {
   );
 
   // --- SpatialIndexSynchronizer ---
-  r.tagged(INITIALIZABLE).singletonFactory(
-    tokens.SpatialIndexSynchronizer,
-    (c) => {
+  registrar
+    .tagged(INITIALIZABLE)
+    .singletonFactory(tokens.SpatialIndexSynchronizer, (c) => {
       return new SpatialIndexSynchronizer({
         spatialIndexManager: c.resolve(tokens.ISpatialIndexManager),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         logger: c.resolve(tokens.ILogger),
       });
-    }
-  );
+    });
   logger.debug(
     `World and Entity Registration: Registered ${String(
       tokens.SpatialIndexSynchronizer
@@ -133,7 +133,7 @@ export function registerWorldAndEntity(container) {
   );
 
   // --- LocationQueryService ---
-  r.singletonFactory(tokens.LocationQueryService, (c) => {
+  registrar.singletonFactory(tokens.LocationQueryService, (c) => {
     return new LocationQueryService({
       spatialIndexManager: /** @type {ISpatialIndexManager} */ (
         c.resolve(tokens.ISpatialIndexManager)


### PR DESCRIPTION
## Summary
- rename the short `r` variable to `registrar` in registration modules

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685afbdfdce8833194ba13edddedbce9