### PR TITLE
[Agent] define LLM config service interface

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -60,7 +60,8 @@ import { loadProxyLlmConfigs } from '../proxyLlmConfigLoader.js';
  */
 
 /**
- *
+ * Service for loading and providing access to LLM configuration data.
+ * @implements {import('../interfaces/ILlmConfigService.js').ILlmConfigService}
  */
 export class LlmConfigService {
   /** @type {IFileSystemReader} */

--- a/llm-proxy-server/src/interfaces/ILlmConfigService.js
+++ b/llm-proxy-server/src/interfaces/ILlmConfigService.js
@@ -1,0 +1,57 @@
+// llm-proxy-server/src/interfaces/ILlmConfigService.js
+/**
+ * @interface ILlmConfigService
+ * @description Defines an interface for working with LLM configuration data.
+ */
+
+/**
+ * Initializes the service by loading and validating configuration data.
+ * @function
+ * @name ILlmConfigService#initialize
+ * @returns {Promise<void>} A promise that resolves when initialization completes.
+ */
+
+/**
+ * Checks if the service has successfully loaded configurations.
+ * @function
+ * @name ILlmConfigService#isOperational
+ * @returns {boolean} True if operational, otherwise false.
+ */
+
+/**
+ * Retrieves all loaded LLM configurations.
+ * @function
+ * @name ILlmConfigService#getLlmConfigs
+ * @returns {LLMConfigurationFileForProxy | null} The configurations or null if unavailable.
+ */
+
+/**
+ * Retrieves a specific LLM configuration by ID.
+ * @function
+ * @name ILlmConfigService#getLlmById
+ * @param {string} id - The ID of the desired LLM.
+ * @returns {LLMModelConfig | null} The configuration or null if not found.
+ */
+
+/**
+ * Gets the resolved configuration file path that was used.
+ * @function
+ * @name ILlmConfigService#getResolvedConfigPath
+ * @returns {string | null} The resolved path or null if not determined.
+ */
+
+/**
+ * Provides details of initialization errors, if any.
+ * @function
+ * @name ILlmConfigService#getInitializationErrorDetails
+ * @returns {StandardizedErrorObject | null} Error details or null if initialization succeeded.
+ */
+
+/**
+ * Indicates whether any LLM configuration relies on a file-based API key.
+ * @function
+ * @name ILlmConfigService#hasFileBasedApiKeys
+ * @returns {boolean} True if any configuration specifies an API key file.
+ */
+
+export {}; // Ensures this file is treated as an ES module


### PR DESCRIPTION
## Summary
- add `ILlmConfigService` interface with LLM config service methods
- note interface implementation in `LlmConfigService`

## Testing Done
- `npm run lint` *(fails: 657 errors, 2581 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d8d1fe44c8331975de754db0c83ac