### PR TITLE
[Agent] Refactor placeholder and LLM utils

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,3 +13,8 @@ export * from './logHelpers.js';
 export * from './objectUtils.js';
 export * from './cloneUtils.js';
 export * from './cloneTotals.js';
+export * from './placeholderPatterns.js';
+export * from './placeholderPathResolver.js';
+export { StructureResolver } from './structureResolver.js';
+export * from './jsonCleaning.js';
+export * from './jsonRepair.js';

--- a/src/utils/jsonCleaning.js
+++ b/src/utils/jsonCleaning.js
@@ -1,0 +1,54 @@
+/**
+ * @module jsonCleaning
+ * @description Utilities for cleaning raw LLM JSON output strings.
+ */
+
+/**
+ * List of common conversational prefixes to remove. Exported for reuse in tests.
+ */
+export const CONVERSATIONAL_PREFIXES = [
+  'certainly, here is the json object:',
+  'here is the json output:',
+  'here is the json:',
+  'here is your json:',
+  "here's the json:",
+  "okay, here's the json:",
+  'sure, here is the json:',
+  'the json response is:',
+];
+
+// Regex to identify and extract content from markdown code block wrappers.
+const MARKDOWN_WRAPPER_REGEX = /^```(?:json|markdown)?\s*?\n?(.*?)\n?\s*?```$/s;
+
+/**
+ * Sanitizes raw string responses from LLMs by removing conversational prefixes and
+ * markdown code block wrappers.
+ *
+ * @param {any} rawOutput - The raw output received from the LLM.
+ * @returns {any} If `rawOutput` is a string, returns the cleaned string. Otherwise returns `rawOutput` unmodified.
+ */
+export function cleanLLMJsonOutput(rawOutput) {
+  if (typeof rawOutput !== 'string') {
+    return rawOutput;
+  }
+
+  let currentString = rawOutput.trim();
+
+  for (const prefix of CONVERSATIONAL_PREFIXES) {
+    const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const prefixRegex = new RegExp(`^${escapedPrefix}\\s*`, 'i');
+
+    if (prefixRegex.test(currentString)) {
+      currentString = currentString.replace(prefixRegex, '');
+      currentString = currentString.trim();
+      break;
+    }
+  }
+
+  const match = currentString.match(MARKDOWN_WRAPPER_REGEX);
+  if (match && typeof match[1] === 'string') {
+    currentString = match[1];
+  }
+
+  return currentString.trim();
+}

--- a/src/utils/jsonRepair.js
+++ b/src/utils/jsonRepair.js
@@ -1,0 +1,111 @@
+/**
+ * @module jsonRepair
+ * @description Utilities for repairing and parsing JSON from LLM output.
+ */
+
+import { repairJson } from '@toolsycc/json-repair';
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+
+/**
+ * Custom error class for errors encountered during JSON processing,
+ * including parsing and repair attempts.
+ */
+export class JsonProcessingError extends Error {
+  /**
+   * @param {string} message - The error message.
+   * @param {object} [details] - Additional details about the error.
+   * @param {string} [details.stage] - The stage where the error occurred.
+   * @param {Error} [details.originalError] - The original error object, if any.
+   * @param {string} [details.attemptedJsonString] - The JSON string that was being processed.
+   */
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'JsonProcessingError';
+    this.stage = details.stage;
+    this.originalError = details.originalError;
+    this.attemptedJsonString = details.attemptedJsonString;
+    if (details.originalError && details.originalError.stack) {
+      this.stack = `${this.stack}\nCaused by: ${details.originalError.stack}`;
+    }
+  }
+}
+
+/**
+ * Attempts to parse a cleaned JSON string.
+ *
+ * @param {string} cleanedJsonString - The cleaned JSON string to parse.
+ * @param {import('../interfaces/coreServices.js').ILogger} log - Logger instance.
+ * @returns {object} Parsed JSON object.
+ * @throws {Error} Re-throws any `JSON.parse` error.
+ */
+export function initialParse(cleanedJsonString, log) {
+  try {
+    return JSON.parse(cleanedJsonString);
+  } catch (error) {
+    if (log && typeof log.debug === 'function') {
+      log.debug('initialParse: JSON.parse failed', { message: error.message });
+    }
+    throw error;
+  }
+}
+
+/**
+ * Attempts to repair a JSON string and then parse the result.
+ *
+ * @param {string} cleanedString - The cleaned JSON string to repair.
+ * @param {import('../interfaces/coreServices.js').ILogger} log - Logger used for debug or error output.
+ * @param {object} [dispatcher] - Optional dispatcher for error reporting.
+ * @param {Error} initialError - The error thrown from `initialParse`.
+ * @returns {object} The repaired and parsed object.
+ * @throws {JsonProcessingError} If repair or parsing fails.
+ */
+export function repairAndParse(cleanedString, log, dispatcher, initialError) {
+  try {
+    const repairedString = repairJson(cleanedString);
+    const repairedObject = JSON.parse(repairedString);
+    log.debug('parseAndRepairJson: Successfully parsed JSON after repair.', {
+      cleanedLength: cleanedString.length,
+      repairedLength: repairedString.length,
+    });
+    return repairedObject;
+  } catch (repairAndParseError) {
+    const errorMessage = `Failed to parse JSON even after repair attempt. Repair/Parse Error: ${repairAndParseError.message}`;
+    if (dispatcher) {
+      safeDispatchError(dispatcher, `parseAndRepairJson: ${errorMessage}`, {
+        cleanedJsonStringLength: cleanedString.length,
+        cleanedJsonPreview:
+          cleanedString.substring(0, 100) +
+          (cleanedString.length > 100 ? '...' : ''),
+        initialParseError: {
+          message: initialError.message,
+          name: initialError.name,
+        },
+        repairAndParseError: {
+          message: repairAndParseError.message,
+          name: repairAndParseError.name,
+        },
+      });
+    } else {
+      log.error(`parseAndRepairJson: ${errorMessage}`, {
+        cleanedJsonStringLength: cleanedString.length,
+        cleanedJsonPreview:
+          cleanedString.substring(0, 100) +
+          (cleanedString.length > 100 ? '...' : ''),
+        initialParseError: {
+          message: initialError.message,
+          name: initialError.name,
+        },
+        repairAndParseError: {
+          message: repairAndParseError.message,
+          name: repairAndParseError.name,
+        },
+      });
+    }
+    throw new JsonProcessingError(errorMessage, {
+      stage: 'final_parse_after_repair',
+      originalError: repairAndParseError,
+      initialParseError: initialError,
+      attemptedJsonString: cleanedString,
+    });
+  }
+}

