### PR TITLE
[Agent] add specific validation errors

### DIFF
--- a/src/actions/validation/inputValidators.js
+++ b/src/actions/validation/inputValidators.js
@@ -7,6 +7,8 @@
 // ActionTargetContext import removed as it's no longer validated here.
 
 // ActionTargetContext model import removed.
+import { InvalidActionDefinitionError } from '../../errors/invalidActionDefinitionError.js';
+import { InvalidActorEntityError } from '../../errors/invalidActorEntityError.js';
 
 /**
  * Validate the core inputs for prerequisite evaluation.
@@ -19,23 +21,19 @@
  * @throws {Error} If any input is missing required properties or has the wrong type.
  * @returns {void}
  */
-export function validateActionInputs(
-  actionDefinition,
-  actorEntity,
-  logger
-) {
+export function validateActionInputs(actionDefinition, actorEntity, logger) {
   if (!actionDefinition?.id?.trim()) {
     logger.error('Invalid actionDefinition provided (missing id).', {
       actionDefinition,
     });
-    throw new Error('Invalid actionDefinition');
+    throw new InvalidActionDefinitionError();
   }
 
   if (!actorEntity?.id?.trim()) {
     logger.error('Invalid actor entity provided (missing id).', {
       actor: actorEntity,
     });
-    throw new Error('Invalid actor entity');
+    throw new InvalidActorEntityError();
   }
 
   // Validation for targetCtx has been removed, as prerequisites are now actor-only.

--- a/src/actions/validation/validationErrorUtils.js
+++ b/src/actions/validation/validationErrorUtils.js
@@ -12,11 +12,14 @@
  * Identifier info used in the message. The `contextType` property is no longer used.
  * @returns {Error} A new Error instance with the formatted message.
  */
+import { InvalidActionDefinitionError } from '../../errors/invalidActionDefinitionError.js';
+import { InvalidActorEntityError } from '../../errors/invalidActorEntityError.js';
+
 export function formatValidationError(err, source, ids) {
   let idInfo = '';
-  if (err.message === 'Invalid actionDefinition') {
+  if (err instanceof InvalidActionDefinitionError) {
     idInfo = `(id: ${ids.actionId})`;
-  } else if (err.message === 'Invalid actor entity') {
+  } else if (err instanceof InvalidActorEntityError) {
     idInfo = `(id: ${ids.actorId})`;
   }
   // Branch for 'Invalid ActionTargetContext' removed as it's no longer thrown.

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -4,3 +4,5 @@ export * from './invalidInstanceIdError.js';
 // ... add other exports as needed
 export * from './invalidEntityIdError.js';
 export * from './InitializationError.js';
+export * from './invalidActionDefinitionError.js';
+export * from './invalidActorEntityError.js';

--- a/src/errors/invalidActionDefinitionError.js
+++ b/src/errors/invalidActionDefinitionError.js
@@ -1,0 +1,24 @@
+/**
+ * @file Error class for invalid action definitions.
+ */
+
+/**
+ * Error thrown when an action definition is missing required properties or otherwise invalid.
+ *
+ * @class InvalidActionDefinitionError
+ * @augments {Error}
+ */
+export class InvalidActionDefinitionError extends Error {
+  /**
+   * @param {string} [message] - Optional custom message.
+   */
+  constructor(message = 'Invalid actionDefinition') {
+    super(message);
+    this.name = 'InvalidActionDefinitionError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidActionDefinitionError);
+    }
+  }
+}
+
+export default InvalidActionDefinitionError;

--- a/src/errors/invalidActorEntityError.js
+++ b/src/errors/invalidActorEntityError.js
@@ -1,0 +1,24 @@
+/**
+ * @file Error class for invalid actor entities.
+ */
+
+/**
+ * Error thrown when an actor entity is missing required properties or otherwise invalid.
+ *
+ * @class InvalidActorEntityError
+ * @augments {Error}
+ */
+export class InvalidActorEntityError extends Error {
+  /**
+   * @param {string} [message] - Optional custom message.
+   */
+  constructor(message = 'Invalid actor entity') {
+    super(message);
+    this.name = 'InvalidActorEntityError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidActorEntityError);
+    }
+  }
+}
+
+export default InvalidActorEntityError;

--- a/tests/unit/actions/validation/validationErrorUtils.test.js
+++ b/tests/unit/actions/validation/validationErrorUtils.test.js
@@ -1,9 +1,11 @@
 import { describe, test, expect } from '@jest/globals';
 import { formatValidationError } from '../../../../src/actions/validation/validationErrorUtils.js';
+import { InvalidActionDefinitionError } from '../../../../src/errors/invalidActionDefinitionError.js';
+import { InvalidActorEntityError } from '../../../../src/errors/invalidActorEntityError.js';
 
 /** Mock error cases used by validateActionInputs */
-const actionErr = new Error('Invalid actionDefinition');
-const actorErr = new Error('Invalid actor entity');
+const actionErr = new InvalidActionDefinitionError();
+const actorErr = new InvalidActorEntityError();
 const ctxErr = new Error('Invalid ActionTargetContext');
 const otherErr = new Error('Something else');
 
@@ -27,9 +29,7 @@ describe('formatValidationError', () => {
     const err = formatValidationError(ctxErr, 'Source.fn', {
       contextType: 'none',
     });
-    expect(err.message).toBe(
-      'Source.fn: invalid ActionTargetContext'
-    );
+    expect(err.message).toBe('Source.fn: invalid ActionTargetContext');
   });
 
   test('handles unknown error message gracefully', () => {


### PR DESCRIPTION
## Summary
- introduce InvalidActionDefinitionError and InvalidActorEntityError
- throw these errors from validateActionInputs
- format validation errors based on specific error classes
- update unit tests for new error classes

## Testing
- `npm run lint` *(fails: 627 errors, 2569 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d64a2f660833190bd37162b680784