### PR TITLE
[Agent] Remove stale FIX comments

### DIFF
--- a/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
+++ b/src/dependencyInjection/registrations/eventBusAdapterRegistrations.js
@@ -30,8 +30,6 @@ export function registerEventBusAdapters(container) {
 
   // --- Register EventBusPromptAdapter ---
   registrar.singletonFactory(tokens.IPromptOutputPort, (c) => {
-    // --- FIX: Check for registration before resolving optional dependencies. ---
-    // This prevents c.resolve() from throwing an error if a dependency isn't registered.
     const safeDispatcher = /** @type {ISafeEventDispatcher | null} */ (
       resolveOptional(c, tokens.ISafeEventDispatcher)
     );

--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -2,7 +2,6 @@
 
 import EventBus from '../../events/eventBus.js';
 import SpatialIndexManager from '../../entities/spatialIndexManager.js';
-// REMOVED: Unused loader imports
 // import ModsLoader from '../../loaders/modsLoader.js';
 // import PromptTextLoader from '../../loaders/promptTextLoader.js';
 import { GameDataRepository } from '../../data/gameDataRepository.js'; // Concrete class
@@ -78,10 +77,6 @@ export function registerInfrastructure(container) {
     `Infrastructure Registration: Registered ${String(tokens.ISpatialIndexManager)}.`
   );
 
-  // --- FIXED: Removed duplicate loader registrations ---
-  // `PromptTextLoader` is now correctly registered only in `loadersRegistrations.js`.
-  // `ModsLoader` is now correctly registered only in `loadersRegistrations.js`.
-
   container.register(
     tokens.IGameDataRepository,
     (c) =>
@@ -94,9 +89,6 @@ export function registerInfrastructure(container) {
   log.debug(
     `Infrastructure Registration: Registered ${String(tokens.IGameDataRepository)}.`
   );
-
-  // DELETED: Duplicate IEntityManager registration removed as per Ticket 8.
-  // The canonical registration is now in worldAndEntityRegistrations.js.
 
   container.register(
     tokens.IValidatedEventDispatcher,


### PR DESCRIPTION
## Summary
- remove outdated `FIX`, `REMOVED`, and `DELETED` comments from DI registrations

## Testing
- `npx eslint src/dependencyInjection/registrations/eventBusAdapterRegistrations.js src/dependencyInjection/registrations/infrastructureRegistrations.js`
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3ccb1af48331bcf214aa4754d458