### PR TITLE
[Feat] inject loader into LlmConfigService

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -69,6 +69,8 @@ export class LlmConfigService {
   #logger;
   /** @type {AppConfigService} */
   #appConfig;
+  /** @type {Function} */
+  #configLoader;
 
   /** @type {string} */
   #_defaultLlmConfigPath;
@@ -86,8 +88,14 @@ export class LlmConfigService {
    * @param {IFileSystemReader} fileSystemReader - An IFileSystemReader instance.
    * @param {ILogger} logger - An ILogger instance.
    * @param {AppConfigService} appConfig - An AppConfigService instance.
+   * @param {Function} [loader] - Loader function for LLM configs.
    */
-  constructor(fileSystemReader, logger, appConfig) {
+  constructor(
+    fileSystemReader,
+    logger,
+    appConfig,
+    loader = loadProxyLlmConfigs
+  ) {
     if (!fileSystemReader) {
       throw new Error('LlmConfigService: fileSystemReader is required.');
     }
@@ -101,6 +109,7 @@ export class LlmConfigService {
     this.#fileSystemReader = fileSystemReader;
     this.#logger = logger;
     this.#appConfig = appConfig;
+    this.#configLoader = loader;
 
     this.#_defaultLlmConfigPath = path.resolve(
       process.cwd(),
@@ -186,7 +195,7 @@ export class LlmConfigService {
     );
 
     try {
-      const result = await loadProxyLlmConfigs(
+      const result = await this.#configLoader(
         this.#resolvedConfigPath,
         this.#logger,
         this.#fileSystemReader


### PR DESCRIPTION
Summary: Allow custom LLM config loading by injecting the loader into the proxy's `LlmConfigService`. Updated tests to use the new parameter.

Changes Made:
- Added optional `loader` param and private `#configLoader` field in `LlmConfigService`.
- Updated `initialize()` to call the injected loader.
- Adjusted `llmConfigService` tests to provide a mock loader.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685c3e9375248331b1863d4d729cb31c