### PR TITLE
[Agent] Refactor engine modules

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -1,0 +1,31 @@
+// src/engine/engineState.js
+
+/**
+ * Represents the mutable runtime state of the game engine.
+ * Tracks initialization status, loop status and the active world name.
+ *
+ * @class EngineState
+ */
+class EngineState {
+  constructor() {
+    /** @type {boolean} */
+    this.isInitialized = false;
+    /** @type {boolean} */
+    this.isGameLoopRunning = false;
+    /** @type {string | null} */
+    this.activeWorld = null;
+  }
+
+  /**
+   * Resets all state flags back to their defaults.
+   *
+   * @returns {void}
+   */
+  reset() {
+    this.isInitialized = false;
+    this.isGameLoopRunning = false;
+    this.activeWorld = null;
+  }
+}
+
+export default EngineState;

--- a/src/engine/gameSessionManager.js
+++ b/src/engine/gameSessionManager.js
@@ -1,0 +1,216 @@
+// src/engine/gameSessionManager.js
+
+import {
+  ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_READY_UI,
+} from '../constants/eventIds.js';
+
+/**
+ * @typedef {import('./engineState.js').default} EngineState
+ * @typedef {import('../turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager
+ * @typedef {import('../interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+/**
+ * Coordinates game session lifecycle tasks for starting and loading games.
+ *
+ * @class GameSessionManager
+ */
+class GameSessionManager {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {ITurnManager} */
+  #turnManager;
+  /** @type {IPlaytimeTracker} */
+  #playtimeTracker;
+  /** @type {ISafeEventDispatcher} */
+  #safeEventDispatcher;
+  /** @type {EngineState} */
+  #state;
+  /** @type {() => Promise<void>} */
+  #stopFn;
+  /** @type {() => Promise<void>} */
+  #resetCoreGameStateFn;
+
+  /**
+   * Creates a new GameSessionManager instance.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logger instance.
+   * @param {ITurnManager} deps.turnManager - Turn manager.
+   * @param {IPlaytimeTracker} deps.playtimeTracker - Playtime tracker.
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for UI events.
+   * @param {EngineState} deps.engineState - Engine state reference.
+   * @param {() => Promise<void>} deps.stopFn - Function to stop the engine.
+   * @param {() => Promise<void>} deps.resetCoreGameStateFn - Function to reset core state.
+   */
+  constructor({
+    logger,
+    turnManager,
+    playtimeTracker,
+    safeEventDispatcher,
+    engineState,
+    stopFn,
+    resetCoreGameStateFn,
+  }) {
+    this.#logger = logger;
+    this.#turnManager = turnManager;
+    this.#playtimeTracker = playtimeTracker;
+    this.#safeEventDispatcher = safeEventDispatcher;
+    this.#state = engineState;
+    this.#stopFn = stopFn;
+    this.#resetCoreGameStateFn = resetCoreGameStateFn;
+  }
+
+  /**
+   * Prepares for starting a new game session.
+   *
+   * @param {string} worldName - Name of the world to start.
+   * @returns {Promise<void>} Resolves when preparation completes.
+   */
+  async prepareForNewGameSession(worldName) {
+    if (this.#state.isInitialized) {
+      this.#logger.warn(
+        'GameSessionManager.prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
+      );
+      await this.#stopFn();
+    }
+    this.#state.activeWorld = worldName;
+    this.#logger.debug(
+      `GameSessionManager: Preparing new game session for world "${worldName}"...`
+    );
+  }
+
+  /**
+   * Finalizes a successful new game start.
+   *
+   * @param {string} worldName - Initialized world name.
+   * @returns {Promise<void>} Resolves when setup is complete.
+   */
+  async finalizeNewGameSuccess(worldName) {
+    this.#logger.debug(
+      `GameSessionManager.finalizeNewGameSuccess: Initialization successful for world "${worldName}". Finalizing new game setup.`
+    );
+
+    this.#state.isInitialized = true;
+    this.#state.isGameLoopRunning = true;
+
+    if (this.#playtimeTracker) {
+      this.#playtimeTracker.startSession();
+    } else {
+      this.#logger.warn(
+        'GameSessionManager.finalizeNewGameSuccess: PlaytimeTracker not available, cannot start session.'
+      );
+    }
+
+    this.#logger.debug(
+      'GameSessionManager.finalizeNewGameSuccess: Dispatching UI event for game ready.'
+    );
+    await this.#safeEventDispatcher.dispatch(ENGINE_READY_UI, {
+      activeWorld: this.#state.activeWorld,
+      message: 'Enter command...',
+    });
+
+    this.#logger.debug(
+      'GameSessionManager.finalizeNewGameSuccess: Starting TurnManager...'
+    );
+    if (this.#turnManager) {
+      await this.#turnManager.start();
+    } else {
+      this.#logger.error(
+        'GameSessionManager.finalizeNewGameSuccess: TurnManager not available. Game cannot start turns.'
+      );
+      throw new Error(
+        'GameSessionManager critical error: TurnManager service is unavailable during game finalization.'
+      );
+    }
+
+    this.#logger.debug(
+      `GameSessionManager.finalizeNewGameSuccess: New game started and ready (World: ${this.#state.activeWorld}).`
+    );
+  }
+
+  /**
+   * Prepares for loading a game session.
+   *
+   * @param {string} saveIdentifier - Identifier of the save to load.
+   * @returns {Promise<void>} Resolves when preparation completes.
+   */
+  async prepareForLoadGameSession(saveIdentifier) {
+    this.#logger.debug(
+      `GameSessionManager.prepareForLoadGameSession: Preparing to load game from identifier: ${saveIdentifier}`
+    );
+
+    if (this.#state.isInitialized || this.#state.isGameLoopRunning) {
+      await this.#stopFn();
+    }
+    await this.#resetCoreGameStateFn();
+
+    this.#logger.debug(
+      'GameSessionManager.prepareForLoadGameSession: Dispatching UI event for load operation in progress.'
+    );
+    const shortSaveName = saveIdentifier.split(/[/\\]/).pop() || saveIdentifier;
+    await this.#safeEventDispatcher.dispatch(ENGINE_OPERATION_IN_PROGRESS_UI, {
+      titleMessage: `Loading ${shortSaveName}...`,
+      inputDisabledMessage: `Loading game from ${shortSaveName}...`,
+    });
+  }
+
+  /**
+   * Finalizes a successful load operation.
+   *
+   * @param {import('../interfaces/ISaveLoadService.js').SaveGameStructure} loadedSaveData - Restored save data.
+   * @param {string} saveIdentifier - Identifier loaded from.
+   * @returns {Promise<{success: true, data: import('../interfaces/ISaveLoadService.js').SaveGameStructure}>}
+   *   Result object containing the loaded save data.
+   */
+  async finalizeLoadSuccess(loadedSaveData, saveIdentifier) {
+    this.#logger.debug(
+      `GameSessionManager.finalizeLoadSuccess: Game state restored successfully from ${saveIdentifier}. Finalizing load setup.`
+    );
+
+    this.#state.activeWorld =
+      loadedSaveData.metadata?.gameTitle || 'Restored Game';
+    this.#state.isInitialized = true;
+    this.#state.isGameLoopRunning = true;
+
+    if (this.#playtimeTracker) {
+      this.#playtimeTracker.startSession();
+    } else {
+      this.#logger.warn(
+        'GameSessionManager.finalizeLoadSuccess: PlaytimeTracker not available, cannot start session for loaded game.'
+      );
+    }
+
+    this.#logger.debug(
+      'GameSessionManager.finalizeLoadSuccess: Dispatching UI event for game ready (after load).'
+    );
+    await this.#safeEventDispatcher.dispatch(ENGINE_READY_UI, {
+      activeWorld: this.#state.activeWorld,
+      message: 'Enter command...',
+    });
+
+    this.#logger.debug(
+      'GameSessionManager.finalizeLoadSuccess: Starting TurnManager for loaded game...'
+    );
+    if (this.#turnManager) {
+      await this.#turnManager.start();
+    } else {
+      this.#logger.error(
+        'GameSessionManager.finalizeLoadSuccess: TurnManager not available. Loaded game may not function correctly.'
+      );
+      throw new Error(
+        'GameSessionManager critical error: TurnManager service is unavailable during loaded game finalization.'
+      );
+    }
+
+    this.#logger.debug(
+      `GameSessionManager.finalizeLoadSuccess: Game loaded from "${saveIdentifier}" (World: ${this.#state.activeWorld}) and resumed.`
+    );
+    return { success: true, data: loadedSaveData };
+  }
+}
+
+export default GameSessionManager;

