### PR TITLE
[Agent] handle missing definitions on load

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -160,6 +160,7 @@ export function registerPersistence(container) {
         logger: c.resolve(tokens.ILogger),
         entityManager: c.resolve(tokens.IEntityManager),
         playtimeTracker: c.resolve(tokens.PlaytimeTracker),
+        safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       }),
     });
   });


### PR DESCRIPTION
## Summary
- dispatch system error when loading save references a missing entity definition
- wire safeEventDispatcher to GameStateRestorer
- add regression test for missing definitions

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685c4b43695883318dfc8e79a2082f5a