### PR TITLE
[Agent] extract start helper mixins

### DIFF
--- a/tests/common/engine/engineStartHelpersMixin.js
+++ b/tests/common/engine/engineStartHelpersMixin.js
@@ -1,0 +1,80 @@
+/**
+ * @file Mixin providing init and start helpers for GameEngine tests.
+ */
+
+import { DEFAULT_TEST_WORLD } from '../constants.js';
+
+/**
+ * @description Extends a test bed with convenience methods for
+ * initializing and starting the GameEngine.
+ * @param {typeof import('../baseTestBed.js').default} Base - Base class to extend.
+ * @returns {typeof import('../baseTestBed.js').default} Extended class.
+ */
+export function EngineStartHelpersMixin(Base) {
+  return class EngineStartHelpers extends Base {
+    /**
+     * Initializes the engine using a default successful result.
+     *
+     * @param {string} [world] - World name to initialize.
+     * @returns {Promise<void>} Promise resolving when started.
+     */
+    async init(world = DEFAULT_TEST_WORLD) {
+      this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+        {
+          success: true,
+        }
+      );
+      await this.engine.startNewGame(world);
+    }
+
+    /**
+     * Initializes the engine and clears mock history.
+     *
+     * @param {string} [world] - World name to initialize.
+     * @returns {Promise<void>} Resolves once initialization completes.
+     */
+    async initAndReset(world = DEFAULT_TEST_WORLD) {
+      await this.withReset(() => this.init(world));
+    }
+
+    /**
+     * Starts a new game with the provided initialization result.
+     *
+     * @param {string} worldName - Name of the world.
+     * @param {import('../../../src/interfaces/IInitializationService.js').InitializationResult} [initResult]
+     *   Initialization result returned by the service.
+     * @returns {Promise<void>} Resolves when started.
+     */
+    async start(worldName, initResult = { success: true }) {
+      this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
+        initResult
+      );
+      await this.engine.startNewGame(worldName);
+    }
+
+    /**
+     * Starts a new game then clears mock history.
+     *
+     * @param {string} world - World name.
+     * @param {import('../../../src/interfaces/IInitializationService.js').InitializationResult} [result]
+     *   Initialization result.
+     * @returns {Promise<void>} Resolves when started.
+     */
+    async startAndReset(world, result = { success: true }) {
+      await this.withReset(() => this.start(world, result));
+    }
+
+    /**
+     * Stops the engine if initialized.
+     *
+     * @returns {Promise<void>} Promise resolving once stopped.
+     */
+    async stop() {
+      if (this.engine.getEngineStatus().isInitialized) {
+        await this.engine.stop();
+      }
+    }
+  };
+}
+
+export default EngineStartHelpersMixin;

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -12,6 +12,7 @@ import { suppressConsoleError } from '../jestHelpers.js';
 import { createDescribeServiceSuite } from '../describeSuite.js';
 import { createTestBedHelpers } from '../createTestBedHelpers.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
+import { EngineStartHelpersMixin } from './engineStartHelpersMixin.js';
 
 /**
  * @description Utility class that instantiates {@link GameEngine} using a mocked
@@ -22,7 +23,9 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
  */
 const StoppableMixin = createStoppableMixin('engine');
 
