### PR TITLE
[Agent] Refactor test env builders & dispatch utils

### DIFF
--- a/scripts/findConditionReferences.js
+++ b/scripts/findConditionReferences.js
@@ -42,7 +42,8 @@ async function findFilesByEnding(dir, targetEndings) {
           const subFiles = await findFilesByEnding(itemPath, targetEndings);
           foundFiles.push(...subFiles);
         }
-      } else { // It's a file, check if its name ends with any of the target strings
+      } else {
+        // It's a file, check if its name ends with any of the target strings
         for (const ending of targetEndings) {
           if (item.name.endsWith(ending)) {
             foundFiles.push(itemPath);
@@ -53,7 +54,9 @@ async function findFilesByEnding(dir, targetEndings) {
     }
   } catch (error) {
     if (error.code !== 'ENOENT') {
-      console.error(`⚠️  Warning: Could not read directory ${dir}: ${error.message}`);
+      console.error(
+        `⚠️  Warning: Could not read directory ${dir}: ${error.message}`
+      );
     }
   }
   return foundFiles;
@@ -72,7 +75,10 @@ async function searchFileForIdentifier(filePath, identifier) {
     const content = await fs.readFile(filePath, 'utf8');
     const lines = content.split('\n');
     // The identifier is escaped to handle any special regex characters it might contain.
-    const escapedIdentifier = identifier.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const escapedIdentifier = identifier.replace(
+      /[-/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    );
     // This regex looks for the identifier, potentially preceded by a 'namespace:' and followed by a word boundary.
     const searchRegex = new RegExp(`(core:|intimacy:)?${escapedIdentifier}\\b`);
 
@@ -82,7 +88,9 @@ async function searchFileForIdentifier(filePath, identifier) {
       }
     }
   } catch (error) {
-    console.error(`⚠️  Warning: Could not read file ${filePath}: ${error.message}`);
+    console.error(
+      `⚠️  Warning: Could not read file ${filePath}: ${error.message}`
+    );
   }
   return matches;
 }
@@ -95,19 +103,22 @@ async function main() {
 
   // 1. Find all '.condition.json' files specifically within the mods directory
   console.log(`\nScanning for condition files...`);
-  const conditionFiles = await findFilesByEnding(
-    MODS_DIR,
-    [CONDITION_FILE_ENDING]
-  );
+  const conditionFiles = await findFilesByEnding(MODS_DIR, [
+    CONDITION_FILE_ENDING,
+  ]);
 
   if (conditionFiles.length === 0) {
-    console.log('\n✅ No *.condition.json files found. Please check the `MODS_DIR` path and file locations.');
+    console.log(
+      '\n✅ No *.condition.json files found. Please check the `MODS_DIR` path and file locations.'
+    );
     return;
   }
   console.log(`Found ${conditionFiles.length} condition file(s) to process.`);
 
   // 2. Find all files to search within (source code, json, and scope files)
-  console.log('\nScanning for files to search within (source code, json, scope)...');
+  console.log(
+    '\nScanning for files to search within (source code, json, scope)...'
+  );
   const filesToSearch = await findFilesByEnding(
     ROOT_DIR,
     SEARCH_TARGET_EXTENSIONS
@@ -116,7 +127,9 @@ async function main() {
 
   // 3. For each condition, search all other files for its identifier
   const allReferences = {};
-  const totalIdentifiers = conditionFiles.map(f => path.basename(f, CONDITION_FILE_ENDING));
+  const totalIdentifiers = conditionFiles.map((f) =>
+    path.basename(f, CONDITION_FILE_ENDING)
+  );
 
   for (const conditionFile of conditionFiles) {
     const identifier = path.basename(conditionFile, CONDITION_FILE_ENDING);
@@ -142,7 +155,9 @@ async function main() {
           lines: matchingLines,
         });
         // Log found references immediately
-        console.log(`  Found in ./${relativePath} on line(s): ${matchingLines.join(', ')}`);
+        console.log(
+          `  Found in ./${relativePath} on line(s): ${matchingLines.join(', ')}`
+        );
       }
     }
   }
@@ -151,13 +166,17 @@ async function main() {
   console.log('\n--- ✅ Search Complete ---');
   const referencedIdentifiers = Object.keys(allReferences);
 
-  console.log(`Found references for ${referencedIdentifiers.length} out of ${totalIdentifiers.length} total identifiers.`);
+  console.log(
+    `Found references for ${referencedIdentifiers.length} out of ${totalIdentifiers.length} total identifiers.`
+  );
 
-  const unreferenced = totalIdentifiers.filter(id => !referencedIdentifiers.includes(id));
+  const unreferenced = totalIdentifiers.filter(
+    (id) => !referencedIdentifiers.includes(id)
+  );
 
   if (unreferenced.length > 0) {
     console.log('\n--- ⚠️  Unreferenced Identifiers ---');
-    unreferenced.forEach(id => console.log(`  - ${id}`));
+    unreferenced.forEach((id) => console.log(`  - ${id}`));
   } else {
     console.log('\n✅ All identifiers appear to be referenced.');
   }

--- a/src/actions/tracing/traceContext.js
+++ b/src/actions/tracing/traceContext.js
@@ -44,12 +44,12 @@ export class TraceContext {
       source,
       timestamp: Date.now(),
     };
-    
+
     // Only add data field if it's not null/undefined
-    if (data != null) {
+    if (data !== null && data !== undefined) {
       logEntry.data = data;
     }
-    
+
     this.logs.push(logEntry);
   }
 }

--- a/tests/common/baseTestBed.js
+++ b/tests/common/baseTestBed.js
@@ -4,7 +4,7 @@
 
 import { jest } from '@jest/globals';
 import { clearMockFunctions } from './jestHelpers.js';
-import { createMockEnvironment } from './mockEnvironment.js';
+import { createMockEnvironment } from './buildTestEnvironment.js';
 import { runWithReset } from './testBedHelpers.js';
 
 /**

--- a/tests/common/buildTestEnvironment.js
+++ b/tests/common/buildTestEnvironment.js
@@ -1,0 +1,66 @@
+/**
+ * @file Shared helpers for creating test environments.
+ */
+
+import { jest } from '@jest/globals';
+import { createMockContainer } from './mockFactories/index.js';
+
+/**
+ * Creates mocks using the provided factory functions.
+ *
+ * @description Given a mapping of keys to factory functions, this helper
+ *   instantiates each mock and returns them along with a cleanup function
+ *   that clears and restores jest mocks.
+ * @param {Record<string, () => any>} factories - Map of mock factory functions.
+ * @returns {{ mocks: Record<string, any>, cleanup: () => void }}
+ *   Generated mocks and a cleanup method.
+ */
+export function createMockEnvironment(factories) {
+  jest.clearAllMocks();
+
+  const mocks = {};
+  for (const [name, factory] of Object.entries(factories)) {
+    mocks[name] = factory();
+  }
+
+  const cleanup = () => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  };
+
+  return { mocks, cleanup };
+}
+
+/**
+ * Builds a full test environment including a mock DI container.
+ *
+ * @description Creates mocks from the provided factory map and sets up a mock
+ *   DI container resolving tokens to those mocks. Overrides allow per-test
+ *   replacements similar to {@link createMockContainer}.
+ * @param {Record<string, () => any>} factoryMap - Map of mock factory
+ *   functions to create.
+ * @param {Record<string | symbol, string | ((m: Record<string, any>) => any) | any>} tokenMap
+ *   Map of DI tokens to mock keys, provider callbacks, or constant values.
+ * @param {Record<string | symbol, any>} [overrides] - Optional per-test token
+ *   overrides for the container.
+ * @returns {{ mocks: Record<string, any>, mockContainer: { resolve: jest.Mock }, cleanup: () => void }}
+ *   Mocks, container and cleanup helper.
+ */
+export function buildTestEnvironment(factoryMap, tokenMap, overrides = {}) {
+  const { mocks, cleanup } = createMockEnvironment(factoryMap);
+
+  const mapping = {};
+  for (const [token, ref] of Object.entries(tokenMap)) {
+    if (typeof ref === 'string') {
+      mapping[token] = mocks[ref];
+    } else if (typeof ref === 'function') {
+      mapping[token] = ref(mocks);
+    } else {
+      mapping[token] = ref;
+    }
+  }
+
+  const mockContainer = createMockContainer(mapping, overrides);
+
+  return { mocks, mockContainer, cleanup };
+}

