### PR TITLE
[Agent] allow custom repository injection for tests

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -684,6 +684,9 @@ class EntityManager extends IEntityManager {
 
     try {
       this.#entityRepository.remove(entityToRemove.id);
+      if (this.#repository && typeof this.#repository.remove === 'function') {
+        this.#repository.remove(entityToRemove.id);
+      }
       this.#logger.info(
         `Entity instance ${entityToRemove.id} removed from EntityManager.`
       );

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -43,10 +43,15 @@ export class TestBed extends FactoryTestBed {
   /**
    * Creates a new TestBed instance.
    *
-   * @param {object} [entityManagerOptions] - Optional options to pass to the EntityManager constructor.
-   * @param {Function} [entityManagerOptions.idGenerator] - A mock ID generator function.
+   * @param {object} [overrides] - Optional overrides.
+   * @param {object} [overrides.entityManagerOptions] - Options forwarded to the EntityManager constructor.
+   * @param {Function} [overrides.idGenerator] - Legacy shortcut for entityManagerOptions.idGenerator.
+   * @param {import('../../../src/ports/IEntityRepository.js').IEntityRepository} [overrides.entityManagerOptions.repository]
+   *   - Repository implementation used by the EntityManager.
    */
-  constructor(entityManagerOptions = {}) {
+  constructor(overrides = {}) {
+    const { entityManagerOptions = {}, ...legacyOptions } = overrides;
+    const emOptions = { ...legacyOptions, ...entityManagerOptions };
     super({
       registry: createSimpleMockDataRegistry,
       validator: createMockSchemaValidator,
@@ -59,7 +64,7 @@ export class TestBed extends FactoryTestBed {
       validator: this.mocks.validator,
       logger: this.mocks.logger,
       dispatcher: this.mocks.eventDispatcher,
-      ...entityManagerOptions,
+      ...emOptions,
     });
   }
 


### PR DESCRIPTION
## Summary
- support `entityManagerOptions.repository` in `TestBed`
- use custom repository stub in lifecycle test
- ensure `EntityManager` forwards repository removal calls

## Testing Done
- `npm run lint` *(fails: 3176 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d5b85a38c8331ae783593b284e4b6