### PR TITLE
[Agent] Refactor validation helpers

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -11,6 +11,7 @@ import {
   isValidEntity,
 } from './entityValidationUtils.js';
 import { isNonBlankString } from './textUtils.js';
+import { safeCall } from './safeExecutionUtils.js';
 
 /** @typedef {import('../entities/entity.js').default} Entity */
 
@@ -34,16 +35,17 @@ export function getComponentFromEntity(entity, componentId, logger) {
     return null;
   }
 
-  try {
-    const data = entity.getComponentData(componentId);
-    return data ?? null;
-  } catch (error) {
-    moduleLogger.debug(
-      'getComponentFromEntity: error retrieving component data.',
-      error
-    );
-    return null;
+  const { success, result, error } = safeCall(() =>
+    entity.getComponentData(componentId)
+  );
+  if (success) {
+    return result ?? null;
   }
+  moduleLogger.debug(
+    'getComponentFromEntity: error retrieving component data.',
+    error
+  );
+  return null;
 }
 
 /** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
@@ -83,16 +85,17 @@ export function getComponentFromManager(
     return null;
   }
 
-  try {
-    const data = entityManager.getComponentData(entityId, componentId);
-    return data ?? null;
-  } catch (error) {
-    moduleLogger.debug(
-      `getComponentFromManager: error retrieving '${componentId}' for entity '${entityId}'.`,
-      error
-    );
-    return null;
+  const { success, result, error } = safeCall(() =>
+    entityManager.getComponentData(entityId, componentId)
+  );
+  if (success) {
+    return result ?? null;
   }
+  moduleLogger.debug(
+    `getComponentFromManager: error retrieving '${componentId}' for entity '${entityId}'.`,
+    error
+  );
+  return null;
 }
 
 /**

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -4,6 +4,7 @@ import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from './dispatcherUtils.js';
 import { isNonBlankString } from './textUtils.js';
+import { safeCall } from './safeExecutionUtils.js';
 
 /**
  * Validate that the context exists and the variable name is valid.
@@ -49,12 +50,10 @@ function _validateContextAndName(variableName, executionContext) {
  * @returns {{success: boolean, error?: Error}} Result of the assignment.
  */
 export function setContextValue(context, key, value) {
-  try {
+  const { success, error } = safeCall(() => {
     context[key] = value;
-    return { success: true };
-  } catch (e) {
-    return { success: false, error: e };
-  }
+  });
+  return success ? { success: true } : { success: false, error };
 }
 
 /**

--- a/src/utils/handlerUtils/paramsUtils.js
+++ b/src/utils/handlerUtils/paramsUtils.js
@@ -1,6 +1,7 @@
 // src/utils/handlerUtils/paramsUtils.js
 
 import { safeDispatchError } from '../safeDispatchErrorUtils.js';
+import { isNonBlankString } from '../textUtils.js';
 
 /**
  * @description Ensures an operation handler received a valid parameters object.
@@ -40,7 +41,7 @@ export function assertParamsObject(params, logger, opName) {
  * @returns {string|null} The trimmed string or `null` if invalid.
  */
 export function validateStringParam(value, name, logger, dispatcher) {
-  if (typeof value === 'string' && value.trim()) {
+  if (isNonBlankString(value)) {
     return value.trim();
   }
   safeDispatchError(

--- a/src/utils/macroUtils.js
+++ b/src/utils/macroUtils.js
@@ -118,6 +118,4 @@ export function validateMacroExpansion(actions, registry, logger) {
  * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for warnings.
  * @returns {object[]} A new array with all macros expanded.
  */
-export function expandActionArray(actions, registry, logger) {
-  return _expandActions(actions, registry, logger);
-}
+export const expandActionArray = expandMacros;

--- a/src/utils/safeExecutionUtils.js
+++ b/src/utils/safeExecutionUtils.js
@@ -1,0 +1,23 @@
+/**
+ * @module safeExecutionUtils
+ * @description Helper for executing functions with error capture.
+ */
+
+/**
+ * Executes a function and captures any thrown error.
+ *
+ * @param {() => any} fn - Function to execute.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger used for debug output.
+ * @param {string} [context] - Context message for logging.
+ * @returns {{success: boolean, result?: any, error?: any}} Execution result.
+ */
+export function safeCall(fn, logger, context = 'safeCall') {
+  try {
+    return { success: true, result: fn() };
+  } catch (error) {
+    if (logger && typeof logger.debug === 'function') {
+      logger.debug(`${context}: operation failed`, error);
+    }
+    return { success: false, error };
+  }
+}


### PR DESCRIPTION
## Summary
- centralize string validation with `isNonBlankString`
- add generic `safeCall` helper for try/catch patterns
- update context and component utils to use the new helper
- alias `expandActionArray` to `expandMacros`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 629 errors)*
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c37927e6c8331b65fab349854f9a0