### PR TITLE
[Agent] add evaluation context utility

### DIFF
--- a/src/logic/operationHandlers/modifyContextArrayHandler.js
+++ b/src/logic/operationHandlers/modifyContextArrayHandler.js
@@ -16,6 +16,7 @@ import {
   ARRAY_MODIFICATION_MODES,
 } from '../utils/arrayModifyUtils.js';
 import { setByPath } from '../utils/objectPathUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * @class ModifyContextArrayHandler
@@ -77,11 +78,12 @@ class ModifyContextArrayHandler {
       return;
     }
 
-    const contextObject = executionContext?.evaluationContext?.context;
+    const contextObject = ensureEvaluationContext(
+      executionContext,
+      this.#dispatcher,
+      log
+    );
     if (!contextObject) {
-      log.warn(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
-      );
       return;
     }
 

--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -24,6 +24,7 @@ import ComponentOperationHandler from './componentOperationHandler.js';
  */
 
 import { writeContextVariable } from '../../utils/contextVariableUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * @implements {OperationHandler}
@@ -75,15 +76,7 @@ class QueryComponentHandler extends ComponentOperationHandler {
       return null;
     }
 
-    if (
-      !executionContext?.evaluationContext?.context ||
-      typeof executionContext.evaluationContext.context !== 'object'
-    ) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentHandler: executionContext.evaluationContext.context is missing or invalid. Cannot store result.',
-        { executionContext }
-      );
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, logger)) {
       return null;
     }
 

--- a/src/logic/operationHandlers/queryComponentsHandler.js
+++ b/src/logic/operationHandlers/queryComponentsHandler.js
@@ -14,6 +14,7 @@
 
 import { writeContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
 
@@ -66,15 +67,7 @@ class QueryComponentsHandler extends ComponentOperationHandler {
       return;
     }
 
-    if (
-      !executionContext?.evaluationContext?.context ||
-      typeof executionContext.evaluationContext.context !== 'object'
-    ) {
-      safeDispatchError(
-        this.#dispatcher,
-        'QueryComponentsHandler: executionContext.evaluationContext.context is missing or invalid.',
-        { executionContext }
-      );
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, logger)) {
       return;
     }
 

