### PR TITLE
[Agent] Remove proxy from EntityManagerAdapter

### DIFF
--- a/src/entities/entityManagerAdapter.js
+++ b/src/entities/entityManagerAdapter.js
@@ -1,67 +1,193 @@
 /**
- * @file Adapter that wraps EntityManager and provides location query functionality.
+ * @file Adapter that wraps EntityManager and exposes a limited subset of its API.
  * @see src/entities/entityManagerAdapter.js
  */
 
 /**
  * @typedef {import('./entityManager.js').default} EntityManager
+ * @typedef {import('./entity.js').default} Entity
  * @typedef {import('./locationQueryService.js').LocationQueryService} LocationQueryService
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
  */
 
+import { IEntityManager } from '../interfaces/IEntityManager.js';
+
 /**
  * @description Adapter that wraps EntityManager and provides location query functionality.
- * This adapter implements IEntityManager and delegates most methods to the wrapped EntityManager,
- * but provides getEntitiesInLocation by delegating to LocationQueryService.
  * @class EntityManagerAdapter
  * @implements {IEntityManager}
  */
-export class EntityManagerAdapter {
+export class EntityManagerAdapter extends IEntityManager {
   /**
    * @param {object} dependencies
    * @param {EntityManager} dependencies.entityManager - The wrapped entity manager.
    * @param {LocationQueryService} dependencies.locationQueryService - The location query service.
    */
   constructor({ entityManager, locationQueryService }) {
+    super();
     /** @private */
     this.entityManager = entityManager;
     /** @private */
     this.locationQueryService = locationQueryService;
-
-    return new Proxy(this, {
-      get(target, prop, receiver) {
-        if (Reflect.has(target, prop)) {
-          return Reflect.get(target, prop, receiver);
-        }
-
-        const value = target.entityManager[prop];
-        if (typeof value === 'function') {
-          return value.bind(target.entityManager);
-        }
-        return value;
-      },
-    });
   }
 
   /**
-   * Retrieves all entity instance IDs (UUIDs) present in a specific location.
-   * This delegates to the LocationQueryService.
+   * Delegates to the wrapped EntityManager to clear all entities.
+   *
+   * @returns {void}
+   */
+  clearAll() {
+    this.entityManager.clearAll();
+  }
+
+  /**
+   * Retrieves all entity instance IDs present in a specific location.
    *
    * @param {string} locationId - The unique ID of the location entity.
-   * @returns {Set<string>} A Set of entity instance IDs (UUIDs) in the specified location.
+   * @returns {Set<string>} Set of entity instance IDs in the location.
    */
   getEntitiesInLocation(locationId) {
     return this.locationQueryService.getEntitiesInLocation(locationId);
   }
 
   /**
-   * Delegates to the wrapped EntityManager to retrieve all active entity IDs.
+   * Returns an iterable of all active entity IDs.
    *
-   * @returns {Iterable<string>} Iterable of entity instance IDs.
+   * @returns {Iterable<string>} Iterable of entity IDs.
    */
   getEntityIds() {
     return this.entityManager.getEntityIds();
   }
 
-  // All other property accesses are delegated via Proxy
+  /**
+   * Retrieves an active entity instance by its unique ID.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @returns {Entity | undefined} The entity instance if found.
+   */
+  getEntityInstance(instanceId) {
+    return this.entityManager.getEntityInstance(instanceId);
+  }
+
+  /**
+   * Creates a new Entity instance from a definition ID.
+   *
+   * @param {string} definitionId - The entity definition ID.
+   * @param {object} [options] - Options for creation.
+   * @returns {Entity} The created entity.
+   */
+  createEntityInstance(definitionId, options = {}) {
+    return this.entityManager.createEntityInstance(definitionId, options);
+  }
+
+  /**
+   * Reconstructs an entity from saved data.
+   *
+   * @param {object} serializedEntity - Saved entity data.
+   * @returns {Entity} The reconstructed entity instance.
+   */
+  reconstructEntity(serializedEntity) {
+    return this.entityManager.reconstructEntity(serializedEntity);
+  }
+
+  /**
+   * Retrieves raw component data for an entity.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @param {string} componentTypeId - The component type ID.
+   * @returns {object | undefined} The component data.
+   */
+  getComponentData(instanceId, componentTypeId) {
+    return this.entityManager.getComponentData(instanceId, componentTypeId);
+  }
+
+  /**
+   * Checks if an entity has data for a component type.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @param {string} componentTypeId - The component type ID.
+   * @returns {boolean} True if the entity has the component.
+   */
+  hasComponent(instanceId, componentTypeId) {
+    return this.entityManager.hasComponent(instanceId, componentTypeId);
+  }
+
+  /**
+   * Checks if an entity has a component override.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @param {string} componentTypeId - The component type ID.
+   * @returns {boolean} True if a component override exists.
+   */
+  hasComponentOverride(instanceId, componentTypeId) {
+    return this.entityManager.hasComponentOverride(instanceId, componentTypeId);
+  }
+
+  /**
+   * Fetches all entities that possess a component type.
+   *
+   * @param {string} componentTypeId - The component type ID.
+   * @returns {Entity[]} Array of matching entities.
+   */
+  getEntitiesWithComponent(componentTypeId) {
+    return this.entityManager.getEntitiesWithComponent(componentTypeId);
+  }
+
+  /**
+   * Adds a component to an entity.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @param {string} componentTypeId - The component type ID.
+   * @param {object} componentData - The component data.
+   * @returns {boolean} True if successful.
+   */
+  addComponent(instanceId, componentTypeId, componentData) {
+    return this.entityManager.addComponent(
+      instanceId,
+      componentTypeId,
+      componentData
+    );
+  }
+
+  /**
+   * Removes a component from an entity.
+   *
+   * @param {string} instanceId - The entity ID.
+   * @param {string} componentTypeId - The component type ID.
+   * @returns {boolean} True if the component was removed.
+   */
+  removeComponent(instanceId, componentTypeId) {
+    return this.entityManager.removeComponent(instanceId, componentTypeId);
+  }
+
+  /**
+   * Finds all active entities that match a query.
+   *
+   * @param {object} query - The query definition.
+   * @returns {Entity[]} Array of matching entities.
+   */
+  findEntities(query) {
+    return this.entityManager.findEntities(query);
+  }
+
+  /**
+   * Iterator over all active entities.
+   *
+   * @returns {IterableIterator<Entity>} Iterator of entities.
+   */
+  get entities() {
+    return this.entityManager.entities;
+  }
+
+  /**
+   * Lists all component type IDs attached to an entity.
+   *
+   * @param {string} entityId - The entity ID.
+   * @returns {string[]} Array of component type IDs.
+   */
+  getAllComponentTypesForEntity(entityId) {
+    return this.entityManager.getAllComponentTypesForEntity(entityId);
+  }
 }
+
+export default EntityManagerAdapter;

--- a/tests/unit/entities/entityManagerAdapter.test.js
+++ b/tests/unit/entities/entityManagerAdapter.test.js
@@ -23,9 +23,13 @@ describe('EntityManagerAdapter', () => {
     expect(entityManager.clearAll).toHaveBeenCalled();
   });
 
-  it('forwards property access to the wrapped entity manager', () => {
+  it('exposes the entities iterator from the wrapped entity manager', () => {
     const entityIterator = Symbol('iterator');
-    const entityManager = { entities: entityIterator };
+    const entityManager = {
+      get entities() {
+        return entityIterator;
+      },
+    };
     const locationQueryService = { getEntitiesInLocation: jest.fn() };
     const adapter = new EntityManagerAdapter({
       entityManager,


### PR DESCRIPTION
## Summary
- implement `EntityManagerAdapter` without using JS `Proxy`
- expose selected `EntityManager` methods directly
- update unit tests for the new adapter API

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c3afedcac8331a709c76b9dcf1144