### PR TITLE
[Agent] simplify world init event dispatch

### DIFF
--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -154,25 +154,6 @@ class WorldInitializer {
   }
 
   /**
-   * Helper method to dispatch world initialization related events with standardized error logging.
-   *
-   * @param {string} eventName - The name of the event.
-   * @param {object} payload - The event payload.
-   * @param {string} identifierForLog - An identifier (e.g., entity ID, definition ID) for logging purposes if dispatch fails.
-   * @private
-   */
-  async #_dispatchWorldInitEvent(eventName, payload, identifierForLog) {
-    await dispatchWithLogging(
-      this.#validatedEventDispatcher,
-      eventName,
-      payload,
-      this.#logger,
-      identifierForLog,
-      { allowSchemaNotFound: true }
-    );
-  }
-
-  /**
    * Loads world data and validates the presence of an instances array.
    *
    * @param {string} worldName - The world identifier.
@@ -302,7 +283,8 @@ class WorldInitializer {
       this.#logger.error(
         `WorldInitializer (Pass 1): Failed to instantiate entity from definition: ${definitionId} for instance: ${instanceId}. createEntityInstance returned null/undefined or threw an error.`
       );
-      await this.#_dispatchWorldInitEvent(
+      await dispatchWithLogging(
+        this.#validatedEventDispatcher,
         WORLDINIT_ENTITY_INSTANTIATION_FAILED_ID,
         {
           instanceId,
@@ -311,7 +293,9 @@ class WorldInitializer {
           error: `Failed to create entity instance. EntityManager returned null/undefined or threw an error.`,
           reason: 'Initial World Load',
         },
-        `instance ${instanceId}`
+        this.#logger,
+        `instance ${instanceId}`,
+        { allowSchemaNotFound: true }
       );
       return { entity: null, success: false };
     }
@@ -320,7 +304,8 @@ class WorldInitializer {
       `WorldInitializer (Pass 1): Successfully instantiated entity ${instance.id} (from definition: ${instance.definitionId})`
     );
 
-    await this.#_dispatchWorldInitEvent(
+    await dispatchWithLogging(
+      this.#validatedEventDispatcher,
       WORLDINIT_ENTITY_INSTANTIATED_ID,
       {
         entityId: instance.id,
@@ -329,7 +314,9 @@ class WorldInitializer {
         worldName: worldName,
         reason: 'Initial World Load',
       },
-      `entity ${instance.id}`
+      this.#logger,
+      `entity ${instance.id}`,
+      { allowSchemaNotFound: true }
     );
 
     return { entity: instance, success: true };

--- a/tests/unit/initializers/worldInitializer.test.js
+++ b/tests/unit/initializers/worldInitializer.test.js
@@ -544,8 +544,8 @@ describe('WorldInitializer', () => {
     });
   });
 
-  // Test for _dispatchWorldInitEvent error handling
-  describe('_dispatchWorldInitEvent error handling', () => {
+  // Ensure dispatchWithLogging error handling works when event dispatch fails
+  describe('dispatchWithLogging error handling', () => {
     it('should log an error if event dispatching fails', async () => {
       const MOCK_ERROR_MESSAGE = 'Dispatch failed';
       mockValidatedEventDispatcher.dispatch.mockRejectedValueOnce(


### PR DESCRIPTION
## Summary
- remove dead `_dispatchWorldInitEvent` helper
- call `dispatchWithLogging` directly from `#dispatchInstantiationEvents`
- update tests for the new dispatch implementation

## Testing Done
- [x] `npm run format`
- [x] `npm run lint` *(fails: 627 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`
- [x] `npm run start`
- [x] `cd llm-proxy-server && npm run start` *(fails: config missing)*


------
https://chatgpt.com/codex/tasks/task_e_685d650b131c8331a99f636773f21717