### PR TITLE
[Agent] add requireNonBlankString utility

### DIFF
--- a/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
+++ b/src/logic/operationHandlers/addPerceptionLogEntryHandler.js
@@ -4,7 +4,10 @@
  */
 
 import { PERCEPTION_LOG_COMPONENT_ID } from '../../constants/componentIds.js';
-import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import {
+  assertParamsObject,
+  requireNonBlankString,
+} from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 
@@ -55,13 +58,13 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
       return null;
     }
     const { location_id, entry } = params;
-    if (typeof location_id !== 'string' || !location_id.trim()) {
-      safeDispatchError(
-        this.#dispatcher,
-        'ADD_PERCEPTION_LOG_ENTRY: location_id is required',
-        { location_id },
-        logger
-      );
+    const locationId = requireNonBlankString(
+      location_id,
+      'location_id',
+      logger,
+      this.#dispatcher
+    );
+    if (!locationId) {
       return null;
     }
     if (!entry || typeof entry !== 'object') {
@@ -73,7 +76,7 @@ class AddPerceptionLogEntryHandler extends BaseOperationHandler {
       );
       return null;
     }
-    return { locationId: location_id.trim(), entry };
+    return { locationId, entry };
   }
 
   /**

--- a/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
+++ b/src/logic/operationHandlers/dispatchPerceptibleEventHandler.js
@@ -9,7 +9,10 @@
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
-import { assertParamsObject } from '../../utils/handlerUtils/paramsUtils.js';
+import {
+  assertParamsObject,
+  requireNonBlankString,
+} from '../../utils/handlerUtils/paramsUtils.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 
 const EVENT_ID = 'core:perceptible_event';
@@ -95,50 +98,42 @@ class DispatchPerceptibleEventHandler {
       log_entry = false,
     } = params;
 
-    if (typeof location_id !== 'string' || !location_id.trim()) {
-      safeDispatchError(
-        this.#dispatcher,
-        'DISPATCH_PERCEPTIBLE_EVENT: location_id required',
-        { location_id },
-        this.#logger
-      );
-      return;
-    }
-    if (typeof description_text !== 'string' || !description_text.trim()) {
-      safeDispatchError(
-        this.#dispatcher,
-        'DISPATCH_PERCEPTIBLE_EVENT: description_text required',
-        { description_text },
-        this.#logger
-      );
-      return;
-    }
-    if (typeof perception_type !== 'string' || !perception_type.trim()) {
-      safeDispatchError(
-        this.#dispatcher,
-        'DISPATCH_PERCEPTIBLE_EVENT: perception_type required',
-        { perception_type },
-        this.#logger
-      );
-      return;
-    }
-    if (typeof actor_id !== 'string' || !actor_id.trim()) {
-      safeDispatchError(
-        this.#dispatcher,
-        'DISPATCH_PERCEPTIBLE_EVENT: actor_id required',
-        { actor_id },
-        this.#logger
-      );
-      return;
-    }
+    const locationId = requireNonBlankString(
+      location_id,
+      'location_id',
+      this.#logger,
+      this.#dispatcher
+    );
+    if (!locationId) return;
+    const descriptionText = requireNonBlankString(
+      description_text,
+      'description_text',
+      this.#logger,
+      this.#dispatcher
+    );
+    if (!descriptionText) return;
+    const perceptionType = requireNonBlankString(
+      perception_type,
+      'perception_type',
+      this.#logger,
+      this.#dispatcher
+    );
+    if (!perceptionType) return;
+    const actorId = requireNonBlankString(
+      actor_id,
+      'actor_id',
+      this.#logger,
+      this.#dispatcher
+    );
+    if (!actorId) return;
 
     const payload = {
       eventName: EVENT_ID,
-      locationId: location_id,
-      descriptionText: description_text,
+      locationId,
+      descriptionText,
       timestamp: new Date().toISOString(),
-      perceptionType: perception_type,
-      actorId: actor_id,
+      perceptionType,
+      actorId,
       targetId: target_id ?? null,
       involvedEntities: Array.isArray(involved_entities)
         ? involved_entities
@@ -156,18 +151,18 @@ class DispatchPerceptibleEventHandler {
 
     if (log_entry) {
       this.#logHandler.execute({
-        location_id,
+        location_id: locationId,
         entry: {
-          descriptionText: description_text,
+          descriptionText,
           timestamp: payload.timestamp,
-          perceptionType: perception_type,
-          actorId: actor_id,
+          perceptionType,
+          actorId,
           targetId: target_id ?? null,
           involvedEntities: Array.isArray(involved_entities)
             ? involved_entities
             : [],
         },
-        originating_actor_id: actor_id,
+        originating_actor_id: actorId,
       });
     }
   }

--- a/src/utils/handlerUtils/paramsUtils.js
+++ b/src/utils/handlerUtils/paramsUtils.js
@@ -53,4 +53,28 @@ export function validateStringParam(value, name, logger, dispatcher) {
   return null;
 }
 
+/**
+ * @description Require a non-blank string parameter.
+ * Logs a warning or dispatches an error when invalid.
+ * @param {*} value - The value to validate.
+ * @param {string} name - Parameter name for diagnostics.
+ * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for reporting.
+ * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher=} dispatcher - Optional dispatcher for error events.
+ * @returns {string|null} Trimmed string or `null` when invalid.
+ */
+export function requireNonBlankString(value, name, logger, dispatcher) {
+  if (isNonBlankString(value)) {
+    return value.trim();
+  }
+  const message = `Invalid or missing "${name}" parameter`;
+  if (dispatcher && typeof dispatcher.dispatch === 'function') {
+    safeDispatchError(dispatcher, message, { [name]: value }, logger);
+  } else if (logger && typeof logger.warn === 'function') {
+    logger.warn(message, { [name]: value });
+  } else {
+    console.warn(message, { [name]: value });
+  }
+  return null;
+}
+
 // deprecated default export removed in favor of named exports only