-export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
+export class GameEngineTestBed extends EngineStartHelpersMixin(
+  StoppableMixin(ContainerTestBed)
+) {
   /** @type {ReturnType<typeof createEnvironment>} */
   env;
   /** @type {import('../../../src/engine/gameEngine.js').default} */
@@ -122,69 +125,7 @@ export class GameEngineTestBed extends StoppableMixin(ContainerTestBed) {
   getInitializationService() {
     return this.initializationService;
   }
-  /**
-   * Initializes the engine using a default successful initialization result.
-   *
-   * @param {string} [world] - World name to initialize.
-   * @returns {Promise<void>} Promise resolving when the engine has started.
-   */
-  async init(world = DEFAULT_TEST_WORLD) {
-    this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
-      {
-        success: true,
-      }
-    );
-    await this.engine.startNewGame(world);
-  }
-
-  /**
-   * Initializes the engine then clears mock call history.
-   *
-   * @param {string} [world] - World name to initialize.
-   * @returns {Promise<void>} Resolves once initialization completes.
-   */
-  async initAndReset(world = DEFAULT_TEST_WORLD) {
-    await this.withReset(() => this.init(world));
-  }
-
-  /**
-   * Presets initialization results and starts a new game.
-   *
-   * @param {string} worldName - Name of the world to initialize.
-   * @param {import('../../src/interfaces/IInitializationService.js').InitializationResult} [initResult]
-   * @returns {Promise<void>} Promise resolving when the engine has started.
-   */
-  async start(worldName, initResult = { success: true }) {
-    this.env.mocks.initializationService.runInitializationSequence.mockResolvedValue(
-      initResult
-    );
-    await this.engine.startNewGame(worldName);
-  }
-
-  /**
-   * Starts a new game and immediately clears mock call history.
-   *
-   * @param {string} world - Name of the world to initialize.
-   * @param {import('../../src/interfaces/IInitializationService.js').InitializationResult} [result]
-   *   Initialization result returned by the service.
-   * @returns {Promise<void>} Resolves when the game has started.
-   */
-  async startAndReset(world, result = { success: true }) {
-    await this.withReset(() => this.start(world, result));
-  }
-
-  /**
-   * Stops the engine if it is initialized.
-   *
-   * @returns {Promise<void>} Promise resolving once stopped.
-   */
-  async stop() {
-    if (this.engine.getEngineStatus().isInitialized) {
-      await this.engine.stop();
-    }
-  }
 }
