### PR TITLE
[Agent] rename LLM config path field

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -73,7 +73,7 @@ export class LlmConfigService {
   #configLoader;
 
   /** @type {string} */
-  #_defaultLlmConfigPath;
+  #defaultLlmConfigPath;
   /** @type {string | null} */
   #resolvedConfigPath = null;
   /** @type {LLMConfigurationFileForProxy | null} */
@@ -111,7 +111,7 @@ export class LlmConfigService {
     this.#appConfig = appConfig;
     this.#configLoader = loader;
 
-    this.#_defaultLlmConfigPath = path.resolve(
+    this.#defaultLlmConfigPath = path.resolve(
       process.cwd(),
       'config/llm-configs.json'
     );
@@ -188,7 +188,7 @@ export class LlmConfigService {
     this.#resolvedConfigPath =
       customPath && customPath.trim() !== ''
         ? path.resolve(customPath)
-        : this.#_defaultLlmConfigPath;
+        : this.#defaultLlmConfigPath;
 
     this.#logger.debug(
       `LlmConfigService: Attempting to load LLM configurations from: ${this.#resolvedConfigPath}`


### PR DESCRIPTION
Summary: fixed naming for the default LLM config path field inside `llmConfigService.js` and updated all internal references.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (with warnings)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685d651ef5d88331a532b9f815c2247a