### PR TITLE
[Agent] Refactor test entity helpers

### DIFF
--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -111,13 +111,12 @@ export class TestBed extends FactoryTestBed {
    *   definition to use.
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
-   * @param {object} [config] - Additional configuration options.
-   * @param {boolean} [config.resetDispatch] - If true, resets the event
+   * @param {boolean} [options.resetDispatch=false] - If true, resets the event
    *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createEntity(defKey, options = {}, { resetDispatch = false } = {}) {
+  createEntity(defKey, { resetDispatch = false, ...options } = {}) {
     const definition = TestData.Definitions[defKey];
     if (!definition) {
       throw new Error(`Unknown test definition key: ${defKey}`);
@@ -151,14 +150,13 @@ export class TestBed extends FactoryTestBed {
    *
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
-   * @param {object} [config] - Additional configuration options.
-   * @param {boolean} [config.resetDispatch] - If true, resets the event
+   * @param {boolean} [options.resetDispatch=false] - If true, resets the event
    *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createBasicEntity(options = {}, config = {}) {
-    return this.createEntity('basic', options, config);
+  createBasicEntity(options = {}) {
+    return this.createEntity('basic', options);
   }
 
   /**
@@ -167,14 +165,13 @@ export class TestBed extends FactoryTestBed {
    *
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
-   * @param {object} [config] - Additional configuration options.
-   * @param {boolean} [config.resetDispatch] - If true, resets the event
+   * @param {boolean} [options.resetDispatch=false] - If true, resets the event
    *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createActorEntity(options = {}, config = {}) {
-    return this.createEntity('actor', options, config);
+  createActorEntity(options = {}) {
+    return this.createEntity('actor', options);
   }
 
   /**
@@ -188,16 +185,21 @@ export class TestBed extends FactoryTestBed {
    *   data.
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
-   * @param {object} [cfg] - Additional configuration options.
+   * @param {boolean} [options.resetDispatch=false] - If true, resets the event
+   *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createEntityWithOverride(defKey, overrides, options = {}, cfg = {}) {
-    return this.createEntity(
-      defKey,
-      { ...options, componentOverrides: overrides },
-      cfg
-    );
+  createEntityWithOverride(
+    defKey,
+    overrides,
+    { resetDispatch = false, ...options } = {}
+  ) {
+    return this.createEntity(defKey, {
+      ...options,
+      componentOverrides: overrides,
+      resetDispatch,
+    });
   }
 
   /**

--- a/tests/unit/entities/entityManager.addComponent.test.js
+++ b/tests/unit/entities/entityManager.addComponent.test.js
@@ -22,13 +22,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       // Arrange
       const { entityManager } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createEntity(
-        'basic',
-        {
-          instanceId: PRIMARY,
-        },
-        { resetDispatch: true }
-      );
+      getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
 
       // Act
       entityManager.addComponent(PRIMARY, NEW_COMPONENT_ID, NEW_COMPONENT_DATA);
@@ -47,13 +44,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       // Arrange
       const { entityManager, mocks } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      const entity = getBed().createEntity(
-        'basic',
-        {
-          instanceId: PRIMARY,
-        },
-        { resetDispatch: true }
-      );
+      const entity = getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
 
       // Act
       entityManager.addComponent(PRIMARY, NEW_COMPONENT_ID, NEW_COMPONENT_DATA);
@@ -95,13 +89,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
       const UPDATED_NAME_DATA = { name: 'Updated Name' };
 
-      const entity = getBed().createEntity(
-        'basic',
-        {
-          instanceId: PRIMARY,
-        },
-        { resetDispatch: true }
-      );
+      const entity = getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
       const originalNameData = entity.getComponentData(NAME_COMPONENT_ID);
 
       // Act
@@ -132,11 +123,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       // Arrange
       const { entityManager, mocks } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createEntity(
-        'basic',
-        { instanceId: PRIMARY },
-        { resetDispatch: true }
-      );
+      getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
 
       const validationErrors = [{ message: 'Invalid data' }];
       mocks.validator.validate.mockReturnValue({
@@ -175,12 +165,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       )
     )('should throw InvalidArgumentError when componentData is %p', (value) => {
       // Arrange
-      const { entityManager, mocks } = getBed();
+      const { entityManager } = getBed();
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       getBed().createBasicEntity({ instanceId: PRIMARY });
-      const receivedType = typeof value;
-      const expectedError = `EntityManager.addComponent: componentData for ${NAME_COMPONENT_ID} on ${PRIMARY} must be an object. Received: ${receivedType}`;
 
       // Act & Assert
       expect(() =>
@@ -198,13 +186,10 @@ describeEntityManagerSuite('EntityManager - addComponent', (getBed) => {
       // Arrange
       const { entityManager, mocks } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      const entity = getBed().createEntity(
-        'basic',
-        {
-          instanceId: PRIMARY,
-        },
-        { resetDispatch: true }
-      );
+      const entity = getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
 
       // Mock the entity's own method to simulate an internal failure
       const addComponentSpy = jest

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -407,11 +407,7 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
     it('should dispatch an ENTITY_REMOVED event upon successful removal', () => {
       // Arrange
       const { entityManager, mocks } = getBed();
-      const entity = getBed().createEntity(
-        'basic',
-        {},
-        { resetDispatch: true }
-      );
+      const entity = getBed().createEntity('basic', { resetDispatch: true });
 
       // Act
       entityManager.removeEntityInstance(entity.id);

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -46,8 +46,7 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const entity = getBed().createEntityWithOverride(
         'basic',
         { [NAME_COMPONENT_ID]: overrideData },
-        { instanceId: PRIMARY },
-        { resetDispatch: true }
+        { instanceId: PRIMARY, resetDispatch: true }
       );
 
       // Act
@@ -67,11 +66,10 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { entityManager, mocks } = getBed();
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createEntity(
-        'basic',
-        { instanceId: PRIMARY },
-        { resetDispatch: true }
-      );
+      getBed().createEntity('basic', {
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
       // NAME_COMPONENT_ID exists on definition, but not as an override
 
       // Act & Assert


### PR DESCRIPTION
Summary: Refactors entity test helpers to accept a single options object with `resetDispatch` support.

Changes Made:
- updated `createEntity` signature and helper docs
- simplified `createBasicEntity`, `createActorEntity`, and `createEntityWithOverride`
- adapted affected unit tests to new API

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685da0e7a088833198c00e9999addde7