### PR TITLE
[Agent] validate parameters for game operations

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -212,6 +212,16 @@ class GameEngine {
   }
 
   async startNewGame(worldName) {
+    if (
+      !worldName ||
+      typeof worldName !== 'string' ||
+      worldName.trim() === ''
+    ) {
+      const errorMsg =
+        'GameEngine.startNewGame: worldName must be a non-empty string.';
+      this.#logger.error(errorMsg);
+      throw new TypeError(errorMsg);
+    }
     this.#logger.debug(
       `GameEngine: startNewGame called for world "${worldName}".`
     );
@@ -313,6 +323,16 @@ class GameEngine {
   }
 
   async loadGame(saveIdentifier) {
+    if (
+      !saveIdentifier ||
+      typeof saveIdentifier !== 'string' ||
+      saveIdentifier.trim() === ''
+    ) {
+      const errorMsg =
+        'GameEngine.loadGame: saveIdentifier must be a non-empty string.';
+      this.#logger.error(errorMsg);
+      throw new TypeError(errorMsg);
+    }
     return this.#persistenceCoordinator.loadGame(saveIdentifier);
   }
 

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -164,5 +164,20 @@ describeEngineSuite('GameEngine', (context) => {
     )(
       'should handle %s unavailability (guard clause) and dispatch UI event directly'
     );
+
+    it.each([null, '', 0])(
+      'should reject invalid save identifiers: %p',
+      async (badId) => {
+        const expectedMessage =
+          'GameEngine.loadGame: saveIdentifier must be a non-empty string.';
+
+        await expect(context.engine.loadGame(badId)).rejects.toThrow(
+          expectedMessage
+        );
+        expect(context.bed.getLogger().error).toHaveBeenCalledWith(
+          expectedMessage
+        );
+      }
+    );
   });
 });

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -98,29 +98,16 @@ describeEngineSuite('GameEngine', (context) => {
     it.each([null, ''])(
       'should reject invalid world names: %p',
       async (badName) => {
-        // startNewGame relies on InitializationService to validate world names. A
-        // null or empty world should cause the service to return a TypeError and
-        // the engine should surface that failure while dispatching the standard
-        // operation failed event.
         const expectedMessage =
-          'InitializationService requires a valid non-empty worldName.';
-        context.bed
-          .getInitializationService()
-          .runInitializationSequence.mockResolvedValue({
-            success: false,
-            error: new TypeError(expectedMessage),
-          });
+          'GameEngine.startNewGame: worldName must be a non-empty string.';
 
         await expect(context.engine.startNewGame(badName)).rejects.toThrow(
           expectedMessage
         );
 
-        expect(
-          context.bed.getSafeEventDispatcher().dispatch
-        ).toHaveBeenCalledWith(ENGINE_OPERATION_FAILED_UI, {
-          errorMessage: `Failed to start new game: ${expectedMessage}`,
-          errorTitle: 'Initialization Error',
-        });
+        expect(context.bed.getLogger().error).toHaveBeenCalledWith(
+          expectedMessage
+        );
         expectEngineStopped(context.engine);
       }
     );


### PR DESCRIPTION
## Summary
- ensure `startNewGame` validates `worldName`
- ensure `loadGame` validates `saveIdentifier`
- update tests for new validation checks

## Testing Done
- `npm test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb55a00fc83318b200b7a3a223da2