### PR TITLE
[Agent] Extract validation helpers

### DIFF
--- a/tests/unit/entities/factories/entityFactory.test.js
+++ b/tests/unit/entities/factories/entityFactory.test.js
@@ -234,6 +234,24 @@ describe('EntityFactory', () => {
       expect(entity.getComponentData('new:component').data).toBe('xyz');
     });
 
+    it('calls validator for each component override', () => {
+      const overrides = {
+        'core:name': { name: 'test' },
+        extra1: { a: 1 },
+        extra2: { b: 2 },
+      };
+
+      factory.create(
+        'test-def:basic',
+        { componentOverrides: overrides },
+        mocks.registry,
+        { has: () => false },
+        null
+      );
+
+      expect(mocks.validator.validate).toHaveBeenCalledTimes(3);
+    });
+
     it('should validate component overrides', () => {
       const overrides = { 'core:description': { text: 'Test' } };
       mocks.validator.validate.mockReturnValue({
@@ -446,6 +464,24 @@ describe('EntityFactory', () => {
       });
 
       expect(entity.getComponentData('core:description')).toBeNull();
+    });
+
+    it('calls validator for each serialized component', () => {
+      const serializedEntity = {
+        instanceId: 'call-count',
+        definitionId: 'test-def:basic',
+        components: {
+          'core:name': { name: 'n1' },
+          new1: { val: 1 },
+          new2: null,
+        },
+      };
+
+      factory.reconstruct(serializedEntity, mocks.registry, {
+        has: () => false,
+      });
+
+      expect(mocks.validator.validate).toHaveBeenCalledTimes(2);
     });
 
     it('should inject default components for actor entities during reconstruction', () => {


### PR DESCRIPTION
## Summary
- add private validation helpers for overrides and reconstruction components
- use helpers from `create` and `reconstruct`
- test that validators run for each override and serialized component

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685b03df4d608331ac76dee7604a41ad