--- a/src/engine/persistenceCoordinator.js
+++ b/src/engine/persistenceCoordinator.js
@@ -1,0 +1,227 @@
+// src/engine/persistenceCoordinator.js
+
+import {
+  GAME_SAVED_ID,
+  ENGINE_OPERATION_IN_PROGRESS_UI,
+  ENGINE_READY_UI,
+} from '../constants/eventIds.js';
+
+/**
+ * @typedef {import('./engineState.js').default} EngineState
+ * @typedef {import('../interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('./gameSessionManager.js').default} GameSessionManager
+ * @typedef {import('../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure
+ * @typedef {import('../interfaces/IGamePersistenceService.js').SaveResult} SaveResult
+ */
+
+/**
+ * Handles persistence operations such as saving and loading the game.
+ *
+ * @class PersistenceCoordinator
+ */
+class PersistenceCoordinator {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {IGamePersistenceService} */
+  #persistenceService;
+  /** @type {ISafeEventDispatcher} */
+  #dispatcher;
+  /** @type {GameSessionManager} */
+  #sessionManager;
+  /** @type {EngineState} */
+  #state;
+  /** @type {(err: string | Error, id: string) => Promise<{success: false, error: string, data: null}>} */
+  #handleLoadFailure;
+
+  /**
+   * Creates a new PersistenceCoordinator instance.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logger instance.
+   * @param {IGamePersistenceService} deps.gamePersistenceService - Persistence service.
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for UI events.
+   * @param {GameSessionManager} deps.sessionManager - Session manager instance.
+   * @param {EngineState} deps.engineState - Engine state reference.
+   * @param {(err: string | Error, id: string) => Promise<{success: false, error: string, data: null}>} deps.handleLoadFailure - Handler for load failures.
+   */
+  constructor({
+    logger,
+    gamePersistenceService,
+    safeEventDispatcher,
+    sessionManager,
+    engineState,
+    handleLoadFailure,
+  }) {
+    this.#logger = logger;
+    this.#persistenceService = gamePersistenceService;
+    this.#dispatcher = safeEventDispatcher;
+    this.#sessionManager = sessionManager;
+    this.#state = engineState;
+    this.#handleLoadFailure = handleLoadFailure;
+  }
+
+  /**
+   * Triggers a manual save of the current game state.
+   *
+   * @param {string} saveName - Desired save name.
+   * @returns {Promise<SaveResult>} Result of the save operation.
+   */
+  async triggerManualSave(saveName) {
+    this.#logger.debug(
+      `GameEngine.triggerManualSave: Manual save process initiated with name: "${saveName}"`
+    );
+
+    if (!this.#state.isInitialized) {
+      const errorMsg = 'Game engine is not initialized. Cannot save game.';
+      this.#logger.error(`GameEngine.triggerManualSave: ${errorMsg}`);
+      return { success: false, error: errorMsg };
+    }
+
+    if (!this.#persistenceService) {
+      const errorMsg =
+        'GamePersistenceService is not available. Cannot save game.';
+      this.#logger.error(`GameEngine.triggerManualSave: ${errorMsg}`);
+      return { success: false, error: errorMsg };
+    }
+
+    /** @type {SaveResult} */
+    let saveResult;
+
+    try {
+      this.#logger.debug(
+        `GameEngine.triggerManualSave: Dispatching ENGINE_OPERATION_IN_PROGRESS_UI for save: "${saveName}".`
+      );
+      await this.#dispatcher.dispatch(ENGINE_OPERATION_IN_PROGRESS_UI, {
+        titleMessage: 'Saving...',
+        inputDisabledMessage: `Saving game "${saveName}"...`,
+      });
+
+      saveResult = await this.#persistenceService.saveGame(
+        saveName,
+        true,
+        this.#state.activeWorld
+      );
+
+      if (saveResult.success) {
+        this.#logger.debug(
+          `GameEngine.triggerManualSave: Save successful. Name: "${saveName}", Path: ${saveResult.filePath || 'N/A'}`
+        );
+
+        await this.#dispatcher.dispatch(GAME_SAVED_ID, {
+          saveName: saveName,
+          path: saveResult.filePath,
+          type: 'manual',
+        });
+        this.#logger.debug(
+          `GameEngine.triggerManualSave: Dispatched GAME_SAVED_ID for "${saveName}".`
+        );
+
+        this.#logger.debug(
+          `GameEngine.triggerManualSave: Save successful. Name: "${saveName}".`
+        );
+      } else {
+        this.#logger.error(
+          `GameEngine.triggerManualSave: Save failed. Name: "${saveName}". Reported error: ${saveResult.error}`
+        );
+        this.#logger.debug(
+          `GameEngine.triggerManualSave: Save failed. Name: "${saveName}".`
+        );
+      }
+    } catch (error) {
+      const caughtErrorMsg =
+        error instanceof Error ? error.message : String(error);
+      this.#logger.error(
+        `GameEngine.triggerManualSave: Unexpected error during save operation for "${saveName}". Error: ${caughtErrorMsg}`,
+        error
+      );
+
+      saveResult = {
+        success: false,
+        error: `Unexpected error during save: ${caughtErrorMsg}`,
+      };
+    } finally {
+      this.#logger.debug(
+        `GameEngine.triggerManualSave: Dispatching ENGINE_READY_UI after save attempt for "${saveName}".`
+      );
+      await this.#dispatcher.dispatch(ENGINE_READY_UI, {
+        activeWorld: this.#state.activeWorld,
+        message: 'Save operation finished. Ready.',
+      });
+    }
+    return saveResult;
+  }
+
+  /**
+   * Calls the persistence service to load and restore game data.
+   *
+   * @param {string} saveIdentifier - Identifier of the save to load.
+   * @returns {Promise<import('../interfaces/IGamePersistenceService.js').LoadAndRestoreResult>} Outcome of the load.
+   */
+  async _executeLoadAndRestore(saveIdentifier) {
+    this.#logger.debug(
+      `GameEngine._executeLoadAndRestore: Calling IGamePersistenceService.loadAndRestoreGame for "${saveIdentifier}"...`
+    );
+    const restoreOutcome =
+      await this.#persistenceService.loadAndRestoreGame(saveIdentifier);
+    this.#logger.debug(
+      `GameEngine._executeLoadAndRestore: Load and restore call completed for "${saveIdentifier}". Success: ${restoreOutcome.success}`
+    );
+    return restoreOutcome;
+  }
+
+  /**
+   * Loads a game from a save identifier.
+   *
+   * @param {string} saveIdentifier - Identifier of the save.
+   * @returns {Promise<{success: boolean, error?: string, data?: SaveGameStructure | null}>} Result of the load attempt.
+   */
+  async loadGame(saveIdentifier) {
+    this.#logger.debug(
+      `GameEngine: loadGame called for identifier: ${saveIdentifier}`
+    );
+
+    if (!this.#persistenceService) {
+      const errorMsg =
+        'GamePersistenceService is not available. Cannot load game.';
+      const fullMsg = `GameEngine.loadGame: ${errorMsg}`;
+      this.#logger.error(fullMsg);
+      this.#state.reset();
+      return { success: false, error: fullMsg, data: null };
+    }
+
+    try {
+      await this.#sessionManager.prepareForLoadGameSession(saveIdentifier);
+      const restoreOutcome = await this._executeLoadAndRestore(saveIdentifier);
+
+      if (restoreOutcome.success && restoreOutcome.data) {
+        const loadedSaveData = /** @type {SaveGameStructure} */ (
+          restoreOutcome.data
+        );
+        return await this.#sessionManager.finalizeLoadSuccess(
+          loadedSaveData,
+          saveIdentifier
+        );
+      } else {
+        const loadError =
+          restoreOutcome.error ||
+          'Restored data was missing or load operation failed.';
+        this.#logger.warn(
+          `GameEngine: Load/restore operation reported failure for "${saveIdentifier}".`
+        );
+        return await this.#handleLoadFailure(loadError, saveIdentifier);
+      }
+    } catch (error) {
+      const caughtError =
+        error instanceof Error ? error : new Error(String(error));
+      this.#logger.error(
+        `GameEngine: Overall catch in loadGame for identifier "${saveIdentifier}". Error: ${caughtError.message || String(caughtError)}`,
+        caughtError
+      );
+      return await this.#handleLoadFailure(caughtError, saveIdentifier);
+    }
+  }
+}
+
+export default PersistenceCoordinator;


### PR DESCRIPTION
## Summary
- extract engine state into an EngineState class
- add GameSessionManager and PersistenceCoordinator
- delegate game loop functions to these new classes
- wire GameEngine to use the new helpers

## Testing
- `npm test`
- `cd llm-proxy-server && npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_685b0180505883319d09a5475cf97059