### PR TITLE
[Agent] Capture asset loading failures

### DIFF
--- a/tests/unit/loaders/uiAssetsLoader.test.js
+++ b/tests/unit/loaders/uiAssetsLoader.test.js
@@ -108,6 +108,7 @@ describe('UiAssetsLoader', () => {
     expect(registry.store).toHaveBeenCalledWith('ui-labels', 'save', 'Save');
     expect(result.count).toBe(2);
     expect(result.errors).toBe(0);
+    expect(result.failures).toEqual([]);
   });
 
   it('categorizes UI files correctly', () => {
@@ -128,5 +129,6 @@ describe('UiAssetsLoader', () => {
     );
     expect(result.count).toBe(0);
     expect(result.errors).toBe(0);
+    expect(result.failures).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- track fetch vs validation failures in `UiAssetsLoader`
- update helper functions to return detailed failures
- adjust ui asset loader tests for new structure

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d5c040a3083318283dc552c326052