### PR TITLE
[Agent] Inject AI persistence listeners

### DIFF
--- a/src/dependencyInjection/registrations/orchestrationRegistrations.js
+++ b/src/dependencyInjection/registrations/orchestrationRegistrations.js
@@ -12,6 +12,8 @@
 // --- Service Imports ---
 import InitializationService from '../../initializers/services/initializationService.js'; // Adjusted path
 import ShutdownService from '../../shutdown/services/shutdownService.js'; // Adjusted path
+import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
+import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
@@ -70,6 +72,15 @@ export function registerOrchestration(container) {
       throw new Error(
         `InitializationService Factory: Failed to resolve dependency: ${tokens.WorldInitializer}`
       );
+    const thoughtListener = new ThoughtPersistenceListener({
+      logger: initLogger,
+      entityManager,
+    });
+    const notesListener = new NotesPersistenceListener({
+      logger: initLogger,
+      entityManager,
+      dispatcher: safeEventDispatcher,
+    });
     return new InitializationService({
       logger: initLogger,
       validatedEventDispatcher: initDispatcher,
@@ -85,6 +96,8 @@ export function registerOrchestration(container) {
       domUiFacade,
       actionIndex,
       gameDataRepository,
+      thoughtListener,
+      notesListener,
     });
   });
   logger.debug(

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -14,8 +14,6 @@
 // --- Interface Imports for JSDoc & `extends` ---
 /** @typedef {import('../../interfaces/IInitializationService.js').InitializationResult} InitializationResult */
 import { IInitializationService } from '../../interfaces/IInitializationService.js';
-import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
-import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
 import {
   ACTION_DECIDED_ID,
   INITIALIZATION_SERVICE_FAILED_ID,
@@ -42,6 +40,8 @@ class InitializationService extends IInitializationService {
   #domUiFacade;
   #actionIndex;
   #gameDataRepository;
+  #thoughtListener;
+  #notesListener;
 
   /**
    * Creates a new InitializationService instance.
@@ -77,6 +77,8 @@ class InitializationService extends IInitializationService {
     domUiFacade,
     actionIndex,
     gameDataRepository,
+    thoughtListener,
+    notesListener,
   }) {
     super();
 
@@ -161,14 +163,27 @@ class InitializationService extends IInitializationService {
         "InitializationService: Missing or invalid required dependency 'actionIndex'."
       );
     }
-    if (!gameDataRepository || typeof gameDataRepository.getAllActionDefinitions !== 'function') {
+    if (
+      !gameDataRepository ||
+      typeof gameDataRepository.getAllActionDefinitions !== 'function'
+    ) {
       throw new Error(
         "InitializationService: Missing or invalid required dependency 'gameDataRepository'."
       );
     }
     if (!domUiFacade) {
       throw new Error(
-        "InitializationService requires a domUiFacade dependency"
+        'InitializationService requires a domUiFacade dependency'
+      );
+    }
+    if (!thoughtListener || typeof thoughtListener.handleEvent !== 'function') {
+      throw new Error(
+        "InitializationService: Missing or invalid required dependency 'thoughtListener'."
+      );
+    }
+    if (!notesListener || typeof notesListener.handleEvent !== 'function') {
+      throw new Error(
+        "InitializationService: Missing or invalid required dependency 'notesListener'."
       );
     }
 
@@ -185,6 +200,8 @@ class InitializationService extends IInitializationService {
     this.#domUiFacade = domUiFacade;
     this.#actionIndex = actionIndex;
     this.#gameDataRepository = gameDataRepository;
+    this.#thoughtListener = thoughtListener;
+    this.#notesListener = notesListener;
 
     this.#logger.debug(
       'InitializationService: Instance created successfully with dependencies.'
@@ -229,10 +246,15 @@ class InitializationService extends IInitializationService {
       );
 
       // Build ActionIndex with loaded action definitions
-      this.#logger.debug('Building ActionIndex with loaded action definitions...');
-      const allActionDefinitions = this.#gameDataRepository.getAllActionDefinitions();
+      this.#logger.debug(
+        'Building ActionIndex with loaded action definitions...'
+      );
+      const allActionDefinitions =
+        this.#gameDataRepository.getAllActionDefinitions();
       this.#actionIndex.buildIndex(allActionDefinitions);
-      this.#logger.debug(`ActionIndex built with ${allActionDefinitions.length} action definitions.`);
+      this.#logger.debug(
+        `ActionIndex built with ${allActionDefinitions.length} action definitions.`
+      );
 
       this.#logger.debug('Initializing ScopeRegistry...');
       const scopes = this.#dataRegistry.getAll('scopes');
@@ -360,23 +382,13 @@ class InitializationService extends IInitializationService {
 
   #setupPersistenceListeners() {
     const dispatcher = this.#safeEventDispatcher;
-    const entityManager = /** @type {IEntityManager} */ (this.#entityManager);
-    const thoughtListener = new ThoughtPersistenceListener({
-      logger: this.#logger,
-      entityManager,
-    });
-    const notesListener = new NotesPersistenceListener({
-      logger: this.#logger,
-      entityManager,
-      dispatcher,
-    });
     dispatcher.subscribe(
       ACTION_DECIDED_ID,
-      thoughtListener.handleEvent.bind(thoughtListener)
+      this.#thoughtListener.handleEvent.bind(this.#thoughtListener)
     );
     dispatcher.subscribe(
       ACTION_DECIDED_ID,
-      notesListener.handleEvent.bind(notesListener)
+      this.#notesListener.handleEvent.bind(this.#notesListener)
     );
     this.#logger.debug('Registered AI persistence listeners.');
   }

--- a/tests/unit/initializers/services/initializationService.constructor.test.js
+++ b/tests/unit/initializers/services/initializationService.constructor.test.js
@@ -15,6 +15,8 @@ let entityManager;
 let domUiFacade;
 let actionIndex;
 let gameDataRepository;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -31,6 +33,8 @@ beforeEach(() => {
   domUiFacade = {};
   actionIndex = { buildIndex: jest.fn() };
   gameDataRepository = { getAllActionDefinitions: jest.fn(() => []) };
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService constructor', () => {
@@ -52,6 +56,8 @@ describe('InitializationService constructor', () => {
           domUiFacade,
           actionIndex,
           gameDataRepository,
+          thoughtListener,
+          notesListener,
         })
     ).not.toThrow();
   });
@@ -73,6 +79,8 @@ describe('InitializationService constructor', () => {
           domUiFacade,
           actionIndex,
           gameDataRepository,
+          thoughtListener,
+          notesListener,
         })
     ).toThrow(/logger/);
   });