--- a/tests/common/engine/dispatchTestUtils.js
+++ b/tests/common/engine/dispatchTestUtils.js
@@ -14,6 +14,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
   ENGINE_STOPPED_UI,
+  ENGINE_OPERATION_FAILED_UI,
   REQUEST_SHOW_LOAD_GAME_UI,
   REQUEST_SHOW_SAVE_GAME_UI,
 } from '../../../src/constants/eventIds.js';
@@ -106,6 +107,80 @@ export function buildStartDispatches(worldName) {
     [
       ENGINE_READY_UI,
       { activeWorld: worldName, message: ENGINE_READY_MESSAGE },
+    ],
+  ];
+}
+
+/**
+ * Builds the dispatch sequence for a successful game load.
+ *
+ * @param {string} saveId - Save identifier being loaded.
+ * @param {string} worldName - Game title from the save data.
+ * @returns {Array<[string, any]>} Dispatch sequence.
+ */
+export function buildLoadSuccessDispatches(saveId, worldName) {
+  return [
+    [
+      ENGINE_OPERATION_IN_PROGRESS_UI,
+      {
+        titleMessage: `Loading ${saveId}...`,
+        inputDisabledMessage: `Loading game from ${saveId}...`,
+      },
+    ],
+    [
+      ENGINE_READY_UI,
+      { activeWorld: worldName, message: ENGINE_READY_MESSAGE },
+    ],
+  ];
+}
+
+/**
+ * Builds the dispatch sequence for a failed game load.
+ *
+ * @param {string} saveId - Save identifier.
+ * @param {string} errorMsg - Failure message.
+ * @returns {Array<[string, any]>} Dispatch sequence.
+ */
+export function buildLoadFailureDispatches(saveId, errorMsg) {
+  return [
+    [
+      ENGINE_OPERATION_IN_PROGRESS_UI,
+      {
+        titleMessage: `Loading ${saveId}...`,
+        inputDisabledMessage: `Loading game from ${saveId}...`,
+      },
+    ],
+    [
+      ENGINE_OPERATION_FAILED_UI,
+      {
+        errorMessage: `Failed to load game: ${errorMsg}`,
+        errorTitle: 'Load Failed',
+      },
+    ],
+  ];
+}
+
+/**
+ * Builds the dispatch sequence when finalization fails after a load.
+ *
+ * @param {string} saveId - Save identifier.
+ * @param {string} worldName - Game title from the save data.
+ * @param {string} errorMsg - Failure message.
+ * @returns {Array<[string, any]>} Dispatch sequence.
+ */
+export function buildLoadFinalizeFailureDispatches(
+  saveId,
+  worldName,
+  errorMsg
+) {
+  return [
+    ...buildLoadSuccessDispatches(saveId, worldName),
+    [
+      ENGINE_OPERATION_FAILED_UI,
+      {
+        errorMessage: `Failed to load game: ${errorMsg}`,
+        errorTitle: 'Load Failed',
+      },
     ],
   ];
 }

