### PR TITLE
[Agent] allow entities without position

### DIFF
--- a/tests/unit/entities/factories/entityFactory.test.js
+++ b/tests/unit/entities/factories/entityFactory.test.js
@@ -27,6 +27,7 @@ import {
   SHORT_TERM_MEMORY_COMPONENT_ID,
   NOTES_COMPONENT_ID,
   GOALS_COMPONENT_ID,
+  POSITION_COMPONENT_ID,
 } from '../../../../src/constants/componentIds.js';
 
 describe('EntityFactory', () => {
@@ -376,6 +377,24 @@ describe('EntityFactory', () => {
         entity.getComponentData(SHORT_TERM_MEMORY_COMPONENT_ID).maxEntries
       ).toBe(5);
     });
+
+    it('should create entity without core:position when definition omits it', () => {
+      const noPosDef = new EntityDefinition('test-def:nopos', {
+        description: 'Entity without position',
+        components: { 'core:name': { name: 'NoPos' } },
+      });
+      mocks.registry.getEntityDefinition.mockReturnValue(noPosDef);
+
+      const entity = factory.create(
+        'test-def:nopos',
+        {},
+        mocks.registry,
+        { has: () => false },
+        null
+      );
+
+      expect(entity.hasComponent(POSITION_COMPONENT_ID)).toBe(false);
+    });
   });
 
   describe('reconstruct', () => {
@@ -574,6 +593,26 @@ describe('EntityFactory', () => {
 
       expect(entity).toBeInstanceOf(Entity);
       expect(entity.id).toBe('test-id');
+    });
+
+    it('should reconstruct entity without core:position when missing', () => {
+      const noPosDef = new EntityDefinition('test-def:nopos', {
+        description: 'Entity without position',
+        components: { 'core:name': { name: 'NoPos' } },
+      });
+      mocks.registry.getEntityDefinition.mockReturnValue(noPosDef);
+
+      const serializedEntity = {
+        instanceId: 'nopos-id',
+        definitionId: 'test-def:nopos',
+        components: { 'core:name': { name: 'NoPos' } },
+      };
+
+      const entity = factory.reconstruct(serializedEntity, mocks.registry, {
+        has: () => false,
+      });
+
+      expect(entity.hasComponent(POSITION_COMPONENT_ID)).toBe(false);
     });
   });
 });

--- a/tests/unit/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/unit/services/gamePersistenceService.edgeCases.test.js
@@ -10,6 +10,7 @@ import {
   SHORT_TERM_MEMORY_COMPONENT_ID,
   PERCEPTION_LOG_COMPONENT_ID,
   CURRENT_ACTOR_COMPONENT_ID,
+  POSITION_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
 import { CORE_MOD_ID } from '../../../src/constants/core.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
@@ -127,6 +128,15 @@ describe('GamePersistenceService edge cases', () => {
         { modId: CORE_MOD_ID, version: 'unknown_fallback' },
       ]);
       expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('captures entity with no core:position component without errors', () => {
+      const entity = makeEntity('door1', 'blocker:door', {});
+      entityManager.activeEntities.set('door1', entity);
+
+      const result = captureService.captureCurrentGameState('World');
+      const overrides = result.gameState.entities[0].overrides;
+      expect(overrides).not.toHaveProperty(POSITION_COMPONENT_ID);
     });
   });
 


### PR DESCRIPTION
Summary: Added tests ensuring that entity instances can be created and reconstructed without `core:position`. Also validated that save capture omits the position component when absent.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (checked modified files)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c29f7d390833198a25eb87e054196