### PR TITLE
[Agent] decouple utils via DI

### DIFF
--- a/src/interfaces/IRetryManager.js
+++ b/src/interfaces/IRetryManager.js
@@ -1,0 +1,38 @@
+// src/interfaces/IRetryManager.js
+// --- FILE START ---
+
+/**
+ * @file Defines the interface for a retry manager utility.
+ */
+
+/**
+ * @interface IRetryManager
+ * @description Provides retry logic with exponential backoff.
+ */
+export class IRetryManager {
+  /**
+   * Calculates delay in milliseconds before the next retry attempt.
+   *
+   * @param {number} attempt - Current attempt number starting at 1.
+   * @param {number} baseDelayMs - Base delay in ms.
+   * @param {number} maxDelayMs - Maximum delay in ms.
+   * @returns {number} Calculated delay.
+   */
+  calculateRetryDelay(attempt, baseDelayMs, maxDelayMs) {
+    throw new Error('IRetryManager.calculateRetryDelay not implemented.');
+  }
+
+  /**
+   * Executes an operation with retry logic.
+   *
+   * @param {function(number): Promise<any>} attemptFn - Function performing a single attempt.
+   * @param {function(any, number): Promise<{retry: boolean, data?: any}>} responseHandler -
+   * Handler to process results.
+   * @returns {Promise<any>} Result of the successful attempt.
+   */
+  async perform(attemptFn, responseHandler) {
+    throw new Error('IRetryManager.perform method not implemented.');
+  }
+}
+
+// --- FILE END ---

--- a/src/utils/httpRetryManager.js
+++ b/src/utils/httpRetryManager.js
@@ -1,12 +1,15 @@
 // src/utils/httpRetryManager.js
 import { getModuleLogger } from './loggerUtils.js';
 
+/** @typedef {import('../interfaces/IRetryManager.js').IRetryManager} IRetryManager */
+
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  */
 
 /**
  * @class RetryManager
+ * @implements {IRetryManager}
  * @description Utility class for performing retry logic with exponential backoff.
  */
 export class RetryManager {

--- a/src/utils/placeholderResolverUtils.js
+++ b/src/utils/placeholderResolverUtils.js
@@ -39,9 +39,10 @@ export class PlaceholderResolver {
   /**
    * Initializes a new instance of the PlaceholderResolver.
    *
-   * @param {ILogger} [logger] - An optional logger instance. If not provided, `console` will be used.
+   * @param {ILogger} [logger] - Optional logger instance. When omitted, a
+   * console-based fallback is used.
    */
-  constructor(logger = console) {
+  constructor(logger) {
     this.#logger = ensureValidLogger(logger, 'PlaceholderResolver');
     const resolvePath = (obj, path) => {
       const { value } = safeResolvePath(

--- a/src/utils/safeDispatchErrorUtils.js
+++ b/src/utils/safeDispatchErrorUtils.js
@@ -9,6 +9,7 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/systemEventIds.js';
+import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * Error thrown when `safeDispatchError` receives an invalid dispatcher.
@@ -32,23 +33,20 @@ export class InvalidDispatcherError extends Error {
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
  * @param {string} message - Human readable error message.
  * @param {object} [details] - Additional structured details for debugging.
- * @param {ILogger} [logger] - Optional logger for error logging.
+ * @param {ILogger} [logger] - Optional logger for error logging. When omitted, a
+ * console-based fallback is used.
  * @throws {InvalidDispatcherError} If the dispatcher is missing or invalid.
  * @returns {void}
  * @example
  * safeDispatchError(safeEventDispatcher, 'Invalid action', { id: 'bad-action' });
  */
-export function safeDispatchError(
-  dispatcher,
-  message,
-  details = {},
-  logger = console
-) {
+export function safeDispatchError(dispatcher, message, details = {}, logger) {
+  const log = ensureValidLogger(logger, 'safeDispatchError');
   const hasDispatch = dispatcher && typeof dispatcher.dispatch === 'function';
   if (!hasDispatch) {
     const errorMsg =
       "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'.";
-    logger.error(errorMsg);
+    log.error(errorMsg);
     throw new InvalidDispatcherError(errorMsg, {
       functionName: 'safeDispatchError',
     });


### PR DESCRIPTION
Summary: Allow dependency injection for fetch retries and logging utilities.

Changes Made:
- Introduced `IRetryManager` interface for retry logic.
- Updated `fetchWithRetry` to accept an optional retry manager instance.
- Modified `PlaceholderResolver` and `safeDispatchError` to validate injected loggers instead of using console defaults.
- Documented `RetryManager` as implementing `IRetryManager`.

Testing Done:
- [x] Code formatted (`npm run format` on changed files)
- [x] Lint passes on modified files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685c16b78e248331a16288c22e838884