--- a/tests/unit/utils/paramsUtils.requireNonBlankString.test.js
+++ b/tests/unit/utils/paramsUtils.requireNonBlankString.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+import { requireNonBlankString } from '../../../src/utils/handlerUtils/paramsUtils.js';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+describe('requireNonBlankString', () => {
+  it('returns trimmed string when valid', () => {
+    const logger = { warn: jest.fn() };
+    const result = requireNonBlankString('  hi  ', 'name', logger);
+    expect(result).toBe('hi');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(safeDispatchError).not.toHaveBeenCalled();
+  });
+
+  it('dispatches error when dispatcher provided', () => {
+    const logger = { warn: jest.fn() };
+    const dispatcher = { dispatch: jest.fn() };
+    const result = requireNonBlankString('  ', 'foo', logger, dispatcher);
+    expect(result).toBeNull();
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'Invalid or missing "foo" parameter',
+      { foo: '  ' },
+      logger
+    );
+  });
+
+  it('logs warning when dispatcher missing', () => {
+    const logger = { warn: jest.fn() };
+    const result = requireNonBlankString('', 'bar', logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Invalid or missing "bar" parameter',
+      { bar: '' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add requireNonBlankString helper for handlers
- use helper in AddPerceptionLogEntryHandler
- use helper in DispatchPerceptibleEventHandler
- test requireNonBlankString

## Testing
- `npx eslint src/utils/handlerUtils/paramsUtils.js src/logic/operationHandlers/addPerceptionLogEntryHandler.js src/logic/operationHandlers/dispatchPerceptibleEventHandler.js tests/unit/utils/paramsUtils.requireNonBlankString.test.js`
- `npx jest tests/unit/utils/paramsUtils.requireNonBlankString.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685d5bb9a12483318b225c664e299dfb