### PR TITLE
[Agent] validate worldName in initializer

### DIFF
--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -441,6 +441,11 @@ class WorldInitializer {
    * @throws {Error} If a critical error occurs during initialization that should stop the process (e.g., world not found).
    */
   async initializeWorldEntities(worldName) {
+    if (typeof worldName !== 'string' || !worldName.trim()) {
+      throw new Error(
+        'initializeWorldEntities requires a valid worldName string.'
+      );
+    }
     this.#logger.debug(
       `WorldInitializer: Starting world entity initialization process for world: ${worldName}...`
     );

--- a/tests/unit/initializers/worldInitializer.test.js
+++ b/tests/unit/initializers/worldInitializer.test.js
@@ -479,6 +479,17 @@ describe('WorldInitializer', () => {
       );
     });
 
+    it.each([[null], [undefined], [''], ['   ']])(
+      'should throw an error for invalid worldName %p',
+      async (badName) => {
+        await expect(
+          worldInitializer.initializeWorldEntities(badName)
+        ).rejects.toThrow(
+          'initializeWorldEntities requires a valid worldName string.'
+        );
+      }
+    );
+
     it('should handle empty instances array gracefully', async () => {
       const worldData = {
         id: 'test:world',


### PR DESCRIPTION
## Summary
- validate the world name parameter in `initializeWorldEntities`
- add unit tests for invalid world names

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d77622da48331b85a94c0b099d860