### PR TITLE
[Agent] Add action-related mock factories

### DIFF
--- a/tests/common/mockFactories/actions.js
+++ b/tests/common/mockFactories/actions.js
@@ -1,0 +1,42 @@
+/**
+ * @file Factory helpers for action-related mocks used in tests.
+ * @see tests/common/mockFactories/actions.js
+ */
+
+import { jest } from '@jest/globals';
+import { createSimpleMock } from './coreServices.js';
+
+/**
+ * Creates a mock prerequisite evaluation service with an `evaluate` method.
+ *
+ * @description Convenience factory for tests needing a simple prerequisite evaluation service.
+ * @returns {{ evaluate: jest.Mock }} Mock service instance
+ */
+export const createMockPrerequisiteEvaluationService = () =>
+  createSimpleMock(['evaluate']);
+
+/**
+ * Creates a mock action index with a `getCandidateActions` method.
+ *
+ * @description Returns a simple mock for retrieving candidate actions.
+ * @returns {{ getCandidateActions: jest.Mock }} Mock action index
+ */
+export const createMockActionIndex = () =>
+  createSimpleMock(['getCandidateActions']);
+
+/**
+ * Creates a mock target resolution service with a `resolveTargets` method.
+ *
+ * @description Simplified mock to resolve action targets in tests.
+ * @returns {{ resolveTargets: jest.Mock }} Mock target resolution service
+ */
+export const createMockTargetResolutionService = () =>
+  createSimpleMock(['resolveTargets']);
+
+/**
+ * Creates a mock formatActionCommand function.
+ *
+ * @description Returns a jest.fn used to format action commands in tests.
+ * @returns {jest.Mock} Mock formatting function
+ */
+export const createMockFormatActionCommandFn = () => jest.fn();

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -8,6 +8,7 @@ export * from './loaders.js';
 export * from './entities.js';
 export * from './container.js';
 export * from './memoryStorageProvider.js';
+export * from './actions.js';
 
 // Explicit convenience exports
 export {


### PR DESCRIPTION
## Summary
- add action mock factories for simpler tests
- re-export new factories in test mockFactories index

## Testing Done
- ✅ `npm run test`
- ✅ `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d647aa9108331a7109dec6311bb55