### PR TITLE
[Agent] Inject initialization service into GameEngine

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -28,8 +28,6 @@ import PersistenceCoordinator from './persistenceCoordinator.js';
 /** @typedef {import('../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure */
 
 class GameEngine {
-  /** @type {AppContainer} */
-  #container;
   /** @type {ILogger} */
   #logger;
   /** @type {IEntityManager} */
@@ -42,6 +40,8 @@ class GameEngine {
   #playtimeTracker;
   /** @type {ISafeEventDispatcher} */
   #safeEventDispatcher;
+  /** @type {IInitializationService} */
+  #initializationService;
 
   /** @type {EngineState} */
   #engineState;
@@ -51,7 +51,6 @@ class GameEngine {
   #persistenceCoordinator;
 
   constructor({ container }) {
-    this.#container = container;
     try {
       this.#logger = container.resolve(tokens.ILogger);
     } catch (e) {
@@ -70,6 +69,9 @@ class GameEngine {
       );
       this.#safeEventDispatcher = container.resolve(
         tokens.ISafeEventDispatcher
+      );
+      this.#initializationService = /** @type {IInitializationService} */ (
+        container.resolve(tokens.IInitializationService)
       );
     } catch (e) {
       this.#logger.error(
@@ -128,11 +130,9 @@ class GameEngine {
       { allowSchemaNotFound: true }
     );
 
+    const initializationService = this.#initializationService;
     this.#logger.debug(
-      'GameEngine._executeInitializationSequence: Resolving InitializationService...'
-    );
-    const initializationService = /** @type {IInitializationService} */ (
-      this.#container.resolve(tokens.IInitializationService)
+      'GameEngine._executeInitializationSequence: Using injected InitializationService.'
     );
 
     this.#logger.debug(

--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -17,7 +17,6 @@ import {
   REQUEST_SHOW_LOAD_GAME_UI,
   REQUEST_SHOW_SAVE_GAME_UI,
 } from '../../../src/constants/eventIds.js';
-import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import {
   DEFAULT_ACTIVE_WORLD_FOR_SAVE,
   ENGINE_READY_MESSAGE,
@@ -283,9 +282,6 @@ export const expectShowSaveGameUIDispatch = createDispatchAsserter(
 export function expectStartSuccess(bed, engine, world) {
   expect(bed.getEntityManager().clearAll).toHaveBeenCalled();
   expect(bed.getPlaytimeTracker().reset).toHaveBeenCalled();
-  expect(bed.env.mockContainer.resolve).toHaveBeenCalledWith(
-    tokens.IInitializationService
-  );
   expect(
     bed.getInitializationService().runInitializationSequence
   ).toHaveBeenCalledWith(world);


### PR DESCRIPTION
## Summary
- inject the initialization service in the GameEngine constructor
- use the injected instance when executing the initialization sequence
- adjust helper test utilities accordingly

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c17e3f40483319754f478a6658548