### PR TITLE
[Feat] Extract initialization helpers

### DIFF
--- a/src/initializers/services/initHelpers.js
+++ b/src/initializers/services/initHelpers.js
@@ -1,0 +1,46 @@
+// src/initializers/services/initHelpers.js
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../actions/actionIndex.js').ActionIndex} ActionIndex */
+
+/**
+ * Validates that a world name is a non-empty string.
+ *
+ * @param {string} worldName - Name of the world to validate.
+ * @param {ILogger} logger - Logger for reporting validation errors.
+ * @returns {void}
+ * @throws {TypeError} If the world name is missing or blank.
+ */
+export function validateWorldName(worldName, logger) {
+  const msg = 'InitializationService requires a valid non-empty worldName.';
+  if (!worldName || typeof worldName !== 'string' || worldName.trim() === '') {
+    logger?.error(msg);
+    throw new TypeError(msg);
+  }
+}
+
+/**
+ * Builds the ActionIndex from definitions provided by the repository.
+ *
+ * @param {ActionIndex} actionIndex - Index instance to populate.
+ * @param {import('../../interfaces/IGameDataRepository.js').IGameDataRepository} gameDataRepository - Repository supplying definitions.
+ * @param {ILogger} logger - Logger for debug output.
+ * @returns {void}
+ * @throws {Error} If required dependencies are missing.
+ */
+export function buildActionIndex(actionIndex, gameDataRepository, logger) {
+  if (
+    !gameDataRepository ||
+    typeof gameDataRepository.getAllActionDefinitions !== 'function'
+  ) {
+    throw new Error('buildActionIndex: invalid gameDataRepository dependency');
+  }
+  if (!actionIndex || typeof actionIndex.buildIndex !== 'function') {
+    throw new Error('buildActionIndex: invalid actionIndex dependency');
+  }
+
+  logger?.debug('Building ActionIndex with loaded action definitions...');
+  const defs = gameDataRepository.getAllActionDefinitions();
+  actionIndex.buildIndex(defs);
+  logger?.debug(`ActionIndex built with ${defs.length} action definitions.`);
+}

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -25,52 +25,7 @@ import {
   WorldInitializationError,
   InitializationError,
 } from '../../errors/InitializationError.js';
-
-/*─────────────────────────────────────────────────────────────────────────*/
-/* Helper Functions                                                        */
-/*─────────────────────────────────────────────────────────────────────────*/
-
-/**
- * Validates that a world name is a non-empty string.
- *
- * @param {string} worldName - Name of the world to validate.
- * @param {ILogger} logger - Logger for reporting validation errors.
- * @returns {void}
- * @throws {TypeError} If the world name is missing or blank.
- */
-export function validateWorldName(worldName, logger) {
-  const msg = 'InitializationService requires a valid non-empty worldName.';
-  if (!worldName || typeof worldName !== 'string' || worldName.trim() === '') {
-    logger?.error(msg);
-    throw new TypeError(msg);
-  }
-}
-
-/**
- * Builds the ActionIndex from definitions provided by the repository.
- *
- * @param {ActionIndex} actionIndex - Index instance to populate.
- * @param {import('../../interfaces/IGameDataRepository.js').IGameDataRepository} gameDataRepository - Repository supplying definitions.
- * @param {ILogger} logger - Logger for debug output.
- * @returns {void}
- * @throws {Error} If required dependencies are missing.
- */
-export function buildActionIndex(actionIndex, gameDataRepository, logger) {
-  if (
-    !gameDataRepository ||
-    typeof gameDataRepository.getAllActionDefinitions !== 'function'
-  ) {
-    throw new Error('buildActionIndex: invalid gameDataRepository dependency');
-  }
-  if (!actionIndex || typeof actionIndex.buildIndex !== 'function') {
-    throw new Error('buildActionIndex: invalid actionIndex dependency');
-  }
-
-  logger?.debug('Building ActionIndex with loaded action definitions...');
-  const defs = gameDataRepository.getAllActionDefinitions();
-  actionIndex.buildIndex(defs);
-  logger?.debug(`ActionIndex built with ${defs.length} action definitions.`);
-}
+import { validateWorldName, buildActionIndex } from './initHelpers.js';
 
 /**
  * Service responsible for orchestrating the entire game initialization sequence.
@@ -88,7 +43,7 @@ class InitializationService extends IInitializationService {
   #systemInitializer;
   #worldInitializer;
   #safeEventDispatcher;
-  #entityManager;  
+  #entityManager;
   #domUiFacade; // eslint-disable-line no-unused-private-class-members
   #actionIndex;
   #gameDataRepository;

--- a/tests/unit/initializers/services/initializationHelpers.test.js
+++ b/tests/unit/initializers/services/initializationHelpers.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import {
   validateWorldName,
   buildActionIndex,
-} from '../../../../src/initializers/services/initializationService.js';
+} from '../../../../src/initializers/services/initHelpers.js';
 
 describe('InitializationService helper functions', () => {
   describe('validateWorldName', () => {


### PR DESCRIPTION
Summary: Move helper functions from InitializationService into a new module and update tests.

Changes Made:
- Added `src/initializers/services/initHelpers.js` with `validateWorldName` and `buildActionIndex`.
- Updated InitializationService to import these helpers.
- Adjusted helper tests to reference the new module.

Testing Done:
- [x] Code formatted (`npx prettier --write src/initializers/services/initHelpers.js src/initializers/services/initializationService.js tests/unit/initializers/services/initializationHelpers.test.js`)
- [x] Lint run on changed files (`npx eslint ...`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685eb8353b108331aa4da2327998c3f5