### PR TITLE
[Agent] fix circular dependencies

### DIFF
--- a/src/bootstrapper/stages/auxiliary/index.js
+++ b/src/bootstrapper/stages/auxiliary/index.js
@@ -7,4 +7,3 @@ export { initLlmSelectionModal } from './initLlmSelectionModal.js';
 export { initCurrentTurnActorRenderer } from './initCurrentTurnActorRenderer.js';
 export { initSpeechBubbleRenderer } from './initSpeechBubbleRenderer.js';
 export { initProcessingIndicatorController } from './initProcessingIndicatorController.js';
-export { initializeAuxiliaryServicesStage } from '../initializeAuxiliaryServicesStage.js';

--- a/src/bootstrapper/stages/index.js
+++ b/src/bootstrapper/stages/index.js
@@ -9,4 +9,4 @@ export {
 } from './containerStages.js';
 export { initializeGameEngineStage, startGameStage } from './engineStages.js';
 export { setupGlobalEventListenersStage } from './eventStages.js';
-export { initializeAuxiliaryServicesStage } from './auxiliary';
+export { initializeAuxiliaryServicesStage } from './initializeAuxiliaryServicesStage.js';

--- a/src/domUI/domUiFacade.js
+++ b/src/domUI/domUiFacade.js
@@ -4,7 +4,7 @@
  */
 
 /** @typedef {import('./actionButtonsRenderer').ActionButtonsRenderer} ActionButtonsRenderer */
-/** @typedef {import('./locationRenderer').LocationRenderer} LocationRenderer */
+/** @typedef {import('./location/typedefs.js').LocationRenderer} LocationRenderer */
 /** @typedef {import('./titleRenderer').TitleRenderer} TitleRenderer */
 /** @typedef {import('./inputStateController').InputStateController} InputStateController */
 /** @typedef {import('./perceptionLogRenderer').PerceptionLogRenderer} PerceptionLogRenderer */

--- a/src/domUI/location/renderLocationLists.js
+++ b/src/domUI/location/renderLocationLists.js
@@ -6,8 +6,10 @@
 /**
  * @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger
  * @typedef {import('./buildLocationDisplayPayload.js').LocationDisplayPayload} LocationDisplayPayload
- * @typedef {import('../locationRenderer.js').LocationRenderer} LocationRenderer
+ * @typedef {import('./typedefs.js').LocationRenderer} LocationRenderer
  */
+
+import './typedefs.js';
 
 /**
  * Uses the renderer's internal `_renderList` method to populate exits and

--- a/src/domUI/location/typedefs.js
+++ b/src/domUI/location/typedefs.js
@@ -1,0 +1,13 @@
+// src/domUI/location/typedefs.js
+/**
+ * @file Shared typedefs for location rendering helpers.
+ */
+
+/**
+ * Minimal interface for LocationRenderer used for documentation.
+ * @typedef {object} LocationRenderer
+ * @property {function(any[], HTMLElement, string, string, string, string=): void} _renderList
+ * @property {{exitsDisplay: HTMLElement, charactersDisplay: HTMLElement}} elements
+ */
+
+export const __locationTypedefs = true;

--- a/src/domUI/saveGameService.js
+++ b/src/domUI/saveGameService.js
@@ -6,8 +6,9 @@
 
 import { validateDependency } from '../utils/validationUtils.js';
 import { ensureValidLogger } from '../utils/index.js';
+import './saveGameTypedefs.js';
 
-/** @typedef {import('./saveGameUI.js').SlotDisplayData} SlotDisplayData */
+/** @typedef {import('./saveGameTypedefs.js').SlotDisplayData} SlotDisplayData */
 /** @typedef {import('../interfaces/ISaveService.js').ISaveService} ISaveService */
 /** @typedef {import('../interfaces/IUserPrompt.js').IUserPrompt} IUserPrompt */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */

--- a/src/domUI/saveGameTypedefs.js
+++ b/src/domUI/saveGameTypedefs.js
@@ -1,0 +1,28 @@
+// src/domUI/saveGameTypedefs.js
+/**
+ * @file Shared typedefs for Save Game UI and service modules.
+ */
+
+/** @typedef {import('../interfaces/ISaveLoadService.js').SaveFileMetadata} SaveFileMetadata */
+
+/**
+ * Represents a filled save slot.
+ * @typedef {SaveFileMetadata & {slotId: number, isEmpty?: false}} FilledSlotData
+ */
+
+/**
+ * Represents an empty save slot.
+ * @typedef {{slotId: number, isEmpty: true, saveName?: string, timestamp?: string, playtimeSeconds?: number, isCorrupted?: false}} EmptySlotData
+ */
+
+/**
+ * Represents a corrupted save slot.
+ * @typedef {{slotId: number, isEmpty: false, saveName?: string, timestamp?: string, playtimeSeconds?: number, isCorrupted: true, identifier?: string}} CorruptedSlotData
+ */
+
+/**
+ * Union of all slot display data types.
+ * @typedef {FilledSlotData | EmptySlotData | CorruptedSlotData} SlotDisplayData
+ */
+
+export const __saveGameTypedefs = true;

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -14,6 +14,7 @@ import { buildModalElementsConfig } from './helpers/buildModalElementsConfig.js'
 import createEmptySlotMessage from './helpers/createEmptySlotMessage.js';
 import { DATASET_SLOT_ID } from '../constants/datasetKeys.js';
 import SaveGameService from './saveGameService.js';
