### PR TITLE
[Agent] refactor processing state

### DIFF
--- a/src/turns/states/helpers/commandProcessingWorkflow.js
+++ b/src/turns/states/helpers/commandProcessingWorkflow.js
@@ -65,9 +65,9 @@ export class CommandProcessingWorkflow {
       turnAction
     );
 
-    if (!this._state._isProcessing) {
+    if (!this._state.isProcessing) {
       logger.warn(
-        `${this._state.getStateName()}: _isProcessing became false after dispatch for ${actorId}.`
+        `${this._state.getStateName()}: processing flag became false after dispatch for ${actorId}.`
       );
       return null;
     }
@@ -176,7 +176,7 @@ export class CommandProcessingWorkflow {
       `${this._state.getStateName()}: Actor ${actorId} - Directive strategy ${directiveStrategy.constructor.name} executed.`
     );
 
-    if (!this._state._isProcessing) {
+    if (!this._state.isProcessing) {
       logger.debug(
         `${this._state.getStateName()}: Processing flag false after directive strategy for ${actorId}.`
       );
@@ -262,13 +262,13 @@ export class CommandProcessingWorkflow {
       }
     } finally {
       if (
-        this._state._isProcessing &&
+        this._state.isProcessing &&
         this._state._handler.getCurrentState() === this._state
       ) {
         const finalLogger =
           this._state._getTurnContext()?.getLogger() ?? turnCtx.getLogger();
         finalLogger.warn(
-          `${this._state.getStateName()}: _isProcessing was unexpectedly true at the end of _processCommandInternal for ${actorId}. Forcing to false.`
+          `${this._state.getStateName()}: isProcessing was unexpectedly true at the end of _processCommandInternal for ${actorId}. Forcing to false.`
         );
         finishProcessing(this._state);
       }

--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -66,7 +66,7 @@ export async function getServiceFromContext(
     }
     logger.error(errorMsg);
 
-    if (state._isProcessing) {
+    if (state.isProcessing) {
       finishProcessing(state);
     }
     throw new ServiceLookupError(errorMsg);

--- a/src/turns/states/helpers/processingErrorUtils.js
+++ b/src/turns/states/helpers/processingErrorUtils.js
@@ -18,7 +18,7 @@ import { safeDispatchError } from '../../../utils/safeDispatchErrorUtils.js';
  * @returns {boolean} The previous _isProcessing value.
  */
 export function resetProcessingFlags(state) {
-  const wasProcessing = state._isProcessing;
+  const wasProcessing = state.isProcessing;
   finishProcessing(state);
   return wasProcessing;
 }
@@ -30,9 +30,14 @@ export function resetProcessingFlags(state) {
  * @returns {void}
  */
 export function finishProcessing(state) {
-  if (state._processingGuard) {
+  if (typeof state.finishProcessing === 'function') {
+    state.finishProcessing();
+  } else if (state._processingGuard) {
     state._processingGuard.finish();
+  } else if (typeof state._setProcessing === 'function') {
+    state._setProcessing(false);
   } else {
+    // fallback for legacy shapes
     state._isProcessing = false;
   }
 }

--- a/src/turns/states/helpers/processingGuard.js
+++ b/src/turns/states/helpers/processingGuard.js
@@ -1,6 +1,6 @@
 /**
  * @file processingGuard.js
- * @description Utility to manage the _isProcessing flag for ProcessingCommandState.
+ * @description Utility to manage the processing flag for ProcessingCommandState.
  */
 
 /**
@@ -9,7 +9,8 @@
  */
 export class ProcessingGuard {
   /**
-   * @param {{ _isProcessing: boolean }} owner - Object owning the flag.
+   * @param {{ _setProcessing: function(boolean): void }} owner -
+   *   Object owning the flag and exposing a setter.
    */
   constructor(owner) {
     this._owner = owner;
@@ -20,8 +21,8 @@ export class ProcessingGuard {
    * @returns {void}
    */
   start() {
-    if (this._owner) {
-      this._owner._isProcessing = true;
+    if (this._owner && typeof this._owner._setProcessing === 'function') {
+      this._owner._setProcessing(true);
     }
   }
 
@@ -30,8 +31,8 @@ export class ProcessingGuard {
    * @returns {void}
    */
   finish() {
-    if (this._owner) {
-      this._owner._isProcessing = false;
+    if (this._owner && typeof this._owner._setProcessing === 'function') {
+      this._owner._setProcessing(false);
     }
   }
 }

--- a/src/turns/states/workflows/processingWorkflow.js
+++ b/src/turns/states/workflows/processingWorkflow.js
@@ -46,7 +46,7 @@ export class ProcessingWorkflow {
     );
     if (!turnCtx) return null;
 
-    if (this._state._isProcessing) {
+    if (this._state.isProcessing) {
       const logger = getLogger(turnCtx, this._state._handler);
       logger.warn(
         `${this._state.getStateName()}: enterState called while already processing. Actor: ${turnCtx?.getActor()?.id ?? 'N/A'}. Aborting re-entry.`
@@ -54,7 +54,7 @@ export class ProcessingWorkflow {
       return null;
     }
 
-    this._state._processingGuard.start();
+    this._state.startProcessing();
 
     await AbstractTurnState.prototype.enterState.call(
       this._state,

--- a/src/types/stateTypes.js
+++ b/src/types/stateTypes.js
@@ -5,7 +5,7 @@
 /**
  * @typedef {object} ProcessingCommandStateLike
  * @description Minimal shape used by helper utilities for ProcessingCommandState.
- * @property {boolean} _isProcessing - Indicates if command processing is active.
+ * @property {function(): boolean} isProcessing - Indicates if command processing is active.
  * @property {function(): string} getStateName - Retrieves the state's name for logging.
  * @property {function(): import('../turns/interfaces/ITurnContext.js').ITurnContext | null} _getTurnContext - Gets the current turn context.
  * @property {{ safeEventDispatcher?: any, _currentState?: any }} _handler - Owning handler reference.

--- a/tests/unit/turns/states/helpers/processingErrorUtils.test.js
+++ b/tests/unit/turns/states/helpers/processingErrorUtils.test.js
@@ -16,44 +16,84 @@ describe('processingErrorUtils', () => {
   });
 
   test('resetProcessingFlags uses guard when present', () => {
-    const owner = { _isProcessing: true };
+    const owner = {
+      _flag: true,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     owner._processingGuard = new ProcessingGuard(owner);
     const spy = jest.spyOn(owner._processingGuard, 'finish');
     const was = resetProcessingFlags(owner);
     expect(was).toBe(true);
     expect(spy).toHaveBeenCalled();
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('resetProcessingFlags toggles flag directly when guard missing', () => {
-    const owner = { _isProcessing: true };
+    const owner = {
+      _flag: true,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     const was = resetProcessingFlags(owner);
     expect(was).toBe(true);
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('finishProcessing uses guard when present', () => {
-    const owner = { _isProcessing: true };
+    const owner = {
+      _flag: true,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     owner._processingGuard = new ProcessingGuard(owner);
     const spy = jest.spyOn(owner._processingGuard, 'finish');
     finishProcessing(owner);
     expect(spy).toHaveBeenCalled();
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('finishProcessing toggles flag directly when guard missing', () => {
-    const owner = { _isProcessing: true };
+    const owner = {
+      _flag: true,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     finishProcessing(owner);
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('ProcessingGuard.start and finishProcessing sequence toggles flag', () => {
-    const owner = { _isProcessing: false };
+    const owner = {
+      _flag: false,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     owner._processingGuard = new ProcessingGuard(owner);
     owner._processingGuard.start();
-    expect(owner._isProcessing).toBe(true);
+    expect(owner.isProcessing).toBe(true);
     finishProcessing(owner);
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('resolveLogger uses context logger when available', () => {

--- a/tests/unit/turns/states/processingCommandState.enterState.test.js
+++ b/tests/unit/turns/states/processingCommandState.enterState.test.js
@@ -189,10 +189,10 @@ describe('ProcessingCommandState', () => {
           }
           if (
             processingState &&
-            processingState['_isProcessing'] &&
+            processingState.isProcessing &&
             oldState === processingState
           ) {
-            processingState['_isProcessing'] = false;
+            processingState.finishProcessing();
           }
           return Promise.resolve();
         }),
@@ -281,7 +281,7 @@ describe('ProcessingCommandState', () => {
         .spyOn(processingState, '_processCommandInternal')
         .mockImplementation(async () => {
           resolveProcessInternal();
-          processingState['_isProcessing'] = false;
+          processingState.finishProcessing();
           return Promise.resolve();
         });
 
@@ -313,7 +313,7 @@ describe('ProcessingCommandState', () => {
       );
 
       await new Promise(process.nextTick);
-      expect(processingState['_isProcessing']).toBe(false);
+      expect(processingState.isProcessing).toBe(false);
     }, 10000);
 
     it('should handle null turn context on entry and use handler reset', async () => {
@@ -330,7 +330,7 @@ describe('ProcessingCommandState', () => {
       );
       expect(mockHandler.requestIdleStateTransition).toHaveBeenCalled();
       expect(processCommandInternalSpy).not.toHaveBeenCalled();
-      expect(processingState['_isProcessing']).toBe(false);
+      expect(processingState.isProcessing).toBe(false);
     });
 
     it('should use constructor-passed ITurnAction if it exists, overriding context action', async () => {

--- a/tests/unit/turns/states/processingCommandState.helpers.test.js
+++ b/tests/unit/turns/states/processingCommandState.helpers.test.js
@@ -36,13 +36,13 @@ describe('ProcessingCommandState helpers', () => {
     state._ensureContext = jest.fn(async () => ctx);
     const result = await workflow._acquireContext(mockHandler, null);
     expect(result).toBe(ctx);
-    expect(state._isProcessing).toBe(true);
+    expect(state.isProcessing).toBe(true);
   });
 
   test('_acquireContext returns null when already processing', async () => {
     const ctx = makeCtx({ id: 'a1' });
     state._ensureContext = jest.fn(async () => ctx);
-    state._isProcessing = true;
+    state.startProcessing();
     const result = await workflow._acquireContext(mockHandler, null);
     expect(result).toBeNull();
   });

--- a/tests/unit/turns/states/processingGuard.test.js
+++ b/tests/unit/turns/states/processingGuard.test.js
@@ -26,21 +26,29 @@ const makeTurnCtx = () => ({
 
 describe('ProcessingGuard', () => {
   test('start and finish toggle flag on owner', () => {
-    const owner = { _isProcessing: false };
+    const owner = {
+      _flag: false,
+      _setProcessing(val) {
+        this._flag = val;
+      },
+      get isProcessing() {
+        return this._flag;
+      },
+    };
     const guard = new ProcessingGuard(owner);
     guard.start();
-    expect(owner._isProcessing).toBe(true);
+    expect(owner.isProcessing).toBe(true);
     guard.finish();
-    expect(owner._isProcessing).toBe(false);
+    expect(owner.isProcessing).toBe(false);
   });
 
   test('finish via handleProcessingException clears flag when processing interrupted', async () => {
     const handler = makeHandler();
     const ctx = makeTurnCtx();
     const state = new ProcessingCommandState(handler, null, null);
-    state._isProcessing = true;
+    state.startProcessing();
     const exceptionHandler = new ProcessingExceptionHandler(state);
     await exceptionHandler.handle(ctx, new Error('boom'), 'actor1');
-    expect(state._isProcessing).toBe(false);
+    expect(state.isProcessing).toBe(false);
   });
 });


### PR DESCRIPTION
Summary:
- use private #isProcessing with helper methods
- adjust ProcessingGuard and utilities for new API
- update workflows to reference the getter
- refactor tests for new processing flag access

Testing Done:
- `npm run lint` *(fails: too many existing issues)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c2f8fbe908331b587b1f7e960673f