### PR TITLE
[Agent] add evaluation context checks

### DIFF
--- a/src/logic/operationHandlers/checkFollowCycleHandler.js
+++ b/src/logic/operationHandlers/checkFollowCycleHandler.js
@@ -17,6 +17,7 @@ import {
   assertParamsObject,
   validateStringParam,
 } from '../../utils/handlerUtils/paramsUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * @typedef {object} CheckFollowCycleParams
@@ -94,6 +95,10 @@ class CheckFollowCycleHandler extends BaseOperationHandler {
       this.#entityManager
     );
     const result = { success: true, cycleDetected };
+
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, log)) {
+      return;
+    }
 
     const res = tryWriteContextVariable(
       resultVar,

--- a/src/logic/operationHandlers/getNameHandler.js
+++ b/src/logic/operationHandlers/getNameHandler.js
@@ -19,6 +19,7 @@ import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { isNonBlankString } from '../../utils/textUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 
 /**
@@ -83,6 +84,9 @@ class GetNameHandler extends BaseOperationHandler {
         'GET_NAME: "result_variable" must be a non-empty string.',
         { params }
       );
+      return;
+    }
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, log)) {
       return;
     }
     const resultVar = result_variable.trim();

--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -6,6 +6,7 @@
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
  * @implements {OperationHandler}
@@ -25,6 +26,9 @@ class GetTimestampHandler extends BaseOperationHandler {
     if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
 
     const resultVariable = params.result_variable.trim();
+    if (!ensureEvaluationContext(executionContext, undefined, logger)) {
+      return;
+    }
     const timestamp = new Date().toISOString();
     const result = tryWriteContextVariable(
       resultVariable,

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -7,6 +7,7 @@ import BaseOperationHandler from './baseOperationHandler.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
@@ -148,6 +149,10 @@ class MathHandler extends BaseOperationHandler {
     }
     if (!expression || typeof expression !== 'object') {
       log.warn('MATH: "expression" must be an object.');
+      return;
+    }
+
+    if (!ensureEvaluationContext(executionContext, this.#dispatcher, log)) {
       return;
     }
 

--- a/src/logic/operationHandlers/mergeClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/mergeClosenessCircleHandler.js
@@ -10,6 +10,7 @@
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import { updateMovementLock } from '../utils/movementUtils.js';
 
 /**
@@ -184,6 +185,11 @@ class MergeClosenessCircleHandler extends BaseOperationHandler {
     this.#lockMovement(members);
 
     if (resultVar) {
+      if (
+        !ensureEvaluationContext(executionContext, this.#dispatcher, logger)
+      ) {
+        return;
+      }
       tryWriteContextVariable(
         resultVar,
         members,

--- a/src/logic/operationHandlers/modifyArrayFieldHandler.js
+++ b/src/logic/operationHandlers/modifyArrayFieldHandler.js
@@ -15,6 +15,7 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 import ComponentOperationHandler from './componentOperationHandler.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import {
   advancedArrayModify,
   ARRAY_MODIFICATION_MODES,
@@ -257,6 +258,11 @@ class ModifyArrayFieldHandler extends ComponentOperationHandler {
 
     // 6. Store Result if requested
     if (result_variable) {
+      if (
+        !ensureEvaluationContext(executionContext, this.#dispatcher, logger)
+      ) {
+        return;
+      }
       const res = tryWriteContextVariable(
         result_variable,
         modification.result,

--- a/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
+++ b/src/logic/operationHandlers/removeFromClosenessCircleHandler.js
@@ -12,6 +12,7 @@ import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 import { updateMovementLock } from '../utils/movementUtils.js';
 
 class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
@@ -72,6 +73,11 @@ class RemoveFromClosenessCircleHandler extends BaseOperationHandler {
     this.#unlockMovement(toUnlock);
 
     if (resultVar) {
+      if (
+        !ensureEvaluationContext(executionContext, this.#dispatcher, logger)
+      ) {
+        return;
+      }
       tryWriteContextVariable(
         resultVar,
         partners,

--- a/tests/unit/logic/operationHandlers/checkFollowCycleHandler.test.js
+++ b/tests/unit/logic/operationHandlers/checkFollowCycleHandler.test.js
@@ -378,7 +378,9 @@ describe('CheckFollowCycleHandler', () => {
       expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
         SYSTEM_ERROR_OCCURRED_ID,
         expect.objectContaining({
-          message: expect.stringContaining('cannot store value'),
+          message: expect.stringContaining(
+            'executionContext.evaluationContext.context is missing'
+          ),
         })
       );
     });


### PR DESCRIPTION
## Summary
- add ensureEvaluationContext validation to math handler and other handlers
- use ensureEvaluationContext before writing context variables
- adjust tests for new error message when context is missing

## Testing Done
- `npm run lint` *(fails: 3132 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c25732c948331a84256987760eb82