### PR TITLE
[Agent] Ignore schema warning for scopes

### DIFF
--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -163,9 +163,16 @@ export class BaseManifestItemLoader extends AbstractLoader {
         `${this.constructor.name}: Primary schema ID for content type '${trimmedContentType}' found: '${this._primarySchemaId}'`
       );
     } else {
-      this._logger.warn(
-        `${this.constructor.name}: Primary schema ID for content type '${trimmedContentType}' not found in configuration. Primary validation might be skipped.`
-      );
+      if (trimmedContentType === 'scopes') {
+        // Scopes are plain text files and intentionally lack a JSON schema
+        this._logger.debug(
+          `${this.constructor.name}: No primary schema configured for content type 'scopes'; skipping schema linking.`
+        );
+      } else {
+        this._logger.warn(
+          `${this.constructor.name}: Primary schema ID for content type '${trimmedContentType}' not found in configuration. Primary validation might be skipped.`
+        );
+      }
       this._primarySchemaId = null;
     }
   }
@@ -410,7 +417,6 @@ export class BaseManifestItemLoader extends AbstractLoader {
       failures,
     };
   }
-
 
   /**
    * Centralized helper method for storing items in the registry with standardized key prefixing,

--- a/tests/unit/loaders/baseManifestItemLoader.constructor.test.js
+++ b/tests/unit/loaders/baseManifestItemLoader.constructor.test.js
@@ -227,6 +227,33 @@ describe('BaseManifestItemLoader Constructor', () => {
     );
   });
 
+  it("should store null for _primarySchemaId and log debug when content type is 'scopes' and schema ID is missing", () => {
+    mockContentType = 'scopes';
+    mockConfig.getContentTypeSchemaId.mockReturnValue(undefined);
+
+    const testLoaderInstance = new BaseManifestItemLoader(
+      mockContentType,
+      mockConfig,
+      mockResolver,
+      mockFetcher,
+      mockValidator,
+      mockRegistry,
+      mockLogger
+    );
+
+    expect(testLoaderInstance._primarySchemaId).toBeNull();
+    expect(mockConfig.getContentTypeSchemaId).toHaveBeenCalledWith(
+      mockContentType
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      "BaseManifestItemLoader: No primary schema configured for content type 'scopes'; skipping schema linking."
+    );
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      `BaseManifestItemLoader: Initialized.`
+    );
+  });
+
   // --- ContentType Validation Failure Tests --- // <<< ADDED section
   describe('ContentType Validation', () => {
     it('should throw TypeError if contentType is null', () => {


### PR DESCRIPTION
Summary: Prevented spurious warnings when loading `.scope` files by handling the absence of a primary schema as a debug log rather than a warning. Added a unit test to ensure this behavior.

Changes Made:
- Updated `BaseManifestItemLoader` to skip warning for the `scopes` content type and log a debug message instead.
- Added a new constructor test covering this scenario.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Skipped in CI)


------
https://chatgpt.com/codex/tasks/task_e_685c18d54b38833189be1ab0b4d20689