@@ -94,6 +102,8 @@ describe('InitializationService constructor', () => {
           domUiFacade,
           actionIndex,
           gameDataRepository,
+          thoughtListener,
+          notesListener,
         })
     ).toThrow(/validatedEventDispatcher/);
   });

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -13,6 +13,8 @@ let worldInitializer;
 let safeEventDispatcher;
 let entityManager;
 let domUiFacade;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -33,6 +35,8 @@ beforeEach(() => {
   safeEventDispatcher = { subscribe: jest.fn() };
   entityManager = {};
   domUiFacade = {};
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService DomUiFacade handling', () => {
@@ -51,7 +55,11 @@ describe('InitializationService DomUiFacade handling', () => {
         safeEventDispatcher,
         entityManager,
         actionIndex: { buildIndex: jest.fn() },
-        gameDataRepository: { getAllActionDefinitions: jest.fn().mockReturnValue([]) },
+        gameDataRepository: {
+          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        },
+        thoughtListener,
+        notesListener,
         // domUiFacade: domUiFacade, // Intentionally omitted
       });
     }).toThrow('InitializationService requires a domUiFacade dependency');

--- a/tests/unit/initializers/services/initializationService.failureScenarios.test.js
+++ b/tests/unit/initializers/services/initializationService.failureScenarios.test.js
@@ -15,6 +15,8 @@ let worldInitializer;
 let safeEventDispatcher;
 let entityManager;
 let domUiFacade;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -35,13 +37,17 @@ beforeEach(() => {
   safeEventDispatcher = { subscribe: jest.fn() };
   entityManager = {};
   domUiFacade = {};
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService failure scenarios', () => {
   const createService = (overrides = {}) => {
     const defaults = {
       logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn() },
-      validatedEventDispatcher: { dispatch: jest.fn().mockResolvedValue(undefined) },
+      validatedEventDispatcher: {
+        dispatch: jest.fn().mockResolvedValue(undefined),
+      },
       modsLoader: { loadMods: jest.fn() },
       scopeRegistry: { initialize: jest.fn() },
       dataRegistry: { getAll: jest.fn().mockReturnValue([]) },
@@ -53,7 +59,11 @@ describe('InitializationService failure scenarios', () => {
       entityManager: {},
       domUiFacade: {},
       actionIndex: { buildIndex: jest.fn() },
-      gameDataRepository: { getAllActionDefinitions: jest.fn().mockReturnValue([]) },
+      gameDataRepository: {
+        getAllActionDefinitions: jest.fn().mockReturnValue([]),
+      },
+      thoughtListener: { handleEvent: jest.fn() },
+      notesListener: { handleEvent: jest.fn() },
     };
     const deps = { ...defaults, ...overrides };
     return new InitializationService(deps);
@@ -62,7 +72,7 @@ describe('InitializationService failure scenarios', () => {
   it('fails when ModsLoader.loadMods rejects', async () => {
     const error = new Error('load');
     const svc = createService({
-      modsLoader: { loadMods: jest.fn().mockRejectedValueOnce(error) }
+      modsLoader: { loadMods: jest.fn().mockRejectedValueOnce(error) },
     });
     const result = await svc.runInitializationSequence(WORLD);
     expect(result.success).toBe(false);
@@ -72,7 +82,11 @@ describe('InitializationService failure scenarios', () => {
   it('fails when ScopeRegistry.initialize throws', async () => {
     const err = new Error('scope');
     const svc = createService({
-      scopeRegistry: { initialize: jest.fn().mockImplementation(() => { throw err; }) }
+      scopeRegistry: {
+        initialize: jest.fn().mockImplementation(() => {
+          throw err;
+        }),
+      },
     });
     const result = await svc.runInitializationSequence(WORLD);
     expect(result.success).toBe(false);
@@ -82,7 +96,9 @@ describe('InitializationService failure scenarios', () => {
   it('fails when SystemInitializer.initializeAll rejects', async () => {
     const err = new Error('sys');
     const svc = createService({
-      systemInitializer: { initializeAll: jest.fn().mockRejectedValueOnce(err) }
+      systemInitializer: {
+        initializeAll: jest.fn().mockRejectedValueOnce(err),
+      },
     });
     const result = await svc.runInitializationSequence(WORLD);
     expect(result.success).toBe(false);
@@ -91,7 +107,9 @@ describe('InitializationService failure scenarios', () => {
 
   it('fails when WorldInitializer reports failure', async () => {
     const svc = createService({
-      worldInitializer: { initializeWorldEntities: jest.fn().mockReturnValueOnce(false) }
+      worldInitializer: {
+        initializeWorldEntities: jest.fn().mockReturnValueOnce(false),
+      },
     });
     const result = await svc.runInitializationSequence(WORLD);
     expect(result.success).toBe(false);

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -13,6 +13,8 @@ let worldInitializer;
 let safeEventDispatcher;
 let entityManager;
 let domUiFacade;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -27,6 +29,8 @@ beforeEach(() => {
   safeEventDispatcher = { subscribe: jest.fn() };
   entityManager = {};
   domUiFacade = {};
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService invalid world name handling', () => {
@@ -47,7 +51,11 @@ describe('InitializationService invalid world name handling', () => {
         entityManager,
         domUiFacade,
         actionIndex: { buildIndex: jest.fn() },
-        gameDataRepository: { getAllActionDefinitions: jest.fn().mockReturnValue([]) },
+        gameDataRepository: {
+          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        },
+        thoughtListener,
+        notesListener,
       });
 
       const result = await service.runInitializationSequence(bad);

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -15,6 +15,8 @@ let worldInitializer;
 let safeEventDispatcher;
 let entityManager;
 let domUiFacade;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -35,6 +37,8 @@ beforeEach(() => {
   safeEventDispatcher = { subscribe: jest.fn() };
   entityManager = {};
   domUiFacade = {};
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService LLM adapter rejection', () => {
@@ -56,7 +60,11 @@ describe('InitializationService LLM adapter rejection', () => {
       entityManager,
       domUiFacade,
       actionIndex: { buildIndex: jest.fn() },
-      gameDataRepository: { getAllActionDefinitions: jest.fn().mockReturnValue([]) },
+      gameDataRepository: {
+        getAllActionDefinitions: jest.fn().mockReturnValue([]),
+      },
+      thoughtListener,
+      notesListener,
     });
 
     const result = await svc.runInitializationSequence(WORLD);

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -17,6 +17,8 @@ let entityManager;
 let domUiFacade;
 let actionIndex;
 let gameDataRepository;
+let thoughtListener;
+let notesListener;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -44,7 +46,11 @@ beforeEach(() => {
   entityManager = {};
   domUiFacade = {};
   actionIndex = { buildIndex: jest.fn() };
-  gameDataRepository = { getAllActionDefinitions: jest.fn().mockReturnValue([]) };
+  gameDataRepository = {
+    getAllActionDefinitions: jest.fn().mockReturnValue([]),
+  };
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
 });
 
 describe('InitializationService success path', () => {
@@ -64,6 +70,8 @@ describe('InitializationService success path', () => {
       domUiFacade,
       actionIndex,
       gameDataRepository,
+      thoughtListener,
+      notesListener,
     });
 
     const result = await service.runInitializationSequence(MOCK_WORLD);


### PR DESCRIPTION
## Summary
- inject ThoughtPersistenceListener and NotesPersistenceListener dependencies into InitializationService
- create listeners in orchestration registration
- pass listeners to InitializationService in tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `PORT=8081 npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685c0a9a6e6c8331aa1037a544b7a2a0