### PR TITLE
refactor: update coding pattern preferences and enhance event schema

### DIFF
--- a/.cursor/rules/coding-pattern-preferences.mdc
+++ b/.cursor/rules/coding-pattern-preferences.mdc
@@ -3,7 +3,7 @@ description:
 globs: *.js
 alwaysApply: false
 ---
-# Coding pattern preferenecs
+# Coding pattern preferences
 
 -If instead of correcting an existing module, you have to create one from zero (a function, a class, etc.), follow a Test-Driven Development approach: first create a test suite of the behavior and interface that the module should have, then run the tests and ensure that test suite fails, then carefully iterate upon the system under test until all the tests pass.
 -Avoid duplication of code whenever possible, which means checking for other areas of the codebase that might already have similar code and functionality.
@@ -11,6 +11,7 @@ alwaysApply: false
 -Keep the codebase very clean and organized. For all the Javascript files you are modifying, run "npm run lint" and the filepath, and ensure that the existing lint issues are fixed, even if they were previous to your modifications.
 -Don't mock data outside of test suites.
 -Never overwrite my .env files without first asking and confirming.
+-After you make a significant change in code, if you run the tests and nothing breaks, that means that no test was covering that behavior. You need to create a focused test suite to cover the behavior.
 
 -Run the corresponding tests after every complete modification in a file (I mean after each group of modifications). Ensuring that the failing tests are fixed as soon as possible is a priority. By corresponding tests I mean: if you're working on the root app, run "npm run test" from root. If you're working on files inside the "llm-proxy-server" subproject, navigate to that folder and run "npm run test" there.
 

--- a/.cursor/rules/scope-rules.mdc
+++ b/.cursor/rules/scope-rules.mdc
@@ -1,0 +1,9 @@
+---
+description: 
+globs: *.scope
+alwaysApply: false
+---
+# Scope files preferences
+
+
+Scope files are the definitions of scopes as used in the Scope DSL system. The modules of the scope DSL are in src/scopeDsl/ and subdirectories. You have the documentation for how to write and interpret the Scope DSL in docs/scope-dsl.md and docs/mods/creating-scopes.md.

--- a/data/mods/core/events/system_error_occurred.event.json
+++ b/data/mods/core/events/system_error_occurred.event.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://example.com/schemas/component.schema.json",
   "id": "core:system_error_occurred",
-  "description": "Fired when a general system‐level error occurs that isn’t tied to a specific action failure.",
+  "description": "Fired when a general system‐level error occurs that isn't tied to a specific action failure.",
   "payloadSchema": {
     "title": "Core: System Error Occurred Event Payload",
     "description": "Defines the payload structure for the 'core:system_error_occurred' event, used for reporting general system‐level errors.",
@@ -35,6 +35,10 @@
             "type": "string",
             "format": "date-time",
             "description": "Optional. ISO 8601 timestamp of when the error occurred."
+          },
+          "scopeName": {
+            "type": "string",
+            "description": "Optional. Name of the scope that caused the error, if applicable."
           }
         },
         "additionalProperties": false

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -258,19 +258,7 @@ class InitializationService extends IInitializationService {
         `ActionIndex built with ${allActionDefinitions.length} action definitions.`
       );
 
-      this.#logger.debug('Initializing ScopeRegistry...');
-      const scopes = this.#dataRegistry.getAll('scopes');
-
-      // Convert array of scope objects to a map by qualified ID
-      const scopeMap = {};
-      scopes.forEach((scope) => {
-        if (scope.id) {
-          scopeMap[scope.id] = scope;
-        }
-      });
-
-      this.#scopeRegistry.initialize(scopeMap);
-      this.#logger.debug('ScopeRegistry initialized.');
+      // ScopeRegistry was already initialized in #initializeScopeRegistry() above
 
       this.#logger.debug(
         `InitializationService: Initialization sequence for world '${worldName}' completed successfully (GameLoop resolution removed).`

