### PR TITLE
[Fix] add missing IUserPrompt dependency

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -209,6 +209,7 @@ export function registerRenderers(registrar, logger) {
         domElementFactory: c.resolve(tokens.DomElementFactory),
         saveLoadService: c.resolve(tokens.ISaveLoadService),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
+        userPrompt: c.resolve(tokens.IUserPrompt),
       })
   );
   logger.debug(`UI Registrations: Registered ${tokens.LoadGameUI}.`);

--- a/tests/unit/config/registrations/uiRegistrations.loadGameUIResolution.test.js
+++ b/tests/unit/config/registrations/uiRegistrations.loadGameUIResolution.test.js
@@ -1,0 +1,50 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import { registerUI } from '../../../../src/dependencyInjection/registrations/uiRegistrations.js';
+import { tokens } from '../../../../src/dependencyInjection/tokens.js';
+import { MockContainer } from '../../../common/mockFactories/index.js';
+import LoadGameUI from '../../../../src/domUI/loadGameUI.js';
+
+const uiElements = {
+  outputDiv: document.createElement('div'),
+  inputElement: document.createElement('input'),
+  titleElement: document.createElement('h1'),
+  document,
+};
+
+describe('registerUI LoadGameUI resolution', () => {
+  /** @type {MockContainer} */
+  let container;
+
+  beforeEach(() => {
+    container = new MockContainer();
+    container.register(tokens.ILogger, {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    });
+    container.register(tokens.ISafeEventDispatcher, {
+      subscribe: jest.fn(),
+      dispatch: jest.fn(),
+    });
+    container.register(tokens.IValidatedEventDispatcher, {
+      subscribe: jest.fn(),
+      dispatch: jest.fn(),
+    });
+    container.register(tokens.IEntityManager, {});
+    container.register(tokens.EntityDisplayDataProvider, {});
+    container.register(tokens.IDataRegistry, {});
+    container.register(tokens.ISaveLoadService, {
+      listManualSaveSlots: jest.fn(),
+      deleteManualSave: jest.fn(),
+    });
+    container.register(tokens.LLMAdapter, {});
+  });
+
+  it('resolves LoadGameUI with IUserPrompt dependency', () => {
+    registerUI(container, uiElements);
+    const loadGameUI = container.resolve(tokens.LoadGameUI);
+    expect(loadGameUI).toBeInstanceOf(LoadGameUI);
+    const resolvedTokens = container.resolve.mock.calls.map((c) => c[0]);
+    expect(resolvedTokens).toContain(tokens.IUserPrompt);
+  });
+});


### PR DESCRIPTION
Summary: Fix app crash by adding IUserPrompt dependency to LoadGameUI registration and add regression test.

Changes Made:
- updated `uiRegistrations.js` to resolve `IUserPrompt` when creating LoadGameUI
- added `uiRegistrations.loadGameUIResolution.test.js` to ensure dependency is injected

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and llm-proxy-server) *(fails: existing project issues)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685c1098023083319e44d812036d48c2