--- a/src/logic/operationHandlers/setVariableHandler.js
+++ b/src/logic/operationHandlers/setVariableHandler.js
@@ -11,6 +11,7 @@
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { evaluateValue } from '../utils/jsonLogicVariableEvaluator.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * Parameters expected by the SetVariableHandler#execute method.
@@ -147,20 +148,15 @@ class SetVariableHandler {
 
     // --- 2. Validate target variable store within executionContext ---
     // The variableStore is expected to be executionContext.evaluationContext.context
-    const evaluationCtx = executionContext?.evaluationContext;
-    const variableStore = evaluationCtx?.context;
-
-    if (typeof variableStore !== 'object' || variableStore === null) {
-      logger.error(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: !!executionContext,
-          hasEvaluationContext: !!evaluationCtx,
-          typeOfVariableStore: typeof variableStore,
-        }
-      );
+    const variableStore = ensureEvaluationContext(
+      executionContext,
+      undefined,
+      logger
+    );
+    if (!variableStore) {
       return;
     }
+    const evaluationCtx = executionContext.evaluationContext;
 
     // --- 3. Evaluate Value if it's JsonLogic ---
     const evalResult = evaluateValue(

--- a/src/utils/evaluationContextUtils.js
+++ b/src/utils/evaluationContextUtils.js
@@ -1,0 +1,42 @@
+// src/utils/evaluationContextUtils.js
+/**
+ * @file Utilities for working with the evaluationContext structure.
+ */
+
+/** @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+
+import { getModuleLogger } from './loggerUtils.js';
+import { resolveSafeDispatcher } from './dispatcherUtils.js';
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+
+/**
+ * Ensures that `executionContext.evaluationContext.context` exists and is an object.
+ * Logs and dispatches a standardized error when the context is missing.
+ *
+ * @param {ExecutionContext} executionContext - The current execution context.
+ * @param {ISafeEventDispatcher} [dispatcher] - Optional dispatcher for error events.
+ * @param {ILogger} [logger] - Optional logger for diagnostics.
+ * @returns {object|null} The context object when available, otherwise `null`.
+ */
+export function ensureEvaluationContext(executionContext, dispatcher, logger) {
+  const log = getModuleLogger('ensureEvaluationContext', logger);
+  const context = executionContext?.evaluationContext?.context;
+  if (context && typeof context === 'object') {
+    return context;
+  }
+
+  const safeDispatcher =
+    dispatcher || resolveSafeDispatcher(executionContext, log);
+  const message =
+    'executionContext.evaluationContext.context is missing or invalid.';
+  if (safeDispatcher) {
+    safeDispatchError(safeDispatcher, message, { executionContext }, log);
+  } else {
+    log.error(message, { hasExecutionContext: !!executionContext });
+  }
+  return null;
+}
+
+// --- FILE END ---

--- a/tests/unit/logic/operationHandlers/modifyContextArrayHandler.test.js
+++ b/tests/unit/logic/operationHandlers/modifyContextArrayHandler.test.js
@@ -106,20 +106,16 @@ describe('ModifyContextArrayHandler', () => {
       );
     });
 
-    it('should log a warning if executionContext or evaluationContext.context is missing', () => {
+    it('should dispatch error if executionContext or evaluationContext.context is missing', () => {
       handler.execute({ variable_path: 'myArray', mode: 'push', value: 4 }, {});
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
-      );
-      mockLogger.warn.mockClear();
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalled();
+      mockSafeEventDispatcher.dispatch.mockClear();
 
       handler.execute(
         { variable_path: 'myArray', mode: 'push', value: 4 },
         { evaluationContext: {} }
       );
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        'MODIFY_CONTEXT_ARRAY: Cannot execute because the execution context is missing.'
-      );
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalled();
     });
 
     describe('when variable_path resolution is problematic', () => {

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -307,8 +307,8 @@ describe('SetVariableHandler', () => {
         // If invalidExecCtx is null/undefined, it won't. If it's an object, we ensure our handler's logger is used.
         handler.execute(validParams, invalidExecCtx);
         expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-          'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-          expectedDetails
+          '[ensureEvaluationContext] executionContext.evaluationContext.context is missing or invalid.',
+          { hasExecutionContext: !!invalidExecCtx }
         );
       }
     );
@@ -317,12 +317,8 @@ describe('SetVariableHandler', () => {
       const invalidExecCtx = 'not an object';
       handler.execute(validParams, invalidExecCtx);
       expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: true,
-          hasEvaluationContext: false,
-          typeOfVariableStore: 'undefined',
-        }
+        '[ensureEvaluationContext] executionContext.evaluationContext.context is missing or invalid.',
+        { hasExecutionContext: true }
       );
     });
   });
@@ -556,12 +552,8 @@ describe('SetVariableHandler', () => {
 
       // Expect the initial validation error for the variable store
       expect(mockLoggerInstance.error).toHaveBeenCalledWith(
-        'SET_VARIABLE: executionContext.evaluationContext.context is missing or invalid. Cannot store variable.',
-        {
-          hasExecutionContext: true,
-          hasEvaluationContext: false,
-          typeOfVariableStore: 'undefined',
-        }
+        '[ensureEvaluationContext] executionContext.evaluationContext.context is missing or invalid.',
+        { hasExecutionContext: true }
       );
       // Ensure the more specific error about JsonLogic evaluation is NOT called because the first check returns.
       expect(mockLoggerInstance.error).not.toHaveBeenCalledWith(

--- a/tests/unit/utils/evaluationContextUtils.test.js
+++ b/tests/unit/utils/evaluationContextUtils.test.js
@@ -1,0 +1,36 @@
+import { describe, test, expect, jest, afterEach } from '@jest/globals';
+import { ensureEvaluationContext } from '../../../src/utils/evaluationContextUtils.js';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ensureEvaluationContext', () => {
+  test('returns context when available', () => {
+    const ctx = { evaluationContext: { context: { foo: 1 } } };
+    const result = ensureEvaluationContext(ctx, null, null);
+    expect(result).toBe(ctx.evaluationContext.context);
+    expect(safeDispatchError).not.toHaveBeenCalled();
+  });
+
+  test('dispatches error and returns null when context missing', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const result = ensureEvaluationContext({}, dispatcher, logger);
+    expect(result).toBeNull();
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'executionContext.evaluationContext.context is missing or invalid.',
+      expect.any(Object),
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `ensureEvaluationContext` helper
- use helper in query and context handlers
- add unit tests for the new helper
- update existing tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c20591170833182ff89925cf7e596