### PR TITLE
[Agent] Switch interface imports to named

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -8,7 +8,7 @@
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../appContainer.js').default} AppContainer */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
+/** @typedef {import('../../interfaces/IPlaytimeTracker.js').IPlaytimeTracker} IPlaytimeTracker */
 /** @typedef {import('../../interfaces/ISaveLoadService.js').ISaveLoadService} ISaveLoadService_Interface */
 /** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('../../interfaces/coreServices.js').IDataRegistry} IDataRegistry_Interface */

--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -21,7 +21,7 @@ import PersistenceCoordinator from './persistenceCoordinator.js';
 /** @typedef {import('../interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
 /** @typedef {import('../interfaces/IGamePersistenceService.js').SaveResult} SaveResult */
 /** @typedef {import('../interfaces/IGamePersistenceService.js').LoadAndRestoreResult} LoadAndRestoreResult */
-/** @typedef {import('../interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
+/** @typedef {import('../interfaces/IPlaytimeTracker.js').IPlaytimeTracker} IPlaytimeTracker */
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 /** @typedef {import('../interfaces/IInitializationService.js').IInitializationService} IInitializationService */
 /** @typedef {import('../interfaces/IInitializationService.js').InitializationResult} InitializationResult */

--- a/src/engine/gameSessionManager.js
+++ b/src/engine/gameSessionManager.js
@@ -8,7 +8,7 @@ import {
 /**
  * @typedef {import('./engineState.js').default} EngineState
  * @typedef {import('../turns/interfaces/ITurnManager.js').ITurnManager} ITurnManager
- * @typedef {import('../interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker
+ * @typedef {import('../interfaces/IPlaytimeTracker.js').IPlaytimeTracker} IPlaytimeTracker
  * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  */

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -1,13 +1,13 @@
 // src/services/playtimeTracker.js
 
-import IPlaytimeTracker from '../interfaces/IPlaytimeTracker.js';
+import { IPlaytimeTracker } from '../interfaces/IPlaytimeTracker.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
- * @typedef {import('../interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker
+ * @typedef {import('../interfaces/IPlaytimeTracker.js').IPlaytimeTracker} IPlaytimeTracker
  */
 
 /**

--- a/src/interfaces/IPlaytimeTracker.js
+++ b/src/interfaces/IPlaytimeTracker.js
@@ -4,7 +4,7 @@
  * @interface IPlaytimeTracker
  * Defines the contract for services that track game playtime.
  */
-class IPlaytimeTracker {
+export class IPlaytimeTracker {
   /**
    * Resets the playtime tracker, clearing accumulated playtime and ending any active session.
    *

--- a/tests/common/engine/engineTestTypedefs.js
+++ b/tests/common/engine/engineTestTypedefs.js
@@ -14,7 +14,7 @@
 
 /** @typedef {import('../../../src/interfaces/IGamePersistenceService.js').IGamePersistenceService} IGamePersistenceService */
 
-/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').default} IPlaytimeTracker */
+/** @typedef {import('../../../src/interfaces/IPlaytimeTracker.js').IPlaytimeTracker} IPlaytimeTracker */
 
 /** @typedef {import('../../../src/interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 


### PR DESCRIPTION
## Summary
- export IPlaytimeTracker class and keep default export
- align interface typedefs with named exports
- switch playtimeTracker to named import

## Testing Done
- `npx prettier -w src/interfaces/IPlaytimeTracker.js src/dependencyInjection/registrations/persistenceRegistrations.js src/engine/gameEngine.js src/engine/gameSessionManager.js src/engine/playtimeTracker.js tests/common/engine/engineTestTypedefs.js`
- `npm run lint` *(fails: 657 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685d6e54a93083318bc75ba6d60becd6