--- a/tests/common/engine/dispatchTestUtils.test.js
+++ b/tests/common/engine/dispatchTestUtils.test.js
@@ -5,6 +5,9 @@ import {
   buildSaveDispatches,
   buildStopDispatches,
   buildStartDispatches,
+  buildLoadSuccessDispatches,
+  buildLoadFailureDispatches,
+  buildLoadFinalizeFailureDispatches,
   expectEngineStatus,
   expectEngineRunning,
   expectEngineStopped,
@@ -31,6 +34,7 @@ import {
   COMPONENT_ADDED_ID,
   COMPONENT_REMOVED_ID,
   ENGINE_STOPPED_UI,
+  ENGINE_OPERATION_FAILED_UI,
 } from '../../../src/constants/eventIds.js';
 
 describe('dispatchTestUtils', () => {
@@ -181,6 +185,73 @@ describe('dispatchTestUtils', () => {
       expect(result[1]).toEqual([
         ENGINE_READY_UI,
         { activeWorld: 'NewWorld', message: ENGINE_READY_MESSAGE },
+      ]);
+    });
+  });
+
+  describe('load dispatch builders', () => {
+    it('builds success sequence', () => {
+      const result = buildLoadSuccessDispatches('Save1', 'World1');
+      expect(result).toEqual([
+        [
+          ENGINE_OPERATION_IN_PROGRESS_UI,
+          {
+            titleMessage: 'Loading Save1...',
+            inputDisabledMessage: 'Loading game from Save1...',
+          },
+        ],
+        [
+          ENGINE_READY_UI,
+          { activeWorld: 'World1', message: ENGINE_READY_MESSAGE },
+        ],
+      ]);
+    });
+
+    it('builds failure sequence', () => {
+      const result = buildLoadFailureDispatches('Save1', 'Oops');
+      expect(result).toEqual([
+        [
+          ENGINE_OPERATION_IN_PROGRESS_UI,
+          {
+            titleMessage: 'Loading Save1...',
+            inputDisabledMessage: 'Loading game from Save1...',
+          },
+        ],
+        [
+          ENGINE_OPERATION_FAILED_UI,
+          {
+            errorMessage: 'Failed to load game: Oops',
+            errorTitle: 'Load Failed',
+          },
+        ],
+      ]);
+    });
+
+    it('builds finalize-failure sequence', () => {
+      const result = buildLoadFinalizeFailureDispatches(
+        'Save1',
+        'World1',
+        'Bad'
+      );
+      expect(result).toEqual([
+        [
+          ENGINE_OPERATION_IN_PROGRESS_UI,
+          {
+            titleMessage: 'Loading Save1...',
+            inputDisabledMessage: 'Loading game from Save1...',
+          },
+        ],
+        [
+          ENGINE_READY_UI,
+          { activeWorld: 'World1', message: ENGINE_READY_MESSAGE },
+        ],
+        [
+          ENGINE_OPERATION_FAILED_UI,
+          {
+            errorMessage: 'Failed to load game: Bad',
+            errorTitle: 'Load Failed',
+          },
+        ],
       ]);
     });
   });

--- a/tests/common/mockEnvironment.js
+++ b/tests/common/mockEnvironment.js
@@ -2,8 +2,10 @@
  * @file Utility for creating a mock environment for tests.
  */
 
-import { jest } from '@jest/globals';
-import { createMockContainer } from './mockFactories';
+import {
+  createMockEnvironment,
+  buildTestEnvironment,
+} from './buildTestEnvironment.js';
 
 /**
  * Creates mocks using the provided factory functions.
@@ -15,21 +17,7 @@ import { createMockContainer } from './mockFactories';
  * @returns {{ mocks: Record<string, any>, cleanup: () => void }}
  *   Generated mocks and a cleanup method.
  */
-export function createMockEnvironment(factories) {
-  jest.clearAllMocks();
-
-  const mocks = {};
-  for (const [name, factory] of Object.entries(factories)) {
-    mocks[name] = factory();
-  }
-
-  const cleanup = () => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  };
-
-  return { mocks, cleanup };
-}
+export { createMockEnvironment };
 
 /**
  * Builds a full test environment including a mock DI container.
@@ -46,24 +34,7 @@ export function createMockEnvironment(factories) {
  * @returns {{ mocks: Record<string, any>, mockContainer: { resolve: jest.Mock }, cleanup: () => void }}
  *   Mocks, container and cleanup helper.
  */