+import './saveGameTypedefs.js';
 
 /**
  * Dataset key storing the numeric slot ID on save slot elements.
@@ -29,13 +30,6 @@ import SaveGameService from './saveGameService.js';
  * @typedef {import('../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService
  * @typedef {import('../interfaces/ISaveLoadService.js').SaveFileMetadata} SaveFileMetadata
  * @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher
- */
-
-/**
- * @typedef {SaveFileMetadata & {slotId: number, isEmpty?: false}} FilledSlotData
- * @typedef {{slotId: number, isEmpty: true, saveName?: string, timestamp?: string, playtimeSeconds?: number, isCorrupted?: false}} EmptySlotData
- * @typedef {{slotId: number, isEmpty: false, saveName?: string, timestamp?: string, playtimeSeconds?: number, isCorrupted: true, identifier?: string}} CorruptedSlotData
- * @typedef {FilledSlotData | EmptySlotData | CorruptedSlotData} SlotDisplayData
  */
 
 const MAX_SAVE_SLOTS = 10;

--- a/src/main.js
+++ b/src/main.js
@@ -15,8 +15,8 @@ import {
   setupMenuButtonListenersStage,
   setupGlobalEventListenersStage,
   startGameStage,
+  initializeAuxiliaryServicesStage,
 } from './bootstrapper/stages/index.js';
-import { initializeAuxiliaryServicesStage } from './bootstrapper/stages/auxiliary';
 
 const ACTIVE_WORLD = 'isekai:world';
 

--- a/tests/unit/main/main.additionalCoverage.test.js
+++ b/tests/unit/main/main.additionalCoverage.test.js
@@ -19,10 +19,6 @@ jest.mock('../../../src/bootstrapper/stages', () => ({
   setupMenuButtonListenersStage: (...args) => mockMenu(...args),
   setupGlobalEventListenersStage: (...args) => mockGlobal(...args),
   startGameStage: (...args) => mockStartGame(...args),
-}));
-
-jest.mock('../../../src/bootstrapper/stages/auxiliary', () => ({
-  __esModule: true,
   initializeAuxiliaryServicesStage: (...args) => mockInitAux(...args),
 }));
 

--- a/tests/unit/main/main.bootstrapFlow.test.js
+++ b/tests/unit/main/main.bootstrapFlow.test.js
@@ -19,9 +19,6 @@ jest.mock('../../../src/bootstrapper/stages', () => ({
   setupMenuButtonListenersStage: (...args) => mockMenu(...args),
   setupGlobalEventListenersStage: (...args) => mockGlobal(...args),
   startGameStage: (...args) => mockStartGame(...args),
-}));
-jest.mock('../../../src/bootstrapper/stages/auxiliary', () => ({
-  __esModule: true,
   initializeAuxiliaryServicesStage: (...args) => mockInitAux(...args),
 }));
 

--- a/tests/unit/main/main.test.js
+++ b/tests/unit/main/main.test.js
@@ -19,9 +19,6 @@ jest.mock('../../../src/bootstrapper/stages', () => ({
   setupMenuButtonListenersStage: (...args) => mockMenu(...args),
   setupGlobalEventListenersStage: (...args) => mockGlobal(...args),
   startGameStage: (...args) => mockStartGame(...args),
-}));
-jest.mock('../../../src/bootstrapper/stages/auxiliary', () => ({
-  __esModule: true,
   initializeAuxiliaryServicesStage: (...args) => mockInitAux(...args),
 }));
 


### PR DESCRIPTION
## Summary
- avoid JSDoc cross-imports with new typedef modules
- export initializeAuxiliaryServicesStage directly to break re-export loop
- update main and tests for new stage import path

## Testing Done
- `npx prettier --write ...`
- `npx eslint src/bootstrapper/stages/auxiliary/index.js src/bootstrapper/stages/index.js src/domUI/domUiFacade.js src/domUI/location/renderLocationLists.js src/domUI/saveGameService.js src/domUI/saveGameUI.js src/main.js tests/unit/main/main.additionalCoverage.test.js tests/unit/main/main.bootstrapFlow.test.js tests/unit/main/main.test.js src/domUI/location/typedefs.js src/domUI/saveGameTypedefs.js`
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4b96eea88331b6710cdb760c2577