### PR TITLE
[Agent] clarify naming in utilities

### DIFF
--- a/src/logic/operationHandlers/baseOperationHandler.js
+++ b/src/logic/operationHandlers/baseOperationHandler.js
@@ -11,7 +11,7 @@
 import {
   initHandlerLogger,
   validateDeps,
-  getExecLogger,
+  resolveExecutionLogger,
 } from '../../utils/handlerUtils/serviceUtils.js';
 
 /**
@@ -72,7 +72,7 @@ class BaseOperationHandler {
    * @returns {ILogger} Logger instance for the current execution.
    */
   getLogger(executionContext) {
-    return getExecLogger(this.#logger, executionContext);
+    return resolveExecutionLogger(this.#logger, executionContext);
   }
 }
 

--- a/src/logic/operationHandlers/componentOperationHandler.js
+++ b/src/logic/operationHandlers/componentOperationHandler.js
@@ -52,12 +52,12 @@ class ComponentOperationHandler extends BaseOperationHandler {
    *
    * @param {'actor'|'target'|string|EntityRefObject} entityRef - Reference to resolve.
    * @param {ILogger} log - Logger used for warnings.
-   * @param {string} [opName] - Optional operation name prefix for logging.
+   * @param {string} [operationName] - Optional operation name prefix for logging.
    * @param {ExecutionContext} executionContext - Execution context for resolution.
    * @returns {string|null} The resolved ID or null when invalid.
    */
-  validateEntityRef(entityRef, log, opName, executionContext) {
-    const prefix = opName ? `${opName}: ` : '';
+  validateEntityRef(entityRef, log, operationName, executionContext) {
+    const prefix = operationName ? `${operationName}: ` : '';
     if (!entityRef) {
       log.warn(`${prefix}"entity_ref" parameter is required.`);
       return null;
@@ -77,11 +77,11 @@ class ComponentOperationHandler extends BaseOperationHandler {
    *
    * @param {*} type - Raw component type.
    * @param {ILogger} log - Logger used for warnings.
-   * @param {string} [opName] - Optional operation name prefix for logging.
+   * @param {string} [operationName] - Optional operation name prefix for logging.
    * @returns {string|null} Trimmed component type or null if invalid.
    */
-  requireComponentType(type, log, opName) {
-    const prefix = opName ? `${opName}: ` : '';
+  requireComponentType(type, log, operationName) {
+    const prefix = operationName ? `${operationName}: ` : '';
     const trimmed = this.validateComponentType(type);
     if (!trimmed) {
       log.warn(
@@ -98,14 +98,23 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * @param {'actor'|'target'|string|EntityRefObject} entityRef
    * @param {*} componentType
    * @param {ILogger} logger
-   * @param {string} [opName]
+   * @param {string} [operationName]
    * @param {ExecutionContext} ctx
    * @returns {{ entityId: string, type: string } | null}
    */
-  validateEntityAndType(entityRef, componentType, logger, opName, ctx) {
-    const entityId = this.validateEntityRef(entityRef, logger, opName, ctx);
+  validateEntityAndType(entityRef, componentType, logger, operationName, ctx) {
+    const entityId = this.validateEntityRef(
+      entityRef,
+      logger,
+      operationName,
+      ctx
+    );
     if (!entityId) return null;
-    const type = this.requireComponentType(componentType, logger, opName);
+    const type = this.requireComponentType(
+      componentType,
+      logger,
+      operationName
+    );
     if (!type) return null;
     return { entityId, type };
   }

--- a/src/logic/operationHandlers/mathHandler.js
+++ b/src/logic/operationHandlers/mathHandler.js
@@ -26,17 +26,17 @@ import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
  *
  * @description Exported for unit testing.
  * @param {number|object} operand - Operand to resolve.
- * @param {object} ctx - Evaluation context passed to json-logic.
+ * @param {object} context - Evaluation context passed to json-logic.
  * @param {ILogger} logger - Logger for warnings.
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher for error events.
  * @returns {number} Resolved numeric value or `NaN` on failure.
  */
-export function resolveOperand(operand, ctx, logger, dispatcher) {
+export function resolveOperand(operand, context, logger, dispatcher) {
   if (typeof operand === 'number') return operand;
   if (operand && typeof operand === 'object') {
     if (Object.prototype.hasOwnProperty.call(operand, 'var')) {
       try {
-        const raw = jsonLogic.apply({ var: operand.var }, ctx);
+        const raw = jsonLogic.apply({ var: operand.var }, context);
         const num = Number(raw);
         return Number.isNaN(num) ? NaN : num;
       } catch (e) {
@@ -49,7 +49,7 @@ export function resolveOperand(operand, ctx, logger, dispatcher) {
       }
     }
     if (operand.operator) {
-      return evaluateExpression(operand, ctx, logger, dispatcher);
+      return evaluateExpression(operand, context, logger, dispatcher);
     }
   }
   logger.warn('MATH: Invalid operand encountered.', { operand });
@@ -61,17 +61,17 @@ export function resolveOperand(operand, ctx, logger, dispatcher) {
  *
  * @description Exported for unit testing.
  * @param {MathExpression} expr - Expression to evaluate.
- * @param {object} ctx - Evaluation context used for variable resolution.
+ * @param {object} context - Evaluation context used for variable resolution.
  * @param {ILogger} logger - Logger for warnings.
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher for error events.
  * @returns {number} The numeric result or `NaN` if evaluation fails.
  */
-export function evaluateExpression(expr, ctx, logger, dispatcher) {
+export function evaluateExpression(expr, context, logger, dispatcher) {
   if (!expr || typeof expr !== 'object') return NaN;
   const { operator, operands } = expr;
   if (!Array.isArray(operands) || operands.length !== 2) return NaN;
-  const left = resolveOperand(operands[0], ctx, logger, dispatcher);
-  const right = resolveOperand(operands[1], ctx, logger, dispatcher);
+  const left = resolveOperand(operands[0], context, logger, dispatcher);
+  const right = resolveOperand(operands[1], context, logger, dispatcher);
   if (
     typeof left !== 'number' ||
     typeof right !== 'number' ||

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -7,7 +7,7 @@
 
 import { AbstractTurnState } from './abstractTurnState.js';
 import { ACTION_DECIDED_ID } from '../../constants/eventIds.js';
-import { getActorType } from '../../utils/actorTypeUtils.js';
+import { determineActorType } from '../../utils/actorTypeUtils.js';
 import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 import { ActionDecisionWorkflow } from './workflows/actionDecisionWorkflow.js';
 
@@ -216,7 +216,7 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
   async _emitActionDecided(turnContext, actor, extractedData) {
     const payload = {
       actorId: actor.id,
-      actorType: getActorType(actor),
+      actorType: determineActorType(actor),
     };
     if (extractedData) {
       payload.extractedData = {

--- a/src/turns/states/helpers/contextUtils.js
+++ b/src/turns/states/helpers/contextUtils.js
@@ -13,21 +13,21 @@
  * Resolves a logger using the provided context or handler.
  * Falls back to the console when unavailable.
  *
- * @param {ITurnContext|null} turnCtx - The current ITurnContext, if any.
+ * @param {ITurnContext|null} turnContext - The current ITurnContext, if any.
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
  * @returns {Logger} The resolved logger instance.
  */
-export function getLogger(turnCtx, handler) {
+export function getLogger(turnContext, handler) {
   try {
-    if (turnCtx && typeof turnCtx.getLogger === 'function') {
-      const logger = turnCtx.getLogger();
+    if (turnContext && typeof turnContext.getLogger === 'function') {
+      const logger = turnContext.getLogger();
       if (logger) {
         return logger;
       }
     }
   } catch (err) {
     console.error(
-      `ContextUtils.getLogger: Error getting logger from turnCtx: ${err.message}`,
+      `ContextUtils.getLogger: Error getting logger from turnContext: ${err.message}`,
       err
     );
   }
@@ -53,20 +53,20 @@ export function getLogger(turnCtx, handler) {
  * Safely resolves a SafeEventDispatcher using the provided context or handler.
  * Falls back to handler.getSafeEventDispatcher() when necessary.
  *
- * @param {ITurnContext|null} turnCtx - The current ITurnContext, if any.
+ * @param {ITurnContext|null} turnContext - The current ITurnContext, if any.
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
  * @returns {ISafeEventDispatcher|null} The resolved dispatcher or null if unavailable.
  */
-export function getSafeEventDispatcher(turnCtx, handler) {
-  if (turnCtx && typeof turnCtx.getSafeEventDispatcher === 'function') {
+export function getSafeEventDispatcher(turnContext, handler) {
+  if (turnContext && typeof turnContext.getSafeEventDispatcher === 'function') {
     try {
-      const dispatcher = turnCtx.getSafeEventDispatcher();
+      const dispatcher = turnContext.getSafeEventDispatcher();
       if (dispatcher && typeof dispatcher.dispatch === 'function') {
         return dispatcher;
       }
     } catch (err) {
-      getLogger(turnCtx, handler).error(
-        `ContextUtils.getSafeEventDispatcher: Error calling turnCtx.getSafeEventDispatcher(): ${err.message}`,
+      getLogger(turnContext, handler).error(
+        `ContextUtils.getSafeEventDispatcher: Error calling turnContext.getSafeEventDispatcher(): ${err.message}`,
         err
       );
     }
@@ -76,20 +76,20 @@ export function getSafeEventDispatcher(turnCtx, handler) {
     try {
       const dispatcher = handler.getSafeEventDispatcher();
       if (dispatcher && typeof dispatcher.dispatch === 'function') {
-        getLogger(turnCtx, handler).warn(
+        getLogger(turnContext, handler).warn(
           'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher not found on ITurnContext. Falling back to handler.getSafeEventDispatcher().'
         );
         return dispatcher;
       }
     } catch (err) {
-      getLogger(turnCtx, handler).error(
+      getLogger(turnContext, handler).error(
         `ContextUtils.getSafeEventDispatcher: Error calling handler.getSafeEventDispatcher(): ${err.message}`,
         err
       );
     }
   }
 
-  getLogger(turnCtx, handler).warn(
+  getLogger(turnContext, handler).warn(
     'ContextUtils.getSafeEventDispatcher: SafeEventDispatcher unavailable.'
   );
   return null;

--- a/src/utils/actorTypeUtils.js
+++ b/src/utils/actorTypeUtils.js
@@ -14,6 +14,6 @@
  * @param {object} actor - Actor entity or model to inspect.
  * @returns {string} `'ai'` if the actor is flagged as AI, otherwise `'human'`.
  */
-export function getActorType(actor) {
+export function determineActorType(actor) {
   return actor && actor.isAi === true ? 'ai' : 'human';
 }

--- a/src/utils/entityRefUtils.js
+++ b/src/utils/entityRefUtils.js
@@ -20,11 +20,11 @@
  * Supports the special keywords 'actor' and 'target', plain ID strings,
  * or objects of the form `{ entityId: string }`.
  * @param {'actor'|'target'|string|EntityRefObject} ref - Reference to resolve.
- * @param {ExecutionContext} ctx - The current execution context providing actor/target.
+ * @param {ExecutionContext} executionContext - The current execution context providing actor/target.
  * @returns {string|null} The resolved entity ID, or `null` if it cannot be resolved.
  */
-export function resolveEntityId(ref, ctx) {
-  const ec = ctx?.evaluationContext ?? {};
+export function resolveEntityId(ref, executionContext) {
+  const ec = executionContext?.evaluationContext ?? {};
   if (typeof ref === 'string') {
     const trimmed = ref.trim();
     if (!trimmed) return null;

--- a/src/utils/evaluationContextUtils.js
+++ b/src/utils/evaluationContextUtils.js
@@ -26,9 +26,9 @@ import { safeDispatchError } from './safeDispatchErrorUtils.js';
 export function ensureEvaluationContext(executionContext, dispatcher, logger) {
   const log = ensureValidLogger(logger, 'ensureEvaluationContext');
 
-  const ctx = executionContext?.evaluationContext?.context;
-  if (ctx && typeof ctx === 'object') {
-    return ctx;
+  const context = executionContext?.evaluationContext?.context;
+  if (context && typeof context === 'object') {
+    return context;
   }
 
   const message =

--- a/src/utils/handlerUtils/indexUtils.js
+++ b/src/utils/handlerUtils/indexUtils.js
@@ -2,9 +2,14 @@ import { assertParamsObject } from './paramsUtils.js';
 import {
   initHandlerLogger,
   validateDeps,
-  getExecLogger,
+  resolveExecutionLogger,
 } from './serviceUtils.js';
 
-export { assertParamsObject, initHandlerLogger, validateDeps, getExecLogger };
+export {
+  assertParamsObject,
+  initHandlerLogger,
+  validateDeps,
+  resolveExecutionLogger,
+};
 
 // deprecated default export removed in favor of named exports only

--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -20,7 +20,7 @@ export {
  * @param {import('../../logic/defs.js').ExecutionContext} [executionContext] - Optional execution context.
  * @returns {ILogger} Logger instance for execution.
  */
-export function getExecLogger(defaultLogger, executionContext) {
+export function resolveExecutionLogger(defaultLogger, executionContext) {
   return executionContext?.logger ?? defaultLogger;
 }
 

--- a/src/utils/logHelpers.js
+++ b/src/utils/logHelpers.js
@@ -13,10 +13,10 @@
  * @description Prepends a play emoji to the provided context string and logs
  * it at the debug level.
  * @param {ILogger} logger - Logger instance used to emit the message.
- * @param {string} ctx - Descriptive context for the log message.
+ * @param {string} context - Descriptive context for the log message.
  * @returns {void}
  */
-export const logStart = (logger, ctx) => logger.debug(`▶️  ${ctx}`);
+export const logStart = (logger, context) => logger.debug(`▶️  ${context}`);
 
 /**
  * Logs an end/completion message using the debug level.
@@ -24,10 +24,10 @@ export const logStart = (logger, ctx) => logger.debug(`▶️  ${ctx}`);
  * @description Prepends a check mark emoji to the provided context string and
  * logs it at the debug level.
  * @param {ILogger} logger - Logger instance used to emit the message.
- * @param {string} ctx - Descriptive context for the log message.
+ * @param {string} context - Descriptive context for the log message.
  * @returns {void}
  */
-export const logEnd = (logger, ctx) => logger.debug(`✅ ${ctx}`);
+export const logEnd = (logger, context) => logger.debug(`✅ ${context}`);
 
 /**
  * Logs an error message using the error level.
@@ -36,9 +36,9 @@ export const logEnd = (logger, ctx) => logger.debug(`✅ ${ctx}`);
  * the error's message. The full error object is also passed to the logger for
  * stack traces.
  * @param {ILogger} logger - Logger instance used to emit the message.
- * @param {string} ctx - Descriptive context for the log message.
+ * @param {string} context - Descriptive context for the log message.
  * @param {Error} err - The error to log alongside the message.
  * @returns {void}
  */
-export const logError = (logger, ctx, err) =>
-  logger.error(`❌ ${ctx}: ${err.message}`, err);
+export const logError = (logger, context, err) =>
+  logger.error(`❌ ${context}: ${err.message}`, err);

--- a/src/utils/placeholderPathResolver.js
+++ b/src/utils/placeholderPathResolver.js
@@ -18,9 +18,12 @@ export function extractContextPath(placeholderPath, executionContext) {
     return { path: placeholderPath, root: executionContext };
   }
 
-  const ctx = executionContext?.evaluationContext?.context;
-  if (ctx && typeof ctx === 'object') {
-    return { path: placeholderPath.substring('context.'.length), root: ctx };
+  const context = executionContext?.evaluationContext?.context;
+  if (context && typeof context === 'object') {
+    return {
+      path: placeholderPath.substring('context.'.length),
+      root: context,
+    };
   }
 
   return null;

--- a/src/utils/wrapperUtils.js
+++ b/src/utils/wrapperUtils.js
@@ -8,13 +8,13 @@
  *
  * @param {{prefix?: string, suffix?: string}|null|undefined} wrappers - Raw prefix/suffix.
  * @param {import('./placeholderResolverUtils.js').PlaceholderResolver} resolver - Placeholder resolver.
- * @param {object} ctx - Context for resolution.
+ * @param {object} context - Context for resolution.
  * @returns {{ prefix: string, suffix: string }} Resolved prefix & suffix.
  */
-export function resolveWrapper(wrappers, resolver, ctx) {
+export function resolveWrapper(wrappers, resolver, context) {
   const { prefix = '', suffix = '' } = wrappers || {};
   return {
-    prefix: resolver.resolve(prefix, ctx),
-    suffix: resolver.resolve(suffix, ctx),
+    prefix: resolver.resolve(prefix, context),
+    suffix: resolver.resolve(suffix, context),
   };
 }

--- a/tests/unit/turns/states/abstractTurnState.test.js
+++ b/tests/unit/turns/states/abstractTurnState.test.js
@@ -62,7 +62,7 @@ describe('AbstractTurnState._resolveLogger', () => {
     expect(result).toBe(logger);
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(consoleSpy.mock.calls[0][0]).toMatch(
-      /Error getting logger from turnCtx/
+      /Error getting logger from turnContext/
     );
     consoleSpy.mockRestore();
   });

--- a/tests/unit/turns/utils/actorTypeUtils.test.js
+++ b/tests/unit/turns/utils/actorTypeUtils.test.js
@@ -1,19 +1,19 @@
 import { describe, it, expect } from '@jest/globals';
-import { getActorType } from '../../../../src/utils/actorTypeUtils.js';
+import { determineActorType } from '../../../../src/utils/actorTypeUtils.js';
 
-describe('getActorType', () => {
+describe('determineActorType', () => {
   it('returns "ai" when actor.isAi is true', () => {
     const actor = { isAi: true };
-    expect(getActorType(actor)).toBe('ai');
+    expect(determineActorType(actor)).toBe('ai');
   });
 
   it('returns "human" when actor.isAi is false', () => {
     const actor = { isAi: false };
-    expect(getActorType(actor)).toBe('human');
+    expect(determineActorType(actor)).toBe('human');
   });
 
   it('defaults to "human" when actor.isAi is undefined', () => {
     const actor = {};
-    expect(getActorType(actor)).toBe('human');
+    expect(determineActorType(actor)).toBe('human');
   });
 });

--- a/tests/unit/utils/handlerUtils.indexUtils.test.js
+++ b/tests/unit/utils/handlerUtils.indexUtils.test.js
@@ -3,13 +3,13 @@ import {
   assertParamsObject,
   initHandlerLogger,
   validateDeps,
-  getExecLogger,
+  resolveExecutionLogger,
 } from '../../../src/utils/handlerUtils/indexUtils.js';
 import { assertParamsObject as paramsAssert } from '../../../src/utils/handlerUtils/paramsUtils.js';
 import {
   initHandlerLogger as serviceInit,
   validateDeps as serviceValidate,
-  getExecLogger as serviceGetExec,
+  resolveExecutionLogger as serviceGetExec,
 } from '../../../src/utils/handlerUtils/serviceUtils.js';
 
 describe('handlerUtils/indexUtils exports', () => {
@@ -17,6 +17,6 @@ describe('handlerUtils/indexUtils exports', () => {
     expect(assertParamsObject).toBe(paramsAssert);
     expect(initHandlerLogger).toBe(serviceInit);
     expect(validateDeps).toBe(serviceValidate);
-    expect(getExecLogger).toBe(serviceGetExec);
+    expect(resolveExecutionLogger).toBe(serviceGetExec);
   });
 });


### PR DESCRIPTION
## Summary
- rename `getExecLogger` to `resolveExecutionLogger`
- rename `getActorType` to `determineActorType`
- expand abbreviated parameter names for clarity
- adjust tests for new function names

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c47882e6c833185b921bc3ce35069