### PR TITLE
[Feat] ensure evaluation context utility

### DIFF
--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -11,6 +11,7 @@ import { resolvePath } from '../../utils/objectUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { cloneDeep } from 'lodash';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import {
   advancedArrayModify,
   ARRAY_MODIFICATION_MODES,
@@ -77,11 +78,12 @@ class ModifyContextArrayHandler {
       return;
     }
 
-    const contextObject = executionContext?.evaluationContext?.context;
+    const contextObject = ensureEvaluationContext(
+      executionContext,
+      this.#dispatcher,
+      log
+    );
     if (!contextObject) {
-      log.warn(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
-      );
       return;
     }
 

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -8,6 +8,7 @@
 /** @typedef {import('../defs.js').OperationParams} OperationParams */
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
 
 /**
@@ -75,15 +76,7 @@ class QueryComponentHandler extends ComponentOperationHandler {
       return null;
     }
 
-    if (
-      !executionContext?.evaluationContext?.context ||
-      typeof executionContext.evaluationContext.context !== 'object'
-    ) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentHandler: executionContext.evaluationContext.context is missing or invalid. Cannot store result.',
-        { executionContext }
-      );
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, logger)) {
       return null;
     }
 

--- a/src/logic/operationHandlers/queryComponentsHandler.js
+++ b/src/logic/operationHandlers/queryComponentsHandler.js
@@ -15,6 +15,7 @@
 import { writeContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
 
 /**
@@ -66,15 +67,7 @@ class QueryComponentsHandler extends ComponentOperationHandler {
       return;
     }
 
-    if (
-      !executionContext?.evaluationContext?.context ||
-      typeof executionContext.evaluationContext.context !== 'object'
-    ) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentsHandler: executionContext.evaluationContext.context is missing or invalid.',
-        { executionContext }
-      );
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, logger)) {
       return;
     }
 

--- a/src/logic/operationHandlers/queryEntitiesHandler.js
+++ b/src/logic/operationHandlers/queryEntitiesHandler.js
@@ -12,6 +12,7 @@
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 
 /**
@@ -135,6 +136,10 @@ class QueryEntitiesHandler extends BaseOperationHandler {
       logger.debug(
         `QUERY_ENTITIES: Applied limit: ${limit}. Results reduced from ${originalCount} to ${finalIds.length}.`
       );
+    }
+
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, logger)) {
+      return;
     }
 
     const res = tryWriteContextVariable(

--- a/src/logic/operationHandlers/setVariableHandler.js
+++ b/src/logic/operationHandlers/setVariableHandler.js
@@ -11,6 +11,7 @@
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { evaluateValue } from '../utils/jsonLogicVariableEvaluator.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * Parameters expected by the SetVariableHandler#execute method.
@@ -146,19 +147,8 @@ class SetVariableHandler {
     }
 
     // --- 2. Validate target variable store within executionContext ---
-    // The variableStore is expected to be executionContext.evaluationContext.context
     const evaluationCtx = executionContext?.evaluationContext;
-    const variableStore = evaluationCtx?.context;
-
-    if (typeof variableStore !== 'object' || variableStore === null) {
-      logger.error(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: !!executionContext,
-          hasEvaluationContext: !!evaluationCtx,
-          typeOfVariableStore: typeof variableStore,
-        }
-      );
+    if (!ensureEvaluationContext(executionContext, undefined, logger)) {
       return;
     }
 

--- a/src/utils/evaluationContextUtils.js
+++ b/src/utils/evaluationContextUtils.js
@@ -1,0 +1,51 @@
+// src/utils/evaluationContextUtils.js
+
+/**
+ * @module evaluationContextUtils
+ * @description Utilities for validating and retrieving the evaluation context.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext */
+
+import { ensureValidLogger } from './loggerUtils.js';
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+
+/**
+ * Ensures that `executionContext.evaluationContext.context` exists and is an object.
+ *
+ * Logs an error and dispatches a `core:system_error_occurred` event when the
+ * context is missing or invalid.
+ *
+ * @param {ExecutionContext} executionContext - The current execution context.
+ * @param {ISafeEventDispatcher} [dispatcher] - Dispatcher for error events.
+ * @param {ILogger} [logger] - Optional logger used when dispatcher is absent.
+ * @returns {object|null} The context object or `null` when unavailable.
+ */
+export function ensureEvaluationContext(executionContext, dispatcher, logger) {
+  const log = ensureValidLogger(logger, 'ensureEvaluationContext');
+
+  const ctx = executionContext?.evaluationContext?.context;
+  if (ctx && typeof ctx === 'object') {
+    return ctx;
+  }
+
+  const message =
+    'ensureEvaluationContext: executionContext.evaluationContext.context is missing or invalid.';
+
+  if (dispatcher && typeof dispatcher.dispatch === 'function') {
+    safeDispatchError(
+      dispatcher,
+      message,
+      { hasExecutionContext: !!executionContext },
+      log
+    );
+  } else {
+    log.error(message);
+  }
+
+  return null;
+}
+
+// --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,3 +18,4 @@ export * from './placeholderPathResolver.js';
 export { StructureResolver } from './structureResolver.js';
 export * from './jsonCleaning.js';
 export * from './jsonRepair.js';
