### PR TITLE
[Agent] centralize loader metadata

### DIFF
--- a/docs/mods/loader.md
+++ b/docs/mods/loader.md
@@ -79,3 +79,9 @@ Reference them in the manifest using a `ui` content category:
 
 During loading, the UiLoader merges icon and label definitions from all mods. If multiple mods define the same key, the entry from the mod loaded last overrides earlier ones, following the same "last mod wins" rule used for other content.
 Files in the `ui/` folder that do not end with `icons.json` or `labels.json` are ignored and a warning is logged, allowing mods to ship extra files without breaking loading.
+
+## Adding New Loader Types
+
+All metadata describing how loaders map manifest keys to disk folders lives in
+`src/loaders/loaderMeta.js`. Update this `meta` map when introducing a new
+loader so that `createContentLoadersConfig` automatically incorporates it.

--- a/src/loaders/defaultLoaderConfig.js
+++ b/src/loaders/defaultLoaderConfig.js
@@ -17,78 +17,20 @@
  * @property {'definitions' | 'instances'} phase - Loading phase for the content type.
  */
 
+import { meta } from './loaderMeta.js';
+
+// All metadata describing loader configuration lives in loaderMeta.js so that
+// new loader types only need to update a single file.
 /**
  * Converts a map of loader instances into the structured configuration array
- * used by {@link ModsLoader} and {@link ContentLoadManager}.
+ * used by {@link ModsLoader} and {@link ContentLoadManager}. Loader metadata
+ * such as manifest keys and disk folders is sourced from {@link meta}.
  *
  * @param {Record<string, BaseManifestItemLoaderInterface>} loaderMap - Map of
  * registry key to loader instance.
  * @returns {LoaderConfigEntry[]} Array describing loader configuration.
  */
 export function createContentLoadersConfig(loaderMap) {
-  const meta = {
-    components: {
-      contentKey: 'components',
-      diskFolder: 'components',
-      phase: 'definitions',
-      registryKey: 'components',
-    },
-    events: {
-      contentKey: 'events',
-      diskFolder: 'events',
-      phase: 'definitions',
-      registryKey: 'events',
-    },
-    conditions: {
-      contentKey: 'conditions',
-      diskFolder: 'conditions',
-      phase: 'definitions',
-      registryKey: 'conditions',
-    },
-    macros: {
-      contentKey: 'macros',
-      diskFolder: 'macros',
-      phase: 'definitions',
-      registryKey: 'macros',
-    },
-    actions: {
-      contentKey: 'actions',
-      diskFolder: 'actions',
-      phase: 'definitions',
-      registryKey: 'actions',
-    },
-    rules: {
-      contentKey: 'rules',
-      diskFolder: 'rules',
-      phase: 'definitions',
-      registryKey: 'rules',
-    },
-    goals: {
-      contentKey: 'goals',
-      diskFolder: 'goals',
-      phase: 'definitions',
-      registryKey: 'goals',
-    },
-    scopes: {
-      contentKey: 'scopes',
-      diskFolder: 'scopes',
-      phase: 'definitions',
-      registryKey: 'scopes',
-    },
-    entityDefinitions: {
-      contentKey: 'entities.definitions',
-      diskFolder: 'entities/definitions',
-      phase: 'definitions',
-      registryKey: 'entityDefinitions',
-    },
-    entityInstances: {
-      contentKey: 'entities.instances',
-      diskFolder: 'entities/instances',
-      phase: 'instances',
-      registryKey: 'entityInstances',
-    },
-  };
-
   return Object.entries(loaderMap).map(([registryKey, loader]) => ({
     loader,
     registryKey: meta[registryKey].registryKey,

--- a/src/loaders/loaderMeta.js
+++ b/src/loaders/loaderMeta.js
@@ -1,0 +1,77 @@
+// src/loaders/loaderMeta.js
+
+/**
+ * @file Contains metadata describing each supported content loader type.
+ * New loaders should be added here so configuration logic stays centralized.
+ */
+
+/**
+ * Mapping of registry keys to loader metadata used by
+ * {@link createContentLoadersConfig}.
+ *
+ * @type {Record<string, {contentKey:string, diskFolder:string, phase:'definitions'|'instances', registryKey:string}>}
+ */
+export const meta = {
+  components: {
+    contentKey: 'components',
+    diskFolder: 'components',
+    phase: 'definitions',
+    registryKey: 'components',
+  },
+  events: {
+    contentKey: 'events',
+    diskFolder: 'events',
+    phase: 'definitions',
+    registryKey: 'events',
+  },
+  conditions: {
+    contentKey: 'conditions',
+    diskFolder: 'conditions',
+    phase: 'definitions',
+    registryKey: 'conditions',
+  },
+  macros: {
+    contentKey: 'macros',
+    diskFolder: 'macros',
+    phase: 'definitions',
+    registryKey: 'macros',
+  },
+  actions: {
+    contentKey: 'actions',
+    diskFolder: 'actions',
+    phase: 'definitions',
+    registryKey: 'actions',
+  },
+  rules: {
+    contentKey: 'rules',
+    diskFolder: 'rules',
+    phase: 'definitions',
+    registryKey: 'rules',
+  },
+  goals: {
+    contentKey: 'goals',
+    diskFolder: 'goals',
+    phase: 'definitions',
+    registryKey: 'goals',
+  },
+  scopes: {
+    contentKey: 'scopes',
+    diskFolder: 'scopes',
+    phase: 'definitions',
+    registryKey: 'scopes',
+  },
+  entityDefinitions: {
+    contentKey: 'entities.definitions',
+    diskFolder: 'entities/definitions',
+    phase: 'definitions',
+    registryKey: 'entityDefinitions',
+  },
+  entityInstances: {
+    contentKey: 'entities.instances',
+    diskFolder: 'entities/instances',
+    phase: 'instances',
+    registryKey: 'entityInstances',
+  },
+};
+
+export default meta;

--- a/tests/unit/loaders/defaultLoaderConfig.test.js
+++ b/tests/unit/loaders/defaultLoaderConfig.test.js
@@ -40,6 +40,21 @@ describe('defaultLoaderConfig', () => {
     expect(config).toHaveLength(Object.keys(loaderMap).length);
   });
 
+  it('createContentLoadersConfig handles minimal loader map', () => {
+    const stubLoader = {};
+    const loaderMap = { components: stubLoader };
+    const config = createContentLoadersConfig(loaderMap);
+    expect(config).toEqual([
+      {
+        loader: stubLoader,
+        registryKey: 'components',
+        contentKey: 'components',
+        diskFolder: 'components',
+        phase: 'definitions',
+      },
+    ]);
+  });
+
   it('createDefaultContentLoadersConfig returns correct array and calls createContentLoadersConfig', () => {
     const stubLoader = {};
     const deps = {


### PR DESCRIPTION
Summary: Centralized loader metadata in `src/loaders/loaderMeta.js` and updated `createContentLoadersConfig` to import it. Documented how to extend loader configuration in docs, and added a unit test for minimal loader maps.

Testing Done:
- [x] Code formatted `npx prettier --write ...`
- [x] Lint ran `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `npm run test --prefix llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_685d65a479048331844a3a90e8a38624