### PR TITLE
[Agent] Simplify API key check logic

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -298,36 +298,15 @@ export class LlmConfigService {
    * @returns {boolean} True if any cloud LLM is configured to use an API key file, false otherwise.
    */
   hasFileBasedApiKeys() {
-    if (!this.#isProxyOperational || !this.#loadedLlmConfigs?.configs) {
+    if (!this.#isProxyOperational || !this.#loadedLlmConfigs) {
       return false;
     }
-
-    for (const llmId in this.#loadedLlmConfigs.configs) {
-      // Using 'configs'
-      // Ensure it's a direct property and not from the prototype chain
-      if (
-        Object.prototype.hasOwnProperty.call(
-          this.#loadedLlmConfigs.configs,
-          llmId
-        )
-      ) {
-        // Using 'configs'
-        const config = this.#loadedLlmConfigs.configs[llmId]; // Using 'configs'
-        const isCloudService =
-          config.apiType &&
-          !LOCAL_API_TYPES_REQUIRING_NO_PROXY_KEY.includes(
-            config.apiType.toLowerCase()
-          );
-        if (
-          isCloudService &&
-          config.apiKeyFileName &&
-          config.apiKeyFileName.trim() !== ''
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return Object.values(this.#loadedLlmConfigs.configs).some((cfg) => {
+      const type = cfg.apiType?.toLowerCase();
+      const cloud =
+        type && !LOCAL_API_TYPES_REQUIRING_NO_PROXY_KEY.includes(type);
+      return cloud && cfg.apiKeyFileName?.trim();
+    });
   }
 }
 

--- a/llm-proxy-server/tests/llmConfigService.test.js
+++ b/llm-proxy-server/tests/llmConfigService.test.js
@@ -84,6 +84,26 @@ describe('LlmConfigService', () => {
     expect(service.hasFileBasedApiKeys()).toBe(true);
   });
 
+  test('hasFileBasedApiKeys returns false when not initialized', () => {
+    expect(service.hasFileBasedApiKeys()).toBe(false);
+  });
+
+  test('hasFileBasedApiKeys ignores local configs with key files', async () => {
+    const localOnly = {
+      defaultConfigId: 'local',
+      configs: {
+        local: {
+          configId: 'local',
+          apiType: 'ollama',
+          apiKeyFileName: 'local.txt',
+        },
+      },
+    };
+    mockLoader.mockResolvedValue({ error: false, llmConfigs: localOnly });
+    await service.initialize();
+    expect(service.hasFileBasedApiKeys()).toBe(false);
+  });
+
   test('initialize handles loader error result', async () => {
     mockLoader.mockResolvedValue({
       error: true,


### PR DESCRIPTION
Summary: simplify the hasFileBasedApiKeys logic and expand tests

Changes Made:
- simplified api key configuration check in llm-proxy-server
- added tests for uninitialized and local config cases

Testing Done:
- [x] Code formatted (`npx prettier -w llm-proxy-server/src/config/llmConfigService.js llm-proxy-server/tests/llmConfigService.test.js`)
- [ ] Lint passes (`npm run lint` fails with existing repo issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (skipped)


------
https://chatgpt.com/codex/tasks/task_e_685d5b93b1608331bb7218ce4dbb6f56