### PR TITLE
[Agent] Extract initialization helpers

### DIFF
--- a/tests/unit/initializers/services/initializationHelpers.test.js
+++ b/tests/unit/initializers/services/initializationHelpers.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  validateWorldName,
+  buildActionIndex,
+} from '../../../../src/initializers/services/initializationService.js';
+
+describe('InitializationService helper functions', () => {
+  describe('validateWorldName', () => {
+    let logger;
+    beforeEach(() => {
+      logger = { error: jest.fn() };
+    });
+
+    it('does nothing for a valid name', () => {
+      expect(() => validateWorldName('world', logger)).not.toThrow();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it.each([[null], [undefined], [''], ['   ']])('throws for %p', (bad) => {
+      expect(() => validateWorldName(bad, logger)).toThrow(TypeError);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('buildActionIndex', () => {
+    let logger;
+    let repo;
+    let index;
+    beforeEach(() => {
+      logger = { debug: jest.fn() };
+      repo = { getAllActionDefinitions: jest.fn().mockReturnValue(['a']) };
+      index = { buildIndex: jest.fn() };
+    });
+
+    it('builds the index using repository data', () => {
+      buildActionIndex(index, repo, logger);
+      expect(repo.getAllActionDefinitions).toHaveBeenCalled();
+      expect(index.buildIndex).toHaveBeenCalledWith(['a']);
+      expect(logger.debug).toHaveBeenCalled();
+    });
+
+    it('throws when dependencies are invalid', () => {
+      expect(() => buildActionIndex({}, repo, logger)).toThrow(Error);
+      expect(() => buildActionIndex(index, {}, logger)).toThrow(Error);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Adds dedicated helper functions to validate the world name and build the ActionIndex. The initialization sequence now calls these helpers and only aggregates the final result. Unit tests cover the new helpers.

Changes Made:
- Introduced `validateWorldName` and `buildActionIndex` with full JSDoc.
- Refactored `runInitializationSequence` to use these helpers and simplified error handling.
- Added `initializationHelpers.test.js` for unit tests of both helpers.

Testing Done:
- [x] Code formatted (`npx prettier -w src/initializers/services/initializationService.js tests/unit/initializers/services/initializationHelpers.test.js`)
- [x] Lint passes (`npx eslint src/initializers/services/initializationService.js tests/unit/initializers/services/initializationHelpers.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685d65b98b288331aa739ad32b8c1d2d