### PR TITLE
[Test] Add DI registration suites

### DIFF
--- a/tests/registrations/registerAI.test.js
+++ b/tests/registrations/registerAI.test.js
@@ -1,0 +1,65 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import { registerAI } from '../../src/dependencyInjection/registrations/aiRegistrations.js';
+import { tokens } from '../../src/dependencyInjection/tokens.js';
+import { ConfigurableLLMAdapter } from '../../src/turns/adapters/configurableLLMAdapter.js';
+import ActorTurnHandler from '../../src/turns/handlers/actorTurnHandler.js';
+
+describe('registerAI', () => {
+  /** @type {AppContainer} */
+  let container;
+
+  beforeEach(() => {
+    container = new AppContainer();
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    container.register(tokens.ILogger, logger);
+    container.register(tokens.ProxyUrl, 'http://proxy.test');
+    container.register(tokens.ISafeEventDispatcher, { dispatch: jest.fn() });
+    container.register(tokens.IValidatedEventDispatcher, {
+      dispatch: jest.fn(),
+    });
+    container.register(tokens.ISchemaValidator, {
+      validate: jest.fn(),
+      isSchemaLoaded: jest.fn(),
+      loadSchema: jest.fn(),
+    });
+    container.register(tokens.IActionDiscoveryService, {
+      getValidActions: jest.fn(),
+    });
+    container.register(tokens.IEntityManager, { getEntityInstance: jest.fn() });
+    container.register(tokens.ActionIndexingService, {
+      indexActions: jest.fn(),
+      resolve: jest.fn(),
+      beginTurn: jest.fn(),
+    });
+    container.register(tokens.JsonLogicEvaluationService, {
+      evaluate: jest.fn(),
+    });
+    container.register(tokens.ITurnStateFactory, {
+      createInitialState: jest.fn().mockReturnValue({ enterState: jest.fn() }),
+    });
+    container.register(tokens.ITurnEndPort, {});
+    container.register(tokens.ICommandProcessor, {});
+    container.register(tokens.TurnStrategyFactory, {});
+    container.register(tokens.TurnContextBuilder, {});
+  });
+
+  it('registers and resolves core AI services', () => {
+    registerAI(container);
+
+    const adapter1 = container.resolve(tokens.LLMAdapter);
+    const adapter2 = container.resolve(tokens.LLMAdapter);
+    expect(adapter1).toBeInstanceOf(ConfigurableLLMAdapter);
+    expect(adapter1).toBe(adapter2); // singleton
+
+    // ActorTurnHandler is registered as a transient factory
+    // but resolving it requires a fully wired turn lifecycle.
+    // Here we simply verify that the registration exists.
+    expect(container.isRegistered(tokens.ActorTurnHandler)).toBe(true);
+  });
+});

--- a/tests/registrations/registerInterpreters.test.js
+++ b/tests/registrations/registerInterpreters.test.js
@@ -1,0 +1,61 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import { registerInterpreters } from '../../src/dependencyInjection/registrations/interpreterRegistrations.js';
+import { tokens } from '../../src/dependencyInjection/tokens.js';
+import OperationRegistry from '../../src/logic/operationRegistry.js';
+import OperationInterpreter from '../../src/logic/operationInterpreter.js';
+import SystemLogicInterpreter from '../../src/logic/systemLogicInterpreter.js';
+
+describe('registerInterpreters', () => {
+  /** @type {AppContainer} */
+  let container;
+
+  beforeEach(() => {
+    container = new AppContainer();
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    container.register(tokens.ILogger, logger);
+    container.register(tokens.EventBus, {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    });
+    container.register(tokens.IDataRegistry, {
+      getAllSystemRules: jest.fn().mockReturnValue([]),
+    });
+    container.register(tokens.JsonLogicEvaluationService, {
+      evaluate: jest.fn(),
+    });
+    container.register(tokens.IEntityManager, {
+      getEntityInstance: jest.fn(),
+      getComponentData: jest.fn(),
+      hasComponent: jest.fn(),
+    });
+    container.register(tokens.IValidatedEventDispatcher, {
+      dispatch: jest.fn(),
+    });
+    container.register(tokens.ISafeEventDispatcher, { dispatch: jest.fn() });
+  });
+
+  it('registers and resolves interpreter services', () => {
+    registerInterpreters(container);
+
+    const reg1 = container.resolve(tokens.OperationRegistry);
+    const reg2 = container.resolve(tokens.OperationRegistry);
+    expect(reg1).toBeInstanceOf(OperationRegistry);
+    expect(reg1).toBe(reg2); // singleton
+
+    const interp1 = container.resolve(tokens.OperationInterpreter);
+    const interp2 = container.resolve(tokens.OperationInterpreter);
+    expect(interp1).toBeInstanceOf(OperationInterpreter);
+    expect(interp1).toBe(interp2); // singleton
+
+    const sys1 = container.resolve(tokens.SystemLogicInterpreter);
+    const sys2 = container.resolve(tokens.SystemLogicInterpreter);
+    expect(sys1).toBeInstanceOf(SystemLogicInterpreter);
+    expect(sys1).toBe(sys2); // singleton
+  });
+});

