### PR TITLE
[Agent] rename error variable names

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -187,7 +187,7 @@ class GameEngine {
     this.#logger.debug(
       `GameEngine: startNewGame called for world "${worldName}".`
     );
-    let specificInitializationError = null;
+    let initError = null;
 
     try {
       await this.#sessionManager.prepareForNewGameSession(worldName);
@@ -201,7 +201,7 @@ class GameEngine {
         const initializationError =
           initResult.error ||
           new Error('Unknown failure from InitializationService.');
-        specificInitializationError = initializationError;
+        initError = initializationError;
         this.#logger.warn(
           `GameEngine: InitializationService reported failure for "${worldName}".`
         );
@@ -215,7 +215,7 @@ class GameEngine {
         `GameEngine: Overall catch in startNewGame for world "${worldName}". Error: ${caughtError.message || String(caughtError)}`,
         caughtError
       );
-      if (caughtError !== specificInitializationError) {
+      if (caughtError !== initError) {
         await this._handleNewGameFailure(caughtError, worldName);
       }
       throw caughtError;

--- a/src/engine/persistenceCoordinator.js
+++ b/src/engine/persistenceCoordinator.js
@@ -95,15 +95,15 @@ class PersistenceCoordinator {
       );
       return { ...result, saveName };
     } catch (error) {
-      const caughtErrorMsg =
+      const errorMessage =
         error instanceof Error ? error.message : String(error);
       this.#logger.error(
-        `GameEngine.triggerManualSave: Unexpected error during save operation for "${saveName}". Error: ${caughtErrorMsg}`,
+        `GameEngine.triggerManualSave: Unexpected error during save operation for "${saveName}". Error: ${errorMessage}`,
         error
       );
       return {
         success: false,
-        error: `Unexpected error during save: ${caughtErrorMsg}`,
+        error: `Unexpected error during save: ${errorMessage}`,
         saveName,
       };
     }


### PR DESCRIPTION
Summary: Renamed internal variables for clearer semantics.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685d8d3ee71883318e012453a50f124c