--- a/src/loaders/helpers/registryStoreUtils.js
+++ b/src/loaders/helpers/registryStoreUtils.js
@@ -55,10 +55,11 @@ export function storeItemInRegistry(
   const isClassInstance = dataToStore.constructor !== Object;
   const isEntityDefinition = category === 'entityDefinitions';
   const isEntityInstance = category === 'entityInstances';
+  const isScope = category === 'scopes';
 
   let dataWithMetadata;
   let finalId = baseItemId;
-  if (isEntityDefinition || isEntityInstance) {
+  if (isEntityDefinition || isEntityInstance || isScope) {
     finalId = qualifiedId;
   }
 

--- a/tests/unit/actions/targetResolutionService.scope-loading.test.js
+++ b/tests/unit/actions/targetResolutionService.scope-loading.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
+import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
+
+describe('TargetResolutionService - Scope Loading Issue', () => {
+  let targetResolutionService;
+  let mockScopeRegistry;
+  let mockScopeEngine;
+  let mockEntityManager;
+  let mockLogger;
+  let mockSafeEventDispatcher;
+  let mockJsonLogicEvalService;
+
+  beforeEach(() => {
+    mockScopeRegistry = {
+      getScope: jest.fn(),
+    };
+
+    mockScopeEngine = {
+      resolve: jest.fn(),
+    };
+
+    mockEntityManager = {};
+
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      trace: jest.fn(),
+    };
+
+    mockSafeEventDispatcher = {
+      dispatch: jest.fn(),
+    };
+
+    mockJsonLogicEvalService = {
+      evaluate: jest.fn(),
+    };
+
+    targetResolutionService = new TargetResolutionService({
+      scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+      safeEventDispatcher: mockSafeEventDispatcher,
+      jsonLogicEvaluationService: mockJsonLogicEvalService,
+    });
+  });
+
+  describe('core:clear_directions scope resolution', () => {
+    it('should find the core:clear_directions scope when properly loaded', async () => {
+      // Mock a properly loaded scope
+      const mockScopeDefinition = {
+        name: 'core:clear_directions',
+        expr: 'location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target',
+        modId: 'core',
+        source: 'file',
+      };
+
+      mockScopeRegistry.getScope.mockReturnValue(mockScopeDefinition);
+      mockScopeEngine.resolve.mockReturnValue(new Set(['location1', 'location2']));
+
+      const mockActor = { id: 'hero', type: 'character' };
+      const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
+
+      const result = await targetResolutionService.resolveTargets(
+        'core:clear_directions',
+        mockActor,
+        mockDiscoveryContext
+      );
+
+      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith('core:clear_directions');
+      expect(result).toHaveLength(2);
+      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing scope gracefully and dispatch error event', async () => {
+      // Mock missing scope (returns null)
+      mockScopeRegistry.getScope.mockReturnValue(null);
+
+      const mockActor = { id: 'hero', type: 'character' };
+      const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
+
+      const result = await targetResolutionService.resolveTargets(
+        'core:clear_directions',
+        mockActor,
+        mockDiscoveryContext
+      );
+
+      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith('core:clear_directions');
+      expect(result).toHaveLength(0);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "TargetResolutionService: Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry."
+      );
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
+        'core:system_error_occurred',
+        {
+          message: "Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry.",
+          details: { scopeName: 'core:clear_directions' },
+        }
+      );
+    });
+
+    it('should handle scope with empty expression gracefully', async () => {
+      // Mock scope with empty expression
+      const mockScopeDefinition = {
+        name: 'core:clear_directions',
+        expr: '',
+        modId: 'core',
+        source: 'file',
+      };
+
+      mockScopeRegistry.getScope.mockReturnValue(mockScopeDefinition);
+
+      const mockActor = { id: 'hero', type: 'character' };
+      const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
+
+      const result = await targetResolutionService.resolveTargets(
+        'core:clear_directions',
+        mockActor,
+        mockDiscoveryContext
+      );
+
+      expect(result).toHaveLength(0);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "TargetResolutionService: Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry."
+      );
+    });
+
+    it('should handle scope parsing errors gracefully', async () => {
+      // Mock scope with invalid DSL expression
+      const mockScopeDefinition = {
+        name: 'core:clear_directions',
+        expr: 'invalid.expression[syntax]',
+        modId: 'core',
+        source: 'file',
+      };
+
+      mockScopeRegistry.getScope.mockReturnValue(mockScopeDefinition);
+
+      const mockActor = { id: 'hero', type: 'character' };
+      const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
+
+      const result = await targetResolutionService.resolveTargets(
+        'core:clear_directions',
+        mockActor,
+        mockDiscoveryContext
+      );
+
+      expect(result).toHaveLength(0);
+      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
+        'core:system_error_occurred',
+        expect.objectContaining({
+          message: expect.stringContaining("Error resolving scope 'core:clear_directions'"),
+          details: expect.objectContaining({
+            error: expect.stringContaining('Unknown source node'),
+          }),
+        })
+      );
+    });
+  });
+
+  describe('Real ScopeRegistry integration', () => {
+    it('should work with a real scope registry containing core:clear_directions', () => {
+      const realScopeRegistry = new ScopeRegistry();
+      
+      // Initialize with the expected scope definition
+      realScopeRegistry.initialize({
+        'core:clear_directions': {
+          name: 'core:clear_directions',
+          expr: 'location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target',
+          modId: 'core',
+          source: 'file',
+        },
+      });
+
+      const scope = realScopeRegistry.getScope('core:clear_directions');
+      expect(scope).toBeDefined();
+      expect(scope.name).toBe('core:clear_directions');
+      expect(scope.expr).toBe('location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target');
+    });
+
+    it('should enforce namespaced scope names in real registry', () => {
+      const realScopeRegistry = new ScopeRegistry();
+      
+      expect(() => {
+        realScopeRegistry.getScope('clear_directions'); // Non-namespaced
+      }).toThrow('Scope names must be namespaced');
+    });
+  });
+}); 