--- a/tests/registrations/registerTurnLifecycle.test.js
+++ b/tests/registrations/registerTurnLifecycle.test.js
@@ -1,0 +1,79 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import { registerTurnLifecycle } from '../../src/dependencyInjection/registrations/turnLifecycleRegistrations.js';
+import { tokens } from '../../src/dependencyInjection/tokens.js';
+import TurnManager from '../../src/turns/turnManager.js';
+import { TurnOrderService } from '../../src/turns/order/turnOrderService.js';
+import TurnHandlerResolver from '../../src/turns/services/turnHandlerResolver.js';
+import { ConcreteTurnStateFactory } from '../../src/turns/factories/concreteTurnStateFactory.js';
+
+import ActorTurnHandler from '../../src/turns/handlers/actorTurnHandler.js';
+
+describe('registerTurnLifecycle', () => {
+  /** @type {AppContainer} */
+  let container;
+
+  beforeEach(() => {
+    container = new AppContainer();
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    container.register(tokens.ILogger, logger);
+    container.register(tokens.IActionDiscoveryService, {
+      getValidActions: jest.fn(),
+    });
+    container.register(tokens.IPromptOutputPort, { prompt: jest.fn() });
+    container.register(tokens.IWorldContext, {});
+    container.register(tokens.IEntityManager, {
+      getEntityInstance: jest.fn(),
+      getComponentData: jest.fn(),
+      hasComponent: jest.fn(),
+    });
+    container.register(tokens.IGameDataRepository, {});
+    container.register(tokens.IValidatedEventDispatcher, {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+    });
+    container.register(tokens.ISafeEventDispatcher, {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+    });
+    container.register(tokens.ICommandProcessor, {});
+    container.register(tokens.ITurnEndPort, {});
+    container.register(tokens.ICommandOutcomeInterpreter, {});
+    container.register(
+      tokens.ActorTurnHandler,
+      () => new ActorTurnHandler({ logger })
+    );
+    container.register(tokens.IActionIndexer, {
+      index: jest.fn(),
+      indexActions: jest.fn(),
+      resolve: jest.fn(),
+      beginTurn: jest.fn(),
+    });
+    container.register(tokens.ITurnActionFactory, {});
+    container.register(tokens.IAvailableActionsProvider, { get: jest.fn() });
+  });
+
+  it('registers and resolves turn lifecycle services', () => {
+    registerTurnLifecycle(container);
+
+    const manager1 = container.resolve(tokens.ITurnManager);
+    const manager2 = container.resolve(tokens.ITurnManager);
+    expect(manager1).toBeInstanceOf(TurnManager);
+    expect(manager1).toBe(manager2); // singleton
+
+    const resolver = container.resolve(tokens.TurnHandlerResolver);
+    expect(resolver).toBeInstanceOf(TurnHandlerResolver);
+
+    const stateFactory = container.resolve(tokens.ITurnStateFactory);
+    expect(stateFactory).toBeInstanceOf(ConcreteTurnStateFactory);
+
+    const provider1 = container.resolve(tokens.IHumanDecisionProvider);
+    const provider2 = container.resolve(tokens.IHumanDecisionProvider);
+    expect(provider1).not.toBe(provider2); // transient
+  });
+});

--- a/tests/registrations/registerUI.test.js
+++ b/tests/registrations/registerUI.test.js
@@ -1,0 +1,53 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import { registerUI } from '../../src/dependencyInjection/registrations/uiRegistrations.js';
+import { tokens } from '../../src/dependencyInjection/tokens.js';
+import InputHandler from '../../src/input/inputHandler.js';
+import { ChatAlertRenderer } from '../../src/domUI/chatAlertRenderer.js';
+
+describe('registerUI', () => {
+  /** @type {AppContainer} */
+  let container;
+  let elements;
+
+  beforeEach(() => {
+    container = new AppContainer();
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    container.register(tokens.ILogger, logger);
+    container.register(tokens.ISafeEventDispatcher, {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+    });
+    container.register(tokens.IValidatedEventDispatcher, {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+    });
+
+    const doc = document;
+    elements = {
+      outputDiv: doc.createElement('div'),
+      inputElement: doc.createElement('input'),
+      titleElement: doc.createElement('h1'),
+      document: doc,
+    };
+  });
+
+  it('registers and resolves UI services', () => {
+    registerUI(container, elements);
+
+    const input1 = container.resolve(tokens.IInputHandler);
+    const input2 = container.resolve(tokens.IInputHandler);
+    expect(input1).toBeInstanceOf(InputHandler);
+    expect(input1).toBe(input2); // singleton
+
+    const chat1 = container.resolve(tokens.ChatAlertRenderer);
+    const chat2 = container.resolve(tokens.ChatAlertRenderer);
+    expect(chat1).toBeInstanceOf(ChatAlertRenderer);
+    expect(chat1).toBe(chat2); // singleton
+  });
+});


### PR DESCRIPTION
Summary: Added new Jest suites verifying key dependency injection registrations for AI, interpreters, turn lifecycle, and UI components.

Changes Made:
- Created `tests/registrations/` directory with four new test files.
- Each suite instantiates a fresh `AppContainer`, invokes the registration helper, and asserts core tokens resolve correctly with proper lifecycles.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685d5c3fcda08331ab99cc118bf2bc1b