### PR TITLE
[Agent] Refactor dispatch assertions in tests

### DIFF
--- a/tests/integration/LLMResponseProcessor.e2e.test.js
+++ b/tests/integration/LLMResponseProcessor.e2e.test.js
@@ -9,6 +9,7 @@ import {
   LLMProcessingError,
 } from '../../src/turns/services/LLMResponseProcessor.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../common/engine/dispatchTestUtils.js';
 
 // Mocked logger for capturing logs
 const makeLogger = () => ({
@@ -68,7 +69,7 @@ describe('LLMResponseProcessor', () => {
     expect(logger.debug).toHaveBeenCalledWith(
       `LLMResponseProcessor: Validated LLM output for actor ${actorId}. Chosen ID: 4`
     );
-    expect(safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(safeEventDispatcher.dispatch);
   });
 
   test('should preserve chosenIndex as a number in the action object', async () => {

--- a/tests/unit/actions/targetResolutionService.scope-loading.test.js
+++ b/tests/unit/actions/targetResolutionService.scope-loading.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describe('TargetResolutionService - Scope Loading Issue', () => {
   let targetResolutionService;
@@ -59,7 +60,9 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       };
 
       mockScopeRegistry.getScope.mockReturnValue(mockScopeDefinition);
-      mockScopeEngine.resolve.mockReturnValue(new Set(['location1', 'location2']));
+      mockScopeEngine.resolve.mockReturnValue(
+        new Set(['location1', 'location2'])
+      );
 
       const mockActor = { id: 'hero', type: 'character' };
       const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
@@ -70,9 +73,11 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
         mockDiscoveryContext
       );
 
-      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith('core:clear_directions');
+      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith(
+        'core:clear_directions'
+      );
       expect(result).toHaveLength(2);
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
 
     it('should handle missing scope gracefully and dispatch error event', async () => {
@@ -88,7 +93,9 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
         mockDiscoveryContext
       );
 
-      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith('core:clear_directions');
+      expect(mockScopeRegistry.getScope).toHaveBeenCalledWith(
+        'core:clear_directions'
+      );
       expect(result).toHaveLength(0);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "TargetResolutionService: Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry."
@@ -96,7 +103,8 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
         'core:system_error_occurred',
         {
-          message: "Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry.",
+          message:
+            "Missing scope definition: Scope 'core:clear_directions' not found or has no expression in registry.",
           details: { scopeName: 'core:clear_directions' },
         }
       );
@@ -152,7 +160,9 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
         'core:system_error_occurred',
         expect.objectContaining({
-          message: expect.stringContaining("Error resolving scope 'core:clear_directions'"),
+          message: expect.stringContaining(
+            "Error resolving scope 'core:clear_directions'"
+          ),
           details: expect.objectContaining({
             error: expect.stringContaining('Unknown source node'),
           }),
@@ -164,7 +174,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
   describe('Real ScopeRegistry integration', () => {
     it('should work with a real scope registry containing core:clear_directions', () => {
       const realScopeRegistry = new ScopeRegistry();
-      
+
       // Initialize with the expected scope definition
       realScopeRegistry.initialize({
         'core:clear_directions': {
@@ -178,15 +188,17 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const scope = realScopeRegistry.getScope('core:clear_directions');
       expect(scope).toBeDefined();
       expect(scope.name).toBe('core:clear_directions');
-      expect(scope.expr).toBe('location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target');
+      expect(scope.expr).toBe(
+        'location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target'
+      );
     });
 
     it('should enforce namespaced scope names in real registry', () => {
       const realScopeRegistry = new ScopeRegistry();
-      
+
       expect(() => {
         realScopeRegistry.getScope('clear_directions'); // Non-namespaced
       }).toThrow('Scope names must be namespaced');
     });
   });
-}); 
+});

--- a/tests/unit/alerting/throttler.test.js
+++ b/tests/unit/alerting/throttler.test.js
@@ -12,6 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import { Throttler } from '../../../src/alerting/throttler.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Create a mock dispatcher that conforms to the ISafeEventDispatcher interface for testing.
 const mockDispatcher = {
@@ -49,7 +50,7 @@ describe('Throttler', () => {
 
     // Assert
     expect(result).toBe(true);
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   /**
@@ -68,7 +69,7 @@ describe('Throttler', () => {
     // Assert
     expect(result2).toBe(false);
     expect(result3).toBe(false);
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   /**
@@ -136,7 +137,7 @@ describe('Throttler', () => {
     jest.advanceTimersByTime(throttleWindowMs);
 
     // Assert
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   /**
@@ -150,18 +151,18 @@ describe('Throttler', () => {
     jest.advanceTimersByTime(throttleWindowMs);
 
     // Assert that no summary was dispatched for the first event
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
 
     // Act: A "new" event with the same key arrives after the window
     const result = throttler.allow(key, payload);
 
     // Assert: It should be allowed again, and no dispatch should happen immediately
     expect(result).toBe(true);
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
 
     // Act: Let the new timer run to completion to ensure no unexpected summary
     jest.advanceTimersByTime(throttleWindowMs);
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   it('should handle multiple keys independently', () => {

--- a/tests/unit/common/engine/gameEngineTestBed.test.js
+++ b/tests/unit/common/engine/gameEngineTestBed.test.js
@@ -13,6 +13,7 @@ import {
 import { createEnvironment } from '../../../common/engine/gameEngineEnvironment.js';
 import GameEngine from '../../../../src/engine/gameEngine.js';
 import { tokens } from '../../../../src/dependencyInjection/tokens.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 jest.mock('../../../../src/engine/gameEngine.js');
 
@@ -209,7 +210,7 @@ describe('GameEngine Test Helpers: GameEngineTestBed', () => {
     expect(testBed.getTurnManager().start).not.toHaveBeenCalled();
     expect(testBed.getGamePersistenceService().saveGame).not.toHaveBeenCalled();
     expect(testBed.getPlaytimeTracker().startSession).not.toHaveBeenCalled();
-    expect(testBed.getSafeEventDispatcher().dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(testBed.getSafeEventDispatcher().dispatch);
     expect(
       testBed.getInitializationService().runInitializationSequence
     ).not.toHaveBeenCalled();

--- a/tests/unit/context/worldContext.edgeCases.test.js
+++ b/tests/unit/context/worldContext.edgeCases.test.js
@@ -8,6 +8,7 @@ import {
   test,
   afterEach,
 } from '@jest/globals';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Define the mock object *first*
 const mockEntityManagerInstance = {
@@ -279,7 +280,7 @@ describe('WorldContext Edge Cases', () => {
     expect(mockEntityManagerInstance.getEntityInstance).toHaveBeenCalledWith(
       'loc1'
     );
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
     expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
@@ -321,7 +322,7 @@ describe('WorldContext Edge Cases', () => {
     expect(mockEntityManagerInstance.getEntityInstance).toHaveBeenCalledWith(
       'nonexistent-loc'
     );
-    expect(dispatcher.dispatch).not.toHaveBeenCalled(); // No error expected here
+    expectNoDispatch(dispatcher.dispatch); // No error expected here
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1); // Warning expected
     // VVVVVV UPDATED LOG MESSAGE CHECK VVVVVV
     expect(loggerWarnSpy).toHaveBeenCalledWith(

--- a/tests/unit/domUI/actionButtonsRenderer.buttonClickSimulation.test.js
+++ b/tests/unit/domUI/actionButtonsRenderer.buttonClickSimulation.test.js
@@ -16,6 +16,7 @@ import DomElementFactory from '../../../src/domUI/domElementFactory.js';
 import ConsoleLogger from '../../../src/logging/consoleLogger.js';
 import ValidatedEventDispatcher from '../../../src/events/validatedEventDispatcher.js';
 import { PLAYER_TURN_SUBMITTED_ID } from '../../../src/constants/eventIds';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Mock dependencies
 jest.mock('../../../src/logging/consoleLogger.js');
@@ -305,7 +306,7 @@ describe('ActionButtonsRenderer', () => {
       );
       expect(renderer.selectedAction).toEqual(actionToSelect);
       expect(renderer.elements.sendButtonElement.disabled).toBe(false);
-      expect(mockVed.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockVed.dispatch);
       expect(mockExamineButton.getAttribute('role')).toBe('radio');
       expect(mockExamineButton.getAttribute('data-action-index')).toBe('1');
     });
@@ -538,7 +539,7 @@ describe('ActionButtonsRenderer', () => {
       await mockActionButton.click(); // Click the action button itself
 
       expect(spy).toHaveBeenCalledWith(mockActionButton, action);
-      expect(mockVed.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockVed.dispatch);
       expect(renderer.selectedAction).toEqual(action);
       expect(renderer.elements.sendButtonElement.disabled).toBe(false);
     });

--- a/tests/unit/domUI/actionButtonsRenderer.confirmActionButton.test.js
+++ b/tests/unit/domUI/actionButtonsRenderer.confirmActionButton.test.js
@@ -15,6 +15,7 @@ import DomElementFactory from '../../../src/domUI/domElementFactory.js';
 import ConsoleLogger from '../../../src/logging/consoleLogger.js';
 import ValidatedEventDispatcher from '../../../src/events/validatedEventDispatcher.js';
 import { PLAYER_TURN_SUBMITTED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 jest.mock('../../../src/logging/consoleLogger.js');
 jest.mock('../../../src/events/validatedEventDispatcher.js');
@@ -374,7 +375,7 @@ describe('ActionButtonsRenderer', () => {
       expect(commandInputElement.value).toBe('Test speech');
       expect(renderer.selectedAction).toEqual(actionToSubmit);
       expect(globalMockSendButton.disabled).toBe(false);
-      expect(spyDispatch).not.toHaveBeenCalled();
+      expectNoDispatch(spyDispatch);
     });
 
     it('should log error and not change UI state if dispatch throws an error', async () => {
@@ -402,7 +403,7 @@ describe('ActionButtonsRenderer', () => {
 
       await globalMockSendButton.click();
 
-      expect(mockVed.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockVed.dispatch);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         `${CLASS_PREFIX} 'Confirm Action' clicked, but no action is selected.`
       );
@@ -423,7 +424,7 @@ describe('ActionButtonsRenderer', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         `${CLASS_PREFIX} #handleSendAction called, but sendButtonElement is null.`
       );
-      expect(mockVed.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockVed.dispatch);
     });
   });
 });

--- a/tests/unit/domUI/chatAlertRenderer.integration.test.js
+++ b/tests/unit/domUI/chatAlertRenderer.integration.test.js
@@ -15,6 +15,8 @@ import {
 // Class under test
 import { ChatAlertRenderer } from '../../../src/domUI';
 
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
+
 // Real implementation needed for creating elements within the test
 import DomElementFactory from '../../../src/domUI/domElementFactory.js';
 
@@ -125,7 +127,7 @@ describe('ChatAlertRenderer Throttling Integration', () => {
       expect(firstBubble.textContent).toContain('Connection timed out.');
 
       // The throttler should not have dispatched a summary event yet.
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
 
       // --- Act: Advance time by 10 seconds to close the throttling window ---
       jest.advanceTimersByTime(10000);
@@ -184,7 +186,7 @@ describe('ChatAlertRenderer Throttling Integration', () => {
 
       // Advance time and assert that no summary is generated for either.
       jest.advanceTimersByTime(10000);
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
       expect(chatPanel.children.length).toBe(2);
     });
   });
@@ -215,7 +217,7 @@ describe('ChatAlertRenderer Throttling Integration', () => {
 
       // --- Assert: Final State ---
       // The throttler's timer will fire, but since suppressedCount is 0, it must NOT dispatch an event.
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
       // Therefore, the number of DOM elements must remain 1.
       expect(chatPanel.children.length).toBe(1);
     });

--- a/tests/unit/entities/entityManager.addComponent.test.js
+++ b/tests/unit/entities/entityManager.addComponent.test.js
@@ -7,7 +7,10 @@ import { runInvalidIdPairTests } from '../../common/entities/index.js';
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 import { ValidationError } from '../../../src/errors/validationError.js';
-import { expectComponentAddedDispatch } from '../../common/engine/dispatchTestUtils.js';
+import {
+  expectComponentAddedDispatch,
+  expectNoDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
   // ----------------------------------------------------------------------//
@@ -149,7 +152,7 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
           NEW_COMPONENT_DATA
         );
       }).toThrow(ValidationError);
-      expect(mocks.eventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mocks.eventDispatcher.dispatch);
     });
 
     it('should throw InvalidArgumentError when componentData is null', () => {
@@ -215,7 +218,7 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       expect(mocks.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('entity.addComponent returned false')
       );
-      expect(mocks.eventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mocks.eventDispatcher.dispatch);
 
       addComponentSpy.mockRestore();
     });

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -5,7 +5,10 @@ import {
 } from '../../common/entities/index.js';
 import { runInvalidIdPairTests } from '../../common/entities/index.js';
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
-import { expectComponentRemovedDispatch } from '../../common/engine/dispatchTestUtils.js';
+import {
+  expectComponentRemovedDispatch,
+  expectNoDispatch,
+} from '../../common/engine/dispatchTestUtils.js';
 
 describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
   describe('removeComponent', () => {
@@ -81,7 +84,7 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       ).toThrow(
         "Component 'core:name' not found as an override on entity 'test-instance-01'. Nothing to remove at instance level."
       );
-      expect(mocks.eventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mocks.eventDispatcher.dispatch);
     });
 
     it('should throw EntityNotFoundError for a non-existent entity', () => {

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -1,5 +1,6 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 let logger;
 let dispatcher;
@@ -63,7 +64,7 @@ describe('InitializationService invalid world name handling', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBeInstanceOf(TypeError);
       expect(modsLoader.loadMods).not.toHaveBeenCalled();
-      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(dispatcher.dispatch);
     }
   );
 });

--- a/tests/unit/interpreters/commandOutcomeInterpreter.fixes.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.fixes.test.js
@@ -3,6 +3,7 @@
 import CommandOutcomeInterpreter from '../../../src/commands/interpreters/commandOutcomeInterpreter.js';
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Mocks
 const mockLogger = {
@@ -60,7 +61,7 @@ describe('CommandOutcomeInterpreter', () => {
         mockTurnContext
       );
       expect(directive).toBe(TurnDirective.WAIT_FOR_EVENT);
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
   });
 });

--- a/tests/unit/interpreters/commandOutcomeInterpreter.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.test.js
@@ -3,6 +3,7 @@
 import CommandOutcomeInterpreter from '../../../src/commands/interpreters/commandOutcomeInterpreter.js';
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Mocks
 const mockLogger = {
@@ -97,7 +98,7 @@ describe('CommandOutcomeInterpreter', () => {
         mockTurnContext
       );
       expect(directive).toBe(TurnDirective.WAIT_FOR_EVENT);
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
   });
 });

--- a/tests/unit/llms/clientApiKeyProvider.test.js
+++ b/tests/unit/llms/clientApiKeyProvider.test.js
@@ -7,6 +7,7 @@ import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
 const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 /**
  * @typedef {import('../../src/llms/interfaces/ILogger.js').ILogger} ILogger
@@ -324,7 +325,7 @@ describe('ClientApiKeyProvider', () => {
       llmConfig.apiType = undefined;
       const key = await provider.getKey(llmConfig, environmentContext);
       expect(key).toBeNull();
-      expect(dispatcher.dispatch).not.toHaveBeenCalled(); // No error for missing identifiers in this case
+      expectNoDispatch(dispatcher.dispatch); // No error for missing identifiers in this case
       expect(logger.debug).toHaveBeenCalledWith(
         'ClientApiKeyProvider.getKey (test-llm): LLM apiType is missing or not a string. Assuming non-cloud or misconfigured. Skipping key identifier checks.'
       );
@@ -335,7 +336,7 @@ describe('ClientApiKeyProvider', () => {
       llmConfig.apiType = 123; // Invalid type
       const key = await provider.getKey(llmConfig, environmentContext);
       expect(key).toBeNull();
-      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(dispatcher.dispatch);
       expect(logger.debug).toHaveBeenCalledWith(
         'ClientApiKeyProvider.getKey (test-llm): LLM apiType is missing or not a string. Assuming non-cloud or misconfigured. Skipping key identifier checks.'
       );

--- a/tests/unit/llms/retryHttpClient.events.test.js
+++ b/tests/unit/llms/retryHttpClient.events.test.js
@@ -11,6 +11,7 @@ import {
   afterEach,
   jest,
 } from '@jest/globals';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Utility to create logger and dispatcher mocks
 const createLogger = () => ({
@@ -117,6 +118,6 @@ describe('RetryHttpClient event dispatching', () => {
 
     await client.request('https://ok.test', { method: 'GET' });
 
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
   });
 });

--- a/tests/unit/loaders/contentLoadManager.processMod.test.js
+++ b/tests/unit/loaders/contentLoadManager.processMod.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import ContentLoadManager from '../../../src/loaders/ContentLoadManager.js';
 import LoadResultAggregator from '../../../src/loaders/LoadResultAggregator.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 /** @typedef {import('../../../src/loaders/LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
 
@@ -151,7 +152,7 @@ describe('ContentLoadManager.processMod', () => {
 
     expect(result.status).toBe('success');
     expect(result.updatedTotals.items.count).toBe(1);
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
   });
 
   it('uses injected timer for duration measurement', async () => {

--- a/tests/unit/logic/operationHandlers/dispatchEventHandler.test.js
+++ b/tests/unit/logic/operationHandlers/dispatchEventHandler.test.js
@@ -4,6 +4,7 @@
  * @jest-environment node
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 import DispatchEventHandler from '../../../../src/logic/operationHandlers/dispatchEventHandler.js'; // Adjust path as needed
 
 // --- JSDoc Imports ---
@@ -244,7 +245,7 @@ describe('DispatchEventHandler', () => {
       'DISPATCH_EVENT: params missing or invalid.',
       { params: null }
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   test('execute should log error and not dispatch if params is empty object', () => {
@@ -254,7 +255,7 @@ describe('DispatchEventHandler', () => {
       expect.stringContaining('Invalid or missing "eventType" parameter'),
       expect.anything()
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   test('execute should log error and not dispatch if eventType is missing', () => {
@@ -265,7 +266,7 @@ describe('DispatchEventHandler', () => {
       expect.stringContaining('Invalid or missing "eventType" parameter'),
       expect.anything()
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   test('execute should log error and not dispatch if eventType is not a string', () => {
@@ -276,7 +277,7 @@ describe('DispatchEventHandler', () => {
       expect.stringContaining('Invalid or missing "eventType" parameter'),
       expect.anything()
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   test('execute should log error and not dispatch if eventType is an empty or whitespace string', () => {
@@ -286,7 +287,7 @@ describe('DispatchEventHandler', () => {
       expect.stringContaining('Invalid or missing "eventType" parameter'),
       expect.anything()
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
     mockLogger.error.mockClear(); // Clear for next check
 
     handler.execute({ eventType: '   ', payload: {} }, mockEvaluationContext);
@@ -295,7 +296,7 @@ describe('DispatchEventHandler', () => {
       expect.stringContaining('Invalid or missing "eventType" parameter'),
       expect.anything()
     );
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 
   // FIX: Corrected a faulty assertion in this test.
@@ -452,7 +453,7 @@ describe('DispatchEventHandler', () => {
     expect(mockEventBus.dispatch).toHaveBeenCalledTimes(1);
     expect(mockEventBus.dispatch).toHaveBeenCalledWith('BUS_EVENT', { id: 1 });
     expect(mockEventBus.listenerCount).toHaveBeenCalledWith('BUS_EVENT');
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled(); // Ensure default VED mock wasn't called
+    expectNoDispatch(mockDispatcher.dispatch); // Ensure default VED mock wasn't called
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining('Attempting to dispatch event "BUS_EVENT"'),

--- a/tests/unit/logic/operationHandlers/dispatchSpeechHandler.test.js
+++ b/tests/unit/logic/operationHandlers/dispatchSpeechHandler.test.js
@@ -7,6 +7,7 @@ import {
   DISPLAY_SPEECH_ID,
   SYSTEM_ERROR_OCCURRED_ID,
 } from '../../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 const makeLogger = () => ({
   debug: jest.fn(),
@@ -85,7 +86,7 @@ describe('DispatchSpeechHandler', () => {
       'DispatchSpeechHandler: DISPATCH_SPEECH: params missing or invalid.',
       { params: null }
     );
-    expect(safeDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(safeDispatcher.dispatch);
   });
 
   test('dispatches error event if underlying dispatch throws', () => {

--- a/tests/unit/logic/operationHandlers/systemMoveEntityHandler.test.js
+++ b/tests/unit/logic/operationHandlers/systemMoveEntityHandler.test.js
@@ -13,6 +13,7 @@ import {
 } from '@jest/globals';
 import SystemMoveEntityHandler from '../../../../src/logic/operationHandlers/systemMoveEntityHandler.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 // --- Mocks ---
 
@@ -105,7 +106,7 @@ describe('SystemMoveEntityHandler', () => {
         'SYSTEM_MOVE_ENTITY: "entity_ref" and "target_location_id" are required.'
       );
       expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
   });
 
@@ -270,7 +271,7 @@ describe('SystemMoveEntityHandler', () => {
         `SYSTEM_MOVE_ENTITY: Entity "${entityId}" is already in location "${fromLocationId}". No move needed.`
       );
       expect(mockEntityManager.addComponent).not.toHaveBeenCalled();
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
 
     test('should abort and warn if the entity has no core:position component', async () => {
@@ -285,7 +286,7 @@ describe('SystemMoveEntityHandler', () => {
         `SYSTEM_MOVE_ENTITY: Entity "${entityId}" has no 'core:position' component. Cannot move.`
       );
       expect(mockEntityManager.addComponent).not.toHaveBeenCalled();
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
 
     test('should abort and warn if addComponent reports failure', async () => {
@@ -302,7 +303,7 @@ describe('SystemMoveEntityHandler', () => {
       expect(execCtx.logger.warn).toHaveBeenCalledWith(
         `SYSTEM_MOVE_ENTITY: EntityManager reported failure for addComponent on entity "${entityId}".`
       );
-      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
   });
 

--- a/tests/unit/services/httpConfigurationProvider.test.js
+++ b/tests/unit/services/httpConfigurationProvider.test.js
@@ -10,6 +10,7 @@ import {
 } from '@jest/globals';
 import { HttpConfigurationProvider } from '../../../src/configuration/httpConfigurationProvider.js'; // Adjust path as needed
 import { createMockLogger } from '../testUtils.js'; // Path updated as per your usage
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 describe('HttpConfigurationProvider', () => {
@@ -78,7 +79,7 @@ describe('HttpConfigurationProvider', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `HttpConfigurationProvider: Successfully fetched and parsed configuration from ${url}.`
       );
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should throw an error and log if sourceUrl is invalid (empty string)', async () => {

--- a/tests/unit/services/modVersionValidator.test.js
+++ b/tests/unit/services/modVersionValidator.test.js
@@ -9,6 +9,7 @@ import validateModEngineVersions from '../../../src/modding/modVersionValidator.
 import ModDependencyError from '../../../src/errors/modDependencyError.js';
 import { ENGINE_VERSION } from '../../../src/engine/engineVersion.js'; // Use the actual engine version
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Mock Logger Factory
 const createMockLogger = () => ({
@@ -47,7 +48,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     // --- Case: No gameVersion ---
@@ -56,7 +57,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should skip and pass if a mod manifest has gameVersion: null', () => {
@@ -64,7 +65,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should skip and pass if a mod manifest has gameVersion: "" (empty string)', () => {
@@ -72,7 +73,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should skip and pass if a mod manifest has gameVersion: "   " (whitespace only)', () => {
@@ -80,7 +81,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     // --- Case: Satisfied range ---
@@ -91,7 +92,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should pass with multiple compatible mods using different valid range types', () => {
@@ -103,7 +104,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should pass with a mix of compatible mods and mods without gameVersion', () => {
@@ -116,7 +117,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).not.toThrow();
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
     });
 
     it('should trim whitespace around a valid and compatible range', () => {
@@ -232,7 +233,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
         .toThrow(new TypeError(expectedTypeErrorMsg));
 
       // --- Assert: Logger receives .error with expected message(s) --- (Should NOT be called for TypeError)
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
       expect(mockLogger.info).not.toHaveBeenCalled();
       expect.assertions(3); // toThrow, error not called, info not called
     });
@@ -252,7 +253,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       ).toThrow(new TypeError(expectedTypeErrorMsg));
 
       // --- Assert: Logger receives .error --- (Should NOT be called)
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
       expect(mockLogger.info).not.toHaveBeenCalled();
       expect.assertions(3);
     });
@@ -271,7 +272,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
         validateModEngineVersions(manifests, mockLogger, mockDispatcher)
       ).toThrow(new TypeError(expectedTypeErrorMsg));
 
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled(); // No ModDependencyError logged
+      expectNoDispatch(mockDispatcher.dispatch); // No ModDependencyError logged
       expect(mockLogger.info).not.toHaveBeenCalled(); // Did not complete successfully
       expect.assertions(3);
     });
@@ -283,7 +284,7 @@ describe('ModVersionValidator Service: validateModEngineVersions', () => {
       expect(() =>
         validateModEngineVersions(invalidInput, mockLogger, mockDispatcher)
       ).toThrow('validateModEngineVersions: Input `manifests` must be a Map.');
-      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockDispatcher.dispatch);
       expect(mockLogger.info).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/services/validatedEventDispatcher.test.js
+++ b/tests/unit/services/validatedEventDispatcher.test.js
@@ -4,6 +4,7 @@ import ValidatedEventDispatcher from '../../../src/events/validatedEventDispatch
 // Mock implementations (can be simplified if only tracking calls)
 import EventBus from '../../../src/events/eventBus.js';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals'; // We'll mock this module
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // --- Mocks Setup ---
 
@@ -213,7 +214,7 @@ describe('ValidatedEventDispatcher', () => {
         schemaId,
         payload
       );
-      expect(mockEventBus.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventBus.dispatch);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Payload validation FAILED for event '${eventName}'. Dispatch SKIPPED. Errors: [/data]: should be number`
@@ -246,7 +247,7 @@ describe('ValidatedEventDispatcher', () => {
 
       // Assert
       expect(result).toBe(false);
-      expect(mockEventBus.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventBus.dispatch);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Payload validation FAILED for event '${eventName}'. Dispatch SKIPPED. Errors: No details available`
@@ -387,7 +388,7 @@ describe('ValidatedEventDispatcher', () => {
       );
       expect(mockSchemaValidator.isSchemaLoaded).toHaveBeenCalledWith(schemaId);
       expect(mockSchemaValidator.validate).not.toHaveBeenCalled();
-      expect(mockEventBus.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventBus.dispatch);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Unexpected error during payload validation process for event '${eventName}'`
@@ -423,7 +424,7 @@ describe('ValidatedEventDispatcher', () => {
         schemaId,
         payload
       );
-      expect(mockEventBus.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventBus.dispatch);
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(
           `Unexpected error during payload validation process for event '${eventName}'`
@@ -472,7 +473,7 @@ describe('ValidatedEventDispatcher', () => {
 
       // Assert
       expect(result).toBe(false); // <<<< CHECK SUT CODE IF THIS FAILS (receives true)
-      expect(mockEventBus.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventBus.dispatch);
       expect(loggedValidationError).toBe(true); // Ensure the mock's logic was hit
 
       // Check the subsequent process error log (logged by the catch block)

--- a/tests/unit/turns/adapters/eventBusPromptAdapter.test.js
+++ b/tests/unit/turns/adapters/eventBusPromptAdapter.test.js
@@ -4,6 +4,7 @@
 import { EventBusPromptAdapter } from '../../../../src/turns/adapters/eventBusPromptAdapter.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { PLAYER_TURN_PROMPT_ID } from '../../../../src/constants/eventIds';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 // --- Mocks ---
 const mockSafeDispatcher = {
@@ -185,7 +186,7 @@ describe('EventBusPromptAdapter', () => {
       availableActions: actions,
       error: errorMsg,
     });
-    expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled(); // Ensure safe wasn't called
+    expectNoDispatch(mockSafeDispatcher.dispatch); // Ensure safe wasn't called
   });
 
   it('should resolve void even if dispatch returns false', async () => {

--- a/tests/unit/turns/providers/humanDecisionProvider.test.js
+++ b/tests/unit/turns/providers/humanDecisionProvider.test.js
@@ -4,6 +4,7 @@ import { jest, describe, beforeEach, expect, test } from '@jest/globals';
 import { HumanDecisionProvider } from '../../../../src/turns/providers/humanDecisionProvider.js';
 import { ITurnDecisionProvider } from '../../../../src/turns/interfaces/ITurnDecisionProvider.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 // Mock dependencies
 const mockPromptCoordinator = {
@@ -159,6 +160,6 @@ describe('HumanDecisionProvider', () => {
     await expect(
       decisionProvider.decide(mockActor, mockContext, mockActions)
     ).rejects.toThrow('Prompt failed!');
-    expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(mockDispatcher.dispatch);
   });
 });

--- a/tests/unit/turns/services/LLMResponseProcessor.notesGuards.test.js
+++ b/tests/unit/turns/services/LLMResponseProcessor.notesGuards.test.js
@@ -7,6 +7,7 @@ import { LLMResponseProcessor } from '../../../../src/turns/services/LLMResponse
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { LLMProcessingError } from '../../../../src/turns/services/LLMResponseProcessor.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 // --- Mocks & Helpers ---
 
@@ -69,7 +70,7 @@ describe('LLMResponseProcessor - notes data extraction', () => {
     expect(result.extractedData.notes).toEqual(notesFromLlm);
 
     // No errors should be logged for a valid response
-    expect(safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(safeEventDispatcher.dispatch);
   });
 
   test('When "notes" key is absent, extractedData.notes is undefined', async () => {
@@ -86,7 +87,7 @@ describe('LLMResponseProcessor - notes data extraction', () => {
 
     expect(result.success).toBe(true);
     expect(result.extractedData.notes).toBeUndefined();
-    expect(safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(safeEventDispatcher.dispatch);
   });
 
   test('When "notes" is not an array, it fails schema validation by throwing an error', async () => {

--- a/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -12,6 +12,7 @@ import {
   jest,
 } from '@jest/globals';
 import { flushPromisesAndTimers } from '../../../common/turns/turnManagerTestBed.js';
+import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 
 // Use fake timers to control setTimeout/clearTimeout and advance time manually.
 jest.useFakeTimers();
@@ -338,7 +339,7 @@ describe('AwaitingExternalTurnEndState', () => {
       await flushPromisesAndTimers();
 
       // Assert
-      expect(mockEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(mockEventDispatcher.dispatch);
       expect(mockTurnContext.endTurn).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.queueNotEmpty.test.js
@@ -8,6 +8,7 @@ import {
 } from '../../common/turns/turnManagerTestBed.js';
 import { expectSystemErrorDispatch } from '../../common/turns/turnManagerTestUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 import { createAiActor } from '../../common/turns/testActors.js';
 import { expectTurnStartedEvents } from '../../common/turns/turnManagerTestUtils.js';
 
@@ -280,7 +281,7 @@ describeRunningTurnManagerSuite(
       expect(
         freshTestBed.mocks.turnHandlerResolver.resolveHandler
       ).not.toHaveBeenCalled();
-      expect(freshTestBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(freshTestBed.mocks.dispatcher.dispatch);
 
       // Clean up the fresh test bed
       await freshTestBed.cleanup();

--- a/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
+++ b/tests/unit/turns/turnManager.advanceTurn.roundStart.test.js
@@ -11,6 +11,7 @@ import { createMockEntity } from '../../common/mockFactories';
 import { createAiActor } from '../../common/turns/testActors.js';
 import { createMockTurnHandler } from '../../common/mockFactories.js';
 import { expectSystemErrorDispatch } from '../../common/turns/turnManagerTestUtils.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describeTurnManagerSuite(
   'TurnManager: advanceTurn() - Round Start (Queue Empty)',
@@ -45,7 +46,7 @@ describeTurnManagerSuite(
       );
       expect(testBed.mocks.turnOrderService.isEmpty).not.toHaveBeenCalled();
       expect(stopSpy).not.toHaveBeenCalled();
-      expect(testBed.mocks.dispatcher.dispatch).not.toHaveBeenCalled();
+      expectNoDispatch(testBed.mocks.dispatcher.dispatch);
       expect(testBed.mocks.dispatcher.subscribe).not.toHaveBeenCalled(); // subscribe happens in start()
     });
 

--- a/tests/unit/utils/contextVariableUtils.test.js
+++ b/tests/unit/utils/contextVariableUtils.test.js
@@ -5,6 +5,7 @@ import {
   withUpdatedContext,
 } from '../../../src/utils/contextVariableUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describe('writeContextVariable', () => {
   test('stores value when context exists', () => {
@@ -19,7 +20,7 @@ describe('writeContextVariable', () => {
     const result = writeContextVariable('foo', 123, ctx, dispatcher, logger);
     expect(result).toEqual({ success: true });
     expect(ctx.evaluationContext.context.foo).toBe(123);
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
   });
 
   test('dispatches error and returns failure when context missing', () => {

--- a/tests/unit/utils/entityAssertionsUtils.test.js
+++ b/tests/unit/utils/entityAssertionsUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import { assertValidEntity } from '../../../src/utils/entityAssertionsUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 describe('assertValidEntity', () => {
   test('dispatches error and throws when actor invalid', () => {
@@ -47,7 +48,7 @@ describe('assertValidEntity', () => {
     expect(() =>
       assertValidEntity(actor, logger, 'Ctx', dispatcher)
     ).not.toThrow();
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/utils/evaluationContextUtils.test.js
+++ b/tests/unit/utils/evaluationContextUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import { ensureEvaluationContext } from '../../../src/utils/evaluationContextUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 const makeLogger = () => ({
   info: jest.fn(),
@@ -20,7 +21,7 @@ describe('ensureEvaluationContext', () => {
     const result = ensureEvaluationContext(ctx, dispatcher, logger);
 
     expect(result).toBe(ctx.evaluationContext.context);
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
   });
 
   test('dispatches error and returns null when context missing', () => {

--- a/tests/unit/utils/validationUtils.additional.test.js
+++ b/tests/unit/utils/validationUtils.additional.test.js
@@ -3,6 +3,7 @@ import * as validationUtils from '../../../src/utils/validationUtils.js';
 import { assertValidActionIndex } from '../../../src/utils/actionIndexUtils.js';
 const { validateDependency, validateDependencies } = validationUtils;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
 // Tests for validateDependency and validateDependencies
 
@@ -100,6 +101,6 @@ describe('assertValidActionIndex', () => {
     expect(() =>
       assertValidActionIndex(2, 3, 'Prov', 'actor3', dispatcher, {})
     ).not.toThrow();
-    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expectNoDispatch(dispatcher.dispatch);
   });
 });


### PR DESCRIPTION
## Summary
- replace direct dispatch checks with `expectNoDispatch`
- add `expectNoDispatch` imports across test suites

## Testing
- `npm run format`
- `npm run lint` *(fails: missing globals module)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d6e6da7748331973f33afae156676