### PR TITLE
[Agent] include error details in action formatting

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -30,6 +30,7 @@ import {
  * @typedef {object} FormatActionError
  * @property {false} ok - Indicates failure.
  * @property {string} error - The reason formatting failed.
+ * @property {string} [details] - Additional error details.
  */
 
 /**
@@ -236,7 +237,8 @@ function applyTargetFormatter(
     );
     return {
       ok: false,
-      error: 'formatActionCommand: Error during placeholder substitution.',
+      error: 'placeholder substitution failed',
+      details: error.message,
     };
   }
 }

--- a/tests/unit/actions/actionFormatter.additional.test.js
+++ b/tests/unit/actions/actionFormatter.additional.test.js
@@ -102,6 +102,7 @@ describe('formatActionCommand additional cases', () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(result.details).toBe('boom');
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- attach error details in applyTargetFormatter
- propagate formatting error details through ActionDiscoveryService
- verify placeholder substitution error in unit test

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d8cd25c9883318ce488e01eddaba4