### PR TITLE
[Agent] extract portrait helpers

### DIFF
--- a/src/entities/utils/portraitUtils.js
+++ b/src/entities/utils/portraitUtils.js
@@ -1,0 +1,101 @@
+// src/entities/utils/portraitUtils.js
+
+import { isNonBlankString } from '../../utils/textUtils.js';
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { extractModId } from '../../utils/idUtils.js';
+import { PORTRAIT_COMPONENT_ID } from '../../constants/componentIds.js';
+
+/**
+ * @module portraitUtils
+ * @description Helper utilities for building entity portrait data.
+ */
+
+/**
+ * @description Constructs the resolved portrait path using the mod ID and image path.
+ * @param {string} modId - The identifier of the mod.
+ * @param {string} imagePath - Raw image path from the portrait component.
+ * @returns {string} The resolved portrait image path.
+ */
+export function buildPortraitPath(modId, imagePath) {
+  return `/data/mods/${modId}/${imagePath}`;
+}
+
+/**
+ * @description Normalizes alternative text for portrait images.
+ * @param {string | undefined} rawAltText - Alt text from the portrait component.
+ * @returns {string | null} Trimmed alt text or null if not provided.
+ */
+export function buildAltText(rawAltText) {
+  return isNonBlankString(rawAltText) ? rawAltText.trim() : null;
+}
+
+/**
+ * @description Builds portrait path and alt text for an entity.
+ * @param {import('../entity.js').default} entity - The entity instance to read portrait data from.
+ * @param {string} contextMsg - The calling method name for log messages.
+ * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for diagnostics.
+ * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} safeEventDispatcher - Dispatcher for error events.
+ * @param {string} logPrefix - Prefix for log messages.
+ * @returns {{ path: string, altText: string | null } | null} Object with path and alt text, or null if portrait data is invalid.
+ */
+export function buildPortraitInfo(
+  entity,
+  contextMsg,
+  logger,
+  safeEventDispatcher,
+  logPrefix
+) {
+  const isLocation = contextMsg === 'getLocationPortraitData';
+  const label = isLocation ? 'Location entity' : 'Entity';
+  const successSubject = isLocation
+    ? `location '${entity.id}'`
+    : `'${entity.id}'`;
+
+  const portraitComponent = entity.getComponentData(PORTRAIT_COMPONENT_ID);
+  if (
+    !portraitComponent ||
+    typeof portraitComponent.imagePath !== 'string' ||
+    !portraitComponent.imagePath.trim()
+  ) {
+    logger.debug(
+      `${logPrefix} ${contextMsg}: ${label} '${entity.id}' has no valid PORTRAIT_COMPONENT_ID data or imagePath.`
+    );
+    return null;
+  }
+
+  if (typeof entity.definitionId !== 'string' || !entity.definitionId) {
+    logger.warn(
+      `${logPrefix} ${contextMsg}: Invalid or missing definitionId. Expected string, got:`,
+      entity.definitionId
+    );
+    return null;
+  }
+
+  const modId = extractModId(entity.definitionId);
+  if (!modId) {
+    safeDispatchError(
+      safeEventDispatcher,
+      `Entity definitionId '${entity.definitionId}' has invalid format. Expected format 'modId:entityName'.`,
+      {
+        raw: JSON.stringify({
+          definitionId: entity.definitionId,
+          expectedFormat: 'modId:entityName',
+          functionName: 'extractModId',
+        }),
+        stack: new Error().stack,
+      },
+      logger
+    );
+    return null;
+  }
+
+  const imagePath = portraitComponent.imagePath.trim();
+  const fullPath = buildPortraitPath(modId, imagePath);
+  const altText = buildAltText(portraitComponent.altText);
+
+  logger.debug(
+    `${logPrefix} ${contextMsg}: Constructed portrait path for ${successSubject}: ${fullPath}`
+  );
+
+  return { path: fullPath, altText };
+}

