### PR TITLE
[Agent] clarify helper parameter names

### DIFF
--- a/tests/common/createTestBedHelpers.js
+++ b/tests/common/createTestBedHelpers.js
@@ -7,20 +7,20 @@ import { createDescribeTestBedSuite } from './describeSuite.js';
 /**
  * Generates helpers for creating test beds and describe suites.
  *
- * @template {new (overrides: any) => any} T
+ * @template {new (bedOverrides: any) => any} T
  * @param {T} TestBedCtor - Constructor used to instantiate the test bed.
  * @param {object} [hooks] - Suite hooks forwarded to
  *   {@link createDescribeTestBedSuite}.
  * @returns {{
- *   createBed: (overrides?: ConstructorParameters<T>[0]) => InstanceType<T>,
+ *   createBed: (bedOverrides?: ConstructorParameters<T>[0]) => InstanceType<T>,
  *   describeSuite: (title: string,
  *                   suiteFn: (getBed: () => InstanceType<T>) => void,
- *                   overrides?: ConstructorParameters<T>[0]) => void
+ *                   bedOverrides?: ConstructorParameters<T>[0]) => void
  * }} Helper functions for the provided TestBed.
  */
 export function createTestBedHelpers(TestBedCtor, hooks = {}) {
   const describeSuite = createDescribeTestBedSuite(TestBedCtor, hooks);
-  const createBed = (overrides) => new TestBedCtor(overrides);
+  const createBed = (bedOverrides) => new TestBedCtor(bedOverrides);
   return { createBed, describeSuite };
 }
 

--- a/tests/common/engine/gameEngineHelpers.js
+++ b/tests/common/engine/gameEngineHelpers.js
@@ -11,18 +11,18 @@ import { DEFAULT_TEST_WORLD } from '../constants.js';
 /**
  * Executes a callback with a temporary {@link GameEngineTestBed} instance.
  *
- * @param {Record<string, any>} [overrides] - Optional dependency overrides.
+ * @param {Record<string, any>} [bedOverrides] - Optional dependency overrides.
  * @param {(bed: import('./gameEngineTestBed.js').GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default) =>
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export async function withGameEngineBed(overrides = {}, testFn) {
-  if (typeof overrides === 'function') {
-    testFn = overrides;
-    overrides = {};
+export async function withGameEngineBed(bedOverrides = {}, testFn) {
+  if (typeof bedOverrides === 'function') {
+    testFn = bedOverrides;
+    bedOverrides = {};
   }
-  const bed = new GameEngineTestBed(overrides);
+  const bed = new GameEngineTestBed(bedOverrides);
   if (typeof bed.resetMocks === 'function') {
     bed.resetMocks();
   }
@@ -39,20 +39,23 @@ export async function withGameEngineBed(overrides = {}, testFn) {
  * @description Creates a temporary test bed, initializes the underlying
  *   engine using {@link GameEngineTestBed.initAndReset}, then runs the provided
  *   callback. Cleanup always occurs after execution.
- * @param {{ overrides?: Record<string, any>, initArg?: string }} [options] -
+ * @param {{ bedOverrides?: Record<string, any>, initArg?: string }} [engineBedOptions] -
  *   Overrides and world used for initialization.
  * @param {(bed: GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default) =>
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export async function withInitializedGameEngineBed(options = {}, testFn) {
-  if (typeof options === 'function') {
-    testFn = options;
-    options = {};
+export async function withInitializedGameEngineBed(
+  engineBedOptions = {},
+  testFn
+) {
+  if (typeof engineBedOptions === 'function') {
+    testFn = engineBedOptions;
+    engineBedOptions = {};
   }
-  const { overrides = {}, initArg = DEFAULT_TEST_WORLD } = options;
-  const bed = new GameEngineTestBed(overrides);
+  const { bedOverrides = {}, initArg = DEFAULT_TEST_WORLD } = engineBedOptions;
+  const bed = new GameEngineTestBed(bedOverrides);
   await bed.initAndReset(initArg);
   if (typeof bed.resetMocks === 'function') {
     bed.resetMocks();
@@ -70,20 +73,20 @@ export async function withInitializedGameEngineBed(options = {}, testFn) {
  * @description Creates a temporary test bed, starts the engine using
  *   {@link GameEngineTestBed.startAndReset}, then runs the provided callback.
  *   Cleanup always occurs after execution.
- * @param {{ overrides?: Record<string, any>, initArg?: string }} [options] -
+ * @param {{ bedOverrides?: Record<string, any>, initArg?: string }} [engineBedOptions] -
  *   Overrides and world used for initialization.
  * @param {(bed: GameEngineTestBed,
  *   engine: import('../../../src/engine/gameEngine.js').default) =>
  *   (Promise<void>|void)} testFn - Function invoked with the bed and engine.
  * @returns {Promise<void>} Resolves when the callback completes.
  */
