### PR TITLE
[Agent] extract save game service

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -29,6 +29,7 @@ import {
   ChatAlertRenderer,
   ActionResultRenderer,
   WindowUserPrompt,
+  SaveGameService,
 } from '../../domUI/index.js';
 import SaveGameUI from '../../domUI/saveGameUI.js';
 import LoadGameUI from '../../domUI/loadGameUI.js';
@@ -45,6 +46,7 @@ import { EngineUIManager } from '../../domUI'; // Corrected import path if Engin
 /** @typedef {import('../../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 /** @typedef {import('../../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService */
 /** @typedef {import('../../entities/entityDisplayDataProvider.js').EntityDisplayDataProvider} EntityDisplayDataProvider */
+/** @typedef {import('../../domUI/saveGameService.js').default} SaveGameService */
 
 /** @typedef {import('../../turns/interfaces/ILLMAdapter.js').ILLMAdapter} ILLMAdapter */
 
@@ -175,6 +177,16 @@ export function registerRenderers(registrar, logger) {
   logger.debug(`UI Registrations: Registered ${tokens.PerceptionLogRenderer}.`);
 
   registrar.singletonFactory(
+    tokens.SaveGameService,
+    (c) =>
+      new SaveGameService({
+        logger: c.resolve(tokens.ILogger),
+        userPrompt: c.resolve(tokens.IUserPrompt),
+      })
+  );
+  logger.debug(`UI Registrations: Registered ${tokens.SaveGameService}.`);
+
+  registrar.singletonFactory(
     tokens.SaveGameUI,
     (c) =>
       new SaveGameUI({
@@ -183,6 +195,7 @@ export function registerRenderers(registrar, logger) {
         domElementFactory: c.resolve(tokens.DomElementFactory),
         saveLoadService: c.resolve(tokens.ISaveLoadService),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        saveGameService: c.resolve(tokens.SaveGameService),
       })
   );
   logger.debug(`UI Registrations: Registered ${tokens.SaveGameUI}.`);

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -40,6 +40,7 @@ import { freeze } from '../utils';
  * @property {DiToken} ActionButtonsRenderer - Token for the component rendering available action buttons.
  * @property {DiToken} PerceptionLogRenderer - Token for the component rendering perception logs.
  * @property {DiToken} DomUiFacade - Token for the facade aggregating all UI components.
+ * @property {DiToken} SaveGameService - Token for the service handling save operations.
  * @property {DiToken} SaveGameUI - Token for the Save Game UI component.
  * @property {DiToken} LoadGameUI - Token for the Load Game UI component.
  * @property {DiToken} LlmSelectionModal - Token for the LLM Selection Modal UI component.
@@ -186,6 +187,7 @@ export const tokens = freeze({
   ActionButtonsRenderer: 'ActionButtonsRenderer',
   PerceptionLogRenderer: 'PerceptionLogRenderer',
   DomUiFacade: 'DomUiFacade',
+  SaveGameService: 'SaveGameService',
   SaveGameUI: 'SaveGameUI',
   LoadGameUI: 'LoadGameUI',
   LlmSelectionModal: 'LlmSelectionModal',

--- a/src/domUI/index.js
+++ b/src/domUI/index.js
@@ -26,6 +26,7 @@ export { ActionResultRenderer } from './actionResultRenderer.js';
 
 // Modals & UI Components
 export { default as SaveGameUI } from './saveGameUI.js';
+export { default as SaveGameService } from './saveGameService.js';
 export { default as LoadGameUI } from './loadGameUI.js';
 export { LlmSelectionModal } from './llmSelectionModal.js';
 export { default as WindowUserPrompt } from './windowUserPrompt.js';

--- a/src/domUI/saveGameService.js
+++ b/src/domUI/saveGameService.js
@@ -1,0 +1,165 @@
+// src/domUI/saveGameService.js
+
+/**
+ * @file Service handling validation and execution of save game operations.
+ */
+
+import { validateDependency } from '../utils/validationUtils.js';
+import { ensureValidLogger } from '../utils/index.js';
+
+/** @typedef {import('./saveGameUI.js').SlotDisplayData} SlotDisplayData */
+/** @typedef {import('../engine/gameEngine.js').default} GameEngine */
+/** @typedef {import('../interfaces/IUserPrompt.js').IUserPrompt} IUserPrompt */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+
+/**
+ * @class SaveGameService
+ * @description Encapsulates logic for validating and executing manual save requests.
+ */
+export default class SaveGameService {
+  /** @type {ILogger} */
+  #logger;
+  /** @type {IUserPrompt} */
+  #userPrompt;
+
+  /**
+   * Creates a new SaveGameService.
+   *
+   * @param {object} deps - Constructor dependencies.
+   * @param {ILogger} deps.logger - Logging instance.
+   * @param {IUserPrompt} deps.userPrompt - Prompt utility for confirmations.
+   */
+  constructor({ logger, userPrompt }) {
+    validateDependency(userPrompt, 'IUserPrompt', logger, {
+      requiredMethods: ['confirm'],
+    });
+    this.#logger = ensureValidLogger(logger, 'SaveGameService');
+    this.#userPrompt = userPrompt;
+    this.#logger.debug('SaveGameService initialized.');
+  }
+
+  /**
+   * Validates that a save can proceed.
+   *
+   * @param {SlotDisplayData | null} selectedSlotData - Currently selected slot.
+   * @param {string} saveName - Proposed save name.
+   * @param {GameEngine | null} gameEngine - Game engine instance.
+   * @returns {string | null} Error message if validation fails, otherwise null.
+   */
+  validatePreconditions(selectedSlotData, saveName, gameEngine) {
+    if (!selectedSlotData || !gameEngine) {
+      this.#logger.error(
+        'SaveGameService.validatePreconditions: missing slot or game engine.'
+      );
+      return 'Cannot save: Internal error. Please select a slot and enter a name.';
+    }
+
+    if (!saveName || saveName.trim() === '') {
+      return 'Please enter a name for your save.';
+    }
+
+    if (selectedSlotData.isCorrupted) {
+      return 'Cannot save to a corrupted slot. Please choose another slot.';
+    }
+
+    return null;
+  }
+
+  /**
+   * Asks the user to confirm overwriting an existing save.
+   *
+   * @param {SlotDisplayData | null} selectedSlotData - Slot to save into.
+   * @param {string} saveName - Proposed save name.
+   * @returns {boolean} True if confirmed or not required.
+   */
+  confirmOverwrite(selectedSlotData, saveName) {
+    if (!selectedSlotData || selectedSlotData.isEmpty) {
+      return true;
+    }
+
+    const originalName =
+      selectedSlotData.saveName || `Slot ${selectedSlotData.slotId + 1}`;
+    const confirmed = this.#userPrompt.confirm(
+      `Are you sure you want to overwrite the existing save "${originalName}" with "${saveName}"?`
+    );
+    if (!confirmed) {
+      this.#logger.debug(
+        `SaveGameService: Save overwrite cancelled for slot ${selectedSlotData.slotId}.`
+      );
+    }
+    return confirmed;
+  }
+
+  /**
+   * Calls the game engine to execute the save.
+   *
+   * @param {SlotDisplayData} selectedSlotData - Slot being saved into.
+   * @param {string} saveName - Name to use when saving.
+   * @param {GameEngine} gameEngine - Game engine instance.
+   * @returns {Promise<{result: any, returnedIdentifier: string | null}>}
+   *   Result from the engine and identifier, if provided.
+   */
+  async executeSave(selectedSlotData, saveName, gameEngine) {
+    this.#logger.debug(
+      `SaveGameService: Triggering manual save "${saveName}" for slot ${selectedSlotData.slotId}. Identifier: ${selectedSlotData.identifier}`
+    );
+    const result = await gameEngine.triggerManualSave(
+      saveName,
+      selectedSlotData.identifier
+    );
+    const returnedIdentifier = result ? result.filePath : null;
+    if (result && result.success && !returnedIdentifier) {
+      this.#logger.error(
+        'SaveGameService: Save operation succeeded but returned no filePath/identifier.',
+        result
+      );
+    }
+    return { result, returnedIdentifier };
+  }
+
+  /**
+   * Executes the save and formats the outcome for the UI layer.
+   *
+   * @param {SlotDisplayData} selectedSlotData - Slot being saved into.
+   * @param {string} saveName - Name to use when saving.
+   * @param {GameEngine} gameEngine - Game engine instance.
+   * @returns {Promise<{success: boolean, message: string, returnedIdentifier: string | null}>}
+   *   Operation outcome details.
+   */
+  async performSave(selectedSlotData, saveName, gameEngine) {
+    let saveSucceeded = false;
+    let finalMessage = '';
+    let returnedIdentifier = null;
+
+    try {
+      const { result, returnedIdentifier: id } = await this.executeSave(
+        selectedSlotData,
+        saveName,
+        gameEngine
+      );
+      returnedIdentifier = id;
+
+      if (result && result.success) {
+        saveSucceeded = true;
+        finalMessage = `Game saved as "${saveName}".`;
+      } else {
+        finalMessage = `Save failed: ${result?.error || 'An unknown error occurred while saving.'}`;
+        this.#logger.error(`SaveGameService.performSave: ${finalMessage}`);
+      }
+    } catch (error) {
+      const exceptionMsg =
+        error instanceof Error ? error.message : String(error);
+      finalMessage = `Save failed: ${exceptionMsg || 'An unexpected error occurred.'}`;
+      this.#logger.error(
+        'SaveGameService.performSave: Exception during save operation:',
+        error
+      );
+    }
+
+    return {
+      success: saveSucceeded,
+      message: finalMessage,
+      returnedIdentifier,
+    };
+  }
+}

