### PR TITLE
[Refactor] Replace special getters with methods

### DIFF
--- a/src/domUI/perceptionLogRenderer.js
+++ b/src/domUI/perceptionLogRenderer.js
@@ -128,7 +128,7 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
    *
    * @returns {string | null} The ID of the actor whose perceptions are displayed.
    */
-  get '#currentActorId'() {
+  getCurrentActorId() {
     return this.#currentActorId;
   }
 
@@ -137,7 +137,7 @@ export class PerceptionLogRenderer extends BaseListDisplayComponent {
    *
    * @param {string | null} value - The actor ID to display logs for.
    */
-  set '#currentActorId'(value) {
+  setCurrentActorId(value) {
     this.#currentActorId = value;
   }
 

--- a/tests/unit/domUI/perceptionLogRenderer.test.js
+++ b/tests/unit/domUI/perceptionLogRenderer.test.js
@@ -35,7 +35,7 @@ describe('PerceptionLogRenderer', () => {
   let turnStartedHandler;
 
   const setInternalCurrentActorId = (rendererInstance, actorId) => {
-    rendererInstance['#currentActorId'] = actorId;
+    rendererInstance.setCurrentActorId(actorId);
   };
 
   beforeEach(() => {
@@ -386,7 +386,7 @@ describe('PerceptionLogRenderer', () => {
         type: TURN_STARTED_ID,
         payload: { entityId: actorId, entityType: 'player' },
       });
-      expect(renderer['#currentActorId']).toBe(actorId);
+      expect(renderer.getCurrentActorId()).toBe(actorId);
       expect(renderer.refreshList).toHaveBeenCalled();
     });
 
@@ -395,7 +395,7 @@ describe('PerceptionLogRenderer', () => {
         type: TURN_STARTED_ID,
         payload: { entityType: 'player' },
       });
-      expect(renderer['#currentActorId']).toBeNull();
+      expect(renderer.getCurrentActorId()).toBeNull();
       expect(renderer.refreshList).toHaveBeenCalled();
     });
 
@@ -463,7 +463,7 @@ describe('PerceptionLogRenderer', () => {
       renderer.dispose();
 
       expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
-      expect(renderer['#currentActorId']).toBeNull();
+      expect(renderer.getCurrentActorId()).toBeNull();
       expect(renderer.elements).toEqual({});
     });
 


### PR DESCRIPTION
Summary: Renamed the unusual '#currentActorId' getter/setter in PerceptionLogRenderer to standard methods and updated related tests.

Changes Made:
- Replaced `get '#currentActorId'()` with `getCurrentActorId()` and matching setter.
- Updated unit tests to use the new methods.

Testing Done:
- [x] Code formatted (`npx prettier --write src/domUI/perceptionLogRenderer.js tests/unit/domUI/perceptionLogRenderer.test.js`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_685d5bd74e9c8331935c2056cb972e9a