### PR TITLE
[Agent] rename query variable

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -643,17 +643,17 @@ class EntityManager extends IEntityManager {
   }
 
   findEntities(queryObj) {
-    const q = new EntityQuery(queryObj);
+    const query = new EntityQuery(queryObj);
 
     // A query must have at least one positive condition.
-    if (!q.hasPositiveConditions()) {
+    if (!query.hasPositiveConditions()) {
       this.#logger.warn(
         'EntityManager.findEntities called with no "withAll" or "withAny" conditions. Returning empty array.'
       );
       return [];
     }
 
-    const results = [...this.entities].filter((e) => q.matches(e));
+    const results = [...this.entities].filter((e) => query.matches(e));
 
     this.#logger.debug(
       `EntityManager.findEntities found ${results.length} entities for query.`


### PR DESCRIPTION
Summary: Rename `const q` to `const query` within `findEntities` for clarity.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint ran `npm run lint` (fails: 628 errors)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685c1720c1008331b8ad7dab4d89a838