### PR TITLE
[Agent] unify slot modal listeners

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -150,23 +150,12 @@ class LoadGameUI extends SlotModalBase {
    */
   _initEventListeners() {
     // Close button listener is automatically added by BaseModalRenderer if 'closeButton' is in elementsConfig.
-    if (this.elements.confirmLoadButtonEl) {
-      this._addDomListener(
-        this.elements.confirmLoadButtonEl,
-        'click',
-        this._handleLoad.bind(this)
-      );
-    }
+    this._initCommonListeners(this._handleLoad.bind(this));
     if (this.elements.deleteSaveButtonEl) {
       this._addDomListener(
         this.elements.deleteSaveButtonEl,
         'click',
         this._handleDelete.bind(this)
-      );
-    }
-    if (this.elements.modalElement) {
-      this._addDomListener(this.elements.modalElement, 'submit', (event) =>
-        event.preventDefault()
       );
     }
     // Keyboard navigation is now handled by SlotModalBase
@@ -388,14 +377,13 @@ class LoadGameUI extends SlotModalBase {
    * @returns {string | null} Error message if validation fails.
    */
   _validateLoadPreconditions() {
-    if (!this.selectedSlotData || this.selectedSlotData.isCorrupted) {
-      this.logger.warn(
-        `${this._logPrefix} Load attempt ignored: no slot selected, or slot corrupted.`
-      );
-      if (this.selectedSlotData?.isCorrupted) {
-        return 'Cannot load a corrupted save file. Please delete it or choose another.';
-      }
-      return 'Please select a save slot to load.';
+    const selectionError = this._validateSlotSelection(true, {
+      noSelection: 'Please select a save slot to load.',
+      corrupted:
+        'Cannot load a corrupted save file. Please delete it or choose another.',
+    });
+    if (selectionError) {
+      return selectionError;
     }
     if (!this.loadService) {
       this.logger.error(
@@ -469,14 +457,11 @@ class LoadGameUI extends SlotModalBase {
    * @async
    */
   async _handleDelete() {
-    if (!this.selectedSlotData) {
-      this.logger.warn(
-        `${this._logPrefix} Delete attempt ignored: no slot selected.`
-      );
-      this._displayStatusMessage(
-        'Please select a save slot to delete.',
-        'error'
-      );
+    const selectionError = this._validateSlotSelection(false, {
+      noSelection: 'Please select a save slot to delete.',
+    });
+    if (selectionError) {
+      this._displayStatusMessage(selectionError, 'error');
       return;
     }
 

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -134,19 +134,8 @@ export class SaveGameUI extends SlotModalBase {
    * @private
    */
   _initModalEventListeners() {
-    if (this.elements.confirmSaveButtonEl) {
-      this._addDomListener(
-        this.elements.confirmSaveButtonEl,
-        'click',
-        this._handleSave.bind(this)
-      );
-    }
-    if (this.elements.modalElement) {
-      this._addDomListener(this.elements.modalElement, 'submit', (event) =>
-        event.preventDefault()
-      );
-    }
-    // Keyboard navigation is now handled by SlotModalBase
+    this._initCommonListeners(this._handleSave.bind(this));
+    // Keyboard navigation is handled by SlotModalBase
     if (this.elements.saveNameInputEl) {
       this._addDomListener(
         this.elements.saveNameInputEl,

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -216,6 +216,63 @@ export class SlotModalBase extends BaseModalRenderer {
   }
 
   /**
+   * Sets up common modal listeners for confirm actions and form submission.
+   *
+   * @protected
+   * @param {Function} confirmHandler - Handler for the confirm button click.
+   * @returns {void}
+   */
+  _initCommonListeners(confirmHandler) {
+    if (this._confirmButtonEl && typeof confirmHandler === 'function') {
+      this._addDomListener(this._confirmButtonEl, 'click', confirmHandler);
+    }
+
+    if (this.elements.modalElement) {
+      this._addDomListener(this.elements.modalElement, 'submit', (event) => {
+        event.preventDefault();
+      });
+    }
+  }
+
+  /**
+   * Validates that a slot has been selected.
+   *
+   * @protected
+   * @param {boolean} [requireUncorrupted] - Reject corrupted slots when true.
+   * @param {object} [messages] - Custom error messages.
+   * @param {string} [messages.noSelection] - Message when no slot is selected.
+   * @param {string} [messages.corrupted] - Message when slot is corrupted.
+   * @returns {string | null} Error message if invalid, otherwise null.
+   */
+  _validateSlotSelection(requireUncorrupted = false, messages = {}) {
+    const {
+      noSelection = 'Please select a save slot first.',
+      corrupted = 'Cannot use a corrupted save file.',
+    } = messages;
+
+    if (!this.selectedSlotData) {
+      this.logger.warn(
+        `${this._logPrefix} Action attempted without selecting a slot.`
+      );
+      return noSelection;
+    }
+
+    if (
+      requireUncorrupted &&
+      Object.prototype.hasOwnProperty.call(
+        this.selectedSlotData,
+        'isCorrupted'
+      ) &&
+      this.selectedSlotData.isCorrupted
+    ) {
+      this.logger.warn(`${this._logPrefix} Selected slot is corrupted.`);
+      return corrupted;
+    }
+
+    return null;
+  }
+
+  /**
    * Core logic to populate the slots list.
    *
    * @protected


### PR DESCRIPTION
## Summary
- add `_initCommonListeners` and `_validateSlotSelection` helpers in `slotModalBase`
- refactor SaveGameUI and LoadGameUI to use `_initCommonListeners`
- integrate `_validateSlotSelection` into LoadGameUI logic

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c3bc0bb2c83319ebb4629ce6cdbd7