### PR TITLE
[Agent] add slot data management methods

### DIFF
--- a/src/domUI/loadGameUI.js
+++ b/src/domUI/loadGameUI.js
@@ -190,7 +190,7 @@ class LoadGameUI extends SlotModalBase {
     if (this.elements.listContainerElement) {
       DomUtils.clearElement(this.elements.listContainerElement);
     }
-    this.currentSlotsDisplayData = [];
+    this.clearSlotData();
     this.selectedSlotData = null;
     // Status message is cleared by BaseModalRenderer.show() -> _clearStatusMessage() on next show.
   }
@@ -240,7 +240,7 @@ class LoadGameUI extends SlotModalBase {
       this._displayStatusMessage('Error loading list of saved games.', 'error');
       return []; // Return empty on error
     }
-    this.currentSlotsDisplayData = displaySlots;
+    this.setSlotData(displaySlots);
     return this.currentSlotsDisplayData;
   }
 
@@ -590,7 +590,7 @@ class LoadGameUI extends SlotModalBase {
     super.dispose(); // Handles VED subscriptions, DOM listeners, and BoundDOMRenderer elements.
     this.loadService = null;
     this.selectedSlotData = null;
-    this.currentSlotsDisplayData = [];
+    this.clearSlotData();
     this.logger.debug(`${this._logPrefix} LoadGameUI disposed.`);
   }
 }

--- a/src/domUI/saveGameUI.js
+++ b/src/domUI/saveGameUI.js
@@ -190,7 +190,7 @@ export class SaveGameUI extends SlotModalBase {
     if (this.elements.listContainerElement) {
       DomUtils.clearElement(this.elements.listContainerElement);
     }
-    this.currentSlotsDisplayData = [];
+    this.clearSlotData();
     this.selectedSlotData = null;
   }
 
@@ -272,7 +272,7 @@ export class SaveGameUI extends SlotModalBase {
       );
       return []; // Return empty on error to prevent further issues
     }
-    this.currentSlotsDisplayData = displaySlots.slice(0, MAX_SAVE_SLOTS);
+    this.setSlotData(displaySlots.slice(0, MAX_SAVE_SLOTS));
     return this.currentSlotsDisplayData;
   }
 
@@ -568,7 +568,7 @@ export class SaveGameUI extends SlotModalBase {
     super.dispose(); // Handles VED subscriptions, DOM listeners, and BoundDOMRenderer elements.
     this.saveService = null;
     this.selectedSlotData = null;
-    this.currentSlotsDisplayData = [];
+    this.clearSlotData();
     this.logger.debug(`${this._logPrefix} SaveGameUI disposed.`);
   }
 }

--- a/src/domUI/slotModalBase.js
+++ b/src/domUI/slotModalBase.js
@@ -50,6 +50,25 @@ export class SlotModalBase extends BaseModalRenderer {
   currentSlotsDisplayData = [];
 
   /**
+   * Replaces the list of currently displayed slots.
+   *
+   * @param {object[]} list - Array of slot data objects.
+   * @returns {void}
+   */
+  setSlotData(list) {
+    this.currentSlotsDisplayData = Array.isArray(list) ? list : [];
+  }
+
+  /**
+   * Clears all slot data currently held in memory.
+   *
+   * @returns {void}
+   */
+  clearSlotData() {
+    this.currentSlotsDisplayData = [];
+  }
+
+  /**
    * Dataset key used on slot elements.
    *
    * @type {string}
@@ -308,7 +327,7 @@ export class SlotModalBase extends BaseModalRenderer {
       this.logger,
       this.domElementFactory
     );
-    this.currentSlotsDisplayData = Array.isArray(data) ? data : [];
+    this.setSlotData(Array.isArray(data) ? data : []);
 
     this._clearStatusMessage();
     this._setOperationInProgress(false);


### PR DESCRIPTION
## Summary
- add `setSlotData()` and `clearSlotData()` to `SlotModalBase`
- use these helpers in `SaveGameUI` and `LoadGameUI`

## Testing Done
- `npm run lint` *(fails: 627 errors, 2559 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d659364508331adc5d062400b08b0