### PR TITLE
[Agent] add SaveGameService and slot list manager tests

### DIFF
--- a/tests/domUI/saveGameService.test.js
+++ b/tests/domUI/saveGameService.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import SaveGameService from '../../src/domUI/saveGameService.js';
+import { createMockLogger } from '../common/mockFactories';
+
+/**
+ *
+ */
+function makeService() {
+  const logger = createMockLogger();
+  const userPrompt = { confirm: jest.fn(() => true) };
+  const service = new SaveGameService({ logger, userPrompt });
+  return { service, logger, userPrompt };
+}
+
+describe('SaveGameService', () => {
+  describe('validatePreconditions', () => {
+    it('returns error when slot missing', () => {
+      const { service } = makeService();
+      const result = service.validatePreconditions(null, 'name');
+      expect(result).toMatch(/Cannot save/);
+    });
+
+    it('returns error when name empty', () => {
+      const { service } = makeService();
+      const result = service.validatePreconditions({ slotId: 0 }, '');
+      expect(result).toBe('Please enter a name for your save.');
+    });
+
+    it('returns error when slot corrupted', () => {
+      const { service } = makeService();
+      const result = service.validatePreconditions(
+        { slotId: 0, isCorrupted: true },
+        'Test'
+      );
+      expect(result).toMatch(/corrupted/);
+    });
+
+    it('returns null when valid', () => {
+      const { service } = makeService();
+      const result = service.validatePreconditions(
+        { slotId: 0, isCorrupted: false },
+        'Valid'
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('confirmOverwrite', () => {
+    it('bypasses confirmation for empty slot', () => {
+      const { service, userPrompt } = makeService();
+      const result = service.confirmOverwrite(
+        { slotId: 0, isEmpty: true },
+        'Test'
+      );
+      expect(result).toBe(true);
+      expect(userPrompt.confirm).not.toHaveBeenCalled();
+    });
+
+    it('asks user when overwriting existing save', () => {
+      const { service, userPrompt } = makeService();
+      userPrompt.confirm.mockReturnValueOnce(false);
+      const result = service.confirmOverwrite(
+        { slotId: 0, isEmpty: false, saveName: 'Old' },
+        'New'
+      );
+      expect(userPrompt.confirm).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('executeSave', () => {
+    it('calls save service with slot and name', async () => {
+      const { service } = makeService();
+      const saveService = {
+        save: jest.fn().mockResolvedValue({ success: true, filePath: 'id1' }),
+      };
+      const slot = { slotId: 1, identifier: 'id1' };
+      const result = await service.executeSave(slot, 'Name', saveService);
+      expect(saveService.save).toHaveBeenCalledWith(1, 'Name');
+      expect(result).toEqual({
+        result: { success: true, filePath: 'id1' },
+        returnedIdentifier: 'id1',
+      });
+    });
+
+    it('logs when success has no filePath', async () => {
+      const { service, logger } = makeService();
+      const saveService = {
+        save: jest.fn().mockResolvedValue({ success: true }),
+      };
+      const slot = { slotId: 1 };
+      const result = await service.executeSave(slot, 'Name', saveService);
+      expect(logger.error).toHaveBeenCalled();
+      expect(result).toEqual({
+        result: { success: true },
+        returnedIdentifier: undefined,
+      });
+    });
+  });
+
+  describe('performSave', () => {
+    it('returns success message on successful save', async () => {
+      const { service } = makeService();
+      jest.spyOn(service, 'executeSave').mockResolvedValue({
+        result: { success: true, filePath: 'id' },
+        returnedIdentifier: 'id',
+      });
+      const slot = { slotId: 0 };
+      const res = await service.performSave(slot, 'Name', {});
+      expect(res).toEqual({
+        success: true,
+        message: 'Game saved as "Name".',
+        returnedIdentifier: 'id',
+      });
+    });
+
+    it('handles failure result', async () => {
+      const { service } = makeService();
+      jest.spyOn(service, 'executeSave').mockResolvedValue({
+        result: { success: false, error: 'fail' },
+        returnedIdentifier: null,
+      });
+      const res = await service.performSave({ slotId: 0 }, 'Name', {});
+      expect(res.success).toBe(false);
+      expect(res.message).toMatch(/fail/);
+      expect(res.returnedIdentifier).toBeNull();
+    });
+
+    it('handles thrown errors', async () => {
+      const { service } = makeService();
+      jest.spyOn(service, 'executeSave').mockRejectedValue(new Error('boom'));
+      const res = await service.performSave({ slotId: 0 }, 'Name', {});
+      expect(res.success).toBe(false);
+      expect(res.message).toMatch(/boom/);
+      expect(res.returnedIdentifier).toBeNull();
+    });
+  });
+});

--- a/tests/domUI/slotListManager.test.js
+++ b/tests/domUI/slotListManager.test.js
@@ -1,0 +1,99 @@
+import { JSDOM } from 'jsdom';
+import { describe, it, expect, jest } from '@jest/globals';
+import SaveGameUI from '../../src/domUI/saveGameUI.js';
+import SaveGameService from '../../src/domUI/saveGameService.js';
+import DocumentContext from '../../src/domUI/documentContext.js';
+import DomElementFactory from '../../src/domUI/domElementFactory.js';
+import { createMockLogger } from '../common/mockFactories';
+
+/**
+ *
+ * @param saveLoadService
+ */
+function setupUI(saveLoadService) {
+  const html = `<!DOCTYPE html><body>
+    <div id="save-game-screen">
+      <button id="cancel-save-button"></button>
+      <div id="save-slots-container"></div>
+      <input id="save-name-input" />
+      <button id="confirm-save-button"></button>
+      <div id="save-game-status-message"></div>
+    </div>
+  </body>`;
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+  const logger = createMockLogger();
+  const docContext = new DocumentContext(document, logger);
+  const factory = new DomElementFactory(docContext);
+  const dispatcher = {
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    dispatch: jest.fn(),
+  };
+  const saveGameService = new SaveGameService({
+    logger,
+    userPrompt: { confirm: jest.fn() },
+  });
+
+  const ui = new SaveGameUI({
+    logger,
+    documentContext: docContext,
+    domElementFactory: factory,
+    saveLoadService,
+    validatedEventDispatcher: dispatcher,
+    saveGameService,
+  });
+
+  return { ui, logger };
+}
+
+describe('slot list manager', () => {
+  it('fetches and formats save slots', async () => {
+    const saveLoadService = {
+      listManualSaveSlots: jest.fn().mockResolvedValue([
+        {
+          identifier: 'id1',
+          saveName: 'First',
+          timestamp: '2023-01-01T00:00:00Z',
+          playtimeSeconds: 5,
+          isCorrupted: false,
+        },
+        {
+          identifier: 'id2',
+          saveName: 'Second',
+          timestamp: '2023-01-02T00:00:00Z',
+          playtimeSeconds: 10,
+          isCorrupted: false,
+        },
+      ]),
+    };
+
+    const { ui } = setupUI(saveLoadService);
+    const data = await ui._getSaveSlotsData();
+
+    expect(saveLoadService.listManualSaveSlots).toHaveBeenCalled();
+    expect(data).toHaveLength(10);
+    expect(data[0]).toMatchObject({
+      slotId: 0,
+      identifier: 'id1',
+      isEmpty: false,
+    });
+    expect(data[2].isEmpty).toBe(true);
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    const saveLoadService = {
+      listManualSaveSlots: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    const { ui, logger } = setupUI(saveLoadService);
+    const statusSpy = jest.spyOn(ui, '_displayStatusMessage');
+    const data = await ui._getSaveSlotsData();
+
+    expect(data).toEqual([]);
+    expect(statusSpy).toHaveBeenCalledWith(
+      'Error loading save slots information.',
+      'error'
+    );
+    expect(logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test slot list data fetching via SaveGameUI
- test SaveGameService validation and save operations

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d8d30f728833183a1faed444b2e0c