### PR TITLE
[Agent] refactor ADS tests to use test bed

### DIFF
--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -1,94 +1,45 @@
-import { jest, describe, beforeEach, expect, it } from '@jest/globals';
+import { beforeEach, expect, it } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
 
-import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
-import { POSITION_COMPONENT_ID } from '../../../src/constants/componentIds.js';
-
-describe('ActionDiscoveryService params exposure', () => {
-  const dummyActionDef = {
-    id: 'core:attack',
-    name: 'Attack',
-    commandVerb: 'attack',
-    description: 'Attack target',
-    scope: 'enemies',
-  };
-
-  let service;
-
-  beforeEach(() => {
-    const gameDataRepo = { getAllActionDefinitions: () => [dummyActionDef] };
-    const entityManager = {
-      getEntityInstance: (id) => {
-        if (id === 'some-room') {
-          return { id: 'some-room', getComponentData: () => null };
-        }
-        if (id === 'rat123') {
-          return { id: 'rat123', getComponentData: () => null };
-        }
-        return null;
-      },
-      getComponentData: (entityId, componentId) => {
-        if (entityId === 'player1' && componentId === POSITION_COMPONENT_ID) {
-          return { locationId: 'some-room' };
-        }
-        return null;
-      },
-    };
-    const actionValidationService = {
-      isValid: () => true,
-    };
-    // FIX: Add the new required dependency
-    const mockPrerequisiteEvaluationService = {
-      evaluate: jest.fn().mockReturnValue(true),
-    };
-    const formatActionCommandFn = () => ({ ok: true, value: 'attack rat123' });
-    const logger = {
-      debug: jest.fn(),
-      info: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-    };
-    const safeEventDispatcher = { dispatch: jest.fn() };
-
-    const mockActionIndex = {
-      getCandidateActions: jest.fn(() => [dummyActionDef]),
-    };
-
-    const mockTargetResolutionService = {
-      resolveTargets: jest.fn().mockResolvedValue([
-        { type: 'entity', entityId: 'rat123' }
-      ]),
-    };
-
-    service = new ActionDiscoveryService({
-      gameDataRepository: gameDataRepo,
-      entityManager,
-      actionValidationService,
-      prerequisiteEvaluationService: mockPrerequisiteEvaluationService, // <-- The fix
-      actionIndex: mockActionIndex,
-      formatActionCommandFn,
-      logger,
-      safeEventDispatcher,
-      targetResolutionService: mockTargetResolutionService,
-      traceContextFactory: jest.fn(() => ({ addLog: jest.fn(), logs: [] })),
-    });
-  });
-
-  it('should include params.targetId for entity-scoped actions', async () => {
-    const actor = {
-      id: 'player1',
-      getComponentData: () => null,
-      addComponent: jest.fn(),
-      removeComponent: jest.fn(),
-    };
-    const context = {
-      jsonLogicEval: {},
-    };
-    const result = await service.getValidActions(actor, context);
-
-    expect(result.actions).toHaveLength(1);
-    expect(result.actions[0]).toMatchObject({
+describeActionDiscoverySuite(
+  'ActionDiscoveryService params exposure',
+  (getBed) => {
+    const dummyActionDef = {
       id: 'core:attack',
-      params: { targetId: 'rat123' },
+      name: 'Attack',
+      commandVerb: 'attack',
+      description: 'Attack target',
+      scope: 'enemies',
+    };
+
+    beforeEach(() => {
+      const bed = getBed();
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+        dummyActionDef,
+      ]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+        { type: 'entity', entityId: 'rat123' },
+      ]);
+      bed.mocks.formatActionCommandFn.mockReturnValue({
+        ok: true,
+        value: 'attack rat123',
+      });
+      bed.mocks.getActorLocationFn.mockReturnValue('some-room');
     });
-  });
-});
+
+    it('should include params.targetId for entity-scoped actions', async () => {
+      const bed = getBed();
+      const actor = { id: 'player1' };
+      const context = { jsonLogicEval: {} };
+
+      const result = await bed.service.getValidActions(actor, context);
+
+      expect(result.actions).toHaveLength(1);
+      expect(result.actions[0]).toMatchObject({
+        id: 'core:attack',
+        params: { targetId: 'rat123' },
+      });
+    });
+  }
+);