-export async function withRunningGameEngineBed(options = {}, testFn) {
-  if (typeof options === 'function') {
-    testFn = options;
-    options = {};
+export async function withRunningGameEngineBed(engineBedOptions = {}, testFn) {
+  if (typeof engineBedOptions === 'function') {
+    testFn = engineBedOptions;
+    engineBedOptions = {};
   }
-  const { overrides = {}, initArg = DEFAULT_TEST_WORLD } = options;
-  const bed = new GameEngineTestBed(overrides);
+  const { bedOverrides = {}, initArg = DEFAULT_TEST_WORLD } = engineBedOptions;
+  const bed = new GameEngineTestBed(bedOverrides);
   await bed.startAndReset(initArg);
   if (typeof bed.resetMocks === 'function') {
     bed.resetMocks();

--- a/tests/common/engine/gameEngineTestBed.js
+++ b/tests/common/engine/gameEngineTestBed.js
@@ -44,10 +44,10 @@ export class GameEngineTestBed extends EngineStartHelpersMixin(
 
   /**
    * @description Constructs a new test bed with optional DI overrides.
-   * @param {{[token: string]: any}} [overrides]
+   * @param {{[token: string]: any}} [diOverrides]
    */
-  constructor(overrides = {}) {
-    const env = createEnvironment(overrides);
+  constructor(diOverrides = {}) {
+    const env = createEnvironment(diOverrides);
     super(env.mockContainer, {
       logger: env.logger,
       entityManager: env.entityManager,
@@ -154,7 +154,7 @@ export const {
  * @param {string} title - Suite title passed to `describe`.
  * @param {(context: { bed: GameEngineTestBed, engine: import('../../../src/engine/gameEngine.js').default }) => void} suiteFn -
  *   Callback containing the tests.
- * @param {{[token: string]: any}} [overrides] - Optional DI overrides.
+ * @param {{[token: string]: any}} [diOverrides] - Optional DI overrides.
  * @returns {void}
  */
 export const describeEngineSuite = createDescribeServiceSuite(
@@ -178,10 +178,10 @@ export function describeInitializedEngineSuite(
   title,
   suiteFn,
   world,
-  overrides
+  diOverrides
 ) {
   if (typeof world === 'object' && world !== null) {
-    overrides = world;
+    diOverrides = world;
     world = DEFAULT_TEST_WORLD;
   }
   world = world || DEFAULT_TEST_WORLD;
@@ -193,7 +193,7 @@ export function describeInitializedEngineSuite(
       });
       suiteFn(ctx);
     },
-    overrides
+    diOverrides
   );
 }
 

--- a/tests/common/prompting/promptPipelineTestBed.js
+++ b/tests/common/prompting/promptPipelineTestBed.js
@@ -115,18 +115,19 @@ export class AIPromptPipelineTestBed extends PipelineFactoryMixin(
   /**
    * Sets up mock resolved values for a successful pipeline run.
    *
-   * @param {object} [options] - Configuration options.
-   * @param {string} [options.llmId] - LLM ID returned by the adapter.
-   * @param {object} [options.gameState] - Game state returned by the provider.
-   * @param {object} [options.promptData] - Prompt data returned by the content provider.
-   * @param {string} [options.finalPrompt] - Final prompt string returned by the builder.
+   * @param {object} [pipelineOptions] - Configuration options.
+   * @param {string} [pipelineOptions.llmId] - LLM ID returned by the adapter.
+   * @param {object} [pipelineOptions.gameState] - Game state returned by the provider.
+   * @param {object} [pipelineOptions.promptData] - Prompt data returned by the content provider.
+   * @param {string} [pipelineOptions.finalPrompt] - Final prompt string returned by the builder.
    */
-  setupMockSuccess({
-    llmId = 'llm-id',
-    gameState = {},
-    promptData = {},
-    finalPrompt = 'PROMPT',
-  } = {}) {
+  setupMockSuccess(pipelineOptions = {}) {
+    const {
+      llmId = 'llm-id',
+      gameState = {},
+      promptData = {},
+      finalPrompt = 'PROMPT',
+    } = pipelineOptions;
     this._successOptions = { llmId, gameState, promptData, finalPrompt };
     this.mocks.llmAdapter.getCurrentActiveLlmId.mockResolvedValue(llmId);
     this.mocks.gameStateProvider.buildGameState.mockResolvedValue(gameState);

--- a/tests/common/serviceFactoryTestBedMixin.js
+++ b/tests/common/serviceFactoryTestBedMixin.js
@@ -8,9 +8,9 @@ import { createStoppableMixin } from './stoppableTestBedMixin.js';
 /**
  * @description Generates a mixin that instantiates a service using mocks
  *   created by {@link FactoryTestBed}.
- * @param {Record<string, () => any>|((overrides: any) => Record<string, () => any>)} factoryMap
+ * @param {Record<string, () => any>|((bedOverrides: any) => Record<string, () => any>)} factoryMap
  *   Map of mock factories or a function returning such a map based on overrides.
- * @param {(mocks: Record<string, any>, overrides?: any) => any} buildFn -
+ * @param {(mocks: Record<string, any>, bedOverrides?: any) => any} buildFn -
  *   Function that constructs the service using generated mocks.
  * @param {string} propName - Property name used to store the created service.
  * @returns {(Base?: typeof FactoryTestBed) => typeof FactoryTestBed} Mixin
@@ -20,11 +20,13 @@ export function createServiceFactoryMixin(factoryMap, buildFn, propName) {
   const StoppableMixin = createStoppableMixin(propName);
   return function ServiceFactoryMixin(Base = FactoryTestBed) {
     return class ServiceFactoryTestBed extends StoppableMixin(Base) {
-      constructor(overrides = {}) {
+      constructor(bedOverrides = {}) {
         const map =
-          typeof factoryMap === 'function' ? factoryMap(overrides) : factoryMap;
+          typeof factoryMap === 'function'
+            ? factoryMap(bedOverrides)
+            : factoryMap;
         super(map);
-        this[propName] = buildFn(this.mocks, overrides);
+        this[propName] = buildFn(this.mocks, bedOverrides);
       }
     };
   };

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -35,7 +35,7 @@ describe('withInitializedGameEngineBed', () => {
   it('initializes engine, runs callback and cleans up', async () => {
     const calls = [];
     await withInitializedGameEngineBed(
-      { overrides: { b: 2 }, initArg: 'World' },
+      { bedOverrides: { b: 2 }, initArg: 'World' },
       (bed, engine) => {
         calls.push('cb');
         expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
@@ -56,7 +56,7 @@ describe('withInitializedGameEngineBed', () => {
   it('passes initialized bed and engine to callback', async () => {
     const calls = [];
     await withInitializedGameEngineBed(
-      { overrides: { c: 3 }, initArg: 'World' },
+      { bedOverrides: { c: 3 }, initArg: 'World' },
       (bed, engine) => {
         calls.push('cb');
         expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
@@ -81,7 +81,7 @@ describe('withRunningGameEngineBed', () => {
   it('starts engine, runs callback and cleans up', async () => {
     const calls = [];
     await withRunningGameEngineBed(
-      { overrides: { d: 4 }, initArg: 'World' },
+      { bedOverrides: { d: 4 }, initArg: 'World' },
       (bed, engine) => {
         calls.push('cb');
         expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);
@@ -100,7 +100,7 @@ describe('withRunningGameEngineBed', () => {
   it('passes running bed and engine to callback', async () => {
     const calls = [];
     await withRunningGameEngineBed(
-      { overrides: { e: 5 }, initArg: 'World' },
+      { bedOverrides: { e: 5 }, initArg: 'World' },
       (bed, engine) => {
         calls.push('cb');
         expect(bed).toBeInstanceOf(bedModule.GameEngineTestBed);


### PR DESCRIPTION
## Summary
- make test bed helpers more descriptive
- rename options to pipelineOptions for clarity
- rename start helper params to bedOverrides

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685da05b12948331ba9fa1315823dc98