### PR TITLE
[Agent] make core reset synchronous

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -191,7 +191,7 @@ class GameEngine {
 
     try {
       await this.#sessionManager.prepareForNewGameSession(worldName);
-      await this._resetCoreGameState();
+      this._resetCoreGameState();
 
       const initResult = await this._executeInitializationSequence(worldName);
 

--- a/src/engine/gameSessionManager.js
+++ b/src/engine/gameSessionManager.js
@@ -78,7 +78,7 @@ class GameSessionManager {
       await this.#stopFn();
     }
 
-    await this.#resetCoreGameStateFn();
+    this.#resetCoreGameStateFn();
 
     if (uiEventId) {
       this.#logger.debug(


### PR DESCRIPTION
## Summary
- call `_resetCoreGameState` synchronously in `startNewGame`
- remove await from `GameSessionManager._prepareEngineForOperation`

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b525e0c833185de188b3755f900