### PR TITLE
[Agent] Extract services from EntityManager

### DIFF
--- a/src/entities/services/definitionCache.js
+++ b/src/entities/services/definitionCache.js
@@ -1,0 +1,74 @@
+/**
+ * @file DefinitionCache - Caches entity definitions for faster lookup.
+ * @description Service responsible for retrieving definitions from the
+ *   data registry and caching them for subsequent access.
+ */
+
+import { validateDependency } from '../../utils/validationUtils.js';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
+import { getDefinition as lookupDefinition } from '../utils/definitionLookup.js';
+
+/** @typedef {import('../../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../entityDefinition.js').default} EntityDefinition */
+
+/**
+ * @class DefinitionCache
+ * @description Provides cached access to entity definitions.
+ */
+export class DefinitionCache {
+  /** @type {Map<string, EntityDefinition>} @private */
+  #cache;
+  /** @type {IDataRegistry} @private */
+  #registry;
+  /** @type {ILogger} @private */
+  #logger;
+
+  /**
+   * @param {object} deps - Dependencies
+   * @param {IDataRegistry} deps.registry - Data registry for definitions
+   * @param {ILogger} deps.logger - Logger instance
+   */
+  constructor({ registry, logger }) {
+    validateDependency(logger, 'ILogger', console, {
+      requiredMethods: ['info', 'error', 'warn', 'debug'],
+    });
+    validateDependency(registry, 'IDataRegistry', logger, {
+      requiredMethods: ['getEntityDefinition'],
+    });
+
+    this.#registry = registry;
+    this.#logger = ensureValidLogger(logger, 'DefinitionCache');
+    this.#cache = new Map();
+    this.#logger.debug('DefinitionCache initialized.');
+  }
+
+  /**
+   * Retrieve a definition by ID, caching the result.
+   *
+   * @param {string} definitionId - Definition identifier
+   * @returns {EntityDefinition|null} The definition or null when missing/invalid
+   */
+  get(definitionId) {
+    if (this.#cache.has(definitionId)) {
+      return this.#cache.get(definitionId);
+    }
+
+    try {
+      const def = lookupDefinition(definitionId, this.#registry, this.#logger);
+      this.#cache.set(definitionId, def);
+      return def;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Clear all cached definitions.
+   */
+  clear() {
+    this.#cache.clear();
+  }
+}
+
+export default DefinitionCache;

--- a/src/entities/utils/createDefaultServices.js
+++ b/src/entities/utils/createDefaultServices.js
@@ -1,0 +1,74 @@
+/**
+ * @file createDefaultServices - Assembles default service instances for EntityManager.
+ * @description Factory helper that constructs the various services used by
+ *   EntityManager when they are not provided via dependency injection.
+ */
+
+import EntityRepositoryAdapter from '../services/entityRepositoryAdapter.js';
+import ComponentMutationService from '../services/componentMutationService.js';
+import ErrorTranslator from '../services/errorTranslator.js';
+import EntityFactory from '../factories/entityFactory.js';
+import DefinitionCache from '../services/definitionCache.js';
+
+/** @typedef {import('../services/entityRepositoryAdapter.js').EntityRepositoryAdapter} EntityRepositoryAdapter */
+/** @typedef {import('../services/componentMutationService.js').ComponentMutationService} ComponentMutationService */
+/** @typedef {import('../services/errorTranslator.js').ErrorTranslator} ErrorTranslator */
+/** @typedef {import('../factories/entityFactory.js').default} EntityFactory */
+/** @typedef {import('../services/definitionCache.js').DefinitionCache} DefinitionCache */
+
+/**
+ * Assemble default service dependencies for {@link EntityManager}.
+ *
+ * @param {object} deps
+ * @param {import('../../interfaces/coreServices.js').IDataRegistry} deps.registry
+ * @param {import('../../interfaces/coreServices.js').ISchemaValidator} deps.validator
+ * @param {import('../../interfaces/coreServices.js').ILogger} deps.logger
+ * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} deps.eventDispatcher
+ * @param {import('../../ports/IIdGenerator.js').IIdGenerator} deps.idGenerator
+ * @param {import('../../ports/IComponentCloner.js').IComponentCloner} deps.cloner
+ * @param {import('../../ports/IDefaultComponentPolicy.js').IDefaultComponentPolicy} deps.defaultPolicy
+ * @returns {{
+ *   entityRepository: EntityRepositoryAdapter,
+ *   componentMutationService: ComponentMutationService,
+ *   errorTranslator: ErrorTranslator,
+ *   entityFactory: EntityFactory,
+ *   definitionCache: DefinitionCache,
+ * }} Collection of default service instances.
+ */
+export function createDefaultServices({
+  registry,
+  validator,
+  logger,
+  eventDispatcher,
+  idGenerator,
+  cloner,
+  defaultPolicy,
+}) {
+  const entityRepository = new EntityRepositoryAdapter({ logger });
+  const componentMutationService = new ComponentMutationService({
+    entityRepository,
+    validator,
+    logger,
+    eventDispatcher,
+    cloner,
+  });
+  const errorTranslator = new ErrorTranslator({ logger });
+  const entityFactory = new EntityFactory({
+    validator,
+    logger,
+    idGenerator,
+    cloner,
+    defaultPolicy,
+  });
+  const definitionCache = new DefinitionCache({ registry, logger });
+
+  return {
+    entityRepository,
+    componentMutationService,
+    errorTranslator,
+    entityFactory,
+    definitionCache,
+  };
+}
+
+export default createDefaultServices;

--- a/tests/unit/entities/services/definitionCache.test.js
+++ b/tests/unit/entities/services/definitionCache.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import DefinitionCache from '../../../../src/entities/services/definitionCache.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../../../common/mockFactories/index.js';
+
+describe('DefinitionCache', () => {
+  let registry;
+  let logger;
+  let cache;
+
+  beforeEach(() => {
+    registry = createSimpleMockDataRegistry();
+    logger = createMockLogger();
+    cache = new DefinitionCache({ registry, logger });
+  });
+
+  it('caches definitions after first lookup', () => {
+    const def = { id: 'foo' };
+    registry.getEntityDefinition.mockReturnValue(def);
+
+    const first = cache.get('foo');
+    const second = cache.get('foo');
+
+    expect(first).toBe(def);
+    expect(second).toBe(def);
+    expect(registry.getEntityDefinition).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when definition lookup fails', () => {
+    registry.getEntityDefinition.mockReturnValue(undefined);
+
+    const result = cache.get('missing');
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/entities/utils/createDefaultServices.test.js
+++ b/tests/unit/entities/utils/createDefaultServices.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createDefaultServices } from '../../../../src/entities/utils/createDefaultServices.js';
+import EntityRepositoryAdapter from '../../../../src/entities/services/entityRepositoryAdapter.js';
+import ComponentMutationService from '../../../../src/entities/services/componentMutationService.js';
+import ErrorTranslator from '../../../../src/entities/services/errorTranslator.js';
+import EntityFactory from '../../../../src/entities/factories/entityFactory.js';
+import DefinitionCache from '../../../../src/entities/services/definitionCache.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockSchemaValidator,
+  createMockLogger,
+  createMockSafeEventDispatcher,
+} from '../../../common/mockFactories/index.js';
+
+describe('createDefaultServices', () => {
+  it('returns properly instantiated services', () => {
+    const registry = createSimpleMockDataRegistry();
+    const validator = createMockSchemaValidator();
+    const logger = createMockLogger();
+    const eventDispatcher = createMockSafeEventDispatcher();
+    const idGen = jest.fn();
+    const cloner = jest.fn((v) => v);
+    const defaultPolicy = { apply: jest.fn() };
+
+    const services = createDefaultServices({
+      registry,
+      validator,
+      logger,
+      eventDispatcher,
+      idGenerator: idGen,
+      cloner,
+      defaultPolicy,
+    });
+
+    expect(services.entityRepository).toBeInstanceOf(EntityRepositoryAdapter);
+    expect(services.componentMutationService).toBeInstanceOf(
+      ComponentMutationService
+    );
+    expect(services.errorTranslator).toBeInstanceOf(ErrorTranslator);
+    expect(services.entityFactory).toBeInstanceOf(EntityFactory);
+    expect(services.definitionCache).toBeInstanceOf(DefinitionCache);
+  });
+});


### PR DESCRIPTION
Summary: Refactored EntityManager to reduce responsibilities by introducing new DefinitionCache service and createDefaultServices helper. ErrorTranslator now handles reconstruction error translation via a `translate` method. Updated EntityManager to use these services through dependency injection. Added unit tests for the new utilities.

Changes Made:
- Added `DefinitionCache` service with caching logic.
- Added `createDefaultServices` factory for default service wiring.
- Updated `ErrorTranslator` with `translate` method and additional error handling.
- Refactored `EntityManager` constructor and methods to utilize injected services.
- Added corresponding unit tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685eb6018d2c8331b23d3b8b4c287154