### PR TITLE
[Agent] Refactor MockDataFetcher fetch implementations

### DIFF
--- a/tests/common/mockFactories/dataFetcherMock.js
+++ b/tests/common/mockFactories/dataFetcherMock.js
@@ -76,16 +76,35 @@ export class MockDataFetcher {
    */
   #setFetchImplementation() {
     if (this.fromDisk) {
-      this.fetch.mockImplementation(async (identifier) => {
-        if (identifier.endsWith('.json')) {
-          const filePath = identifier.replace(/^\.\//, '');
-          return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-        }
-        throw new Error('Unsupported identifier: ' + identifier);
-      });
-      return;
+      this.#setDiskFetchImplementation();
+    } else {
+      this.#setMemoryFetchImplementation();
     }
+  }
 
+  /**
+   * Sets up fetch to read JSON files from disk.
+   *
+   * @private
+   * @returns {void}
+   */
+  #setDiskFetchImplementation() {
+    this.fetch.mockImplementation(async (identifier) => {
+      if (identifier.endsWith('.json')) {
+        const filePath = identifier.replace(/^\.\//, '');
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      }
+      throw new Error('Unsupported identifier: ' + identifier);
+    });
+  }
+
+  /**
+   * Sets up fetch to resolve data from memory mappings.
+   *
+   * @private
+   * @returns {void}
+   */
+  #setMemoryFetchImplementation() {
     this.fetch.mockImplementation(async (p) => {
       if (this.errorPaths.includes(p)) {
         const message =


### PR DESCRIPTION
## Summary
- streamline `MockDataFetcher` helpers for disk and memory modes

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c0bf8835483319a81cbf202563deb