### PR TITLE
[Feat] Add helpers for service lookup

### DIFF
--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -478,9 +478,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     expect(spyDispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({
-        message: expect.stringContaining(
-          'Failed to retrieve ICommandProcessor'
-        ),
+        message: expect.stringContaining('Invalid turnCtx'),
         details: expect.any(Object),
       })
     );


### PR DESCRIPTION
Summary: Refactored service retrieval logic by introducing `validateContextForService` and `reportServiceLookupFailure` helpers. Updated `getServiceFromContext` to use them and adjusted tests.

Changes Made:
- Added validation and error reporting helpers in `getServiceFromContext.js`.
- Simplified `getServiceFromContext` implementation.
- Updated coverage tests for the new behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` has known project-wide issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685d5ae2d28083318f45cbaa626875b7