### PR TITLE
[Agent] remove obsolete helper

### DIFF
--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -15,7 +15,6 @@
 import { AbstractTurnState } from './abstractTurnState.js';
 import { ENTITY_SPOKE_ID } from '../../constants/eventIds.js';
 import { CommandProcessingWorkflow } from './helpers/commandProcessingWorkflow.js';
-import { getServiceFromContext } from './helpers/getServiceFromContext.js';
 import { ProcessingWorkflow } from './workflows/processingWorkflow.js';
 import { ProcessingExceptionHandler } from './helpers/processingExceptionHandler.js';
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
@@ -179,21 +178,6 @@ export class ProcessingCommandState extends AbstractTurnState {
     await workflow.processCommand(turnCtx, actor, turnAction);
   }
 
-  async _getServiceFromContext(
-    turnCtx,
-    contextMethod,
-    serviceLabel,
-    actorIdForLog
-  ) {
-    return getServiceFromContext(
-      this,
-      turnCtx,
-      contextMethod,
-      serviceLabel,
-      actorIdForLog,
-      this._exceptionHandler
-    );
-  }
 
   async exitState(handler, nextState) {
     const wasProcessing = this._isProcessing;

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -15,7 +15,10 @@ import {
 } from '../../../../src/constants/eventIds.js';
 import TurnDirective from '../../../../src/turns/constants/turnDirectives.js';
 import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
-import { ServiceLookupError } from '../../../../src/turns/states/helpers/getServiceFromContext.js';
+import {
+  ServiceLookupError,
+  getServiceFromContext,
+} from '../../../../src/turns/states/helpers/getServiceFromContext.js';
 
 class MockActor {
   constructor(id = 'actorXYZ') {
@@ -399,11 +402,12 @@ describe('ProcessingCommandState.enterState – error branches', () => {
   });
 });
 
-describe('ProcessingCommandState._getServiceFromContext – error branches', () => {
+describe('getServiceFromContext helper – error branches', () => {
   test('should throw ServiceLookupError and clear _isProcessing when turnCtx is null', async () => {
     processingState['_isProcessing'] = true;
     await expect(
-      processingState['_getServiceFromContext'](
+      getServiceFromContext(
+        processingState,
         null,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -428,7 +432,8 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     const dummyCtx = {};
 
     await expect(
-      processingState['_getServiceFromContext'](
+      getServiceFromContext(
+        processingState,
         dummyCtx,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -459,7 +464,8 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     await expect(
-      processingState['_getServiceFromContext'](
+      getServiceFromContext(
+        processingState,
         mockTurnContext,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -497,7 +503,8 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     await expect(
-      processingState['_getServiceFromContext'](
+      getServiceFromContext(
+        processingState,
         mockTurnContext,
         'getCommandProcessor',
         'ICommandProcessor',


### PR DESCRIPTION
Summary: Removed the `_getServiceFromContext` wrapper from `ProcessingCommandState` and updated tests to use `getServiceFromContext` directly.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685c177984108331ad6cfcd800b7c7ce