--- a/tests/domUI/saveGameUI.instantiate.test.js
+++ b/tests/domUI/saveGameUI.instantiate.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import SaveGameUI from '../../src/domUI/saveGameUI.js';
+import SaveGameService from '../../src/domUI/saveGameService.js';
 import DocumentContext from '../../src/domUI/documentContext.js';
 import DomElementFactory from '../../src/domUI/domElementFactory.js';
 import { describe, it, expect, jest } from '@jest/globals';
@@ -32,6 +33,10 @@ describe('SaveGameUI instantiation', () => {
       dispatch: jest.fn(),
     };
     const userPrompt = { confirm: jest.fn(() => true) };
+    const saveGameService = new SaveGameService({
+      logger: mockLogger,
+      userPrompt,
+    });
 
     const ui = new SaveGameUI({
       logger: mockLogger,
@@ -39,7 +44,7 @@ describe('SaveGameUI instantiation', () => {
       domElementFactory: factory,
       saveLoadService,
       validatedEventDispatcher: dispatcher,
-      userPrompt,
+      saveGameService,
     });
 
     expect(ui).toBeInstanceOf(SaveGameUI);

--- a/tests/unit/domUI/saveGameUI.test.js
+++ b/tests/unit/domUI/saveGameUI.test.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 
 import { JSDOM } from 'jsdom';
-import { SaveGameUI } from '../../../src/domUI'; // Adjust path if necessary
+import { SaveGameUI, SaveGameService } from '../../../src/domUI';
 import DomElementFactory from '../../../src/domUI/domElementFactory.js';
 import * as renderSlotItemModule from '../../../src/domUI/helpers/renderSlotItem.js';
 import {
@@ -125,6 +125,10 @@ describe('SaveGameUI', () => {
     mockGameEngine = { triggerManualSave: jest.fn() };
     mockSaveLoadService = { listManualSaveSlots: jest.fn() };
     mockUserPrompt = { confirm: jest.fn(() => true) };
+    const saveGameService = new SaveGameService({
+      logger: mockLogger,
+      userPrompt: mockUserPrompt,
+    });
 
     saveGameUI = new SaveGameUI({
       logger: mockLogger,
@@ -132,7 +136,7 @@ describe('SaveGameUI', () => {
       domElementFactory: mockDomElementFactory,
       saveLoadService: mockSaveLoadService,
       validatedEventDispatcher: mockValidatedEventDispatcher,
-      userPrompt: mockUserPrompt,
+      saveGameService,
     });
     saveGameUI.init(mockGameEngine);
     renderSlotItemSpy = jest.spyOn(
@@ -379,7 +383,7 @@ describe('SaveGameUI', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Save operation succeeded but did not return a valid filePath/identifier'
+          'SaveGameService: Save operation succeeded but returned no filePath/identifier.'
         ),
         expect.any(Object)
       );


### PR DESCRIPTION
## Summary
- create `SaveGameService` to own save-logic helpers
- update `SaveGameUI` to delegate to the new service
- register the service in DI container
- update unit tests for new injection

## Testing
- `npm run format`
- `npx eslint src/domUI/saveGameService.js src/domUI/saveGameUI.js tests/unit/domUI/saveGameUI.test.js tests/domUI/saveGameUI.instantiate.test.js src/dependencyInjection/registrations/uiRegistrations.js src/dependencyInjection/tokens.js src/domUI/index.js --fix`
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c0294c6f88331b9fc3e2422d0c5e1