### PR TITLE
[Agent] Improve file loading parallelism

### DIFF
--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -147,9 +147,10 @@ export class WorldLoader extends AbstractLoader {
         continue;
       }
 
-      for (const filename of worldFiles) {
-        await this._processWorldFile(modId, filename, worldSchemaId, totals);
-      }
+      const filePromises = worldFiles.map((filename) =>
+        this._processWorldFile(modId, filename, worldSchemaId, totals)
+      );
+      await Promise.all(filePromises);
     }
 
     totalCounts.worlds = {

--- a/tests/unit/services/schemaLoader.errors.test.js
+++ b/tests/unit/services/schemaLoader.errors.test.js
@@ -30,7 +30,6 @@ const mockLogger = {
 const commonSchemaFile = 'common.schema.json';
 const entityDefinitionSchemaFile = 'entity-definition.schema.json';
 const entityInstanceSchemaFile = 'entity-instance.schema.json';
-const manifestSchemaId = 'test://schemas/manifest'; // Needed for initial check bypass
 const commonSchemaPath = `./test/schemas/${commonSchemaFile}`;
 const entityDefinitionSchemaPath = `./test/schemas/${entityDefinitionSchemaFile}`;
 const entityInstanceSchemaPath = `./test/schemas/${entityInstanceSchemaFile}`;
@@ -160,8 +159,8 @@ describe('SchemaLoader - Error Handling', () => {
     console.log('[Fetch Error] Rejection confirmed.');
 
     // Assertions
-    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(2);
-    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(2);
+    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(3);
+    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(3);
 
     // With batch registration, no schemas should be registered if there's a fetch error
     console.log(
@@ -218,8 +217,8 @@ describe('SchemaLoader - Error Handling', () => {
     console.log('[Missing $id] Rejection confirmed.');
 
     // Assertions
-    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(2);
-    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(2);
+    expect(mockPathResolver.resolveSchemaPath).toHaveBeenCalledTimes(3);
+    expect(mockDataFetcher.fetch).toHaveBeenCalledTimes(3);
 
     // With batch registration, no schemas should be registered if there's a missing $id error
     console.log(


### PR DESCRIPTION
## Summary
- remove unused single schema loader helper and load schemas in parallel
- process multiple world files concurrently
- update schema loader error tests for new parallel fetch counts

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3079 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c0f9f0cf48331bbe3cab7b1c6634d