### PR TITLE
[Agent] Add resolveOptional helper

### DIFF
--- a/src/dependencyInjection/registrarHelpers.js
+++ b/src/dependencyInjection/registrarHelpers.js
@@ -177,3 +177,15 @@ export class Registrar {
     return this.register(token, factoryFn, { lifecycle: 'transient' });
   }
 }
+
+/**
+ * Resolve an optional dependency from the DI container.
+ *
+ * @description Returns `null` if the token is not registered.
+ * @param {AppContainer} container - The container to resolve from.
+ * @param {DiToken} token - The dependency token to resolve.
+ * @returns {* | null} The resolved instance or `null`.
+ */
+export function resolveOptional(container, token) {
+  return container.isRegistered(token) ? container.resolve(token) : null;
+}

--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -44,7 +44,7 @@
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
-import { Registrar } from '../registrarHelpers.js';
+import { Registrar, resolveOptional } from '../registrarHelpers.js';
 
 // --- LLM Adapter Imports ---
 import { ConfigurableLLMAdapter } from '../../turns/adapters/configurableLLMAdapter.js';
@@ -112,12 +112,9 @@ import { registerActorAwareStrategy } from './registerActorAwareStrategy.js';
  */
 export function registerLlmInfrastructure(registrar, logger) {
   registrar.singletonFactory(tokens.IHttpClient, (c) => {
-    let dispatcher = null;
-    if (c.isRegistered(tokens.ISafeEventDispatcher)) {
-      dispatcher = c.resolve(tokens.ISafeEventDispatcher);
-    } else if (c.isRegistered(tokens.IValidatedEventDispatcher)) {
-      dispatcher = c.resolve(tokens.IValidatedEventDispatcher);
-    }
+    const dispatcher =
+      resolveOptional(c, tokens.ISafeEventDispatcher) ??
+      resolveOptional(c, tokens.IValidatedEventDispatcher);
     return new RetryHttpClient({
       logger: c.resolve(tokens.ILogger),
       dispatcher,

--- a/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
+++ b/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
@@ -10,7 +10,7 @@
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
-import { Registrar } from '../registrarHelpers.js';
+import { Registrar, resolveOptional } from '../registrarHelpers.js';
 import { SHUTDOWNABLE as _SHUTDOWNABLE } from '../tags.js';
 
 // --- Adapter Imports ---
@@ -32,16 +32,13 @@ export function registerEventBusAdapters(container) {
   registrar.singletonFactory(tokens.IPromptOutputPort, (c) => {
     // --- FIX: Check for registration before resolving optional dependencies. ---
     // This prevents c.resolve() from throwing an error if a dependency isn't registered.
-    const safeDispatcher = c.isRegistered(tokens.ISafeEventDispatcher)
-      ? /** @type {ISafeEventDispatcher | null} */ (
-          c.resolve(tokens.ISafeEventDispatcher)
-        )
-      : null;
-    const validatedDispatcher = c.isRegistered(tokens.IValidatedEventDispatcher)
-      ? /** @type {IValidatedEventDispatcher | null} */ (
-          c.resolve(tokens.IValidatedEventDispatcher)
-        )
-      : null;
+    const safeDispatcher = /** @type {ISafeEventDispatcher | null} */ (
+      resolveOptional(c, tokens.ISafeEventDispatcher)
+    );
+    const validatedDispatcher =
+      /** @type {IValidatedEventDispatcher | null} */ (
+        resolveOptional(c, tokens.IValidatedEventDispatcher)
+      );
 
     if (!safeDispatcher && !validatedDispatcher) {
       logger.error(
@@ -62,11 +59,9 @@ export function registerEventBusAdapters(container) {
 
   // --- Register EventBusTurnEndAdapter ---
   registrar.singletonFactory(tokens.ITurnEndPort, (c) => {
-    const safeDispatcher = c.isRegistered(tokens.ISafeEventDispatcher)
-      ? /** @type {ISafeEventDispatcher} */ (
-          c.resolve(tokens.ISafeEventDispatcher)
-        )
-      : null;
+    const safeDispatcher = /** @type {ISafeEventDispatcher | null} */ (
+      resolveOptional(c, tokens.ISafeEventDispatcher)
+    );
 
     if (!safeDispatcher) {
       logger.error(

--- a/src/dependencyInjection/registrations/registerActorAwareStrategy.js
+++ b/src/dependencyInjection/registrations/registerActorAwareStrategy.js
@@ -6,7 +6,7 @@
 /** @typedef {import('../appContainer.js').default} AppContainer */
 
 import { tokens } from '../tokens.js';
-import { Registrar } from '../registrarHelpers.js';
+import { Registrar, resolveOptional } from '../registrarHelpers.js';
 import { TurnActionChoicePipeline } from '../../turns/pipeline/turnActionChoicePipeline.js';
 import { TurnActionFactory } from '../../turns/factories/turnActionFactory.js';
 import { ActorAwareStrategyFactory } from '../../turns/factories/actorAwareStrategyFactory.js';
@@ -57,8 +57,12 @@ export function registerActorAwareStrategy(container) {
         actorLookup: (id) =>
           c.resolve(tokens.IEntityManager).getEntityInstance(id),
       };
-      if (c.isRegistered(tokens.IAIFallbackActionFactory)) {
-        opts.fallbackFactory = c.resolve(tokens.IAIFallbackActionFactory);
+      const fallbackFactory = resolveOptional(
+        c,
+        tokens.IAIFallbackActionFactory
+      );
+      if (fallbackFactory) {
+        opts.fallbackFactory = fallbackFactory;
       }
       opts.providerResolver = (actor) => {
         const type = actor?.aiType ?? actor?.components?.ai?.type;

--- a/tests/unit/dependencyInjection/registrarHelpers.test.js
+++ b/tests/unit/dependencyInjection/registrarHelpers.test.js
@@ -1,5 +1,8 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
-import { Registrar } from '../../../src/dependencyInjection/registrarHelpers.js';
+import {
+  Registrar,
+  resolveOptional,
+} from '../../../src/dependencyInjection/registrarHelpers.js';
 
 /** @type {import('../../../src/dependencyInjection/appContainer.js').default} */
 let mockContainer;
@@ -76,5 +79,32 @@ describe('Registrar basic behaviors', () => {
     expect(() => registrar.transientFactory('tok', 1)).toThrow(
       'Registrar.transientFactory requires a function'
     );
+  });
+});
+
+describe('resolveOptional', () => {
+  /** @type {import('../../../src/dependencyInjection/appContainer.js').default} */
+  let mockResolveContainer;
+
+  beforeEach(() => {
+    mockResolveContainer = {
+      isRegistered: jest.fn(),
+      resolve: jest.fn(),
+    };
+  });
+
+  it('returns resolved instance when token registered', () => {
+    mockResolveContainer.isRegistered.mockReturnValue(true);
+    mockResolveContainer.resolve.mockReturnValue('value');
+    const result = resolveOptional(mockResolveContainer, 'tok');
+    expect(mockResolveContainer.resolve).toHaveBeenCalledWith('tok');
+    expect(result).toBe('value');
+  });
+
+  it('returns null when token not registered', () => {
+    mockResolveContainer.isRegistered.mockReturnValue(false);
+    const result = resolveOptional(mockResolveContainer, 'tok');
+    expect(mockResolveContainer.resolve).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Summary: 
- add new resolveOptional helper in registrarHelpers
- use helper in adapter factories
- update AI infrastructure registration
- extend registrarHelpers tests

Testing Done:
- `npx prettier -w src/dependencyInjection/registrarHelpers.js src/dependencyInjection/registrations/aiRegistrations.js src/dependencyInjection/registrations/eventBusAdapterRegistrations.js src/dependencyInjection/registrations/registerActorAwareStrategy.js tests/unit/dependencyInjection/registrarHelpers.test.js`
- `npm run lint` *(fails: 630 errors, 2444 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c09f8d51883318caf518a810a79ca