### PR TITLE
[Agent] extract TestData module

### DIFF
--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -1,6 +1,7 @@
 export { default as SimpleEntityManager } from './simpleEntityManager.js';
 export { default as TestBed } from './testBed.js';
 export * from './testBed.js';
+export { TestData } from './testData.js';
 export * from './serializationUtils.js';
 export * from './execContext.js';
 export * from './invalidInputHelpers.js';

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -6,15 +6,7 @@
  */
 
 import EntityManager from '../../../src/entities/entityManager.js';
-import EntityDefinition from '../../../src/entities/entityDefinition.js';
-import {
-  ACTOR_COMPONENT_ID,
-  POSITION_COMPONENT_ID,
-  SHORT_TERM_MEMORY_COMPONENT_ID,
-  NOTES_COMPONENT_ID,
-  GOALS_COMPONENT_ID,
-  NAME_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
+import { TestData } from './testData.js';
 import {
   createMockLogger,
   createMockSchemaValidator,
@@ -28,86 +20,6 @@ import { createDescribeTestBedSuite } from '../describeSuite.js';
 // Mock creation functions are now imported.
 
 // --- Centralized Test Data (UNCHANGED) ---
-
-/**
- * Provides a centralized repository of common data used across EntityManager tests.
- * This includes component IDs, definition IDs, pre-built mock definitions, and instance IDs.
- */
-export const TestData = {
-  ComponentIDs: {
-    ACTOR_COMPONENT_ID,
-    POSITION_COMPONENT_ID,
-    SHORT_TERM_MEMORY_COMPONENT_ID,
-    NOTES_COMPONENT_ID,
-    GOALS_COMPONENT_ID,
-    NAME_COMPONENT_ID,
-  },
-  DefinitionIDs: {
-    BASIC: 'test-def:basic',
-    ACTOR: 'test-def:actor',
-    WITH_POS: 'test-def:with-pos',
-  },
-  /** Pre-built, reusable definitions */
-  Definitions: {
-    basic: new EntityDefinition('test-def:basic', {
-      description: 'A basic definition for general testing',
-      components: { 'core:name': { name: 'Basic' } },
-    }),
-    actor: new EntityDefinition('test-def:actor', {
-      description: 'A definition containing the actor component',
-      components: { [ACTOR_COMPONENT_ID]: {} },
-    }),
-    withPos: new EntityDefinition('test-def:with-pos', {
-      description: 'A definition containing the position component',
-      components: {
-        [POSITION_COMPONENT_ID]: { locationId: 'zone:a' },
-      },
-    }),
-  },
-  InstanceIDs: {
-    PRIMARY: 'test-instance-01',
-    SECONDARY: 'test-instance-02',
-    GHOST: 'non-existent-instance-id',
-  },
-
-  /**
-   * Default payloads that {@link EntityManager} injects for core components.
-   *
-   * @type {Record<string, object>}
-   */
-  DefaultComponentData: {
-    [SHORT_TERM_MEMORY_COMPONENT_ID]: { thoughts: [], maxEntries: 10 },
-    [NOTES_COMPONENT_ID]: { notes: [] },
-    [GOALS_COMPONENT_ID]: { goals: [] },
-  },
-
-  /**
-   * Collections of intentionally invalid values for negative test cases.
-   *
-   * @property {Array<*>} componentDataNotObject - Values that are not objects
-   *   when component data is expected.
-   * @property {Array<Array<*>>} invalidIdPairs - Invalid definition/instance ID
-   *   pairs used in tests.
-   * @property {Array<*>} invalidIds - Generic invalid ID values.
-   * @property {Array<*>} serializedEntityShapes - Invalid serialized entity
-   *   structures passed to {@link EntityManager#reconstructEntity}.
-   * @property {Array<*>} serializedInstanceIds - Invalid instanceId values used
-   *   in reconstruction tests.
-   */
-  InvalidValues: {
-    componentDataNotObject: [null, 42, 'string', [], true],
-    invalidIdPairs: [
-      [null, 'id'],
-      ['def', null],
-      ['', ''],
-      [123, {}],
-    ],
-    invalidIds: [null, undefined, '', 123, {}, []],
-    invalidDefinitionIds: [null, undefined, '', 123, {}, []],
-    serializedEntityShapes: [null, 'invalid', 42, [], { foo: 'bar' }],
-    serializedInstanceIds: [null, undefined, '', 42],
-  },
-};
 
 /**
  * Encapsulates the complete test setup for EntityManager tests.

--- a/tests/common/entities/testData.js
+++ b/tests/common/entities/testData.js
@@ -1,0 +1,89 @@
+import EntityDefinition from '../../../src/entities/entityDefinition.js';
+import {
+  ACTOR_COMPONENT_ID,
+  POSITION_COMPONENT_ID,
+  SHORT_TERM_MEMORY_COMPONENT_ID,
+  NOTES_COMPONENT_ID,
+  GOALS_COMPONENT_ID,
+  NAME_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+
+/**
+ * Provides a centralized repository of common data used across EntityManager tests.
+ * This includes component IDs, definition IDs, pre-built mock definitions, and instance IDs.
+ */
+export const TestData = {
+  ComponentIDs: {
+    ACTOR_COMPONENT_ID,
+    POSITION_COMPONENT_ID,
+    SHORT_TERM_MEMORY_COMPONENT_ID,
+    NOTES_COMPONENT_ID,
+    GOALS_COMPONENT_ID,
+    NAME_COMPONENT_ID,
+  },
+  DefinitionIDs: {
+    BASIC: 'test-def:basic',
+    ACTOR: 'test-def:actor',
+    WITH_POS: 'test-def:with-pos',
+  },
+  /** Pre-built, reusable definitions */
+  Definitions: {
+    basic: new EntityDefinition('test-def:basic', {
+      description: 'A basic definition for general testing',
+      components: { 'core:name': { name: 'Basic' } },
+    }),
+    actor: new EntityDefinition('test-def:actor', {
+      description: 'A definition containing the actor component',
+      components: { [ACTOR_COMPONENT_ID]: {} },
+    }),
+    withPos: new EntityDefinition('test-def:with-pos', {
+      description: 'A definition containing the position component',
+      components: {
+        [POSITION_COMPONENT_ID]: { locationId: 'zone:a' },
+      },
+    }),
+  },
+  InstanceIDs: {
+    PRIMARY: 'test-instance-01',
+    SECONDARY: 'test-instance-02',
+    GHOST: 'non-existent-instance-id',
+  },
+
+  /**
+   * Default payloads that {@link EntityManager} injects for core components.
+   *
+   * @type {Record<string, object>}
+   */
+  DefaultComponentData: {
+    [SHORT_TERM_MEMORY_COMPONENT_ID]: { thoughts: [], maxEntries: 10 },
+    [NOTES_COMPONENT_ID]: { notes: [] },
+    [GOALS_COMPONENT_ID]: { goals: [] },
+  },
+
+  /**
+   * Collections of intentionally invalid values for negative test cases.
+   *
+   * @property {Array<*>} componentDataNotObject - Values that are not objects
+   *   when component data is expected.
+   * @property {Array<Array<*>>} invalidIdPairs - Invalid definition/instance ID
+   *   pairs used in tests.
+   * @property {Array<*>} invalidIds - Generic invalid ID values.
+   * @property {Array<*>} serializedEntityShapes - Invalid serialized entity
+   *   structures passed to {@link EntityManager#reconstructEntity}.
+   * @property {Array<*>} serializedInstanceIds - Invalid instanceId values used
+   *   in reconstruction tests.
+   */
+  InvalidValues: {
+    componentDataNotObject: [null, 42, 'string', [], true],
+    invalidIdPairs: [
+      [null, 'id'],
+      ['def', null],
+      ['', ''],
+      [123, {}],
+    ],
+    invalidIds: [null, undefined, '', 123, {}, []],
+    invalidDefinitionIds: [null, undefined, '', 123, {}, []],
+    serializedEntityShapes: [null, 'invalid', 42, [], { foo: 'bar' }],
+    serializedInstanceIds: [null, undefined, '', 42],
+  },
+};


### PR DESCRIPTION
## Summary
- extract `TestData` into its own module for reuse
- import `TestData` in `testBed.js`
- export `TestData` through `tests/common/entities/index.js`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 627 errors, 2502 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c42cc90a483319f4af5d4735d6fa8