+export * from './evaluationContextUtils.js';

--- a/tests/unit/logic/operationHandlers/modifyContextArrayHandler.test.js
+++ b/tests/unit/logic/operationHandlers/modifyContextArrayHandler.test.js
@@ -1,6 +1,7 @@
 import ModifyContextArrayHandler from '../../../../src/logic/operationHandlers/modifyContextArrayHandler.js';
 // import { ExecutionContext } from '../../../src/logic/defs.js'; // ExecutionContext is a typedef, not a class
 import { cloneDeep } from 'lodash';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
 
 describe('ModifyContextArrayHandler', () => {
   let handler;
@@ -106,19 +107,29 @@ describe('ModifyContextArrayHandler', () => {
       );
     });
 
-    it('should log a warning if executionContext or evaluationContext.context is missing', () => {
+    it('should dispatch error if evaluation context is missing', () => {
       handler.execute({ variable_path: 'myArray', mode: 'push', value: 4 }, {});
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'evaluationContext.context is missing'
+          ),
+        })
       );
-      mockLogger.warn.mockClear();
+      mockSafeEventDispatcher.dispatch.mockClear();
 
       handler.execute(
         { variable_path: 'myArray', mode: 'push', value: 4 },
         { evaluationContext: {} }
       );
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
+        SYSTEM_ERROR_OCCURRED_ID,
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'evaluationContext.context is missing'
+          ),
+        })
       );
     });
 

--- a/tests/unit/logic/operationHandlers/queryEntitiesHandler.test.js
+++ b/tests/unit/logic/operationHandlers/queryEntitiesHandler.test.js
@@ -392,8 +392,9 @@ describe('QueryEntitiesHandler', () => {
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
-          message: expect.stringContaining('Cannot store result'),
-          details: { resultVariable: 'x' },
+          message: expect.stringContaining(
+            'evaluationContext.context is missing'
+          ),
         })
       );
     });

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -307,8 +307,7 @@ describe('SetVariableHandler', () => {
         // If invalidExecCtx is null/undefined, it won't. If it's an object, we ensure our handler's logger is used.
         handler.execute(validParams, invalidExecCtx);
         expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-          'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-          expectedDetails
+          'ensureEvaluationContext: executionContext.evaluationContext.context is missing or invalid.'
         );
       }
     );
@@ -317,12 +316,7 @@ describe('SetVariableHandler', () => {
       const invalidExecCtx = 'not an object';
       handler.execute(validParams, invalidExecCtx);
       expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: true,
-          hasEvaluationContext: false,
-          typeOfVariableStore: 'undefined',
-        }
+        'ensureEvaluationContext: executionContext.evaluationContext.context is missing or invalid.'
       );
     });
   });
@@ -556,12 +550,7 @@ describe('SetVariableHandler', () => {
 
       // Expect the initial validation error for the variable store
       expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: true,
-          hasEvaluationContext: false,
-          typeOfVariableStore: 'undefined',
-        }
+        'ensureEvaluationContext: executionContext.evaluationContext.context is missing or invalid.'
       );
       // Ensure the more specific error about JsonLogic evaluation is NOT called because the first check returns.
       expect(mockLoggerInstance.error).not.toHaveBeenCalledWith(

--- a/tests/unit/utils/evaluationContextUtils.test.js
+++ b/tests/unit/utils/evaluationContextUtils.test.js
@@ -1,0 +1,43 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { ensureEvaluationContext } from '../../../src/utils/evaluationContextUtils.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+const makeDispatcher = () => ({ dispatch: jest.fn() });
+
+describe('ensureEvaluationContext', () => {
+  test('returns context when present', () => {
+    const ctx = { evaluationContext: { context: { foo: 1 } } };
+    const dispatcher = makeDispatcher();
+    const logger = makeLogger();
+
+    const result = ensureEvaluationContext(ctx, dispatcher, logger);
+
+    expect(result).toBe(ctx.evaluationContext.context);
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  test('dispatches error and returns null when context missing', () => {
+    const ctx = { evaluationContext: {} };
+    const dispatcher = makeDispatcher();
+    const logger = makeLogger();
+
+    const result = ensureEvaluationContext(ctx, dispatcher, logger);
+
+    expect(result).toBeNull();
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'evaluationContext.context is missing'
+        ),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added helper function to validate and retrieve `executionContext.evaluationContext.context` and integrated it into relevant operation handlers.

Changes Made:
- Created `ensureEvaluationContext` utility with logging and dispatching.
- Updated operation handlers to use the new helper.
- Added unit tests for the utility and updated affected handler tests.

Testing Done:
- [x] Code formatted (`npm run format` limited to changed files)
- [x] Lint executed (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685c1d8796048331a21aeee70f691190