### PR TITLE
refactor: remove unused services from TurnContext and related factories

### DIFF
--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -48,11 +48,8 @@ export function registerTurnLifecycle(container) {
         logger: c.resolve(tokens.ILogger),
         gameWorldAccess: c.resolve(tokens.IWorldContext),
         turnEndPort: c.resolve(tokens.ITurnEndPort),
-        commandProcessor: c.resolve(tokens.ICommandProcessor),
-        commandOutcomeInterpreter: c.resolve(tokens.ICommandOutcomeInterpreter),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         entityManager: c.resolve(tokens.IEntityManager),
-        actionDiscoverySystem: c.resolve(tokens.IActionDiscoveryService),
       })
   );
 

--- a/src/turns/context/turnContext.js
+++ b/src/turns/context/turnContext.js
@@ -20,13 +20,10 @@
 /**
  * @typedef {object} TurnContextServices
  * @property {IPromptCoordinator}             [promptCoordinator]
- * @property {ICommandProcessor}              [commandProcessor]
- * @property {ICommandOutcomeInterpreter}     [commandOutcomeInterpreter]
  * @property {ISafeEventDispatcher}           [safeEventDispatcher]
  * @property {ITurnEndPort}                   [turnEndPort]
  * @property {IEntityManager}                 [entityManager]
- * @property {IActionDiscoveryService}        [actionDiscoverySystem]
- * // …extend as needed
+ * // Removed unused services: commandProcessor, commandOutcomeInterpreter, actionDiscoverySystem
  */
 
 import { ITurnContext } from '../interfaces/ITurnContext.js';
