### PR TITLE
[Agent] centralize initializer event dispatch logging

### DIFF
--- a/src/initializers/systemInitializer.js
+++ b/src/initializers/systemInitializer.js
@@ -9,6 +9,7 @@
 // Type imports for JSDoc
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */ // Corrected path
+import { dispatchWithLogging } from '../utils/eventDispatchUtils.js';
 
 /**
  * Service responsible for initializing essential systems of the application.
@@ -147,21 +148,14 @@ class SystemInitializer {
           error: initError?.message || 'Unknown error',
           stack: initError?.stack,
         };
-        this.#validatedEventDispatcher
-          .dispatch('system:initialization_failed', failurePayload, {
-            allowSchemaNotFound: true,
-          })
-          .then(() =>
-            this.#logger.debug(
-              `Dispatched 'system:initialization_failed' event for ${systemName}.`
-            )
-          )
-          .catch((e) =>
-            this.#logger.error(
-              `Failed to dispatch 'system:initialization_failed' event for ${systemName}.`,
-              e
-            )
-          );
+        dispatchWithLogging(
+          this.#validatedEventDispatcher,
+          'system:initialization_failed',
+          failurePayload,
+          this.#logger,
+          systemName,
+          { allowSchemaNotFound: true }
+        );
       }
     } else {
       if (system) {

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -22,6 +22,7 @@ import {
 
 // --- Utility Imports ---
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { dispatchWithLogging } from '../utils/eventDispatchUtils.js';
 
 /**
  * Service responsible for instantiating entities defined
@@ -136,19 +137,14 @@ class WorldInitializer {
    * @private
    */
   async #_dispatchWorldInitEvent(eventName, payload, identifierForLog) {
-    try {
-      await this.#validatedEventDispatcher.dispatch(eventName, payload, {
-        allowSchemaNotFound: true,
-      });
-      this.#logger.debug(
-        `WorldInitializer (EventDispatch): Successfully dispatched '${eventName}' for ${identifierForLog}.`
-      );
-    } catch (e) {
-      this.#logger.error(
-        `WorldInitializer (EventDispatch): Failed dispatching '${eventName}' event for ${identifierForLog}. Error:`,
-        e
-      );
-    }
+    await dispatchWithLogging(
+      this.#validatedEventDispatcher,
+      eventName,
+      payload,
+      this.#logger,
+      identifierForLog,
+      { allowSchemaNotFound: true }
+    );
   }
 
   /**

--- a/src/utils/eventDispatchUtils.js
+++ b/src/utils/eventDispatchUtils.js
@@ -1,0 +1,53 @@
+/**
+ * @file Utility for dispatching events with standardized success/error logging.
+ */
+
+/**
+ * @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher
+ */
+/**
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+import { ensureValidLogger } from './loggerUtils.js';
+
+/**
+ * Dispatches an event and logs the outcome.
+ *
+ * @description
+ * Calls `.dispatch()` on the provided dispatcher and logs a debug message on
+ * success or an error message on failure. The promise resolves either way and
+ * errors are not re-thrown.
+ * @param {IValidatedEventDispatcher|ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
+ * @param {string} eventName - Event name to dispatch.
+ * @param {object} payload - Event payload.
+ * @param {ILogger} [logger] - Logger for debug/error output.
+ * @param {string} [identifierForLog] - Optional identifier appended to log messages.
+ * @param {object} [options] - Options forwarded to the dispatch call.
+ * @returns {Promise<void>} Resolves when dispatch completes.
+ */
+export async function dispatchWithLogging(
+  dispatcher,
+  eventName,
+  payload,
+  logger,
+  identifierForLog = '',
+  options = {}
+) {
+  const log = ensureValidLogger(logger, 'dispatchWithLogging');
+  const context = identifierForLog ? ` for ${identifierForLog}` : '';
+
+  return dispatcher
+    .dispatch(eventName, payload, options)
+    .then(() => {
+      log.debug(`Dispatched '${eventName}'${context}.`);
+    })
+    .catch((e) => {
+      log.error(`Failed dispatching '${eventName}' event${context}.`, e);
+    });
+}
+
+// --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,3 +19,4 @@ export { StructureResolver } from './structureResolver.js';
 export * from './jsonCleaning.js';
 export * from './jsonRepair.js';
 export * from './evaluationContextUtils.js';
+export * from './eventDispatchUtils.js';


### PR DESCRIPTION
## Summary
- add `dispatchWithLogging` to handle event dispatch logging
- use dispatchWithLogging in `SystemInitializer` and `WorldInitializer`
- verify helper use in unit tests and confirm error logging on dispatch failures

## Testing Done
- `npm run lint` *(fails: many pre-existing warnings/errors)*
- `npx eslint src/utils/eventDispatchUtils.js src/utils/index.js src/initializers/systemInitializer.js src/initializers/worldInitializer.js tests/unit/initializers/systemInitializer.initialization.test.js tests/unit/initializers/worldInitializer.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2a048eb483319d10e99e5609a6ff