### PR TITLE
[Agent] resolve circular utils imports

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -7,7 +7,7 @@ import {
   EXITS_COMPONENT_ID,
 } from '../constants/componentIds.js';
 import { validateDependency } from '../utils/validationUtils.js';
-import { ensureValidLogger } from '../utils';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { isNonBlankString } from '../utils/textUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';

--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -39,7 +39,7 @@ import {
 } from '../utils/parameterGuards.js';
 import { IEntityManager } from '../interfaces/IEntityManager.js';
 import { validateDependency } from '../utils/validationUtils.js';
-import { ensureValidLogger } from '../utils';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 import { DefinitionNotFoundError } from '../errors/definitionNotFoundError.js';
 import { EntityNotFoundError } from '../errors/entityNotFoundError';
 import { InvalidArgumentError } from '../errors/invalidArgumentError.js';

--- a/src/entities/factories/entityFactory.js
+++ b/src/entities/factories/entityFactory.js
@@ -25,7 +25,7 @@ import {
 } from '../../utils/parameterGuards.js';
 import { injectDefaultComponents } from '../utils/defaultComponentInjector.js';
 import { validateDependency } from '../../utils/validationUtils.js';
-import { ensureValidLogger } from '../../utils';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { DefinitionNotFoundError } from '../../errors/definitionNotFoundError.js';
 import { SerializedEntityError } from '../../errors/serializedEntityError.js';
 import { InvalidInstanceIdError } from '../../errors/invalidInstanceIdError.js';

--- a/src/entities/services/componentMutationService.js
+++ b/src/entities/services/componentMutationService.js
@@ -5,7 +5,7 @@
  */
 
 import { validateDependency } from '../../utils/validationUtils.js';
-import { ensureValidLogger } from '../../utils/index.js';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { EntityNotFoundError } from '../../errors/entityNotFoundError.js';
 import { ValidationError } from '../../errors/validationError.js';
 import { validateAndClone as validateAndCloneUtil } from '../utils/componentValidation.js';

--- a/src/entities/services/entityRepositoryAdapter.js
+++ b/src/entities/services/entityRepositoryAdapter.js
@@ -6,7 +6,7 @@
 
 import { MapManager } from '../../utils/mapManagerUtils.js';
 import { validateDependency } from '../../utils/validationUtils.js';
-import { ensureValidLogger } from '../../utils/index.js';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { EntityNotFoundError } from '../../errors/entityNotFoundError.js';
 import { DuplicateEntityError } from '../../errors/duplicateEntityError.js';
 

--- a/src/entities/services/errorTranslator.js
+++ b/src/entities/services/errorTranslator.js
@@ -5,7 +5,7 @@
  */
 
 import { validateDependency } from '../../utils/validationUtils.js';
-import { ensureValidLogger } from '../../utils/index.js';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { DuplicateEntityError } from '../../errors/duplicateEntityError.js';
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */


### PR DESCRIPTION
Summary: fix circular dependencies triggered by importing ensureValidLogger via utils index. Updated entity-related modules to import directly from loggerUtils.js.

Testing Done:
- [x] Code formatted with Prettier
- [x] Lint passes on modified files
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `npm run test --prefix llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_685c58e8ff808331b7e48d31b6d7bb48