@@ -138,17 +135,6 @@ export class TurnContext extends ITurnContext {
 
   getPlayerPromptService() {
     return this.#require('promptCoordinator', 'PlayerPromptService');
-  }
-
-  getCommandProcessor() {
-    return this.#require('commandProcessor', 'CommandProcessor');
-  }
-
-  getCommandOutcomeInterpreter() {
-    return this.#require(
-      'commandOutcomeInterpreter',
-      'CommandOutcomeInterpreter'
-    );
   }
 
   getSafeEventDispatcher() {

--- a/src/turns/factories/concreteTurnContextFactory.js
+++ b/src/turns/factories/concreteTurnContextFactory.js
@@ -15,11 +15,8 @@ import { TurnContext } from '../context/turnContext.js';
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../interfaces/IWorldContext.js').IWorldContext} IWorldContext
  * @typedef {import('../ports/ITurnEndPort.js').ITurnEndPort} ITurnEndPort
- * @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor
- * @typedef {import('../../commands/interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreter
  * @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  * @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager
- * @typedef {import('../../interfaces/IActionDiscoveryService.js').IActionDiscoveryService} IActionDiscoveryService
  */
 
 /** @typedef {function(Error | null): void} OnEndTurnCallback */
@@ -40,16 +37,10 @@ export class ConcreteTurnContextFactory extends ITurnContextFactory {
   #gameWorldAccess;
   /** @type {ITurnEndPort} */
   #turnEndPort;
-  /** @type {ICommandProcessor} */
-  #commandProcessor;
-  /** @type {ICommandOutcomeInterpreter} */
-  #commandOutcomeInterpreter;
   /** @type {ISafeEventDispatcher} */
   #safeEventDispatcher;
   /** @type {IEntityManager} */
   #entityManager;
-  /** @type {IActionDiscoveryService} */
-  #actionDiscoverySystem;
 
   /**
    * Constructs the factory and caches all necessary dependencies.
@@ -58,21 +49,15 @@ export class ConcreteTurnContextFactory extends ITurnContextFactory {
    * @param {ILogger} dependencies.logger
    * @param {IWorldContext} dependencies.gameWorldAccess
    * @param {ITurnEndPort} dependencies.turnEndPort
-   * @param {ICommandProcessor} dependencies.commandProcessor
-   * @param {ICommandOutcomeInterpreter} dependencies.commandOutcomeInterpreter
    * @param {ISafeEventDispatcher} dependencies.safeEventDispatcher
    * @param {IEntityManager} dependencies.entityManager
-   * @param {IActionDiscoveryService} dependencies.actionDiscoverySystem
    */
   constructor({
     logger,
     gameWorldAccess,
     turnEndPort,
-    commandProcessor,
-    commandOutcomeInterpreter,
     safeEventDispatcher,
     entityManager,
-    actionDiscoverySystem,
   }) {
     super();
     if (!logger)
@@ -83,33 +68,18 @@ export class ConcreteTurnContextFactory extends ITurnContextFactory {
       );
     if (!turnEndPort)
       throw new Error('ConcreteTurnContextFactory: turnEndPort is required.');
-    if (!commandProcessor)
-      throw new Error(
-        'ConcreteTurnContextFactory: commandProcessor is required.'
-      );
-    if (!commandOutcomeInterpreter)
-      throw new Error(
-        'ConcreteTurnContextFactory: commandOutcomeInterpreter is required.'
-      );
     if (!safeEventDispatcher)
       throw new Error(
         'ConcreteTurnContextFactory: safeEventDispatcher is required.'
       );
     if (!entityManager)
       throw new Error('ConcreteTurnContextFactory: entityManager is required.');
-    if (!actionDiscoverySystem)
-      throw new Error(
-        'ConcreteTurnContextFactory: actionDiscoverySystem is required.'
-      );
 
     this.#logger = logger;
     this.#gameWorldAccess = gameWorldAccess;
     this.#turnEndPort = turnEndPort;
-    this.#commandProcessor = commandProcessor;
-    this.#commandOutcomeInterpreter = commandOutcomeInterpreter;
     this.#safeEventDispatcher = safeEventDispatcher;
     this.#entityManager = entityManager;
-    this.#actionDiscoverySystem = actionDiscoverySystem;
   }
 
   /**
@@ -133,15 +103,12 @@ export class ConcreteTurnContextFactory extends ITurnContextFactory {
     isAwaitingExternalEventProvider,
     onSetAwaitingExternalEventCallback,
   }) {
-    // The `services` object is now created internally from cached dependencies.
+    // The `services` object is now created internally from cached dependencies.  
     const servicesForContext = {
       game: this.#gameWorldAccess,
       turnEndPort: this.#turnEndPort,
-      commandProcessor: this.#commandProcessor,
-      commandOutcomeInterpreter: this.#commandOutcomeInterpreter,
       safeEventDispatcher: this.#safeEventDispatcher,
       entityManager: this.#entityManager,
-      actionDiscoverySystem: this.#actionDiscoverySystem,
     };
 
     return new TurnContext({

--- a/src/turns/interfaces/ITurnContext.js
+++ b/src/turns/interfaces/ITurnContext.js
@@ -2,8 +2,6 @@
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../ports/ITurnEndPort.js').ITurnEndPort} ITurnEndPort
- * @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor
- * @typedef {import('../../commands/interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreter
  * @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  */
 
@@ -56,38 +54,7 @@ export class ITurnContext {
     throw new Error("Method 'getLogger()' must be implemented.");
   }
 
-  /**
-   * Retrieves the player prompt service for interacting with a human player.
-   * Note: This might need generalization if non-player entities require analogous services.
-   *
-   * @returns {IPromptCoordinator} The player prompt service instance.
-   * @throws {Error} If the service is not available in the current context.
-   */
-  getPlayerPromptService() {
-    throw new Error("Method 'getPlayerPromptService()' must be implemented.");
-  }
 
-  /**
-   * Retrieves the CommandProcessor service.
-   *
-   * @returns {ICommandProcessor} The command processor instance.
-   * @throws {Error} If the service is not available in the current context.
-   */
-  getCommandProcessor() {
-    throw new Error("Method 'getCommandProcessor()' must be implemented.");
-  }
-
-  /**
-   * Retrieves the CommandOutcomeInterpreter service.
-   *
-   * @returns {ICommandOutcomeInterpreter} The command outcome interpreter instance.
-   * @throws {Error} If the service is not available in the current context.
-   */
-  getCommandOutcomeInterpreter() {
-    throw new Error(
-      "Method 'getCommandOutcomeInterpreter()' must be implemented."
-    );
-  }
 
   /**
    * Retrieves the SafeEventDispatcher service.

--- a/tests/unit/turns/factories/concreteTurnContextFactory.test.js
+++ b/tests/unit/turns/factories/concreteTurnContextFactory.test.js
@@ -15,11 +15,8 @@ jest.mock('../../../../src/turns/context/turnContext.js');
 const mockLogger = { debug: jest.fn(), error: jest.fn() };
 const mockGameWorldAccess = {};
 const mockTurnEndPort = {};
-const mockCommandProcessor = {};
-const mockCommandOutcomeInterpreter = {};
 const mockSafeEventDispatcher = {};
 const mockEntityManager = {};
-const mockActionDiscoverySystem = {};
 
 // --- Mock Arguments for the create() method ---
 const mockActor = { id: 'test-actor' };
@@ -38,11 +35,8 @@ describe('ConcreteTurnContextFactory', () => {
       logger: mockLogger,
       gameWorldAccess: mockGameWorldAccess,
       turnEndPort: mockTurnEndPort,
-      commandProcessor: mockCommandProcessor,
-      commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
       safeEventDispatcher: mockSafeEventDispatcher,
       entityManager: mockEntityManager,
-      actionDiscoverySystem: mockActionDiscoverySystem,
     };
   });
 
@@ -63,12 +57,6 @@ describe('ConcreteTurnContextFactory', () => {
 
     // NOTE: In a real-world scenario, a test for each missing dependency would be added.
     // For brevity, only a few are shown here.
-    it('should throw an error if commandProcessor is not provided', () => {
-      delete factoryDependencies.commandProcessor;
-      expect(() => new ConcreteTurnContextFactory(factoryDependencies)).toThrow(
-        'ConcreteTurnContextFactory: commandProcessor is required.'
-      );
-    });
 
     it('should construct successfully when all dependencies are provided', () => {
       expect(
@@ -100,11 +88,8 @@ describe('ConcreteTurnContextFactory', () => {
       const expectedServicesForContext = {
         game: mockGameWorldAccess,
         turnEndPort: mockTurnEndPort,
-        commandProcessor: mockCommandProcessor,
-        commandOutcomeInterpreter: mockCommandOutcomeInterpreter,
         safeEventDispatcher: mockSafeEventDispatcher,
         entityManager: mockEntityManager,
-        actionDiscoverySystem: mockActionDiscoverySystem,
       };
 
       expect(TurnContext).toHaveBeenCalledWith({


### PR DESCRIPTION
- Eliminated commandProcessor, commandOutcomeInterpreter, and actionDiscoverySystem from TurnContext and its factory.
- Updated related interfaces and tests to reflect the removal of these services, streamlining the dependency injection process.