### PR TITLE
[Agent] Streamline runtime registration

### DIFF
--- a/src/dependencyInjection/registrations/runtimeRegistrations.js
+++ b/src/dependencyInjection/registrations/runtimeRegistrations.js
@@ -1,49 +1,22 @@
 // src/dependencyInjection/registrations/runtimeRegistrations.js
-// ****** MODIFIED FILE ******
 import { tokens } from '../tokens.js';
 import { Registrar } from '../registrarHelpers.js';
-// REMOVED: GameLoop import (no longer directly instantiated here)
-// import GameLoop from "../../gameLoop.js";
 
-// --- Import Interfaces for Type Hinting ---
-/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../appContainer.js').default} AppContainer */
-/** @typedef {import('../../interfaces/coreServices.js').IWorldContext} IGameStateManager */
-// REMOVED: IInputHandler (Not directly used by GameLoop or other registrations here)
-// REMOVED: IActionExecutor (Delegated to CommandProcessor via TurnHandlers) // <<< REMOVED
-/** @typedef {import('../../events/eventBus.js').default} EventBus */ // Assuming EventBus is concrete (Needed? Check if InputSetup needs it) -> No, uses VED
-/** @typedef {import('../../entities/entityManager.js').default} EntityManager */ // Assuming EntityManager is concrete
-/** @typedef {import('../../data/gameDataRepository.js').GameDataRepository} GameDataRepository */ // Assuming concrete
-/** @typedef {import('../../interfaces/coreServices.js').IActionDiscoveryService} IActionDiscoveryService */
-/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../../interfaces/coreServices.js').ITurnManager} ITurnManager */
-
-/** @typedef {import('../../turns/interfaces/ITurnHandlerResolver.js').ITurnHandlerResolver} ITurnHandlerResolver */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
 /**
- * Registers runtime services like TurnManager and input setup.
- * NOTE: GameLoop registration has been removed from this file.
+ * Registers runtime-level services. The GameLoop is created during
+ * application bootstrapping and is not registered here.
  *
- * @export
- * @param {AppContainer} container - The application's DI container.
+ * @param {AppContainer} container - Application dependency container.
  */
 export function registerRuntime(container) {
-  const registrar = new Registrar(container);
-  /** @type {ILogger} */
-  const log = container.resolve(tokens.ILogger); // Use explicit type
-  log.debug('Runtime Registration: Starting...'); // <<< Moved log up
+  const _registrar = new Registrar(container); // Reserved for future runtime services
+  const logger = /** @type {ILogger} */ (container.resolve(tokens.ILogger));
+  logger.debug('Runtime Registration: starting…');
 
-  // ====================================================================
-  // REMOVED: Register GameLoop as Singleton
-  // The GameLoop instance is now expected to be created and managed
-  // elsewhere, likely within the main application bootstrapping process
-  // or initialization service, *after* the container is configured.
-  // ====================================================================
-  // registrar.singletonFactory(tokens.GameLoop, c => { ... }); // <<< ENTIRE BLOCK REMOVED
-  // log.info(`Runtime Registration: Registered ${tokens.GameLoop} (Singleton).`); // <<< REMOVED
+  // Place runtime service registrations below as the engine evolves.
 
-  // Note: Other runtime services like TurnManager, TurnHandlerResolver etc.
-  // are assumed to be registered elsewhere (e.g., serviceRegistrations.js or coreRegistrations.js)
-
-  log.debug('Runtime Registration: complete.');
+  logger.debug('Runtime Registration: complete.');
 }


### PR DESCRIPTION
Summary: Removed obsolete comments from `runtimeRegistrations.js` and simplified the `registerRuntime` function. The file now clearly indicates where runtime services should be registered.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: repo-wide issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685c18165ac48331848ae9ed12055429