### PR TITLE
refactor: rename context parameter to baseContext in ActionDiscoveryS…

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -134,18 +134,18 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   /**
    * @description Prepares a populated discovery context for the specified actor.
    * @param {Entity} actorEntity
-   * @param {ActionContext} context
+   * @param {ActionContext} baseContext
    * @returns {ActionContext}
    * @private
    */
-  #prepareDiscoveryContext(actorEntity, context) {
-    const discoveryContext = { ...context };
+  #prepareDiscoveryContext(actorEntity, baseContext) {
+    const discoveryContext = { ...baseContext };
     if (!discoveryContext.getActor) {
       discoveryContext.getActor = () => actorEntity;
     }
 
     discoveryContext.currentLocation =
-      context.currentLocation ??
+      baseContext.currentLocation ??
       this.#getActorLocationFn(actorEntity.id, this.#entityManager);
 
     return discoveryContext;

--- a/src/interfaces/IActionDiscoveryService.js
+++ b/src/interfaces/IActionDiscoveryService.js
@@ -28,12 +28,12 @@ export class IActionDiscoveryService {
    * Determines all valid actions that the specified entity can currently perform.
    *
    * @param {Entity} actingEntity - The entity for whom to discover actions.
-   * @param {ActionContext} context - The LEAN context, containing only dynamic state.
+   * @param {ActionContext} baseContext - The base action context, which will be enriched.
    * @param {object} [options={}] Optional settings.
    * @returns {Promise<DiscoveredActionsResult>}
    * @throws {Error}
    */
-  async getValidActions(actingEntity, context, options = {}) {
+  async getValidActions(actingEntity, baseContext, options = {}) {
     throw new Error(
       'IActionDiscoveryService.getValidActions method not implemented.'
     );


### PR DESCRIPTION
…ervice

- Updated the parameter name in #prepareDiscoveryContext and getValidActions methods for clarity.
- Ensured consistency in naming across the ActionDiscoveryService and IActionDiscoveryService interfaces.