### PR TITLE
[Agent] Preserve validation error details

### DIFF
--- a/src/entities/utils/parameterValidators.js
+++ b/src/entities/utils/parameterValidators.js
@@ -34,13 +34,9 @@ function _assertIds(methodName, instanceId, componentTypeId, logger) {
       methodName,
       logger
     );
-  } catch {
-    const msg = `${methodName}: Invalid parameters - instanceId: '${instanceId}', componentTypeId: '${componentTypeId}'`;
-    logger.warn(msg);
-    throw new InvalidArgumentError(msg, 'instanceId/componentTypeId', {
-      instanceId,
-      componentTypeId,
-    });
+  } catch (err) {
+    logger.error(err);
+    throw new InvalidArgumentError(`Invalid ID: ${err.message}`);
   }
 }
 

--- a/tests/common/entities/invalidInputHelpers.js
+++ b/tests/common/entities/invalidInputHelpers.js
@@ -57,10 +57,21 @@ function createInvalidInputTest(values, message) {
  * @returns {void}
  */
 export function runInvalidIdPairTests(getBed, invoke) {
-  createInvalidInputTest(
-    TestData.InvalidValues.invalidIdPairs,
-    'should throw InvalidArgumentError for invalid inputs'
-  )(getBed, invoke);
+  it.each(TestData.InvalidValues.invalidIdPairs)(
+    'should throw InvalidArgumentError for invalid inputs',
+    (instanceId, componentId) => {
+      const { entityManager, mocks } = getBed();
+      let error;
+      try {
+        invoke(entityManager, instanceId, componentId);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(InvalidArgumentError);
+      expect(error.message).toContain('Invalid ID:');
+      expect(mocks.logger.error).toHaveBeenCalled();
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep original error message when validating entity/component IDs
- update invalid input unit tests to check error details

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685da0c966c48331aa4d546337ac11ab