--- a/tests/unit/entities/utils/portraitUtils.test.js
+++ b/tests/unit/entities/utils/portraitUtils.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  buildPortraitPath,
+  buildAltText,
+  buildPortraitInfo,
+} from '../../../../src/entities/utils/portraitUtils.js';
+import { safeDispatchError } from '../../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+const LOG_PREFIX = '[EntityDisplayDataProvider]';
+
+describe('portraitUtils', () => {
+  describe('buildPortraitPath', () => {
+    it('constructs a mod-relative path', () => {
+      expect(buildPortraitPath('core', 'img.png')).toBe(
+        '/data/mods/core/img.png'
+      );
+    });
+  });
+
+  describe('buildAltText', () => {
+    it('trims non-blank text', () => {
+      expect(buildAltText('  hero  ')).toBe('hero');
+    });
+
+    it('returns null for blank text', () => {
+      expect(buildAltText('')).toBeNull();
+      expect(buildAltText('   ')).toBeNull();
+    });
+  });
+
+  describe('buildPortraitInfo', () => {
+    let logger;
+    let dispatcher;
+
+    beforeEach(() => {
+      logger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+      dispatcher = { dispatch: jest.fn() };
+      safeDispatchError.mockClear();
+    });
+
+    it('returns path and alt text when data valid', () => {
+      const entity = {
+        id: 'e1',
+        definitionId: 'core:test',
+        getComponentData: jest.fn(() => ({
+          imagePath: 'img.png',
+          altText: ' alt ',
+        })),
+      };
+
+      const result = buildPortraitInfo(
+        entity,
+        'getEntityPortraitPath',
+        logger,
+        dispatcher,
+        LOG_PREFIX
+      );
+
+      expect(result).toEqual({
+        path: '/data/mods/core/img.png',
+        altText: 'alt',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        `${LOG_PREFIX} getEntityPortraitPath: Constructed portrait path for 'e1': /data/mods/core/img.png`
+      );
+      expect(safeDispatchError).not.toHaveBeenCalled();
+    });
+
+    it('returns null when portrait component missing', () => {
+      const entity = {
+        id: 'e1',
+        definitionId: 'core:test',
+        getComponentData: jest.fn(() => undefined),
+      };
+
+      const result = buildPortraitInfo(
+        entity,
+        'getEntityPortraitPath',
+        logger,
+        dispatcher,
+        LOG_PREFIX
+      );
+
+      expect(result).toBeNull();
+      expect(logger.debug).toHaveBeenCalledWith(
+        `${LOG_PREFIX} getEntityPortraitPath: Entity 'e1' has no valid PORTRAIT_COMPONENT_ID data or imagePath.`
+      );
+    });
+
+    it('returns null and warns when definitionId invalid', () => {
+      const entity = {
+        id: 'e1',
+        definitionId: '',
+        getComponentData: jest.fn(() => ({ imagePath: 'img.png' })),
+      };
+
+      const result = buildPortraitInfo(
+        entity,
+        'getEntityPortraitPath',
+        logger,
+        dispatcher,
+        LOG_PREFIX
+      );
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        `${LOG_PREFIX} getEntityPortraitPath: Invalid or missing definitionId. Expected string, got:`,
+        ''
+      );
+    });
+
+    it('dispatches error when mod id cannot be extracted', () => {
+      const entity = {
+        id: 'e1',
+        definitionId: 'badformat',
+        getComponentData: jest.fn(() => ({ imagePath: 'img.png' })),
+      };
+
+      const result = buildPortraitInfo(
+        entity,
+        'getEntityPortraitPath',
+        logger,
+        dispatcher,
+        LOG_PREFIX
+      );
+
+      expect(result).toBeNull();
+      expect(safeDispatchError).toHaveBeenCalledWith(
+        dispatcher,
+        "Entity definitionId 'badformat' has invalid format. Expected format 'modId:entityName'.",
+        expect.any(Object),
+        logger
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract portrait helper methods to `portraitUtils`
- refactor `EntityDisplayDataProvider` to use helpers
- add unit tests for `portraitUtils`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing warnings and errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685d64cef6e083319f41fd5d8c0da60c