### PR TITLE
refactor: update turn lifecycle and state factory registrations

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -459,6 +459,7 @@ export function registerAITurnHandler(registrar, logger) {
         turnEndPort: c.resolve(tokens.ITurnEndPort),
         strategyFactory: c.resolve(tokens.TurnStrategyFactory),
         turnContextBuilder: c.resolve(tokens.TurnContextBuilder),
+        container: c,
       })
   );
   logger.debug(

--- a/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
+++ b/src/dependencyInjection/registrations/turnLifecycleRegistrations.js
@@ -2,7 +2,7 @@
 /**
  * Registers core turn-lifecycle systems (player-agnostic).
  * Ensures ActionIndexingService is always present so PromptCoordinator
- * can resolve integer choices even when the AI setup hasn’t been wired.
+ * can resolve integer choices even when the AI setup hasn't been wired.
  */
 
 import TurnManager from '../../turns/turnManager.js';
@@ -38,7 +38,11 @@ export function registerTurnLifecycle(container) {
     tokens.ITurnOrderService,
     (c) => new TurnOrderService({ logger: c.resolve(tokens.ILogger) })
   );
-  registrar.single(tokens.ITurnStateFactory, ConcreteTurnStateFactory);
+  registrar.singletonFactory(tokens.ITurnStateFactory, 
+    (c) => new ConcreteTurnStateFactory({
+      commandProcessor: c.resolve(tokens.ICommandProcessor)
+    })
+  );
 
   // ─────────────────── Turn-context factory ──────────────────
   registrar.singletonFactory(

--- a/src/turns/factories/concreteTurnStateFactory.js
+++ b/src/turns/factories/concreteTurnStateFactory.js
@@ -13,6 +13,7 @@ import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyRe
  * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
  * @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
  * @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState
+ * @typedef {import('../../interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor
  */
 
 /**
@@ -22,6 +23,20 @@ import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyRe
  * Concrete factory for creating various turn state instances.
  */
 export class ConcreteTurnStateFactory extends ITurnStateFactory {
+  #commandProcessor;
+
+  /**
+   * @param {object} deps Dependencies
+   * @param {ICommandProcessor} deps.commandProcessor The command processor.
+   */
+  constructor({ commandProcessor }) {
+    super();
+    if (!commandProcessor) {
+      throw new Error('ConcreteTurnStateFactory: commandProcessor is required.');
+    }
+    this.#commandProcessor = commandProcessor;
+  }
+
   /**
    * @override
    */
@@ -55,17 +70,17 @@ export class ConcreteTurnStateFactory extends ITurnStateFactory {
    * @param {BaseTurnHandler} handler
    * @param {string} commandString
    * @param {ITurnAction} turnAction
+   * @param {Function} directiveResolver - Resolver for command directives.
    */
   createProcessingCommandState(
     handler,
-    commandProcessor,
     commandString,
     turnAction,
-    directiveResolver = TurnDirectiveStrategyResolver
+    directiveResolver
   ) {
     return new ProcessingCommandState({
       handler,
-      commandProcessor,
+      commandProcessor: this.#commandProcessor,
       commandString,
       turnAction,
       directiveResolver,

--- a/src/turns/handlers/baseTurnHandler.js
+++ b/src/turns/handlers/baseTurnHandler.js
@@ -14,6 +14,7 @@
  */
 
 import { ITurnStateHost } from '../interfaces/ITurnStateHost.js';
+import TurnDirectiveStrategyResolver from '../strategies/turnDirectiveStrategyResolver.js';
 
 /**
  * @abstract
@@ -603,13 +604,12 @@ export class BaseTurnHandler {
     this.getLogger().debug(
       `${this.constructor.name}: Received request to transition to ProcessingCommand state.`
     );
-    const commandProcessor = this._container.resolve('commandProcessor');
     await this._transitionToState(
       this._turnStateFactory.createProcessingCommandState(
         this,
-        commandProcessor,
         commandString,
-        turnAction
+        turnAction,
+        TurnDirectiveStrategyResolver
       )
     );
   }

--- a/src/turns/interfaces/ITurnStateFactory.js
+++ b/src/turns/interfaces/ITurnStateFactory.js
@@ -64,13 +64,14 @@ export class ITurnStateFactory {
   }
 
   /**
-   * Creates a Processing Command state instance.
+   * Creates an instance of the state responsible for processing a chosen command.
    *
-   * @param {ITurnStateHost} handler
-   * @param {string} commandString - The command string to be processed.
-   * @param {ITurnAction} turnAction - The turn action associated with the command.
-   * @param {{ resolveStrategy(directive: string): ITurnDirectiveStrategy }} [directiveResolver]
-   * @returns {ITurnState} The created processing command state.
+   * @param {BaseTurnHandler} handler - The handler managing the state.
+   * @param {string} commandString - The command string to process.
+   * @param {ITurnAction} turnAction - The chosen turn action.
+   * @param {Function} directiveResolver - Resolver for command directives.
+   * @returns {ProcessingCommandState} A new processing command state instance.
+   * @abstract
    */
   createProcessingCommandState(
     handler,

--- a/tests/unit/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/turnLifecycleRegistrations.test.js
@@ -138,7 +138,7 @@ describe('registerTurnLifecycle', () => {
     {
       token: tokens.ITurnStateFactory,
       Class: ConcreteTurnStateFactory,
-      lifecycle: 'singleton',
+      lifecycle: 'singletonFactory',
     },
     {
       token: tokens.ITurnContextFactory,

--- a/tests/unit/turns/factories/concreteTurnStateFactory.test.js
+++ b/tests/unit/turns/factories/concreteTurnStateFactory.test.js
@@ -14,8 +14,13 @@ import { TurnEndingState } from '../../../../src/turns/states/turnEndingState.js
 import { AwaitingActorDecisionState } from '../../../../src/turns/states/awaitingActorDecisionState.js';
 import { ProcessingCommandState } from '../../../../src/turns/states/processingCommandState.js';
 import { AwaitingExternalTurnEndState } from '../../../../src/turns/states/awaitingExternalTurnEndState.js';
+import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
 
 // --- Mocks ---
+const mockCommandProcessor = {
+  dispatchAction: jest.fn(),
+  // Add any other methods of ICommandProcessor that might be called by ProcessingCommandState
+};
 
 // A mock logger to be returned by other mocks.
 const mockLogger = {
@@ -49,7 +54,7 @@ describe('ConcreteTurnStateFactory', () => {
 
   beforeEach(() => {
     // Create a new factory instance before each test to ensure isolation.
-    factory = new ConcreteTurnStateFactory();
+    factory = new ConcreteTurnStateFactory({ commandProcessor: mockCommandProcessor });
     // Clear any previous mock calls to avoid test cross-contamination.
     jest.clearAllMocks();
   });
@@ -143,11 +148,11 @@ describe('ConcreteTurnStateFactory', () => {
       const state = factory.createProcessingCommandState(
         mockHandler,
         commandString,
-        turnAction
+        turnAction,
+        TurnDirectiveStrategyResolver
       );
 
       // Assert: Verify the created instance is of the correct class.
-      // We do not assert private fields anymore.
       expect(state).toBeInstanceOf(ProcessingCommandState);
       expect(state._handler).toBe(mockHandler);
     });


### PR DESCRIPTION
- Added container reference to the AI turn handler registration for improved dependency management.
- Changed ITurnStateFactory registration to use singletonFactory for better instantiation control.
- Enhanced ConcreteTurnStateFactory to require commandProcessor as a dependency, ensuring proper command handling.
- Updated related tests to reflect changes in factory instantiation and command processing logic.