### PR TITLE
[Agent] add entity override helper

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -178,6 +178,29 @@ export class TestBed extends FactoryTestBed {
   }
 
   /**
+   * Convenience helper for creating an entity with initial component overrides.
+   *
+   * @description Creates a new entity instance from {@link TestData} with the
+   *   provided component overrides applied.
+   * @param {keyof typeof TestData.Definitions} defKey - Key of the test
+   *   definition to use.
+   * @param {Record<string, object>} overrides - Map of component IDs to override
+   *   data.
+   * @param {object} [options] - Options forwarded to
+   *   {@link EntityManager#createEntityInstance}.
+   * @param {object} [cfg] - Additional configuration options.
+   * @returns {import('../../../src/entities/entity.js').default} The created
+   *   entity instance.
+   */
+  createEntityWithOverride(defKey, overrides, options = {}, cfg = {}) {
+    return this.createEntity(
+      defKey,
+      { ...options, componentOverrides: overrides },
+      cfg
+    );
+  }
+
+  /**
    * Resets the dispatch mock on the internal event dispatcher.
    *
    * @returns {void}

--- a/tests/unit/entities/entityManager.getComponentData.test.js
+++ b/tests/unit/entities/entityManager.getComponentData.test.js
@@ -28,8 +28,11 @@ describeEntityManagerSuite('EntityManager - getComponentData', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'Override' };
-      getBed().createBasicEntity({ instanceId: PRIMARY });
-      entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, overrideData);
+      getBed().createEntityWithOverride(
+        'basic',
+        { [NAME_COMPONENT_ID]: overrideData },
+        { instanceId: PRIMARY }
+      );
 
       // Act
       const data = entityManager.getComponentData(PRIMARY, NAME_COMPONENT_ID);

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -25,10 +25,13 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
       // Arrange
       const { entityManager } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createBasicEntity({ instanceId: PRIMARY });
+      getBed().createEntityWithOverride(
+        'basic',
+        { 'new:component': { data: 'test' } },
+        { instanceId: PRIMARY }
+      );
 
       // Act
-      entityManager.addComponent(PRIMARY, 'new:component', { data: 'test' });
       const result = entityManager.hasComponent(PRIMARY, 'new:component');
 
       // Assert
@@ -88,10 +91,11 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createBasicEntity({ instanceId: PRIMARY });
-        entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
-          name: 'Override',
-        });
+        getBed().createEntityWithOverride(
+          'basic',
+          { [NAME_COMPONENT_ID]: { name: 'Override' } },
+          { instanceId: PRIMARY }
+        );
 
         // Act
         const result = entityManager.hasComponent(
@@ -128,10 +132,11 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createBasicEntity({ instanceId: PRIMARY });
-        entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
-          name: 'Override',
-        });
+        getBed().createEntityWithOverride(
+          'basic',
+          { [NAME_COMPONENT_ID]: { name: 'Override' } },
+          { instanceId: PRIMARY }
+        );
 
         // Act
         const result = entityManager.hasComponentOverride(

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -19,12 +19,11 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
 
       // Add component as an override
-      getBed().createBasicEntity({
-        instanceId: PRIMARY,
-      });
-      entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, {
-        name: 'Override',
-      });
+      getBed().createEntityWithOverride(
+        'basic',
+        { [NAME_COMPONENT_ID]: { name: 'Override' } },
+        { instanceId: PRIMARY }
+      );
       expect(entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID, true)).toBe(
         true
       );
@@ -44,15 +43,12 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'ToBeRemoved' };
-      const entity = getBed().createEntity(
+      const entity = getBed().createEntityWithOverride(
         'basic',
-        {
-          instanceId: PRIMARY,
-        },
+        { [NAME_COMPONENT_ID]: overrideData },
+        { instanceId: PRIMARY },
         { resetDispatch: true }
       );
-      entityManager.addComponent(PRIMARY, NAME_COMPONENT_ID, overrideData);
-      getBed().resetDispatchMock();
 
       // Act
       entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);


### PR DESCRIPTION
## Summary
- add `createEntityWithOverride` helper to entity testbed
- use the helper to simplify add/remove component tests
- apply helper in other tests with override setup

## Testing Done
- `npm run lint` *(fails: 3239 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d77d0100883318c07b3b2d4c4e633