### PR TITLE
[Refactor] loaders use shared process helper

### DIFF
--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -5,6 +5,7 @@
 
 // --- Base Class Import ---
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
 /** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
@@ -47,7 +48,8 @@ class ActionLoader extends BaseManifestItemLoader {
   }
 
   /**
-   * Processes a single fetched action file's data.
+   * Processes a single fetched action file's data and stores it in the registry.
+   * Delegates ID parsing and storage to {@link processAndStoreItem}.
    *
    * @override
    * @protected
@@ -63,14 +65,13 @@ class ActionLoader extends BaseManifestItemLoader {
       `ActionLoader [${modId}]: Processing fetched item: ${filename} (Type: ${registryKey})`
     );
 
-    // Use the reliable base class helper to handle ID parsing and storage.
-    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
       data,
-      'id',
-      'actions',
+      idProp: 'id',
+      category: 'actions',
       modId,
-      filename
-    );
+      filename,
+    });
 
     this._logger.debug(
       `ActionLoader [${modId}]: Successfully processed action from ${filename}. Returning final registry key: ${qualifiedId}, Overwrite: ${didOverride}`

--- a/src/loaders/goalLoader.js
+++ b/src/loaders/goalLoader.js
@@ -17,6 +17,7 @@
  */
 
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration}   IConfiguration
@@ -56,6 +57,7 @@ export default class GoalLoader extends BaseManifestItemLoader {
 
   /**
    * Processes a validated goal data object and stores it in the data registry.
+   * Delegates ID parsing and storage to {@link processAndStoreItem}.
    *
    * @protected
    * @override
@@ -67,15 +69,14 @@ export default class GoalLoader extends BaseManifestItemLoader {
    * @returns {Promise<{qualifiedId: string, didOverride: boolean}>} A promise resolving with the result.
    */
   async _processFetchedItem(modId, filename, resolvedPath, data, registryKey) {
-    // FIX: Updated method signature to match the base class abstract method.
     // schema validation already happened – just persist it
-    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
       data,
-      'id',
-      'goals', // registry category
+      idProp: 'id',
+      category: 'goals',
       modId,
-      filename
-    );
+      filename,
+    });
 
     return { qualifiedId, didOverride };
   }

