### PR TITLE
[Agent] Deep freeze configs after load

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -211,9 +211,17 @@ export class LlmConfigService {
         return;
       }
 
+      const frozenConfigs = Object.freeze(
+        Object.fromEntries(
+          Object.entries(result.llmConfigs.configs).map(([id, cfg]) => [
+            id,
+            Object.freeze(cfg),
+          ])
+        )
+      );
       this.#loadedLlmConfigs = Object.freeze({
         ...result.llmConfigs,
-        configs: Object.freeze(result.llmConfigs.configs),
+        configs: frozenConfigs,
       });
       this.#isProxyOperational = true;
       this.#initializationError = null;


### PR DESCRIPTION
## Summary
- freeze loaded LLM configs at the individual level in LlmConfigService

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d6ea81f9c833194189ba724055343