### PR TITLE
[Agent] add immutable context helper and clarify cloning

### DIFF
--- a/src/utils/cloneUtils.js
+++ b/src/utils/cloneUtils.js
@@ -34,8 +34,10 @@ export function freeze(o) {
  *
  * @description
  * Suitable for cloning simple data structures that do not contain
- * functions or circular references. Non-serializable values will be
- * dropped during cloning.
+ * functions or circular references. When `structuredClone` is not available
+ * and JSON serialization is used, function values are omitted and
+ * properties that cannot be stringified are silently dropped. Circular
+ * references will cause an error to be thrown.
  * @template T
  * @param {T} value - The value to clone.
  * @returns {T} The cloned value or the original primitive.

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -43,7 +43,8 @@ function _validateContextAndName(variableName, executionContext) {
  * Safely assign a key-value pair on the provided context object.
  *
  * @description Safely assigns a value to a key on the provided context object.
- *   Any thrown error is caught and returned in the result structure.
+ *   Any thrown error is caught and returned in the result structure. **This
+ *   function mutates the provided `context` object.**
  * @param {object} context - Context object that will receive the new value.
  * @param {string} key - Property name to set on the context.
  * @param {*} value - Value to assign.
@@ -54,6 +55,34 @@ export function setContextValue(context, key, value) {
     context[key] = value;
   });
   return success ? { success: true } : { success: false, error };
+}
+
+/**
+ * Creates a new context object with the specified key/value pair assigned.
+ *
+ * @description Immutable alternative to {@link setContextValue}. The original
+ *   `context` object is not modified.
+ * @param {object} context - Original context object.
+ * @param {string} key - Property name to set on the context.
+ * @param {*} value - Value to assign.
+ * @returns {{success: boolean, context?: object, error?: Error}} Result object
+ *   containing the new context when successful.
+ */
+export function withUpdatedContext(context, key, value) {
+  if (!context || typeof context !== 'object') {
+    return {
+      success: false,
+      error: new Error('withUpdatedContext: invalid context object'),
+    };
+  }
+
+  const { success, result, error } = safeCall(() => ({
+    ...context,
+    [key]: value,
+  }));
+  return success
+    ? { success: true, context: result }
+    : { success: false, error };
 }
 
 /**

--- a/tests/unit/utils/cloneUtils.test.js
+++ b/tests/unit/utils/cloneUtils.test.js
@@ -48,4 +48,22 @@ describe('deepClone', () => {
 
     global.structuredClone = original;
   });
+
+  it('drops function properties when JSON fallback is used', () => {
+    const original = global.structuredClone;
+    global.structuredClone = undefined;
+
+    const obj = { a: 1, fn: () => 2 };
+    const clone = deepClone(obj);
+
+    expect(clone).toEqual({ a: 1 });
+
+    global.structuredClone = original;
+  });
+
+  it('throws on circular structures', () => {
+    const obj = {};
+    obj.self = obj;
+    expect(() => deepClone(obj)).toThrow();
+  });
 });

--- a/tests/unit/utils/contextVariableUtils.test.js
+++ b/tests/unit/utils/contextVariableUtils.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals';
 import {
   writeContextVariable,
   tryWriteContextVariable,
+  withUpdatedContext,
 } from '../../../src/utils/contextVariableUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
@@ -116,5 +117,22 @@ describe('tryWriteContextVariable', () => {
 
     expect(result.success).toBe(false);
     expect(ctx.evaluationContext.context).toEqual({ bar: 2 });
+  });
+});
+
+describe('withUpdatedContext', () => {
+  test('returns new object with value set', () => {
+    const original = { foo: 1 };
+    const { success, context } = withUpdatedContext(original, 'bar', 2);
+    expect(success).toBe(true);
+    expect(context).toEqual({ foo: 1, bar: 2 });
+    expect(original).toEqual({ foo: 1 });
+  });
+
+  test('handles errors gracefully', () => {
+    const obj = null;
+    const { success, error } = withUpdatedContext(obj, 'x', 1);
+    expect(success).toBe(false);
+    expect(error).toBeInstanceOf(Error);
   });
 });


### PR DESCRIPTION
## Summary
- clarify mutation in `setContextValue`
- add `withUpdatedContext` as immutable alternative
- document cloning caveats for `deepClone`
- test new context helper
- test additional deepClone behaviors

## Testing Done
- `npm run format` *(on changed files)*
- `npx eslint src/utils/contextVariableUtils.js src/utils/cloneUtils.js tests/unit/utils/contextVariableUtils.test.js tests/unit/utils/cloneUtils.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c5aa176008331a01eeb1c7cdf93d1