-export function buildTestEnvironment(factoryMap, tokenMap, overrides = {}) {
-  const { mocks, cleanup } = createMockEnvironment(factoryMap);
-
-  const mapping = {};
-  for (const [token, ref] of Object.entries(tokenMap)) {
-    if (typeof ref === 'string') {
-      mapping[token] = mocks[ref];
-    } else if (typeof ref === 'function') {
-      mapping[token] = ref(mocks);
-    } else {
-      mapping[token] = ref;
-    }
-  }
-
-  const mockContainer = createMockContainer(mapping, overrides);
-
-  return { mocks, mockContainer, cleanup };
-}
+export { buildTestEnvironment };
 
 /**
  * Builds and optionally instantiates a test environment.

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -5,19 +5,14 @@ import {
   expectEngineRunning,
   expectEngineStopped,
   expectNoDispatch,
+  buildLoadSuccessDispatches,
+  buildLoadFailureDispatches,
+  buildLoadFinalizeFailureDispatches,
 } from '../../common/engine/dispatchTestUtils.js';
-import {
-  ENGINE_OPERATION_IN_PROGRESS_UI,
-  ENGINE_READY_UI,
-  ENGINE_OPERATION_FAILED_UI,
-} from '../../../src/constants/eventIds.js';
 import { tokens } from '../../../src/dependencyInjection/tokens.js';
 import { describeEngineSuite } from '../../common/engine/gameEngineTestBed.js';
 import { generateServiceUnavailableTests } from '../../common/engine/gameEngineHelpers.js';
-import {
-  DEFAULT_SAVE_ID,
-  ENGINE_READY_MESSAGE,
-} from '../../common/constants.js';
+import { DEFAULT_SAVE_ID } from '../../common/constants.js';
 import { GAME_PERSISTENCE_LOAD_GAME_UNAVAILABLE } from '../../common/engine/unavailableMessages.js';
 
 describeEngineSuite('GameEngine', (context) => {
@@ -47,20 +42,10 @@ describeEngineSuite('GameEngine', (context) => {
       ).toHaveBeenCalledWith(SAVE_ID);
       expectDispatchSequence(
         context.bed.getSafeEventDispatcher().dispatch,
-        [
-          ENGINE_OPERATION_IN_PROGRESS_UI,
-          {
-            titleMessage: `Loading ${SAVE_ID}...`,
-            inputDisabledMessage: `Loading game from ${SAVE_ID}...`,
-          },
-        ],
-        [
-          ENGINE_READY_UI,
-          {
-            activeWorld: typedMockSaveData.metadata.gameTitle,
-            message: ENGINE_READY_MESSAGE,
-          },
-        ]
+        ...buildLoadSuccessDispatches(
+          SAVE_ID,
+          typedMockSaveData.metadata.gameTitle
+        )
       );
       expect(context.bed.getTurnManager().start).toHaveBeenCalled();
       expect(result).toEqual({ success: true, data: typedMockSaveData });
@@ -88,20 +73,7 @@ describeEngineSuite('GameEngine', (context) => {
         );
         expectDispatchSequence(
           context.bed.getSafeEventDispatcher().dispatch,
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: `Loading ${SAVE_ID}...`,
-              inputDisabledMessage: `Loading game from ${SAVE_ID}...`,
-            },
-          ],
-          [
-            ENGINE_OPERATION_FAILED_UI,
-            {
-              errorMessage: `Failed to load game: ${errorMsg}`,
-              errorTitle: 'Load Failed',
-            },
-          ]
+          ...buildLoadFailureDispatches(SAVE_ID, errorMsg)
         );
         expect(result).toEqual({ success: false, error: errorMsg, data: null });
         expectEngineStopped(context.engine);
@@ -126,20 +98,7 @@ describeEngineSuite('GameEngine', (context) => {
         );
         expectDispatchSequence(
           context.bed.getSafeEventDispatcher().dispatch,
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: `Loading ${SAVE_ID}...`,
-              inputDisabledMessage: `Loading game from ${SAVE_ID}...`,
-            },
-          ],
-          [
-            ENGINE_OPERATION_FAILED_UI,
-            {
-              errorMessage: `Failed to load game: ${errorObj.message}`,
-              errorTitle: 'Load Failed',
-            },
-          ]
+          ...buildLoadFailureDispatches(SAVE_ID, errorObj.message)
         );
         expect(result).toEqual({
           success: false,
@@ -166,27 +125,11 @@ describeEngineSuite('GameEngine', (context) => {
         );
         expectDispatchSequence(
           context.bed.getSafeEventDispatcher().dispatch,
-          [
-            ENGINE_OPERATION_IN_PROGRESS_UI,
-            {
-              titleMessage: `Loading ${SAVE_ID}...`,
-              inputDisabledMessage: `Loading game from ${SAVE_ID}...`,
-            },
-          ],
-          [
-            ENGINE_READY_UI,
-            {
-              activeWorld: typedMockSaveData.metadata.gameTitle,
-              message: ENGINE_READY_MESSAGE,
-            },
-          ],
-          [
-            ENGINE_OPERATION_FAILED_UI,
-            {
-              errorMessage: `Failed to load game: ${errorObj.message}`,
-              errorTitle: 'Load Failed',
-            },
-          ]
+          ...buildLoadFinalizeFailureDispatches(
+            SAVE_ID,
+            typedMockSaveData.metadata.gameTitle,
+            errorObj.message
+          )
         );
         expect(result).toEqual({
           success: false,


### PR DESCRIPTION
Summary: Consolidated environment-building helpers and dispatch sequence generators to remove duplication across tests.

Changes Made:
- Added `buildTestEnvironment.js` with shared `createMockEnvironment` and `buildTestEnvironment` utilities
- Updated existing helpers to import from the new module and switched `baseTestBed` to use it
- Extended `dispatchTestUtils` with load-game dispatch builders and created corresponding tests
- Simplified `loadGame.test.js` using the new builders
- Fixed lint error in `findConditionReferences.js` and addressed equality check in `traceContext.js`

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685c4008aec88331909145a7f3b6bce7