### PR TITLE
feat: enhance addComponent method to return success status

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -492,12 +492,13 @@ class EntityManager extends IEntityManager {
    * @param {string} instanceId - The ID of the entity instance.
    * @param {string} componentTypeId - The unique ID of the component type.
    * @param {object} componentData - The data for the component.
+   * @returns {boolean} True if the component was added or updated successfully, false otherwise.
    * @throws {EntityNotFoundError} If entity not found.
    * @throws {InvalidArgumentError} If parameters are invalid.
    * @throws {ValidationError} If component data validation fails.
    */
   addComponent(instanceId, componentTypeId, componentData) {
-    this.#componentMutationService.addComponent(
+    return this.#componentMutationService.addComponent(
       instanceId,
       componentTypeId,
       componentData

--- a/src/entities/services/componentMutationService.js
+++ b/src/entities/services/componentMutationService.js
@@ -205,6 +205,8 @@ export class ComponentMutationService {
     this.#logger.debug(
       `Successfully added/updated component '${componentTypeId}' data on entity '${instanceId}'.`
     );
+
+    return true;
   }
 
   /**

--- a/tests/unit/logic/operationHandlers/modifyComponentHandler.test.js
+++ b/tests/unit/logic/operationHandlers/modifyComponentHandler.test.js
@@ -394,4 +394,53 @@ describe('ModifyComponentHandler', () => {
       })
     );
   });
+
+  // ---------------------------------------------------------------------------
+  //  EntityManager.addComponent return value handling
+  // ---------------------------------------------------------------------------
+  test('logs a warning if addComponent returns a falsy value', () => {
+    const initialCompObj = { value: 10 };
+    mockEntityManager.getComponentData.mockReturnValue(initialCompObj);
+    mockEntityManager.addComponent.mockReturnValue(false); // Simulate failure
+
+    const params = {
+      entity_ref: 'actor',
+      component_type: 'game:stats',
+      field: 'value',
+      mode: 'set',
+      value: 20,
+    };
+    handler.execute(params, buildCtx());
+
+    expect(mockEntityManager.addComponent).toHaveBeenCalledWith(
+      actorId,
+      'game:stats',
+      { value: 20 }
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `MODIFY_COMPONENT: EntityManager.addComponent reported an unexpected failure for component "game:stats" on entity "actor-1".`
+    );
+  });
+
+  test('does not log a warning if addComponent returns a truthy value', () => {
+    const initialCompObj = { value: 10 };
+    mockEntityManager.getComponentData.mockReturnValue(initialCompObj);
+    mockEntityManager.addComponent.mockReturnValue(true); // Simulate success
+
+    const params = {
+      entity_ref: 'actor',
+      component_type: 'game:stats',
+      field: 'value',
+      mode: 'set',
+      value: 20,
+    };
+    handler.execute(params, buildCtx());
+
+    expect(mockEntityManager.addComponent).toHaveBeenCalledWith(
+      actorId,
+      'game:stats',
+      { value: 20 }
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- Updated EntityManager.addComponent to return a boolean indicating success or failure of component addition.
- Modified ComponentMutationService to return true upon successful addition or update of a component.
- Added unit tests to verify logging behavior based on the return value of addComponent, ensuring warnings are logged for failures and not for successes.