### PR TITLE
[Fix] Return validation error objects

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -131,7 +131,6 @@ export const targetFormatterMap = {
  * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} displayNameFn - Utility to resolve entity names.
  * @param {ISafeEventDispatcher} dispatcher - Dispatcher used for error events.
  * @returns {FormatActionError | null} An error result if validation fails, otherwise `null`.
- * @throws {Error} If `entityManager` or `displayNameFn` are invalid.
  */
 function validateFormatInputs(
   actionDefinition,
@@ -160,18 +159,22 @@ function validateFormatInputs(
       'formatActionCommand: Invalid or missing entityManager.',
       { entityManager }
     );
-    throw new Error(
-      'formatActionCommand: entityManager parameter must be a valid EntityManager instance.'
-    );
+    return {
+      ok: false,
+      error:
+        'formatActionCommand: entityManager parameter must be a valid EntityManager instance.',
+    };
   }
   if (typeof displayNameFn !== 'function') {
     safeDispatchError(
       dispatcher,
       'formatActionCommand: getEntityDisplayName utility function is not available.'
     );
-    throw new Error(
-      'formatActionCommand: getEntityDisplayName parameter must be a function.'
-    );
+    return {
+      ok: false,
+      error:
+        'formatActionCommand: getEntityDisplayName parameter must be a function.',
+    };
   }
 
   return null;
@@ -266,7 +269,6 @@ function finalizeCommand(command, logger, debug) {
  * Function used to resolve entity display names.
  * @param {TargetFormatterMap} [formatterMap] - Map of target types to formatter functions.
  * @returns {FormatActionCommandResult} Result object containing the formatted command or an error.
- * @throws {Error} If critical dependencies (entityManager, displayNameFn) are missing or invalid during processing.
  */
 export function formatActionCommand(
   actionDefinition,

--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -104,18 +104,19 @@ describe('formatActionCommand', () => {
     );
   });
 
-  it('throws when entityManager is invalid', () => {
-    expect(() =>
-      formatActionCommand(
-        { id: 'core:use', template: 'use {target}' },
-        { type: TARGET_TYPE_ENTITY, entityId: 'e1' },
-        {},
-        { logger, safeEventDispatcher: dispatcher },
-        displayNameFn
-      )
-    ).toThrow(
-      'formatActionCommand: entityManager parameter must be a valid EntityManager instance.'
+  it('returns error when entityManager is invalid', () => {
+    const result = formatActionCommand(
+      { id: 'core:use', template: 'use {target}' },
+      { type: TARGET_TYPE_ENTITY, entityId: 'e1' },
+      {},
+      { logger, safeEventDispatcher: dispatcher },
+      displayNameFn
     );
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'formatActionCommand: entityManager parameter must be a valid EntityManager instance.',
+    });
   });
 
   it('warns on unknown target type', () => {


### PR DESCRIPTION
Summary: Update actionFormatter's validation to return `{ok:false}` objects for missing dependencies and adjust tests.

Changes Made:
- `validateFormatInputs()` now returns `FormatActionError` for invalid `entityManager` or `displayNameFn` instead of throwing.
- `formatActionCommand()` documentation updated accordingly.
- Updated unit test to check returned error object.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685d6d1406a88331b5a56cf20deff868