### PR TITLE
[Agent] validate result variable in timestamp handler

### DIFF
--- a/src/logic/operationHandlers/getTimestampHandler.js
+++ b/src/logic/operationHandlers/getTimestampHandler.js
@@ -6,6 +6,7 @@
 import BaseOperationHandler from './baseOperationHandler.js';
 import { tryWriteContextVariable } from '../../utils/contextVariableUtils.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+import { validateStringParam } from '../../utils/handlerUtils/paramsUtils.js';
 import { ensureEvaluationContext } from '../../utils/evaluationContextUtils.js';
 
 /**
@@ -25,7 +26,13 @@ class GetTimestampHandler extends BaseOperationHandler {
     const logger = this.getLogger(executionContext);
     if (!assertParamsObject(params, logger, 'GET_TIMESTAMP')) return;
 
-    const resultVariable = params.result_variable.trim();
+    const resultVariable = validateStringParam(
+      params.result_variable,
+      'result_variable',
+      logger,
+      undefined
+    );
+    if (resultVariable === null) return;
     if (!ensureEvaluationContext(executionContext, undefined, logger)) {
       return;
     }

--- a/src/utils/handlerUtils/paramsUtils.js
+++ b/src/utils/handlerUtils/paramsUtils.js
@@ -44,12 +44,17 @@ export function validateStringParam(value, name, logger, dispatcher) {
   if (isNonBlankString(value)) {
     return value.trim();
   }
-  safeDispatchError(
-    dispatcher,
-    `Invalid "${name}" parameter`,
-    { [name]: value },
-    logger
-  );
+  const hasDispatcher = dispatcher && typeof dispatcher.dispatch === 'function';
+  if (hasDispatcher) {
+    safeDispatchError(
+      dispatcher,
+      `Invalid "${name}" parameter`,
+      { [name]: value },
+      logger
+    );
+  } else if (logger && typeof logger.warn === 'function') {
+    logger.warn(`Invalid "${name}" parameter`, { [name]: value });
+  }
   return null;
 }
 

--- a/tests/unit/logic/operationHandlers/getTimestampHandler.test.js
+++ b/tests/unit/logic/operationHandlers/getTimestampHandler.test.js
@@ -154,14 +154,24 @@ describe('GetTimestampHandler', () => {
       );
     });
 
-    test('should throw a TypeError if result_variable is missing from params', () => {
-      // Arrange
-      const params = {}; // Missing result_variable
-
-      // Act & Assert
-      expect(() => handler.execute(params, mockExecutionContext)).toThrow(
-        "Cannot read properties of undefined (reading 'trim')"
+    test('should warn and return if result_variable is missing', () => {
+      const params = {};
+      handler.execute(params, mockExecutionContext);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Invalid "result_variable" parameter',
+        { result_variable: undefined }
       );
+      expect(mockExecutionContext.evaluationContext.context).toEqual({});
+    });
+
+    test('should warn and return if result_variable is blank', () => {
+      const params = { result_variable: '   ' };
+      handler.execute(params, mockExecutionContext);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Invalid "result_variable" parameter',
+        { result_variable: '   ' }
+      );
+      expect(mockExecutionContext.evaluationContext.context).toEqual({});
     });
 
     test('should handle a malformed execution context gracefully', () => {


### PR DESCRIPTION
## Summary
- validate the `result_variable` param in `getTimestampHandler`
- add warnings for missing or blank `result_variable`
- ensure handlers without dispatchers warn instead of throwing
- test timestamp handler parameter validation

## Testing Done
- `npm run format`
- `npx eslint src/logic/operationHandlers/getTimestampHandler.js src/utils/handlerUtils/paramsUtils.js tests/unit/logic/operationHandlers/getTimestampHandler.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d8d04d6708331ba409e136ea82396