--- a/tests/unit/actions/actionDiscoveryService.tracing.test.js
+++ b/tests/unit/actions/actionDiscoveryService.tracing.test.js
@@ -1,195 +1,260 @@
-/**
- * @file Tests the tracing behavior inside ActionDiscoveryService.
- * @see tests/unit/actions/actionDiscoveryService.tracing.test.js
- */
-
-import { jest, describe, beforeEach, it, expect } from '@jest/globals';
-import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
 import { TraceContext } from '../../../src/actions/tracing/traceContext.js';
-import { mock, mockDeep } from 'jest-mock-extended';
 
-// Mock TraceContext and its constructor
-jest.mock('../../../src/actions/tracing/traceContext.js', () => {
-  return {
-    TraceContext: jest.fn().mockImplementation(() => ({
-      addLog: jest.fn(),
-      logs: [],
-    })),
-  };
-});
+jest.mock('../../../src/actions/tracing/traceContext.js', () => ({
+  TraceContext: jest
+    .fn()
+    .mockImplementation(() => ({ addLog: jest.fn(), logs: [] })),
+}));
 
-describe('ActionDiscoveryService Tracing', () => {
-  let service;
-  let deps;
-  let actorEntity;
-  let context;
+describeActionDiscoverySuite(
+  'ActionDiscoveryService Tracing',
+  (getBed) => {
+    let actorEntity;
+    let context;
 
-  const actionDefPrereq = { id: 'action1', name: 'With Prereqs', prerequisites: [{ op: 'test' }], scope: 'someScope' };
-  const actionDefScope = { id: 'action2', name: 'With Scope', scope: 'someScope' };
-  const actionDefSimple = { id: 'action3', name: 'Simple', scope: 'none' };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    deps = {
-      gameDataRepository: mockDeep(),
-      entityManager: mockDeep(),
-      prerequisiteEvaluationService: mock(),
-      actionIndex: mock(),
-      logger: mock(),
-      formatActionCommandFn: jest.fn(),
-      safeEventDispatcher: mockDeep(),
-      targetResolutionService: {
-        resolveTargets: jest.fn(),
-      },
-      traceContextFactory: jest.fn(() => new TraceContext()),
-      getActorLocationFn: jest.fn(),
-      getEntityDisplayNameFn: jest.fn(),
+    const actionDefPrereq = {
+      id: 'action1',
+      name: 'With Prereqs',
+      prerequisites: [{ op: 'test' }],
+      scope: 'someScope',
     };
+    const actionDefScope = {
+      id: 'action2',
+      name: 'With Scope',
+      scope: 'someScope',
+    };
+    const actionDefSimple = { id: 'action3', name: 'Simple', scope: 'none' };
 
-    actorEntity = { id: 'player' };
-    context = { a: 1 };
-
-    // Default mock behaviors
-    deps.getActorLocationFn.mockReturnValue('location1');
-    deps.actionIndex.getCandidateActions.mockReturnValue([]);
-    deps.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-    deps.targetResolutionService.resolveTargets.mockImplementation(async (scopeName) => {
-      if (scopeName === 'someScope') return [
-        { type: 'entity', entityId: 'target1' },
-        { type: 'entity', entityId: 'target2' }
-      ];
-      if (scopeName === 'none') return [{ type: 'none', entityId: null }];
-      if (scopeName === 'self') return [{ type: 'entity', entityId: actorEntity.id }];
-      return [];
-    });
-    deps.formatActionCommandFn.mockReturnValue({ ok: true, value: 'do action' });
-
-    service = new ActionDiscoveryService(deps);
-  });
-
-  // New test structure for getValidActions with tracing
-  describe('getValidActions({ trace: true })', () => {
-
-    it('should create a new TraceContext and log the start of the trace', async () => {
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(TraceContext).toHaveBeenCalledTimes(1);
-      expect(trace.addLog).toHaveBeenCalledWith(
-        'info',
-        `Starting action discovery for actor '${actorEntity.id}'.`,
-        'getValidActions',
-        { withTrace: true }
+    beforeEach(() => {
+      jest.clearAllMocks();
+      const bed = getBed();
+      actorEntity = { id: 'player' };
+      context = { a: 1 };
+      bed.mocks.getActorLocationFn.mockReturnValue('location1');
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+      bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
+        async (scopeName) => {
+          if (scopeName === 'someScope') {
+            return [
+              { type: 'entity', entityId: 'target1' },
+              { type: 'entity', entityId: 'target2' },
+            ];
+          }
+          if (scopeName === 'none') return [{ type: 'none', entityId: null }];
+          if (scopeName === 'self')
+            return [{ type: 'entity', entityId: actorEntity.id }];
+          return [];
+        }
       );
+      bed.mocks.formatActionCommandFn.mockReturnValue({
+        ok: true,
+        value: 'do action',
+      });
     });
 
-    it('should call getCandidateActions with the actor and the trace object', async () => {
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
+    describe('getValidActions({ trace: true })', () => {
+      it('should create a new TraceContext and log the start of the trace', async () => {
+        const bed = getBed();
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
 
-      expect(deps.actionIndex.getCandidateActions).toHaveBeenCalledWith(actorEntity, trace);
-    });
-
-    it('should log each candidate action being processed', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefSimple, actionDefScope]);
-
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(trace.addLog).toHaveBeenCalledWith(
-        'step',
-        `Processing candidate action: '${actionDefSimple.id}'`,
-        'ActionDiscoveryService.#processCandidateAction'
-      );
-      expect(trace.addLog).toHaveBeenCalledWith(
-        'step',
-        `Processing candidate action: '${actionDefScope.id}'`,
-        'ActionDiscoveryService.#processCandidateAction'
-      );
-    });
-
-    it('should pass the trace object to the prerequisite check', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefPrereq]);
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(deps.prerequisiteEvaluationService.evaluate).toHaveBeenCalledWith(
-        actionDefPrereq.prerequisites,
-        actionDefPrereq,
-        actorEntity,
-        trace // The trace object
-      );
-    });
-
-    it('should log when prerequisites pass', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefPrereq]);
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(trace.addLog).toHaveBeenCalledWith(
-        'success',
-        `Action '${actionDefPrereq.id}' passed actor prerequisite check.`,
-        'ActionDiscoveryService.#processCandidateAction'
-      );
-    });
-
-    it('should log and discard action when prerequisites fail', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefPrereq]);
-      deps.prerequisiteEvaluationService.evaluate.mockReturnValue(false);
-
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(trace.addLog).toHaveBeenCalledWith(
-        'failure',
-        `Action '${actionDefPrereq.id}' discarded due to failed actor prerequisites.`,
-        'ActionDiscoveryService.#processCandidateAction'
-      );
-      // The rest of the processing for this action should be skipped
-      expect(deps.targetResolutionService.resolveTargets).not.toHaveBeenCalled();
-    });
-
-    it('should pass the trace object to the scope resolution', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefScope]);
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-
-      expect(deps.targetResolutionService.resolveTargets).toHaveBeenCalledWith(
-        actionDefScope.scope,
-        actorEntity,
-        expect.anything(), // The runtime context
-        trace // The trace object
-      );
-    });
-
-    it('should orchestrate a full trace, logging multiple steps in order', async () => {
-      deps.actionIndex.getCandidateActions.mockReturnValue([actionDefPrereq, actionDefScope]);
-      deps.prerequisiteEvaluationService.evaluate.mockImplementation((prereqs, actionDef) => {
-        // Fail prereqs only for the first action
-        return actionDef.id !== actionDefPrereq.id;
+        expect(TraceContext).toHaveBeenCalledTimes(1);
+        expect(trace.addLog).toHaveBeenCalledWith(
+          'info',
+          `Starting action discovery for actor '${actorEntity.id}'.`,
+          'getValidActions',
+          { withTrace: true }
+        );
       });
 
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-      const calls = trace.addLog.mock.calls;
+      it('should call getCandidateActions with the actor and the trace object', async () => {
+        const bed = getBed();
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
 
-      expect(calls[0][1]).toContain('Starting action discovery');
-      expect(calls[1][1]).toContain(`Processing candidate action: '${actionDefPrereq.id}'`);
-      expect(calls[2][1]).toContain(`discarded due to failed actor prerequisites`);
-      expect(calls[3][1]).toContain(`Processing candidate action: '${actionDefScope.id}'`);
-      expect(calls[4][1]).toContain('passed actor prerequisite check');
+        expect(bed.mocks.actionIndex.getCandidateActions).toHaveBeenCalledWith(
+          actorEntity,
+          trace
+        );
+      });
 
-      // The trace logging has changed since we now delegate to the TargetResolutionService
-      // Find the final log message in the calls array
-      const finalLogCall = calls.find(call => call[1].includes("Finished discovery"));
-      expect(finalLogCall).toBeDefined();
-      expect(finalLogCall[1]).toContain("Finished discovery. Found 2 valid actions");
+      it('should log each candidate action being processed', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefSimple,
+          actionDefScope,
+        ]);
+
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+
+        expect(trace.addLog).toHaveBeenCalledWith(
+          'step',
+          `Processing candidate action: '${actionDefSimple.id}'`,
+          'ActionDiscoveryService.#processCandidateAction'
+        );
+        expect(trace.addLog).toHaveBeenCalledWith(
+          'step',
+          `Processing candidate action: '${actionDefScope.id}'`,
+          'ActionDiscoveryService.#processCandidateAction'
+        );
+      });
+
+      it('should pass the trace object to the prerequisite check', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefPrereq,
+        ]);
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+
+        expect(
+          bed.mocks.prerequisiteEvaluationService.evaluate
+        ).toHaveBeenCalledWith(
+          actionDefPrereq.prerequisites,
+          actionDefPrereq,
+          actorEntity,
+          trace
+        );
+      });
+
+      it('should log when prerequisites pass', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefPrereq,
+        ]);
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+
+        expect(trace.addLog).toHaveBeenCalledWith(
+          'success',
+          `Action '${actionDefPrereq.id}' passed actor prerequisite check.`,
+          'ActionDiscoveryService.#processCandidateAction'
+        );
+      });
+
+      it('should log and discard action when prerequisites fail', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefPrereq,
+        ]);
+        bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(false);
+
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+
+        expect(trace.addLog).toHaveBeenCalledWith(
+          'failure',
+          `Action '${actionDefPrereq.id}' discarded due to failed actor prerequisites.`,
+          'ActionDiscoveryService.#processCandidateAction'
+        );
+        expect(
+          bed.mocks.targetResolutionService.resolveTargets
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should pass the trace object to the scope resolution', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefScope,
+        ]);
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+
+        expect(
+          bed.mocks.targetResolutionService.resolveTargets
+        ).toHaveBeenCalledWith(
+          actionDefScope.scope,
+          actorEntity,
+          expect.anything(),
+          trace
+        );
+      });
+
+      it('should orchestrate a full trace, logging multiple steps in order', async () => {
+        const bed = getBed();
+        bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+          actionDefPrereq,
+          actionDefScope,
+        ]);
+        bed.mocks.prerequisiteEvaluationService.evaluate.mockImplementation(
+          (_, actionDef) => actionDef.id !== actionDefPrereq.id
+        );
+
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+        const calls = trace.addLog.mock.calls;
+
+        expect(calls[0][1]).toContain('Starting action discovery');
+        expect(calls[1][1]).toContain(
+          `Processing candidate action: '${actionDefPrereq.id}'`
+        );
+        expect(calls[2][1]).toContain(
+          'discarded due to failed actor prerequisites'
+        );
+        expect(calls[3][1]).toContain(
+          `Processing candidate action: '${actionDefScope.id}'`
+        );
+        expect(calls[4][1]).toContain('passed actor prerequisite check');
+        const finalLogCall = calls.find((call) =>
+          call[1].includes('Finished discovery')
+        );
+        expect(finalLogCall).toBeDefined();
+        expect(finalLogCall[1]).toContain(
+          'Finished discovery. Found 2 valid actions'
+        );
+      });
+
+      it('should return the populated trace object in the result', async () => {
+        const bed = getBed();
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: true }
+        );
+        expect(trace).not.toBeNull();
+        expect(trace).toBeInstanceOf(Object);
+        expect(trace.addLog).toBeDefined();
+      });
+
+      it('should return a null trace when tracing is disabled', async () => {
+        const bed = getBed();
+        const { trace } = await bed.service.getValidActions(
+          actorEntity,
+          context,
+          { trace: false }
+        );
+        expect(trace).toBeNull();
+        expect(TraceContext).not.toHaveBeenCalled();
+      });
     });
-
-    it('should return the populated trace object in the result', async () => {
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: true });
-      expect(trace).not.toBeNull();
-      expect(trace).toBeInstanceOf(Object);
-      expect(trace.addLog).toBeDefined();
-    });
-
-    it('should return a null trace when tracing is disabled', async () => {
-      const { trace } = await service.getValidActions(actorEntity, context, { trace: false });
-      expect(trace).toBeNull();
-      expect(TraceContext).not.toHaveBeenCalled();
-    });
-  });
-});
+  },
+  { traceContextFactory: () => new TraceContext() }
+);


### PR DESCRIPTION
## Summary
- refactor ActionDiscoveryService unit tests to use ActionDiscoveryServiceTestBed

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d8caf5d148331a8f210a435612bea