--- a/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
+++ b/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+describe('Scope Registry Initialization - Focused Test', () => {
+  let mockLogger;
+  let mockScopeRegistry;
+  let mockDataRegistry;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    mockScopeRegistry = {
+      initialize: jest.fn(),
+    };
+
+    mockDataRegistry = {
+      getAll: jest.fn(),
+    };
+  });
+
+  describe('scope registry initialization behavior', () => {
+    it('should map scopes correctly using their id property', async () => {
+      // Mock scopes as they would be stored after our registryStoreUtils fix
+      const mockScopes = [
+        {
+          id: 'core:potential_leaders', // Qualified ID as id property (FIXED)
+          name: 'core:potential_leaders',
+          expr: 'entities(core:position)[actor.components.core:leadership]',
+          modId: 'core',
+          source: 'file',
+          _modId: 'core',
+          _sourceFile: 'potential_leaders.scope',
+          _fullId: 'core:potential_leaders',
+        },
+        {
+          id: 'core:clear_directions', // Qualified ID as id property (FIXED)
+          name: 'core:clear_directions',
+          expr: 'exits()',
+          modId: 'core',
+          source: 'file',
+          _modId: 'core',
+          _sourceFile: 'clear_directions.scope',
+          _fullId: 'core:clear_directions',
+        },
+        {
+          id: 'core:actors_in_location', // Qualified ID as id property (FIXED)
+          name: 'core:actors_in_location',
+          expr: 'entities(core:position)',
+          modId: 'core',
+          source: 'file',
+          _modId: 'core',
+          _sourceFile: 'actors_in_location.scope',
+          _fullId: 'core:actors_in_location',
+        },
+      ];
+
+      mockDataRegistry.getAll.mockReturnValue(mockScopes);
+
+      // Simulate the scope registry initialization logic
+      const scopes = mockDataRegistry.getAll('scopes');
+      const scopeMap = {};
+      scopes.forEach((scope) => {
+        if (scope.id) {
+          scopeMap[scope.id] = scope;
+        }
+      });
+      mockScopeRegistry.initialize(scopeMap);
+
+      // Verify the scope registry was initialized with the correct mapping
+      expect(mockScopeRegistry.initialize).toHaveBeenCalledWith({
+        'core:potential_leaders': mockScopes[0],
+        'core:clear_directions': mockScopes[1],
+        'core:actors_in_location': mockScopes[2],
+      });
+
+      expect(mockDataRegistry.getAll).toHaveBeenCalledWith('scopes');
+    });
+
+    it('should demonstrate the bug that was fixed', async () => {
+      // Mock scopes as they would have been stored BEFORE our fix
+      const mockScopesWithBug = [
+        {
+          id: 'potential_leaders', // Base ID instead of qualified (BUG)
+          name: 'core:potential_leaders',
+          expr: 'entities(core:position)[actor.components.core:leadership]',
+          modId: 'core',
+          source: 'file',
+          _fullId: 'core:potential_leaders',
+        },
+        {
+          id: 'clear_directions', // Base ID instead of qualified (BUG)
+          name: 'core:clear_directions',
+          expr: 'exits()',
+          modId: 'core',
+          source: 'file',
+          _fullId: 'core:clear_directions',
+        },
+      ];
+
+      mockDataRegistry.getAll.mockReturnValue(mockScopesWithBug);
+
+      // Simulate the scope registry initialization logic
+      const scopes = mockDataRegistry.getAll('scopes');
+      const scopeMap = {};
+      scopes.forEach((scope) => {
+        if (scope.id) {
+          scopeMap[scope.id] = scope;
+        }
+      });
+      mockScopeRegistry.initialize(scopeMap);
+
+      // With the bug, scope registry would be initialized with base IDs as keys
+      expect(mockScopeRegistry.initialize).toHaveBeenCalledWith({
+        'potential_leaders': mockScopesWithBug[0], // Wrong - this causes the bug
+        'clear_directions': mockScopesWithBug[1],  // Wrong - this causes the bug
+      });
+
+      // This demonstrates why TargetResolutionService couldn't find 'core:potential_leaders'
+      // It was looking for 'core:potential_leaders' but the map only had 'potential_leaders'
+    });
+
+    it('should handle edge cases gracefully', async () => {
+      // Mock scenario with mixed valid and invalid scopes
+      const mockScopes = [
+        {
+          id: 'core:valid_scope',
+          name: 'core:valid_scope',
+          expr: 'entities()',
+          modId: 'core',
+          source: 'file',
+        },
+        {
+          // Missing id property - should be ignored
+          name: 'core:invalid_scope',
+          expr: 'entities()',
+          modId: 'core',
+          source: 'file',
+        },
+        {
+          id: '', // Empty id - should be ignored
+          name: 'core:empty_id_scope',
+          expr: 'entities()',
+          modId: 'core',
+          source: 'file',
+        },
+      ];
+
+      mockDataRegistry.getAll.mockReturnValue(mockScopes);
+
+      // Simulate the scope registry initialization logic
+      const scopes = mockDataRegistry.getAll('scopes');
+      const scopeMap = {};
+      scopes.forEach((scope) => {
+        if (scope.id) {
+          scopeMap[scope.id] = scope;
+        }
+      });
+      mockScopeRegistry.initialize(scopeMap);
+
+      // Only the valid scope should be in the map
+      expect(mockScopeRegistry.initialize).toHaveBeenCalledWith({
+        'core:valid_scope': mockScopes[0],
+      });
+    });
+  });
+
+  describe('regression prevention assertions', () => {
+    it('should ensure scopes are accessible by their qualified names', () => {
+      // This test verifies the specific scenario that was failing
+      const properlyFormattedScopes = [
+        {
+          id: 'core:potential_leaders', // Must be qualified ID
+          name: 'core:potential_leaders',
+          expr: 'entities(core:position)[actor.components.core:leadership]',
+          modId: 'core',
+          source: 'file',
+        },
+      ];
+
+      mockDataRegistry.getAll.mockReturnValue(properlyFormattedScopes);
+
+      // Simulate initialization
+      const scopes = mockDataRegistry.getAll('scopes');
+      const scopeMap = {};
+      scopes.forEach((scope) => {
+        if (scope.id) {
+          scopeMap[scope.id] = scope;
+        }
+      });
+
+      // Critical assertion: the scope should be accessible by its qualified name
+      expect(scopeMap['core:potential_leaders']).toBeDefined();
+      expect(scopeMap['core:potential_leaders']).toBe(properlyFormattedScopes[0]);
+      
+      // Anti-regression: it should NOT be accessible by base name only
+      expect(scopeMap['potential_leaders']).toBeUndefined();
+
+      // This ensures TargetResolutionService can find 'core:potential_leaders'
+      mockScopeRegistry.initialize(scopeMap);
+      expect(mockScopeRegistry.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'core:potential_leaders': expect.any(Object),
+        })
+      );
+    });
+
+    it('should verify all problematic scopes from the bug report are properly mapped', () => {
+      const allProblematicScopes = [
+        {
+          id: 'core:potential_leaders',
+          name: 'core:potential_leaders',
+          expr: 'entities(core:position)[actor.components.core:leadership]',
+          modId: 'core',
+        },
+        {
+          id: 'core:clear_directions',
+          name: 'core:clear_directions', 
+          expr: 'exits()',
+          modId: 'core',
+        },
+        {
+          id: 'core:actors_in_location',
+          name: 'core:actors_in_location',
+          expr: 'entities(core:position)',
+          modId: 'core',
+        },
+      ];
+
+      mockDataRegistry.getAll.mockReturnValue(allProblematicScopes);
+
+      // Simulate initialization
+      const scopes = mockDataRegistry.getAll('scopes');
+      const scopeMap = {};
+      scopes.forEach((scope) => {
+        if (scope.id) {
+          scopeMap[scope.id] = scope;
+        }
+      });
+
+      // All scopes should be accessible by their qualified names
+      expect(scopeMap['core:potential_leaders']).toBeDefined();
+      expect(scopeMap['core:clear_directions']).toBeDefined();
+      expect(scopeMap['core:actors_in_location']).toBeDefined();
+
+      // None should be accessible by base names (anti-regression)
+      expect(scopeMap['potential_leaders']).toBeUndefined();
+      expect(scopeMap['clear_directions']).toBeUndefined();
+      expect(scopeMap['actors_in_location']).toBeUndefined();
+
+      mockScopeRegistry.initialize(scopeMap);
+      expect(mockScopeRegistry.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'core:potential_leaders': expect.any(Object),
+          'core:clear_directions': expect.any(Object),
+          'core:actors_in_location': expect.any(Object),
+        })
+      );
+    });
+  });
+}); 

