### PR TITLE
[Agent] handle missing entity definitions on load

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -160,6 +160,7 @@ export function registerPersistence(container) {
         logger: c.resolve(tokens.ILogger),
         entityManager: c.resolve(tokens.IEntityManager),
         playtimeTracker: c.resolve(tokens.PlaytimeTracker),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       }),
     });
   });

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -141,6 +141,7 @@ describe('Persistence round-trip', () => {
       logger,
       entityManager,
       playtimeTracker,
+      safeEventDispatcher: { dispatch: jest.fn() },
     });
     const manualSaveCoordinator = new ManualSaveCoordinator({
       logger,

--- a/tests/unit/entities/entityManagerAdapter.test.js
+++ b/tests/unit/entities/entityManagerAdapter.test.js
@@ -74,6 +74,7 @@ describe('EntityManagerAdapter', () => {
       logger,
       entityManager: adapter,
       playtimeTracker,
+      safeEventDispatcher: { dispatch: jest.fn() },
     });
 
     expect(restorer).toBeInstanceOf(GameStateRestorer);

--- a/tests/unit/services/gamePersistenceService.edgeCases.test.js
+++ b/tests/unit/services/gamePersistenceService.edgeCases.test.js
@@ -89,6 +89,7 @@ describe('GamePersistenceService edge cases', () => {
       logger,
       entityManager,
       playtimeTracker,
+      safeEventDispatcher,
     });
     service = new GamePersistenceService({
       logger,

--- a/tests/unit/services/gamePersistenceService.errorPaths.test.js
+++ b/tests/unit/services/gamePersistenceService.errorPaths.test.js
@@ -73,6 +73,7 @@ describe('GamePersistenceService error paths', () => {
       logger,
       entityManager,
       playtimeTracker,
+      safeEventDispatcher,
     });
     service = new GamePersistenceService({
       logger,

--- a/tests/unit/services/gamePersistenceService.privateHelpers.test.js
+++ b/tests/unit/services/gamePersistenceService.privateHelpers.test.js
@@ -30,6 +30,7 @@ function makeService() {
     logger,
     entityManager,
     playtimeTracker,
+    safeEventDispatcher: { dispatch: jest.fn() },
   });
 
   const service = new GamePersistenceService({

--- a/tests/unit/services/persistenceConstructorValidation.test.js
+++ b/tests/unit/services/persistenceConstructorValidation.test.js
@@ -86,6 +86,7 @@ describe('Persistence service constructor validation', () => {
       logger: createMockLogger(),
       entityManager: { clearAll: jest.fn(), reconstructEntity: jest.fn() },
       playtimeTracker: { setAccumulatedPlaytime: jest.fn() },
+      safeEventDispatcher: { dispatch: jest.fn() },
     });
     expect(restorer).toBeInstanceOf(BaseService);
   });


### PR DESCRIPTION
## Summary
- dispatch SYSTEM_ERROR_OCCURRED_ID when entity definition missing during load
- crash load process when missing entity definitions
- register GameStateRestorer with safeEventDispatcher
- add tests covering definition missing errors

## Testing Done
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c431bb7588331b782133310d33fc3