### PR TITLE
[Fix] unify dispatch retrieval

### DIFF
--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -22,7 +22,7 @@ import { ProcessingExceptionHandler } from './helpers/processingExceptionHandler
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
-import { getLogger } from './helpers/contextUtils.js';
+import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 import turnDirectiveResolverAdapter from '../adapters/turnDirectiveResolverAdapter.js';
 import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js';
 import {
@@ -235,17 +235,13 @@ export class ProcessingCommandState extends AbstractTurnState {
       );
 
       try {
-        const eventDispatcher = turnCtx.getSafeEventDispatcher?.();
+        const eventDispatcher = getSafeEventDispatcher(turnCtx, this._handler);
         if (eventDispatcher) {
           const payload = { entityId: actorId, ...payloadBase };
           await eventDispatcher.dispatch(ENTITY_SPOKE_ID, payload);
           logger.debug(
             `${this.getStateName()}: Attempted dispatch of ${ENTITY_SPOKE_ID} for actor ${actorId} via TurnContext's SafeEventDispatcher.`,
             { payload }
-          );
-        } else {
-          logger.warn(
-            `${this.getStateName()}: Could not get SafeEventDispatcher from TurnContext. ${ENTITY_SPOKE_ID} event not dispatched for actor ${actorId}.`
           );
         }
       } catch (eventDispatchError) {

--- a/src/turns/states/processingCommandState.js.temp
+++ b/src/turns/states/processingCommandState.js.temp
@@ -21,7 +21,7 @@ import { ProcessingExceptionHandler } from './helpers/processingExceptionHandler
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
-import { getLogger } from './helpers/contextUtils.js';
+import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 import turnDirectiveResolverAdapter from '../adapters/turnDirectiveResolverAdapter.js';
 import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js';
 
@@ -171,17 +171,13 @@ export class ProcessingCommandState extends AbstractTurnState {
       );
 
       try {
-        const eventDispatcher = turnCtx.getSafeEventDispatcher?.();
+        const eventDispatcher = getSafeEventDispatcher(turnCtx, this._handler);
         if (eventDispatcher) {
           const payload = { entityId: actorId, ...payloadBase };
           await eventDispatcher.dispatch(ENTITY_SPOKE_ID, payload);
           logger.debug(
             `${this.getStateName()}: Attempted dispatch of ${ENTITY_SPOKE_ID} for actor ${actorId} via TurnContext's SafeEventDispatcher.`,
             { payload }
-          );
-        } else {
-          logger.warn(
-            `${this.getStateName()}: Could not get SafeEventDispatcher from TurnContext. ${ENTITY_SPOKE_ID} event not dispatched for actor ${actorId}.`
           );
         }
       } catch (eventDispatchError) {

--- a/tests/unit/turns/states/processingCommandState.helpers.test.js
+++ b/tests/unit/turns/states/processingCommandState.helpers.test.js
@@ -88,7 +88,10 @@ describe('ProcessingCommandState helpers', () => {
 
   test('_obtainTurnAction uses constructor action', async () => {
     const actor = { id: 'a1' };
-    const specificAction = { actionDefinitionId: 'specificAct', commandString: 'specific command' };
+    const specificAction = {
+      actionDefinitionId: 'specificAct',
+      commandString: 'specific command',
+    };
     state = new ProcessingCommandState({
       handler: mockHandler,
       commandProcessor: mockCommandProcessor,
@@ -97,9 +100,11 @@ describe('ProcessingCommandState helpers', () => {
       turnAction: specificAction,
       directiveResolver: TurnDirectiveStrategyResolver,
     });
-    workflow = new ProcessingWorkflow(state, null, specificAction, (a) => {});
+    workflow = new ProcessingWorkflow(state, null, specificAction, () => {});
     const ctx = makeCtx(actor);
-    await expect(workflow._obtainTurnAction(ctx, actor)).resolves.toBe(specificAction);
+    await expect(workflow._obtainTurnAction(ctx, actor)).resolves.toBe(
+      specificAction
+    );
   });
 
   test('_dispatchSpeech dispatches when speech present', async () => {
@@ -108,6 +113,15 @@ describe('ProcessingCommandState helpers', () => {
     const ctx = makeCtx(actor, { getSafeEventDispatcher: () => dispatcher });
     await state._dispatchSpeech(ctx, actor, { speech: 'hi' });
     expect(dispatcher.dispatch).toHaveBeenCalled();
+  });
+
+  test('_dispatchSpeech warns when dispatcher missing', async () => {
+    const actor = { id: 'a1' };
+    const ctx = makeCtx(actor, { getSafeEventDispatcher: () => null });
+    await state._dispatchSpeech(ctx, actor, { speech: 'hi' });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('SafeEventDispatcher unavailable')
+    );
   });
 
   test('_dispatchSpeechIfNeeded forwards metadata', async () => {


### PR DESCRIPTION
Summary: replaced direct calls to `turnCtx.getSafeEventDispatcher?.()` with `getSafeEventDispatcher(turnCtx, this._handler)` and removed redundant warning log. Added unit test checking warning when dispatcher is missing.

Changes Made:
- imported and used `getSafeEventDispatcher` in `ProcessingCommandState`
- updated backup `.temp` file accordingly
- added missing-dispatcher test in `processingCommandState.helpers.test.js`

Testing Done:
- [x] Code formatted (`npm run format` on changed files)
- [x] Lint passes on changed files (`npx eslint src/turns/states/processingCommandState.js src/turns/states/processingCommandState.js.temp tests/unit/turns/states/processingCommandState.helpers.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685da0af452883319ebfc394706dc46e