--- a/tests/unit/loaders/helpers/registryStoreUtils.scope-id-mapping.test.js
+++ b/tests/unit/loaders/helpers/registryStoreUtils.scope-id-mapping.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { storeItemInRegistry } from '../../../../src/loaders/helpers/registryStoreUtils.js';
+
+describe('registryStoreUtils - Scope ID Mapping', () => {
+  let mockLogger;
+  let mockRegistry;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    mockRegistry = {
+      store: jest.fn().mockReturnValue(false), // false = no override
+    };
+  });
+
+  describe('scope ID mapping behavior', () => {
+    it('should store scopes with qualified ID as the id property', () => {
+      const scopeData = {
+        name: 'core:test_scope',
+        expr: 'entities(core:position)',
+        modId: 'core',
+        source: 'file',
+      };
+
+      const result = storeItemInRegistry(
+        mockLogger,
+        mockRegistry,
+        'ScopeLoader',
+        'scopes',
+        'core',
+        'test_scope',
+        scopeData,
+        'test_scope.scope'
+      );
+
+      // Verify the registry.store was called with the qualified ID as the key
+      expect(mockRegistry.store).toHaveBeenCalledWith(
+        'scopes',
+        'core:test_scope',
+        expect.objectContaining({
+          id: 'core:test_scope', // This is the critical assertion - id should be qualified
+          name: 'core:test_scope',
+          expr: 'entities(core:position)',
+          modId: 'core',
+          source: 'file',
+          _modId: 'core',
+          _sourceFile: 'test_scope.scope',
+          _fullId: 'core:test_scope',
+        })
+      );
+
+      expect(result).toEqual({
+        qualifiedId: 'core:test_scope',
+        didOverride: false,
+      });
+    });
+
+    it('should handle multiple scopes with different qualified IDs', () => {
+      const scopes = [
+        {
+          name: 'core:potential_leaders',
+          expr: 'entities(core:position)[actor.components.core:leadership]',
+          modId: 'core',
+          source: 'file',
+        },
+        {
+          name: 'core:clear_directions',
+          expr: 'exits()',
+          modId: 'core',
+          source: 'file',
+        },
+        {
+          name: 'core:actors_in_location',
+          expr: 'entities(core:position)',
+          modId: 'core',
+          source: 'file',
+        },
+      ];
+
+      scopes.forEach((scopeData, index) => {
+        const baseName = scopeData.name.split(':', 2)[1];
+        const result = storeItemInRegistry(
+          mockLogger,
+          mockRegistry,
+          'ScopeLoader',
+          'scopes',
+          'core',
+          baseName,
+          scopeData,
+          `${baseName}.scope`
+        );
+
+        expect(result.qualifiedId).toBe(scopeData.name);
+      });
+
+      // Verify all scopes were stored with their qualified IDs
+      expect(mockRegistry.store).toHaveBeenCalledTimes(3);
+      
+      // Check each specific call
+      expect(mockRegistry.store).toHaveBeenNthCalledWith(
+        1,
+        'scopes',
+        'core:potential_leaders',
+        expect.objectContaining({ id: 'core:potential_leaders' })
+      );
+      
+      expect(mockRegistry.store).toHaveBeenNthCalledWith(
+        2,
+        'scopes',
+        'core:clear_directions',
+        expect.objectContaining({ id: 'core:clear_directions' })
+      );
+      
+      expect(mockRegistry.store).toHaveBeenNthCalledWith(
+        3,
+        'scopes',
+        'core:actors_in_location',
+        expect.objectContaining({ id: 'core:actors_in_location' })
+      );
+    });
+
+         it('should differentiate scope ID behavior from other categories', () => {
+       const testCases = [
+         {
+           category: 'actions',
+           baseId: 'test_actions',
+           expectedId: 'test_actions', // base ID for actions
+         },
+         {
+           category: 'scopes',
+           baseId: 'test_scope',
+           expectedId: 'core:test_scope', // qualified ID for scopes
+         },
+         {
+           category: 'entityDefinitions',
+           baseId: 'test_entity',
+           expectedId: 'core:test_entity', // qualified ID for entity definitions
+         },
+         {
+           category: 'entityInstances',
+           baseId: 'test_instance',
+           expectedId: 'core:test_instance', // qualified ID for entity instances
+         },
+       ];
+
+       testCases.forEach(({ category, baseId, expectedId }) => {
+         mockRegistry.store.mockClear();
+         
+         const itemData = {
+           name: `core:${baseId}`,
+           someProperty: 'value',
+         };
+
+         storeItemInRegistry(
+           mockLogger,
+           mockRegistry,
+           'TestLoader',
+           category,
+           'core',
+           baseId,
+           itemData,
+           `${baseId}.json`
+         );
+
+         expect(mockRegistry.store).toHaveBeenCalledWith(
+           category,
+           `core:${baseId}`,
+           expect.objectContaining({
+             id: expectedId,
+           })
+         );
+       });
+     });
+  });
+
+  describe('regression prevention', () => {
+    it('should prevent the specific bug where scopes had base ID but were accessed by qualified ID', () => {
+      // This test simulates the exact scenario that was broken
+      const scopeData = {
+        name: 'core:potential_leaders',
+        expr: 'entities(core:position)[actor.components.core:leadership]',
+        modId: 'core',
+        source: 'file',
+      };
+
+      // This is how ScopeLoader calls storeItemInRegistry
+      storeItemInRegistry(
+        mockLogger,
+        mockRegistry,
+        'ScopeLoader',
+        'scopes',
+        'core',
+        'potential_leaders', // Base name extracted from qualified name
+        scopeData,
+        'potential_leaders.scope'
+      );
+
+      // The stored object should have the qualified ID as its id property
+      const storedObject = mockRegistry.store.mock.calls[0][2];
+      
+      // This is the critical assertion that would have failed before the fix
+      expect(storedObject.id).toBe('core:potential_leaders');
+      expect(storedObject.id).not.toBe('potential_leaders'); // This was the bug
+      
+      // Additional assertions to ensure the object is properly formed
+      expect(storedObject).toMatchObject({
+        id: 'core:potential_leaders',
+        name: 'core:potential_leaders',
+        expr: 'entities(core:position)[actor.components.core:leadership]',
+        modId: 'core',
+        source: 'file',
+        _modId: 'core',
+        _sourceFile: 'potential_leaders.scope',
+        _fullId: 'core:potential_leaders',
+      });
+    });
+  });
+}); 


### PR DESCRIPTION
- Corrected a typo in the coding pattern preferences documentation.
- Added a new guideline for creating focused test suites after significant code changes.
- Updated the description in the system_error_occurred event schema for clarity.
- Introduced a new optional field 'scopeName' in the event payload schema to specify the scope that caused the error.
- Modified the initializationService to remove redundant scope initialization code.
- Expanded the registryStoreUtils to handle 'scopes' category in the item storage logic.