-
 const engineSuiteHooks = (() => {
   let consoleSpy;
   return {

--- a/tests/common/turns/startHelpersMixin.js
+++ b/tests/common/turns/startHelpersMixin.js
@@ -1,0 +1,176 @@
+/**
+ * @file Mixin providing start and spy utilities for TurnManager tests.
+ */
+
+import { jest } from '@jest/globals';
+import { flushPromisesAndTimers } from '../jestHelpers.js';
+
+/**
+ * @description Extends a test bed with helpers for starting the manager
+ * and spying on lifecycle methods.
+ * @param {typeof import('../baseTestBed.js').default} Base - Base class to extend.
+ * @returns {typeof import('../baseTestBed.js').default} Extended class with start helpers.
+ */
+export function StartHelpersMixin(Base) {
+  return class StartHelpers extends Base {
+    /**
+     * Executes start logic within {@link BaseTestBed#withReset}.
+     *
+     * @param {() => Promise<void>} startFn - Start callback.
+     * @returns {Promise<void>} Resolves when start completes.
+     * @private
+     */
+    async #startInternal(startFn) {
+      await this.withReset(startFn);
+    }
+
+    /**
+     * Adds entities then starts the manager.
+     *
+     * @param {...{ id: string }} entities - Entities to register.
+     * @returns {Promise<void>} Resolves once started.
+     */
+    async startWithEntities(...entities) {
+      await this.#startInternal(async () => {
+        this.setActiveEntities(...entities);
+        await this.turnManager.start();
+      });
+    }
+
+    /**
+     * Starts the manager without advancing the first turn.
+     *
+     * @returns {Promise<void>} Resolves once running.
+     */
+    async startRunning() {
+      await this.#startInternal(async () => {
+        const spy = jest
+          .spyOn(this.turnManager, 'advanceTurn')
+          .mockImplementationOnce(async () => {});
+        await this.turnManager.start();
+        spy.mockRestore();
+      });
+    }
+
+    /**
+     * Starts the manager then flushes timers and promises.
+     *
+     * @returns {Promise<void>} Resolves when flush completes.
+     */
+    async startAndFlush() {
+      await this.#startInternal(async () => {
+        await this.turnManager.start();
+      });
+      await flushPromisesAndTimers();
+    }
+
+    /**
+     * Adds entities, starts the manager and flushes timers.
+     *
+     * @param {...{ id: string }} entities - Entities to register.
+     * @returns {Promise<void>} Resolves once flush completes.
+     */
+    async startWithEntitiesAndFlush(...entities) {
+      await this.startWithEntities(...entities);
+      await flushPromisesAndTimers();
+    }
+
+    /**
+     * Starts with default actors and flushes pending tasks.
+     *
+     * @returns {Promise<{ ai1: object, ai2: object, player: object }>} Created actors.
+     */
+    async startWithDefaultActorsAndFlush() {
+      const actors = this.addDefaultActors();
+      await this.startAndFlush();
+      return actors;
+    }
+
+    /**
+     * Calls advanceTurn then flushes timers/promises.
+     *
+     * @returns {Promise<void>} Resolves when flush completes.
+     */
+    async advanceAndFlush() {
+      await this.turnManager.advanceTurn();
+      await flushPromisesAndTimers();
+    }
+
+    /**
+     * Spies on {@link import('../../../src/turns/turnManager.js').default.stop}.
+     *
+     * @returns {import('@jest/globals').Mock} Spy instance.
+     */
+    spyOnStop() {
+      const spy = jest.spyOn(this.turnManager, 'stop');
+      this.trackSpy(spy);
+      return spy;
+    }
+
+    /**
+     * Spies on {@link import('../../../src/turns/turnManager.js').default.stop}
+     * and logs invocation.
+     *
+     * @returns {import('@jest/globals').Mock} Spy instance.
+     */
+    spyOnStopWithDebug() {
+      const spy = this.spyOnStop();
+      spy.mockImplementation(() => {
+        this.mocks.logger.debug('Mocked instance.stop() called.');
+      });
+      return spy;
+    }
+
+    /**
+     * Spies on {@link import('../../../src/turns/turnManager.js').default.stop}
+     * resolving without side effects.
+     *
+     * @returns {import('@jest/globals').Mock} Spy instance.
+     */
+    spyOnStopNoOp() {
+      const spy = this.spyOnStop();
+      spy.mockResolvedValue();
+      return spy;
+    }
+
+    /**
+     * Spies on {@link import('../../../src/turns/turnManager.js').default.advanceTurn}.
+     *
+     * @returns {import('@jest/globals').Mock} Spy instance.
+     */
+    spyOnAdvanceTurn() {
+      const spy = jest.spyOn(this.turnManager, 'advanceTurn');
+      this.trackSpy(spy);
+      return spy;
+    }
+
+    /**
+     * Prepares the manager for {@link import('../../../src/turns/turnManager.js').default.start}.
+     *
+     * @returns {import('@jest/globals').Mock} Spy used during preparation.
+     */
+    prepareRunningManager() {
+      this.setupMockHandlerResolver();
+      const spy = this.spyOnAdvanceTurn();
+      spy.mockResolvedValue(undefined);
+      this.resetMocks();
+      return spy;
+    }
+
+    /**
+     * Forces {@link import('../../../src/turns/turnManager.js').default.start} to fail.
+     *
+     * @param {Error} [error] - Error to reject with.
+     * @returns {import('@jest/globals').Mock} Rejecting spy.
+     */
+    mockStartFailure(error = new Error('Start failure')) {
+      this.setupMockHandlerResolver();
+      const spy = this.spyOnAdvanceTurn();
+      spy.mockRejectedValue(error);
+      this.resetMocks();
+      return spy;
+    }
+  };
+}
+
+export default StartHelpersMixin;


### PR DESCRIPTION
Summary:
- create StartHelpersMixin for turn manager tests
- create EngineStartHelpersMixin for engine tests
- use new mixins in TurnManagerTestBed and GameEngineTestBed

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 629 errors, 2476 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c196f67588331bedc044c5a7a6959