### PR TITLE
[Agent] Switch WorldInitializer to interface-based validation

### DIFF
--- a/tests/unit/initializers/worldInitializer.test.js
+++ b/tests/unit/initializers/worldInitializer.test.js
@@ -130,7 +130,7 @@ describe('WorldInitializer', () => {
       [
         'EntityManager',
         'entityManager',
-        'WorldInitializer requires an EntityManager.',
+        'WorldInitializer requires an IEntityManager with createEntityInstance().',
       ],
       [
         'WorldContext',
@@ -140,18 +140,18 @@ describe('WorldInitializer', () => {
       [
         'GameDataRepository',
         'gameDataRepository',
-        'WorldInitializer requires a GameDataRepository.',
+        'WorldInitializer requires an IGameDataRepository with getWorld(), getEntityInstanceDefinition(), and get().',
       ],
       [
         'ValidatedEventDispatcher',
         'validatedEventDispatcher',
-        'WorldInitializer requires a ValidatedEventDispatcher.',
+        'WorldInitializer requires a ValidatedEventDispatcher with dispatch().',
       ],
       ['ILogger', 'logger', 'WorldInitializer requires an ILogger.'],
       [
         'ScopeRegistry',
         'scopeRegistry',
-        'WorldInitializer requires a ScopeRegistry.',
+        'WorldInitializer requires an IScopeRegistry with initialize().',
       ],
     ];
 


### PR DESCRIPTION
## Summary
- use IEntityManager, IGameDataRepository and IScopeRegistry in `WorldInitializer`
- validate dependencies by checking interface methods
- update initializer tests to expect new validation messages

## Testing Done
- `npm run lint` *(fails: 3187 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c5a429c688331b8888006198a7691