### PR TITLE
[Agent] inject logger into GameEngine

### DIFF
--- a/src/bootstrapper/stages/engineStages.js
+++ b/src/bootstrapper/stages/engineStages.js
@@ -29,7 +29,7 @@ export async function initializeGameEngineStage(
   let gameEngine;
   try {
     logger.debug('GameEngine Stage: Creating GameEngine instance...');
-    gameEngine = createGameEngine({ container });
+    gameEngine = createGameEngine({ container, logger });
     if (!gameEngine) {
       throw new Error('GameEngine constructor returned null or undefined.');
     }

--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -50,13 +50,11 @@ class GameEngine {
   /** @type {PersistenceCoordinator} */
   #persistenceCoordinator;
 
-  constructor({ container }) {
-    try {
-      this.#logger = container.resolve(tokens.ILogger);
-    } catch (e) {
-      console.error('GameEngine: CRITICAL - Logger not resolved.', e);
+  constructor({ container, logger }) {
+    if (!logger) {
       throw new Error('GameEngine requires a logger.');
     }
+    this.#logger = logger;
     this.#logger.debug('GameEngine: Constructor called.');
     try {
       this.#entityManager = container.resolve(tokens.IEntityManager);

--- a/src/main.js
+++ b/src/main.js
@@ -73,7 +73,7 @@ export async function bootstrapApp() {
     currentPhaseForError = 'Game Engine Initialization';
     logger.debug(`main.js: Executing ${currentPhaseForError} stage...`);
     const engineResult = await initializeGameEngineStage(container, logger, {
-      createGameEngine: (opts) => new GameEngine(opts),
+      createGameEngine: (opts) => new GameEngine({ ...opts, logger }),
     });
     if (!engineResult.success) throw engineResult.error;
     gameEngine = engineResult.payload;

--- a/tests/common/engine/gameEngineEnvironment.js
+++ b/tests/common/engine/gameEngineEnvironment.js
@@ -61,7 +61,11 @@ export function createEnvironment(overrides = {}) {
   const env = createServiceTestEnvironment({
     factoryMap,
     tokenMap,
-    build: (container) => new GameEngine({ container }),
+    build: (container) =>
+      new GameEngine({
+        container,
+        logger: container.resolve(tokens.ILogger),
+      }),
     overrides,
   });
   return env;

--- a/tests/unit/bootstrapper/stages.additional.test.js
+++ b/tests/unit/bootstrapper/stages.additional.test.js
@@ -127,7 +127,7 @@ describe('initializeGameEngineStage', () => {
     const result = await initializeGameEngineStage(container, logger, {
       createGameEngine: (opts) => GameEngine(opts),
     });
-    expect(GameEngine).toHaveBeenCalledWith({ container });
+    expect(GameEngine).toHaveBeenCalledWith({ container, logger });
     expect(result.success).toBe(true);
     expect(result.payload).toEqual({ mocked: true });
   });
@@ -155,7 +155,7 @@ describe('initializeGameEngineStage', () => {
       createGameEngine: factory,
     });
 
-    expect(factory).toHaveBeenCalledWith({ container });
+    expect(factory).toHaveBeenCalledWith({ container, logger });
     expect(result.success).toBe(true);
     expect(result.payload).toBe(engine);
   });

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -58,6 +58,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     expect(GameEngine).toHaveBeenCalledTimes(1);
     expect(GameEngine).toHaveBeenCalledWith({
       container: testBed.env.mockContainer,
+      logger: testBed.env.mocks.logger,
     });
     expect(testBed.engine).toBe(engine);
     expect(testBed.getLogger()).toBe(testBed.env.mocks.logger);

--- a/tests/unit/engine/gameEngine.test.js
+++ b/tests/unit/engine/gameEngine.test.js
@@ -11,6 +11,7 @@ describeEngineSuite('GameEngine', (context) => {
       const testBed = context.bed;
       new GameEngine({
         container: testBed.env.mockContainer,
+        logger: testBed.env.mocks.logger,
       }); // Instantiation for this test
       expect(testBed.env.mockContainer.resolve).toHaveBeenCalledWith(
         tokens.ILogger
@@ -32,19 +33,11 @@ describeEngineSuite('GameEngine', (context) => {
       );
     });
 
-    it('should throw an error if ILogger cannot be resolved', () => {
+    it('should throw an error if logger is missing', () => {
       const testBed = context.bed;
-      testBed.withTokenOverride(tokens.ILogger, () => {
-        throw new Error('Logger failed to resolve');
-      });
-
       expect(
         () => new GameEngine({ container: testBed.env.mockContainer })
       ).toThrow('GameEngine requires a logger.');
-      expect(console.error).toHaveBeenCalledWith(
-        'GameEngine: CRITICAL - Logger not resolved.',
-        expect.any(Error)
-      );
     });
 
     it.each([


### PR DESCRIPTION
## Summary
- accept a logger in the GameEngine constructor
- pass the logger via initializeGameEngineStage and main
- update the test environment and suites for the new signature

## Testing
- `npm run lint` *(fails: 3127 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c403296508331a6208b9c7b54f353