### PR TITLE
[Agent] simplify game engine helpers

### DIFF
--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -7,21 +7,6 @@ import { expect, jest, it } from '@jest/globals';
 import { expectNoDispatch } from './dispatchTestUtils.js';
 import { GameEngineTestBed } from './gameEngineTestBed.js';
 import { DEFAULT_TEST_WORLD } from '../constants.js';
-import { createWithBed, createInitializedBed } from '../testBedHelpers.js';
-
-const withBed = createWithBed(GameEngineTestBed, (b) => [b, b.engine]);
-const withInitialized = createInitializedBed(
-  GameEngineTestBed,
-  'initAndReset',
-  DEFAULT_TEST_WORLD,
-  (b) => [b, b.engine]
-);
-const withRunning = createInitializedBed(
-  GameEngineTestBed,
-  'startAndReset',
-  DEFAULT_TEST_WORLD,
-  (b) => [b, b.engine]
-);
 
 /**
  * Executes a callback with a temporary {@link GameEngineTestBed} instance.
@@ -32,8 +17,20 @@ const withRunning = createInitializedBed(
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export function withGameEngineBed(overrides = {}, testFn) {
-  return withBed(overrides, testFn);
+export async function withGameEngineBed(overrides = {}, testFn) {
+  if (typeof overrides === 'function') {
+    testFn = overrides;
+    overrides = {};
+  }
+  const bed = new GameEngineTestBed(overrides);
+  if (typeof bed.resetMocks === 'function') {
+    bed.resetMocks();
+  }
+  try {
+    await testFn(bed, bed.engine);
+  } finally {
+    await bed.cleanup();
+  }
 }
 
 /**
@@ -49,8 +46,22 @@ export function withGameEngineBed(overrides = {}, testFn) {
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export function withInitializedGameEngineBed(options, testFn) {
-  return withInitialized(options, testFn);
+export async function withInitializedGameEngineBed(options = {}, testFn) {
+  if (typeof options === 'function') {
+    testFn = options;
+    options = {};
+  }
+  const { overrides = {}, initArg = DEFAULT_TEST_WORLD } = options;
+  const bed = new GameEngineTestBed(overrides);
+  await bed.initAndReset(initArg);
+  if (typeof bed.resetMocks === 'function') {
+    bed.resetMocks();
+  }
+  try {
+    await testFn(bed, bed.engine);
+  } finally {
+    await bed.cleanup();
+  }
 }
 
 /**
@@ -66,8 +77,22 @@ export function withInitializedGameEngineBed(options, testFn) {
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export function withRunningGameEngineBed(options, testFn) {
-  return withRunning(options, testFn);
+export async function withRunningGameEngineBed(options = {}, testFn) {
+  if (typeof options === 'function') {
+    testFn = options;
+    options = {};
+  }
+  const { overrides = {}, initArg = DEFAULT_TEST_WORLD } = options;
+  const bed = new GameEngineTestBed(overrides);
+  await bed.startAndReset(initArg);
+  if (typeof bed.resetMocks === 'function') {
+    bed.resetMocks();
+  }
+  try {
+    await testFn(bed, bed.engine);
+  } finally {
+    await bed.cleanup();
+  }
 }
 
 /**

--- a/tests/common/turns/entitySetupMixin.js
+++ b/tests/common/turns/entitySetupMixin.js
@@ -20,6 +20,7 @@ export function EntitySetupMixin(Base) {
     setActiveEntities(...entities) {
       const map = this.entityManager.activeEntities;
       map.clear();
+      if (entities.length === 0) return;
       for (const e of entities) {
         map.set(e.id, e);
       }
@@ -54,6 +55,10 @@ export function EntitySetupMixin(Base) {
      * @returns {void}
      */
     mockActorSequence(...actors) {
+      if (actors.length === 0) {
+        this.mockEmptyQueue();
+        return;
+      }
       this.mocks.turnOrderService.isEmpty.mockResolvedValue(false);
       let index = 0;
       this.mocks.turnOrderService.getNextEntity.mockImplementation(() =>


### PR DESCRIPTION
## Summary
- avoid layered helpers and expose direct implementations for GameEngine beds
- add guard clauses for empty input handling in test utilities

## Testing Done
- `npm run lint` *(fails: 629 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c477a678c8331b43c9c50600cfcef