### PR TITLE
[Agent] Rename local test bed variables

### DIFF
--- a/tests/unit/entities/entityManager.definitionMutation.test.js
+++ b/tests/unit/entities/entityManager.definitionMutation.test.js
@@ -11,20 +11,20 @@ describeEntityManagerSuite(
   'EntityManager.createEntityInstance does not mutate definitions',
   (getBed) => {
     test('components property remains unchanged when null', () => {
-      const tb = getBed();
+      const testBed = getBed();
       const definition = { id: 'test:nullComps', components: null };
       const regDef = new EntityDefinition(definition.id, {
         components: definition.components,
       });
-      tb.setupDefinitions(regDef);
+      testBed.setupDefinitions(regDef);
 
-      const entity = tb.entityManager.createEntityInstance(definition.id);
+      const entity = testBed.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toBeNull();
     });
 
     test('components property remains unchanged when valid object', () => {
-      const tb = getBed();
+      const testBed = getBed();
       const definition = {
         id: 'test:validComps',
         components: { 'core:name': { value: 'A' } },
@@ -32,9 +32,9 @@ describeEntityManagerSuite(
       const regDef = new EntityDefinition(definition.id, {
         components: definition.components,
       });
-      tb.setupDefinitions(regDef);
+      testBed.setupDefinitions(regDef);
 
-      const entity = tb.entityManager.createEntityInstance(definition.id);
+      const entity = testBed.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toEqual({ 'core:name': { value: 'A' } });
     });

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -67,11 +67,11 @@ describeEntityManagerSuite(
 
       it('should use the injected idGenerator', () => {
         const mockIdGenerator = jest.fn();
-        const localTestBed = new TestBed({ idGenerator: mockIdGenerator });
+        const testBed = new TestBed({ idGenerator: mockIdGenerator });
         // This test simply checks if the generator is stored,
         // createEntityInstance tests will check if it's *used*.
         // We can't directly access the private field, so we rely on functional tests.
-        expect(localTestBed.entityManager).toBeDefined();
+        expect(testBed.entityManager).toBeDefined();
       });
 
       it('should default to a UUIDv4 generator if none is provided', () => {
@@ -97,9 +97,9 @@ describeEntityManagerSuite('EntityManager - createEntityInstance', (getBed) => {
     it('should create an entity with an ID from the injected generator if no instanceId is provided', () => {
       // Arrange
       const mockIdGenerator = () => 'test-entity-id-123';
-      const localTestBed = new TestBed({ idGenerator: mockIdGenerator });
+      const testBed = new TestBed({ idGenerator: mockIdGenerator });
 
-      const entity = localTestBed.createBasicEntity();
+      const entity = testBed.createBasicEntity();
 
       // Assert
       expect(entity).toBeInstanceOf(Entity);
@@ -110,10 +110,10 @@ describeEntityManagerSuite('EntityManager - createEntityInstance', (getBed) => {
     it('should create an entity with a specific instanceId if provided, ignoring the generator', () => {
       // Arrange
       const mockIdGenerator = jest.fn(() => 'should-not-be-called');
-      const localTestBed = new TestBed({ idGenerator: mockIdGenerator });
+      const testBed = new TestBed({ idGenerator: mockIdGenerator });
       const { PRIMARY } = TestData.InstanceIDs;
 
-      const entity = localTestBed.createBasicEntity({
+      const entity = testBed.createBasicEntity({
         instanceId: PRIMARY,
       });
 
@@ -449,12 +449,12 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
       };
 
       // Arrange
-      const localTestBed = new TestBed({
+      const testBed = new TestBed({
         entityManagerOptions: { repository: stubRepo },
       });
-      const { entityManager, mocks } = localTestBed;
+      const { entityManager, mocks } = testBed;
       const { PRIMARY } = TestData.InstanceIDs;
-      localTestBed.createBasicEntity({ instanceId: PRIMARY });
+      testBed.createBasicEntity({ instanceId: PRIMARY });
 
       // Act & Assert
       expect(() => entityManager.removeEntityInstance(PRIMARY)).toThrow(
@@ -465,7 +465,7 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
           'EntityRepository.remove failed for already retrieved entity'
         )
       );
-      localTestBed.cleanup();
+      testBed.cleanup();
     });
   });
 });

--- a/tests/unit/smoke/newCharacterMemory.test.js
+++ b/tests/unit/smoke/newCharacterMemory.test.js
@@ -27,13 +27,15 @@ describeEntityManagerSuite(
   'Smoke › New Character › Short-Term Memory bootstrap',
   (getBed) => {
     test('EntityManager injects default short-term memory', () => {
-      const tb = getBed();
+      const testBed = getBed();
       const definition = new EntityDefinition('test:alice', {
         components: { [ACTOR_COMPONENT_ID]: {} },
       });
-      tb.setupDefinitions(definition);
+      testBed.setupDefinitions(definition);
 
-      const character = tb.entityManager.createEntityInstance(definition.id);
+      const character = testBed.entityManager.createEntityInstance(
+        definition.id
+      );
 
       expect(character).toBeDefined();
       expect(character.hasComponent(SHORT_TERM_MEMORY_COMPONENT_ID)).toBe(true);


### PR DESCRIPTION
## Summary
- rename `tb` and `localTestBed` variables to `testBed`
- keep references consistent in entity manager tests

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d781063bc8331a9a5b7e8ae483762