### PR TITLE
[Agent] Rename internal methods to private

### DIFF
--- a/src/initializers/systemInitializer.js
+++ b/src/initializers/systemInitializer.js
@@ -82,7 +82,7 @@ class SystemInitializer {
    * @returns {Promise<Array<any>>} An array of resolved systems.
    * @throws {Error} If resolution fails critically.
    */
-  async _resolveSystems() {
+  async #resolveSystems() {
     let resolvedSystems = [];
     try {
       this.#logger.debug(
@@ -123,7 +123,7 @@ class SystemInitializer {
    * @param {any} system - The system object.
    * @returns {Promise<void>}
    */
-  async #_initializeSingleSystem(system) {
+  async #initializeSingleSystem(system) {
     const systemName = system?.constructor?.name ?? 'UnnamedSystem';
 
     if (system && typeof system.initialize === 'function') {
@@ -184,13 +184,13 @@ class SystemInitializer {
       `SystemInitializer: Starting initialization for systems tagged with '${this.#initializationTag}'...`
     );
 
-    const systemsToInitialize = await this._resolveSystems();
+    const systemsToInitialize = await this.#resolveSystems();
     this.#logger.debug(
       `SystemInitializer: Proceeding to initialize ${systemsToInitialize.length} resolved systems sequentially...`
     );
 
     for (const system of systemsToInitialize) {
-      await this.#_initializeSingleSystem(system); // Handles individual errors and events
+      await this.#initializeSingleSystem(system); // Handles individual errors and events
     }
 
     this.#logger.debug(


### PR DESCRIPTION
## Summary
- rename `_resolveSystems` to `#resolveSystems`
- rename `#_initializeSingleSystem` to `#initializeSingleSystem`
- adjust usage of renamed methods

## Testing Done
- `npm run lint` *(fails: 3187 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b66bb648331a47c34d31714c004