### PR TITLE
[Agent] enforce unique instanceId at load

### DIFF
--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -386,8 +386,16 @@ class WorldInitializer {
     const instantiatedEntities = [];
     let instantiatedCount = 0;
     let failedCount = 0;
+    const seenIds = new Set();
 
     for (const worldInstance of instances) {
+      if (seenIds.has(worldInstance.instanceId)) {
+        this.#logger.error(
+          `WorldInitializer: Duplicate instanceId '${worldInstance.instanceId}' encountered. Skipping duplicate.`
+        );
+        continue;
+      }
+      seenIds.add(worldInstance.instanceId);
       const { entity, success } = await this.#instantiateInstance(
         worldName,
         worldInstance


### PR DESCRIPTION
## Summary
- enforce unique instanceId values when loading a world
- test duplicate instanceId handling

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c572115508331a2a1f8959cfb14d5