--- a/src/loaders/macroLoader.js
+++ b/src/loaders/macroLoader.js
@@ -1,6 +1,7 @@
 // src/loaders/macroLoader.js
 
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration
@@ -50,6 +51,7 @@ class MacroLoader extends BaseManifestItemLoader {
 
   /**
    * Processes a single macro definition file after validation.
+   * Utilizes {@link processAndStoreItem} for ID parsing and storage.
    *
    * @protected
    * @override
@@ -66,14 +68,14 @@ class MacroLoader extends BaseManifestItemLoader {
       `MacroLoader [${modId}]: Processing macro file ${filename} (${registryKey}).`
     );
 
-    const { qualifiedId, didOverride } = this._parseIdAndStoreItem(
+    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
       data,
-      'id',
-      'macros',
+      idProp: 'id',
+      category: 'macros',
       modId,
       filename,
-      { allowFallback: true }
-    );
+      parseOptions: { allowFallback: true },
+    });
 
     return { qualifiedId, didOverride };
   }

--- a/tests/unit/loaders/goalLoader.fixes.test.js
+++ b/tests/unit/loaders/goalLoader.fixes.test.js
@@ -18,6 +18,7 @@ import { mock } from 'jest-mock-extended';
 
 // System Under Test (SUT)
 import GoalLoader from '../../../src/loaders/goalLoader.js';
+import * as processHelper from '../../../src/loaders/helpers/processAndStoreItem.js';
 
 // Mocks for constructor dependencies
 const mockConfig = mock();
@@ -106,7 +107,7 @@ describe('GoalLoader', () => {
   });
 
   describe('_processFetchedItem', () => {
-    test('should call _parseIdAndStoreItem with correct parameters, proving correct argument handling', async () => {
+    test('should call processAndStoreItem with correct parameters, proving correct argument handling', async () => {
       // Arrange
       const loader = new GoalLoader(
         mockConfig,
@@ -117,10 +118,10 @@ describe('GoalLoader', () => {
         mockLogger
       );
 
-      // Spy on the internal method to check the arguments it receives.
-      const parseAndStoreSpy = jest
-        .spyOn(loader, '_parseIdAndStoreItem')
-        .mockReturnValue({
+      // Spy on the helper to check the arguments it receives.
+      const processSpy = jest
+        .spyOn(processHelper, 'processAndStoreItem')
+        .mockResolvedValue({
           qualifiedId: 'test-mod:goal-1',
           didOverride: false,
         });
@@ -142,13 +143,14 @@ describe('GoalLoader', () => {
 
       // Assert: This confirms the second bug fix. The method signature is correct,
       // and the `data` object is passed correctly, not the `resolvedPath` string.
-      expect(parseAndStoreSpy).toHaveBeenCalledWith(
-        goalData, // The actual data object
-        'id', // The id property
-        'goals', // The registry category
-        modId, // The mod ID
-        filename // The source filename
-      );
+      expect(processSpy).toHaveBeenCalledWith(loader, {
+        data: goalData,
+        idProp: 'id',
+        category: 'goals',
+        modId,
+        filename,
+      });
+      processSpy.mockRestore();
     });
   });
 

--- a/tests/unit/loaders/goalLoader.test.js
+++ b/tests/unit/loaders/goalLoader.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import GoalLoader from '../../../src/loaders/goalLoader.js';
 import { BaseManifestItemLoader } from '../../../src/loaders/baseManifestItemLoader.js';
+import * as processHelper from '../../../src/loaders/helpers/processAndStoreItem.js';
 
 /**
  * Creates minimal mock dependencies required for GoalLoader.
@@ -52,10 +53,10 @@ describe('GoalLoader._processFetchedItem', () => {
     );
   });
 
-  it('calls _parseIdAndStoreItem with correct arguments and returns result', async () => {
-    const parseSpy = jest
-      .spyOn(BaseManifestItemLoader.prototype, '_parseIdAndStoreItem')
-      .mockReturnValue({ qualifiedId: 'test:goal', didOverride: false });
+  it('calls processAndStoreItem with correct arguments and returns result', async () => {
+    const processSpy = jest
+      .spyOn(processHelper, 'processAndStoreItem')
+      .mockResolvedValue({ qualifiedId: 'test:goal', didOverride: false });
 
     const data = { id: 'goal' };
     // FIX: Updated call to match the 5-argument signature of _processFetchedItem.
@@ -68,21 +69,21 @@ describe('GoalLoader._processFetchedItem', () => {
       'goals'
     );
 
-    expect(parseSpy).toHaveBeenCalledWith(
+    expect(processSpy).toHaveBeenCalledWith(loader, {
       data,
-      'id',
-      'goals',
-      'test',
-      'goal.json'
-    );
+      idProp: 'id',
+      category: 'goals',
+      modId: 'test',
+      filename: 'goal.json',
+    });
     expect(result).toEqual({ qualifiedId: 'test:goal', didOverride: false });
-    parseSpy.mockRestore();
+    processSpy.mockRestore();
   });
 
   it('propagates didOverride flag from _parseIdAndStoreItem', async () => {
-    const parseSpy = jest
-      .spyOn(BaseManifestItemLoader.prototype, '_parseIdAndStoreItem')
-      .mockReturnValue({ qualifiedId: 'mod:goal2', didOverride: true });
+    const processSpy = jest
+      .spyOn(processHelper, 'processAndStoreItem')
+      .mockResolvedValue({ qualifiedId: 'mod:goal2', didOverride: true });
 
     const data = { id: 'goal2' };
     // FIX: Updated call to match the 5-argument signature.
@@ -95,16 +96,14 @@ describe('GoalLoader._processFetchedItem', () => {
     );
 
     expect(result).toEqual({ qualifiedId: 'mod:goal2', didOverride: true });
-    parseSpy.mockRestore();
+    processSpy.mockRestore();
   });
 
   it('rethrows errors from _parseIdAndStoreItem', async () => {
     const error = new Error('parse failed');
     const parseSpy = jest
-      .spyOn(BaseManifestItemLoader.prototype, '_parseIdAndStoreItem')
-      .mockImplementation(() => {
-        throw error;
-      });
+      .spyOn(processHelper, 'processAndStoreItem')
+      .mockRejectedValue(error);
 
     const data = { id: 'bad' };
     // FIX: Updated call to match the 5-argument signature.


### PR DESCRIPTION
Summary: Refactors several loaders to use the `processAndStoreItem` helper for ID parsing and storage. Updates accompanying JSDoc and unit tests.

Changes Made:
- `ActionLoader`, `MacroLoader`, `GoalLoader`, and `ComponentLoader` now delegate item parsing and registry writes to `processAndStoreItem`.
- Updated `ComponentLoader` to keep schema registration but rely on the helper for storing items.
- Adjusted relevant unit tests for `GoalLoader`.

Testing Done:
- [x] Code formatted (`npx prettier` on touched files)
- [x] Lint run (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (not applicable)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685c0e76bad88331877c977dbb51960c