--- a/src/utils/llmUtils.js
+++ b/src/utils/llmUtils.js
@@ -1,195 +1,25 @@
 // src/utils/llmUtils.js
 // --- FILE START ---
-
 /**
- * @file Utility functions for handling Large Language Model (LLM) outputs,
- * including cleaning, parsing, repairing, and validating JSON.
+ * @file Utility functions for handling Large Language Model (LLM) JSON outputs.
+ * Provides a high-level orchestrator to clean, repair, and parse JSON strings.
  */
 
-// Import the chosen JSON repair library
-import { repairJson } from '@toolsycc/json-repair';
 import { ensureValidLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
+import { cleanLLMJsonOutput, CONVERSATIONAL_PREFIXES } from './jsonCleaning.js';
+import {
+  JsonProcessingError,
+  initialParse,
+  repairAndParse,
+} from './jsonRepair.js';
 
-/**
- * Custom error class for errors encountered during JSON processing,
- * including parsing and repair attempts.
- */
-export class JsonProcessingError extends Error {
-  /**
-   * @param {string} message - The error message.
-   * @param {object} [details] - Additional details about the error.
-   * @param {string} [details.stage] - The stage where the error occurred (e.g., 'initial_parse', 'repair', 'final_parse').
-   * @param {Error} [details.originalError] - The original error object, if any.
-   * @param {string} [details.attemptedJsonString] - The JSON string that was being processed.
-   */
-  constructor(message, details = {}) {
-    super(message);
-    this.name = 'JsonProcessingError';
-    this.stage = details.stage;
-    this.originalError = details.originalError;
-    this.attemptedJsonString = details.attemptedJsonString;
-    if (details.originalError && details.originalError.stack) {
-      this.stack = `${this.stack}\nCaused by: ${details.originalError.stack}`;
-    }
-  }
-}
-
-// List of common conversational prefixes to remove.
-// Exported because the provided test file imports it.
-export const CONVERSATIONAL_PREFIXES = [
-  'certainly, here is the json object:',
-  'here is the json output:',
-  'here is the json:',
-  'here is your json:',
-  "here's the json:",
-  "okay, here's the json:",
-  'sure, here is the json:',
-  'the json response is:',
-];
-
-// Regex to identify and extract content from markdown code block wrappers.
-const MARKDOWN_WRAPPER_REGEX = /^```(?:json|markdown)?\s*?\n?(.*?)\n?\s*?```$/s;
-
-/**
- * Sanitizes raw string responses from LLMs by removing common extraneous text,
- * conversational artifacts, and markdown code block wrappers.
- * This is intended as a first step in a JSON post-processing pipeline,
- * ensuring that subsequent parsing attempts operate on the cleanest possible string.
- *
- * @param {any} rawOutput - The raw output received from the LLM.
- * Could be a string or any other data type.
- * @returns {any} If `rawOutput` is a string, it returns the cleaned string.
- * Otherwise, it returns the `rawOutput` as is without modification.
- * If cleaning results in an empty string (e.g., input was only
- * prefixes/wrappers and whitespace), an empty string is returned.
- */
-export function cleanLLMJsonOutput(rawOutput) {
-  if (typeof rawOutput !== 'string') {
-    return rawOutput;
-  }
-
-  // Initial trim to handle leading/trailing whitespace on the overall input.
-  let currentString = rawOutput.trim();
-
-  // 1. Attempt to remove conversational prefixes.
-  //    Prefixes are case-insensitive and can be followed by optional whitespace.
-  //    They are expected at the very beginning of the (now initially trimmed) string.
-  for (const prefix of CONVERSATIONAL_PREFIXES) {
-    const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const prefixRegex = new RegExp(`^${escapedPrefix}\\s*`, 'i');
-
-    if (prefixRegex.test(currentString)) {
-      currentString = currentString.replace(prefixRegex, '');
-      // Trim again after prefix removal to ensure the string starts cleanly
-      // for the subsequent markdown wrapper check.
-      currentString = currentString.trim();
-      break; // Only remove the first matching prefix.
-    }
-  }
-
-  // 2. Attempt to remove markdown code block wrappers.
-  //    The regex is designed to match if the wrapper encompasses the entire (remaining, trimmed) string.
-  const match = currentString.match(MARKDOWN_WRAPPER_REGEX);
-  if (match && typeof match[1] === 'string') {
-    // match[1] contains the content *inside* the wrapper.
-    currentString = match[1];
-  }
-
-  // 3. Final trim. This cleans the content extracted from the wrapper,
-  //    or the string if it had no recognized prefixes or wrappers but might have had internal content
-  //    that now needs trimming (e.g. if a wrapper contained only spaces).
-  return currentString.trim();
-}
-
-/**
- * @typedef {object} ILogger - Assumed logger interface.
- * @property {(message: any, ...optionalParams: any[]) => void} debug
- * @property {(message: any, ...optionalParams: any[]) => void} info
- * @property {(message: any, ...optionalParams: any[]) => void} warn
- * @property {(message: any, ...optionalParams: any[]) => void} error
- */
-
-/**
- * Attempts to parse a cleaned JSON string.
- *
- * @param {string} cleanedJsonString - The JSON string already processed by
- * `cleanLLMJsonOutput`.
- * @param {ILogger} log - Logger used for any debug output.
- * @returns {object} The parsed JSON object.
- * @throws {Error} Re-throws any `JSON.parse` error.
- */
-export function initialParse(cleanedJsonString, log) {
-  try {
-    return JSON.parse(cleanedJsonString);
-  } catch (error) {
-    if (log && typeof log.debug === 'function') {
-      log.debug('initialParse: JSON.parse failed', { message: error.message });
-    }
-    throw error;
-  }
-}
-
-/**
- * Attempts to repair a JSON string and then parse the result.
- *
- * @param {string} cleanedString - The cleaned JSON string to repair.
- * @param {ILogger} log - Logger used for debug or error output.
- * @param {object} [dispatcher] - Optional dispatcher for error reporting.
- * @param {Error} initialError - The error thrown from `initialParse`.
- * @returns {object} The repaired and parsed object.
- * @throws {JsonProcessingError} If repair or parsing fails.
- */
-export function repairAndParse(cleanedString, log, dispatcher, initialError) {
-  try {
-    const repairedString = repairJson(cleanedString);
-    const repairedObject = JSON.parse(repairedString);
-    log.debug('parseAndRepairJson: Successfully parsed JSON after repair.', {
-      cleanedLength: cleanedString.length,
-      repairedLength: repairedString.length,
-    });
-    return repairedObject;
-  } catch (repairAndParseError) {
-    const errorMessage = `Failed to parse JSON even after repair attempt. Repair/Parse Error: ${repairAndParseError.message}`;
-    if (dispatcher) {
-      safeDispatchError(dispatcher, `parseAndRepairJson: ${errorMessage}`, {
-        cleanedJsonStringLength: cleanedString.length,
-        cleanedJsonPreview:
-          cleanedString.substring(0, 100) +
-          (cleanedString.length > 100 ? '...' : ''),
-        initialParseError: {
-          message: initialError.message,
-          name: initialError.name,
-        },
-        repairAndParseError: {
-          message: repairAndParseError.message,
-          name: repairAndParseError.name,
-        },
-      });
-    } else {
-      log.error(`parseAndRepairJson: ${errorMessage}`, {
-        cleanedJsonStringLength: cleanedString.length,
-        cleanedJsonPreview:
-          cleanedString.substring(0, 100) +
-          (cleanedString.length > 100 ? '...' : ''),
-        initialParseError: {
-          message: initialError.message,
-          name: initialError.name,
-        },
-        repairAndParseError: {
-          message: repairAndParseError.message,
-          name: repairAndParseError.name,
-        },
-      });
-    }
-    throw new JsonProcessingError(errorMessage, {
-      stage: 'final_parse_after_repair',
-      originalError: repairAndParseError,
-      initialParseError: initialError,
-      attemptedJsonString: cleanedString,
-    });
-  }
-}
+export { cleanLLMJsonOutput, CONVERSATIONAL_PREFIXES } from './jsonCleaning.js';
+export {
+  JsonProcessingError,
+  initialParse,
+  repairAndParse,
+} from './jsonRepair.js';
 
 /**
  * Parses a JSON string, attempting to repair it if initial parsing fails.
@@ -197,7 +27,7 @@ export function repairAndParse(cleanedString, log, dispatcher, initialError) {
  *
  * @async
  * @param {string} jsonString - The raw JSON string to parse and potentially repair.
- * @param {ILogger} [logger] - Optional logger instance for logging warnings and errors.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger instance.
  * @param {object} [dispatcher] - Optional dispatcher for error reporting.
  * @returns {Promise<object>} A promise that resolves with the parsed JavaScript object.
  * @throws {JsonProcessingError} If the input string is invalid, or if parsing fails even after repair attempts.
@@ -220,7 +50,7 @@ export async function parseAndRepairJson(jsonString, logger, dispatcher) {
     throw new TypeError(errorMessage);
   }
 
-  const cleanedJsonString = cleanLLMJsonOutput(jsonString); // [cite: 1, 995]
+  const cleanedJsonString = cleanLLMJsonOutput(jsonString);
 
   if (cleanedJsonString === null || cleanedJsonString.trim() === '') {
     const errorMessage = 'Cleaned JSON string is null or empty, cannot parse.';

--- a/src/utils/placeholderParsing.js
+++ b/src/utils/placeholderParsing.js
@@ -3,14 +3,4 @@
  * @description Utilities for parsing placeholder syntax.
  */
 
-/**
- * Parses a placeholder key and determines whether it is optional.
- *
- * @param {string} key - Raw placeholder key.
- * @returns {{ key: string, optional: boolean }} Parsed key and optional flag.
- */
-export function parsePlaceholderKey(key) {
-  const trimmed = key.trim();
-  const optional = trimmed.endsWith('?');
-  return { key: optional ? trimmed.slice(0, -1) : trimmed, optional };
-}
+export { parsePlaceholderKey } from './placeholderPatterns.js';

--- a/src/utils/placeholderPathResolver.js
+++ b/src/utils/placeholderPathResolver.js
@@ -1,0 +1,76 @@
+/**
+ * @module placeholderPathResolver
+ * @description Helper functions for resolving placeholder paths against an execution context.
+ */
+
+import { safeResolvePath } from './objectUtils.js';
+import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
+
+/**
+ * Extracts the effective root and path when handling `context.` placeholders.
+ *
+ * @param {string} placeholderPath - Original placeholder path.
+ * @param {object} executionContext - The current execution context.
+ * @returns {{ path: string, root: object } | null} Extracted info or `null` on invalid context.
+ */
+export function extractContextPath(placeholderPath, executionContext) {
+  if (!placeholderPath.startsWith('context.')) {
+    return { path: placeholderPath, root: executionContext };
+  }
+
+  const ctx = executionContext?.evaluationContext?.context;
+  if (ctx && typeof ctx === 'object') {
+    return { path: placeholderPath.substring('context.'.length), root: ctx };
+  }
+
+  return null;
+}
+
+/**
+ * Resolves a placeholder path against the provided execution context.
+ *
+ * @param {string} placeholderPath - Path from the placeholder (e.g., `context.varA`).
+ * @param {object} executionContext - The execution context root object.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for warnings and errors.
+ * @param {string} [logPath] - String used in log messages to indicate the source of the resolution attempt.
+ * @returns {any|undefined} The resolved value, or `undefined` when resolution fails.
+ */
+export function resolvePlaceholderPath(
+  placeholderPath,
+  executionContext,
+  logger,
+  logPath = ''
+) {
+  if (!placeholderPath) {
+    logger?.warn(`Failed to extract path from placeholder at ${logPath}`);
+    return undefined;
+  }
+
+  if (!executionContext || typeof executionContext !== 'object') {
+    logger?.warn(
+      `Cannot resolve placeholder path "${placeholderPath}" at ${logPath}: executionContext is not a valid object.`
+    );
+    return undefined;
+  }
+
+  const contextInfo = extractContextPath(placeholderPath, executionContext);
+  if (contextInfo === null) {
+    logger?.warn(
+      `Placeholder "${placeholderPath}" uses "context." prefix, but executionContext.evaluationContext.context is missing or invalid. Path: ${logPath}`
+    );
+    return undefined;
+  }
+
+  const { value, error } = safeResolvePath(
+    contextInfo.root,
+    contextInfo.path,
+    logger,
+    `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
+  );
+
+  const resolvedValue =
+    (error ? undefined : value) ??
+    resolveEntityNameFallback(placeholderPath, executionContext, logger);
+
+  return resolvedValue;
+}

--- a/src/utils/placeholderPatterns.js
+++ b/src/utils/placeholderPatterns.js
@@ -1,0 +1,33 @@
+/**
+ * @module placeholderPatterns
+ * @description Regular expressions and helper functions for placeholder parsing.
+ */
+
+/**
+ * Regex to find placeholders like {path.to.value} within a string.
+ * Group 1 captures the path without braces.
+ * The global flag ensures all occurrences are matched.
+ *
+ * @type {RegExp}
+ */
+export const PLACEHOLDER_FIND_REGEX = /{\s*([^}\s]+)\s*}/g;
+
+/**
+ * Regex to check if an entire string is only a placeholder.
+ * Group 1 captures the path within the braces.
+ *
+ * @type {RegExp}
+ */
+export const FULL_STRING_PLACEHOLDER_REGEX = /^{\s*([^}\s]+)\s*}$/;
+
+/**
+ * Parses a placeholder key and determines whether it is optional.
+ *
+ * @param {string} key - Raw placeholder key.
+ * @returns {{ key: string, optional: boolean }} Parsed key and optional flag.
+ */
+export function parsePlaceholderKey(key) {
+  const trimmed = key.trim();
+  const optional = trimmed.endsWith('?');
+  return { key: optional ? trimmed.slice(0, -1) : trimmed, optional };
+}

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -2,41 +2,39 @@
 // --- FILE START ---
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-import { safeResolvePath } from './objectUtils.js';
-import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
+
 import { ensureValidLogger } from './loggerUtils.js';
-import { parsePlaceholderKey } from './placeholderParsing.js';
+import { safeResolvePath } from './objectUtils.js';
+import {
+  PLACEHOLDER_FIND_REGEX,
+  FULL_STRING_PLACEHOLDER_REGEX,
+  parsePlaceholderKey,
+} from './placeholderPatterns.js';
+import {
+  extractContextPath,
+  resolvePlaceholderPath,
+} from './placeholderPathResolver.js';
+import { StructureResolver } from './structureResolver.js';
 
-/**
- * Regex to find placeholders like {path.to.value} within a string.
- * Group 1 captures the path without braces.
- * The global flag ensures all occurrences are matched.
- *
- * @type {RegExp}
- */
-export const PLACEHOLDER_FIND_REGEX = /{\s*([^}\s]+)\s*}/g;
-
-/**
- * Regex to check if an entire string is only a placeholder.
- * Group 1 captures the path within the braces.
- *
- * @type {RegExp}
- */
-export const FULL_STRING_PLACEHOLDER_REGEX = /^{\s*([^}\s]+)\s*}$/;
+export {
+  PLACEHOLDER_FIND_REGEX,
+  FULL_STRING_PLACEHOLDER_REGEX,
+  parsePlaceholderKey,
+} from './placeholderPatterns.js';
+export {
+  extractContextPath,
+  resolvePlaceholderPath,
+} from './placeholderPathResolver.js';
 
 /**
  * @class PlaceholderResolver
- * @description A utility class dedicated to resolving placeholders in strings.
- * It replaces placeholders (e.g., `{key}`) with values from provided data objects.
- * This class is designed to be reusable and independently testable.
+ * @description A utility class dedicated to resolving placeholders in strings and structures.
  */
 export class PlaceholderResolver {
-  /**
-   * @private
-   * @type {ILogger}
-   * @description Logger instance. Defaults to console if no logger is provided.
-   */
+  /** @type {ILogger} */
   #logger;
+  /** @type {StructureResolver} */
+  #resolver;
 
   /**
    * Initializes a new instance of the PlaceholderResolver.
@@ -45,405 +43,53 @@ export class PlaceholderResolver {
    */
   constructor(logger = console) {
     this.#logger = ensureValidLogger(logger, 'PlaceholderResolver');
-  }
-
-  /**
-   * Builds the data sources for placeholder resolution.
-   *
-   * @description Creates the base, root context, and fallback sources used by
-   *   {@link PlaceholderResolver#resolveStructure}.
-   * @param {object} executionContext - Execution context supplying actor, target,
-   *   and evaluationContext data.
-   * @returns {{sources: object[], fallback: object}} Sources array and fallback
-   *   object for {@link PlaceholderResolver#resolveStructure}.
-   */
-
-  /**
-   * Extracts the effective root and path when handling `context.` placeholders.
-   *
-   * @description Returns an object containing the trimmed path and the root
-   * context object. When the prefix is used but `executionContext.evaluationContext.context`
-   * is missing, `null` is returned.
-   * @param {string} placeholderPath - Original placeholder path.
-   * @param {object} executionContext - The current execution context.
-   * @returns {{ path: string, root: object } | null} Extracted info or `null` on
-   *   invalid context.
-   */
-  static extractContextPath(placeholderPath, executionContext) {
-    if (!placeholderPath.startsWith('context.')) {
-      return { path: placeholderPath, root: executionContext };
-    }
-
-    const ctx = executionContext?.evaluationContext?.context;
-    if (ctx && typeof ctx === 'object') {
-      return { path: placeholderPath.substring('context.'.length), root: ctx };
-    }
-
-    return null;
-  }
-
-  /**
-   * Resolves a placeholder path against the provided execution context.
-   *
-   * @description Handles the `context.` prefix, uses {@link safeResolvePath}, and
-   * falls back to {@link resolveEntityNameFallback} when direct resolution fails.
-   * @param {string} placeholderPath - Path from the placeholder (e.g.,
-   *   `context.varA`).
-   * @param {object} executionContext - The execution context root object.
-   * @param {ILogger} [logger] - Optional logger for warnings and errors.
-   * @param {string} [logPath] - String used in log messages to indicate the
-   *   source of the resolution attempt.
-   * @returns {any|undefined} The resolved value, or `undefined` when resolution
-   *   fails.
-   */
-  static resolvePlaceholderPath(
-    placeholderPath,
-    executionContext,
-    logger,
-    logPath = ''
-  ) {
-    if (!placeholderPath) {
-      logger?.warn(`Failed to extract path from placeholder at ${logPath}`);
-      return undefined;
-    }
-
-    if (!executionContext || typeof executionContext !== 'object') {
-      logger?.warn(
-        `Cannot resolve placeholder path "${placeholderPath}" at ${logPath}: executionContext is not a valid object.`
+    const resolvePath = (obj, path) => {
+      const { value } = safeResolvePath(
+        obj,
+        path,
+        this.#logger,
+        'PlaceholderResolver.resolvePath'
       );
-      return undefined;
-    }
-
-    const contextInfo = this.extractContextPath(
-      placeholderPath,
-      executionContext
-    );
-    if (contextInfo === null) {
-      logger?.warn(
-        `Placeholder "${placeholderPath}" uses "context." prefix, but executionContext.evaluationContext.context is missing or invalid. Path: ${logPath}`
-      );
-      return undefined;
-    }
-
-    const { value, error } = safeResolvePath(
-      contextInfo.root,
-      contextInfo.path,
-      logger,
-      `resolvePlaceholderPath for "${placeholderPath}" at ${logPath}`
-    );
-
-    const resolvedValue =
-      (error ? undefined : value) ??
-      resolveEntityNameFallback(placeholderPath, executionContext, logger);
-
-    return resolvedValue;
+      return value;
+    };
+    this.#resolver = new StructureResolver(resolvePath, this.#logger);
   }
 
-  /**
-   * Resolves a dotted path against a given object.
-   *
-   * @param {object} obj - Root object to resolve against.
-   * @param {string} path - Dot separated path.
-   * @returns {any|undefined} Resolved value or undefined if not found.
-   */
-  resolvePath(obj, path) {
-    const { value } = safeResolvePath(
-      obj,
-      path,
-      this.#logger,
-      'PlaceholderResolver.resolvePath'
-    );
-    return value;
-  }
+  // Static helpers exposed for convenience
+  static extractContextPath = extractContextPath;
+  static resolvePlaceholderPath = resolvePlaceholderPath;
 
   /**
-   * Resolves placeholders in a string using data from one or more source objects.
-   * Placeholders are expected in the format `{key}`.
+   * Resolves placeholders in a string using data from source objects.
    *
-   * For each placeholder:
-   * - The `key` (trimmed of whitespace) is searched in each `dataSource` object, in the order they are provided.
-   * - If the `key` is found, the placeholder is replaced with its corresponding value.
-   * - If the value is `null` or `undefined`, it's replaced with an empty string.
-   * - Other values (numbers, booleans, etc.) are converted to strings.
-   * - If the `key` is not found in any `dataSource`, the placeholder is replaced with an empty string,
-   * and a warning is logged via the injected logger.
-   *
-   * If the input `str` is not a string or is empty, an empty string is returned.
-   * Non-object items in `dataSources` are gracefully skipped during the key search.
-   *
-   * @param {string} str - The string potentially containing placeholders (e.g., "Hello {name}, welcome to {place}!").
-   * @param {...object} dataSources - A variable number of data source objects to search for placeholder values.
-   * Earlier objects in the list take precedence.
-   * @returns {string} The string with all recognized placeholders processed, or an empty string if the input `str` was invalid.
+   * @param {string} str - String that may contain placeholders.
+   * @param {...object} dataSources - Data sources to resolve against.
+   * @returns {string} The resolved string.
    */
   resolve(str, ...dataSources) {
-    if (!str || typeof str !== 'string') {
-      return '';
-    }
-
-    return str.replace(PLACEHOLDER_FIND_REGEX, (match, placeholderKey) => {
-      const { key: trimmedKey, optional: isOptional } =
-        parsePlaceholderKey(placeholderKey);
-      for (const dataSource of dataSources) {
-        if (dataSource && typeof dataSource === 'object') {
-          const value = this.resolvePath(dataSource, trimmedKey);
-          if (value !== undefined) {
-            if (value === null) {
-              return '';
-            }
-            return String(value);
-          } else {
-            const parts = trimmedKey.split('.');
-            const last = parts.pop();
-            const parentPath = parts.join('.');
-            const parent =
-              parentPath === ''
-                ? dataSource
-                : this.resolvePath(dataSource, parentPath);
-            if (
-              parent &&
-              typeof parent === 'object' &&
-              Object.prototype.hasOwnProperty.call(parent, last)
-            ) {
-              return '';
-            }
-          }
-        }
-      }
-      if (!isOptional) {
-        this.#logger.warn(
-          `PlaceholderResolver: Placeholder "{${trimmedKey}}" not found in provided data sources. Replacing with empty string.`
-        );
-      }
-      return '';
-    });
-  }
-
-  /**
-   * Resolves a value from an array of source objects using a dotted path.
-   *
-   * @private
-   * @param {{key: string, optional: boolean}} placeholderInfo - Parsed
-   *   placeholder key information.
-   * @param {object[]} sources - Ordered list of source objects.
-   * @returns {*} Resolved value or `undefined` if not found.
-   */
-  _resolveFromSources(placeholderInfo, sources) {
-    const { key } = placeholderInfo;
-    for (const source of sources) {
-      if (source && typeof source === 'object') {
-        const value = this.resolvePath(source, key);
-        if (value !== undefined) {
-          return value;
-        } else {
-          const parts = key.split('.');
-          const last = parts.pop();
-          const parentPath = parts.join('.');
-          const parent =
-            parentPath === '' ? source : this.resolvePath(source, parentPath);
-          if (
-            parent &&
-            typeof parent === 'object' &&
-            Object.prototype.hasOwnProperty.call(parent, last)
-          ) {
-            return parent[last];
-          }
-        }
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Handles cases where the entire string is a single placeholder.
-   *
-   * @private
-   * @param {string} value - String potentially consisting solely of a placeholder.
-   * @param {object[]} sources - Resolution sources.
-   * @returns {{changed: boolean, value: *}} Resulting value and change flag.
-   */
-  _handleFullString(value, sources) {
-    const fullMatch = value.match(FULL_STRING_PLACEHOLDER_REGEX);
-    if (!fullMatch) {
-      return { changed: false, value };
-    }
-
-    // Trigger warning handling by attempting normal resolution first.
-    this.resolve(value, ...sources);
-
-    const placeholderInfo = parsePlaceholderKey(fullMatch[1]);
-    const resolved = this._resolveFromSources(placeholderInfo, sources);
-    const { key: placeholderPath, optional: isOptional } = placeholderInfo;
-    if (resolved !== undefined) {
-      this.#logger.debug(
-        `Resolved full string placeholder {${placeholderPath}${isOptional ? '?' : ''}} to: ${
-          typeof resolved === 'object' ? JSON.stringify(resolved) : resolved
-        }`
-      );
-      return { changed: true, value: resolved };
-    }
-    return { changed: true, value: undefined };
-  }
-
-  /**
-   * Replaces embedded placeholders within a string.
-   *
-   * @private
-   * @param {string} value - String potentially containing embedded placeholders.
-   * @param {object[]} sources - Resolution sources.
-   * @returns {{changed: boolean, value: *}} Resulting value and change flag.
-   */
-  _replaceEmbedded(value, sources) {
-    const replaced = this.resolve(value, ...sources);
-    if (replaced !== value) {
-      let match;
-      PLACEHOLDER_FIND_REGEX.lastIndex = 0;
-      while ((match = PLACEHOLDER_FIND_REGEX.exec(value))) {
-        const placeholderSyntax = match[0];
-        const placeholderInfo = parsePlaceholderKey(match[1]);
-        const resolved = this._resolveFromSources(placeholderInfo, sources);
-        const { key: placeholderPath } = placeholderInfo;
-        if (resolved !== undefined) {
-          const stringValue = resolved === null ? 'null' : String(resolved);
-          this.#logger.debug(
-            `Replaced embedded placeholder ${placeholderSyntax} with string: "${stringValue}"`
-          );
-        }
-      }
-      return { changed: true, value: replaced };
-    }
-    return { changed: false, value };
-  }
-
-  /**
-   * Handles string placeholder resolution.
-   *
-   * @private
-   * @param {string} value String potentially containing placeholders.
-   * @param {object[]} sources Resolution sources.
-   * @returns {{changed: boolean, value: *}} Resulting value and change flag.
-   */
-  _resolveString(value, sources) {
-    const fullResult = this._handleFullString(value, sources);
-    if (fullResult.changed) {
-      return fullResult;
-    }
-
-    return this._replaceEmbedded(value, sources);
-  }
-
-  /**
-   * Handles array placeholder resolution.
-   *
-   * @private
-   * @param {Array} arr Array potentially containing placeholders.
-   * @param {object[]} sources Resolution sources.
-   * @returns {{changed: boolean, value: *}} Resulting value and change flag.
-   */
-  _resolveArray(arr, sources) {
-    let changed = false;
-    const resolvedArr = arr.map((item) => {
-      const { value: resolvedItem, changed: c } = this._resolveValue(
-        item,
-        sources
-      );
-      if (c) {
-        changed = true;
-      }
-      return resolvedItem;
-    });
-    return { changed, value: changed ? resolvedArr : arr };
-  }
-
-  /**
-   * Handles object placeholder resolution.
-   *
-   * @private
-   * @param {object} obj Object potentially containing placeholders.
-   * @param {object[]} sources Resolution sources.
-   * @param {Set<string>} skipKeys Keys that should not be resolved at this level.
-   * @returns {{changed: boolean, value: *}} Resulting value and change flag.
-   */
-  _resolveObject(obj, sources, skipKeys) {
-    let changed = false;
-    const result = {};
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        if (skipKeys && skipKeys.has(key)) {
-          result[key] = obj[key];
-        } else {
-          const { value: resolvedVal, changed: c } = this._resolveValue(
-            obj[key],
-            sources
-          );
-          if (c) {
-            changed = true;
-          }
-          result[key] = resolvedVal;
-        }
-      }
-    }
-    return { changed, value: changed ? result : obj };
-  }
-
-  /**
-   * Recursively resolves placeholders within a value using provided sources.
-   *
-   * @private
-   * @param {*} value - Value that may contain placeholders.
-   * @param {object[]} sources - Ordered list of source objects.
-   * @param {Set<string>} skipKeys - Keys to skip when resolving objects.
-   * @returns {*} Value with placeholders resolved.
-   */
-  _resolveValue(value, sources, skipKeys) {
-    if (typeof value === 'string') {
-      return this._resolveString(value, sources);
-    }
-
-    if (Array.isArray(value)) {
-      return this._resolveArray(value, sources);
-    }
-
-    if (value && typeof value === 'object' && !(value instanceof Date)) {
-      return this._resolveObject(value, sources, skipKeys);
-    }
-
-    return { changed: false, value };
+    return this.#resolver.resolve(str, ...dataSources);
   }
 
   /**
    * Recursively resolves placeholders within a complex structure.
    *
-   * @description Strings are processed with {@link PlaceholderResolver#resolve}.
-   * If a string consists solely of a single placeholder, the resolved value is
-   * returned with its original type. Arrays and objects are traversed
-   * recursively.
    * @param {*} input - The value that may contain placeholders.
-   * @param {object|object[]} context - Primary data source or array of sources
-   *   used for resolution.
+   * @param {object|object[]} context - Primary data source or array of sources.
    * @param {object} [fallback] - Optional fallback data source.
-   * @param {Iterable<string>} [skipKeys] - Keys to leave unresolved when
-   *   encountered at the current object level. Defaults to `[]`.
+   * @param {Iterable<string>} [skipKeys] - Keys to leave unresolved at the current object level.
    * @returns {*} The input with all placeholders resolved.
    */
   resolveStructure(input, context, fallback = {}, skipKeys = []) {
-    const sources = Array.isArray(context) ? [...context] : [context];
-    if (
-      fallback &&
-      typeof fallback === 'object' &&
-      Object.keys(fallback).length
-    ) {
-      sources.push(fallback);
-    }
+    return this.#resolver.resolveStructure(input, context, fallback, skipKeys);
+  }
 
-    const skipSet =
-      skipKeys instanceof Set
-        ? skipKeys
-        : Array.isArray(skipKeys)
-          ? new Set(skipKeys)
-          : new Set();
+  // Proxy private helpers for existing unit tests
+  _handleFullString(value, sources) {
+    return this.#resolver._handleFullString(value, sources);
+  }
 
-    return this._resolveValue(input, sources, skipSet).value;
+  _replaceEmbedded(value, sources) {
+    return this.#resolver._replaceEmbedded(value, sources);
   }
 }
 

--- a/src/utils/structureResolver.js
+++ b/src/utils/structureResolver.js
@@ -1,0 +1,228 @@
+/**
+ * @module structureResolver
+ * @description Functions for resolving placeholders within complex structures.
+ */
+
+import {
+  parsePlaceholderKey,
+  PLACEHOLDER_FIND_REGEX,
+  FULL_STRING_PLACEHOLDER_REGEX,
+} from './placeholderPatterns.js';
+
+/**
+ * @class StructureResolver
+ * @description Class responsible for resolving placeholders inside strings,
+ * arrays and objects.
+ */
+export class StructureResolver {
+  /**
+   * @param {(obj: object, path: string) => any} resolvePath - Function used to resolve dotted paths.
+   * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger instance.
+   */
+  constructor(resolvePath, logger) {
+    this.resolvePath = resolvePath;
+    this.logger = logger;
+  }
+
+  /**
+   * Resolves placeholders in a string using provided data sources.
+   *
+   * @param {string} str - The string potentially containing placeholders.
+   * @param {...object} dataSources - Source objects for resolution.
+   * @returns {string} The string with placeholders replaced.
+   */
+  resolve(str, ...dataSources) {
+    if (!str || typeof str !== 'string') {
+      return '';
+    }
+
+    return str.replace(PLACEHOLDER_FIND_REGEX, (match, placeholderKey) => {
+      const { key: trimmedKey, optional: isOptional } =
+        parsePlaceholderKey(placeholderKey);
+      for (const dataSource of dataSources) {
+        if (dataSource && typeof dataSource === 'object') {
+          const value = this.resolvePath(dataSource, trimmedKey);
+          if (value !== undefined) {
+            if (value === null) {
+              return '';
+            }
+            return String(value);
+          } else {
+            const parts = trimmedKey.split('.');
+            const last = parts.pop();
+            const parentPath = parts.join('.');
+            const parent =
+              parentPath === ''
+                ? dataSource
+                : this.resolvePath(dataSource, parentPath);
+            if (
+              parent &&
+              typeof parent === 'object' &&
+              Object.prototype.hasOwnProperty.call(parent, last)
+            ) {
+              return '';
+            }
+          }
+        }
+      }
+      if (!isOptional) {
+        this.logger.warn(
+          `PlaceholderResolver: Placeholder "{${trimmedKey}}" not found in provided data sources. Replacing with empty string.`
+        );
+      }
+      return '';
+    });
+  }
+
+  _resolveFromSources(placeholderInfo, sources) {
+    const { key } = placeholderInfo;
+    for (const source of sources) {
+      if (source && typeof source === 'object') {
+        const value = this.resolvePath(source, key);
+        if (value !== undefined) {
+          return value;
+        } else {
+          const parts = key.split('.');
+          const last = parts.pop();
+          const parentPath = parts.join('.');
+          const parent =
+            parentPath === '' ? source : this.resolvePath(source, parentPath);
+          if (
+            parent &&
+            typeof parent === 'object' &&
+            Object.prototype.hasOwnProperty.call(parent, last)
+          ) {
+            return parent[last];
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  _handleFullString(value, sources) {
+    const fullMatch = value.match(FULL_STRING_PLACEHOLDER_REGEX);
+    if (!fullMatch) {
+      return { changed: false, value };
+    }
+
+    // Trigger warning handling by attempting normal resolution first.
+    this.resolve(value, ...sources);
+
+    const placeholderInfo = parsePlaceholderKey(fullMatch[1]);
+    const resolved = this._resolveFromSources(placeholderInfo, sources);
+    const { key: placeholderPath, optional: isOptional } = placeholderInfo;
+    if (resolved !== undefined) {
+      this.logger.debug(
+        `Resolved full string placeholder {${placeholderPath}${isOptional ? '?' : ''}} to: ${
+          typeof resolved === 'object' ? JSON.stringify(resolved) : resolved
+        }`
+      );
+      return { changed: true, value: resolved };
+    }
+    return { changed: true, value: undefined };
+  }
+
+  _replaceEmbedded(value, sources) {
+    const replaced = this.resolve(value, ...sources);
+    if (replaced !== value) {
+      let match;
+      PLACEHOLDER_FIND_REGEX.lastIndex = 0;
+      while ((match = PLACEHOLDER_FIND_REGEX.exec(value))) {
+        const placeholderSyntax = match[0];
+        const placeholderInfo = parsePlaceholderKey(match[1]);
+        const resolved = this._resolveFromSources(placeholderInfo, sources);
+        if (resolved !== undefined) {
+          const stringValue = resolved === null ? 'null' : String(resolved);
+          this.logger.debug(
+            `Replaced embedded placeholder ${placeholderSyntax} with string: "${stringValue}"`
+          );
+        }
+      }
+      return { changed: true, value: replaced };
+    }
+    return { changed: false, value };
+  }
+
+  _resolveString(value, sources) {
+    const fullResult = this._handleFullString(value, sources);
+    if (fullResult.changed) {
+      return fullResult;
+    }
+
+    return this._replaceEmbedded(value, sources);
+  }
+
+  _resolveArray(arr, sources) {
+    let changed = false;
+    const resolvedArr = arr.map((item) => {
+      const { value: resolvedItem, changed: c } = this._resolveValue(
+        item,
+        sources
+      );
+      if (c) {
+        changed = true;
+      }
+      return resolvedItem;
+    });
+    return { changed, value: changed ? resolvedArr : arr };
+  }
+
+  _resolveObject(obj, sources, skipKeys) {
+    let changed = false;
+    const result = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        if (skipKeys && skipKeys.has(key)) {
+          result[key] = obj[key];
+        } else {
+          const { value: resolvedVal, changed: c } = this._resolveValue(
+            obj[key],
+            sources
+          );
+          if (c) {
+            changed = true;
+          }
+          result[key] = resolvedVal;
+        }
+      }
+    }
+    return { changed, value: changed ? result : obj };
+  }
+
+  _resolveValue(value, sources, skipKeys) {
+    if (typeof value === 'string') {
+      return this._resolveString(value, sources);
+    }
+
+    if (Array.isArray(value)) {
+      return this._resolveArray(value, sources);
+    }
+
+    if (value && typeof value === 'object' && !(value instanceof Date)) {
+      return this._resolveObject(value, sources, skipKeys);
+    }
+
+    return { changed: false, value };
+  }
+
+  resolveStructure(input, context, fallback = {}, skipKeys = []) {
+    const sources = Array.isArray(context) ? [...context] : [context];
+    if (
+      fallback &&
+      typeof fallback === 'object' &&
+      Object.keys(fallback).length
+    ) {
+      sources.push(fallback);
+    }
+
+    const skipSet =
+      skipKeys instanceof Set
+        ? skipKeys
+        : Array.isArray(skipKeys)
+          ? new Set(skipKeys)
+          : new Set();
+
+    return this._resolveValue(input, sources, skipSet).value;
+  }
+}

--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -9,7 +9,7 @@ import {
   afterEach,
 } from '@jest/globals';
 import { PlaceholderResolver } from '../../../src/utils/placeholderResolverUtils.js';
-import { parsePlaceholderKey } from '../../../src/utils/placeholderParsing.js';
+import { parsePlaceholderKey } from '../../../src/utils/placeholderPatterns.js';
 import { buildResolutionSources } from '../../../src/utils/placeholderSources.js';
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed (assuming testUtils.js from previous adjustment)
 import * as loggerUtils from '../../../src/utils/loggerUtils.js';


### PR DESCRIPTION
## Summary
- extract placeholder regex and helpers into placeholderPatterns
- add placeholderPathResolver and structureResolver modules
- delegate placeholder logic in PlaceholderResolver to new helpers
- split JSON cleaning and repair helpers into dedicated modules
- orchestrate JSON parsing in llmUtils

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 629 errors, 2447 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c0c29743c8331830037f834455c7d