### PR TITLE
Add DuplicateContentError handling to registry storage logic

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(npm test:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Living Narrative Engine is a browser-based platform for creating highly moddable, data-driven adventure games with AI-powered NPCs. The engine uses an Entity Component System (ECS) architecture and integrates with LLMs for dynamic character interactions.
+
+## Architecture
+
+The project consists of two main parts:
+- **Main Application** (`/`): Browser-based game engine
+- **LLM Proxy Server** (`/llm-proxy-server`): Node.js microservice for LLM communication
+
+Key architectural patterns:
+- **Entity Component System (ECS)** for game objects
+- **Event-driven architecture** with centralized event bus
+- **Dependency injection** using IoC container
+- **Data-driven design** - all game logic defined in JSON files
+- **Modular content system** - even core content is a replaceable mod
+
+## Essential Commands
+
+```bash
+# Development
+npm run dev              # Start app + proxy server concurrently
+npm run start            # Build and serve main app only
+npm run start:all        # Start both services
+
+# Code Quality (run after modifications)
+npm run format           # Format code with Prettier
+npm run lint            # Fix ESLint issues
+npm run scope:lint      # Validate scope DSL files
+
+# Testing
+npm run test            # Run all tests with coverage
+npm run test:single     # Run tests sequentially (for debugging)
+
+# Build
+npm run build           # Bundle for browser with esbuild
+
+# Utilities
+npm run create-mod      # Create new mod scaffold
+npm run update-manifest # Update mod manifests
+npm run find-condition-refs # Find condition usage
+```
+
+For LLM proxy server (from `/llm-proxy-server`):
+```bash
+npm install
+npm run dev             # Start proxy server
+npm run test           # Run proxy tests
+```
+
+## Critical Configuration
+
+### game.json
+Required file at `./data/game.json` that controls mod loading:
+```json
+{
+  "mods": ["core", "your-mod"]  // Load order matters - later mods override earlier
+}
+```
+
+### Project Structure
+```
+src/
+├── actions/           # Action discovery and execution
+├── entities/          # ECS implementation
+├── scopeDsl/          # Scope DSL engine (max depth: 4)
+├── turns/             # Turn management system
+└── loaders/           # Content loading system
+
+data/
+├── mods/              # Modular content packs
+├── schemas/           # JSON schemas for validation
+└── game.json          # Mod configuration
+
+tests/
+├── unit/              # Component tests
+├── integration/       # Cross-system tests
+└── common/            # Test utilities
+```
+
+## Development Guidelines
+
+### Coding Patterns
+- **Test-Driven Development**: Write tests first for new modules
+- **Lint compliance**: Always run `npm run lint` after modifications
+- **No production mocking**: Only mock in test files
+- **Check for duplicates**: Search for existing functionality before creating new code
+
+### Testing Requirements
+- Framework: Jest with jsdom
+- Coverage targets: 80% branches, 90% functions/lines
+- Run tests after every complete modification
+- When tests pass without changes after code modifications, write new focused tests
+
+### Mod System
+- Mod IDs are case-insensitive for validation but preserve original casing
+- Each mod requires `mod-manifest.json`
+- UI assets in optional `ui/` folder with `icons.json` and `labels.json`
+
+### Memory Components
+Actors use four distinct memory systems:
+- `core:short_term_memory` - Internal monologue (max 10 entries)
+- `core:perception_log` - Event history (max 50 entries)
+- `core:notes` - Persistent thoughts (uncapped, deduped)
+- `core:goals` - Designer-defined objectives (uncapped)
+
+### Scope DSL
+Custom language for entity queries without hardcoded JavaScript:
+- Files use `.scope` extension
+- Located in mod directories
+- Max expression depth: 4
+- See `docs/scope-dsl.md` for syntax
+
+## Important Notes
+
+- Engine requires `game.json` to start - fails fast without it
+- All game logic is data-driven through JSON files
+- JSON files must match their schemas (in `data/schemas/`)
+- Entity references in perception logs use runtime IDs
+- System errors are logged to `error_logs.txt` and dispatched as events
+
+## Key Documentation
+
+- `README.md` - Project setup and overview
+- `docs/scope-dsl.md` - Scope DSL specification
+- `docs/mods/` - Mod system documentation
+- `AGENTS.md` - AI agent configuration
+- `.cursor/rules/` - Additional coding patterns

--- a/src/errors/duplicateContentError.js
+++ b/src/errors/duplicateContentError.js
@@ -1,0 +1,39 @@
+/**
+ * @file Error class for duplicate content identifiers.
+ */
+
+/**
+ * Error thrown when attempting to load content with an identifier that already exists.
+ *
+ * @class DuplicateContentError
+ * @augments {Error}
+ */
+export class DuplicateContentError extends Error {
+  /**
+   * @param {string} contentType - The type of content (e.g., 'action', 'component', 'entity').
+   * @param {string} qualifiedId - The fully qualified identifier (e.g., 'core:move').
+   * @param {string} modId - The ID of the mod attempting to override.
+   * @param {string} existingModId - The ID of the mod that originally defined the content.
+   * @param {string} [sourceFile] - The source file attempting to define the duplicate.
+   */
+  constructor(contentType, qualifiedId, modId, existingModId, sourceFile) {
+    const sourceInfo = sourceFile ? ` from file '${sourceFile}'` : '';
+    const message = `Duplicate ${contentType} identifier '${qualifiedId}' detected. ` +
+      `Mod '${modId}'${sourceInfo} is attempting to override content originally defined by mod '${existingModId}'. ` +
+      `Mod overrides are not allowed.`;
+    
+    super(message);
+    this.name = 'DuplicateContentError';
+    this.contentType = contentType;
+    this.qualifiedId = qualifiedId;
+    this.modId = modId;
+    this.existingModId = existingModId;
+    this.sourceFile = sourceFile;
+    
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DuplicateContentError);
+    }
+  }
+}
+
+export default DuplicateContentError;

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -6,3 +6,4 @@ export * from './invalidEntityIdError.js';
 export * from './InitializationError.js';
 export * from './invalidActionDefinitionError.js';
 export * from './invalidActorEntityError.js';
+export * from './duplicateContentError.js';

--- a/tests/integration/loaders/multiModsWorldLoader.integration.test.js
+++ b/tests/integration/loaders/multiModsWorldLoader.integration.test.js
@@ -179,7 +179,9 @@ describe('Multi-mod content loading and world validation', () => {
     const totals = {};
     await env.manager.loadContent(finalOrder, manifests, totals);
 
-    expect(env.logger.warn).toHaveBeenCalled();
+    // The duplicate instance should cause an error (not a warning)
+    expect(totals.entityInstances?.errors).toBe(1);
+    
     await env.worldLoader.loadWorlds(finalOrder, manifests, totals);
     expect(totals.worlds.errors).toBe(1);
   });

--- a/tests/unit/loaders/helpers/registryStoreUtils.scope-id-mapping.test.js
+++ b/tests/unit/loaders/helpers/registryStoreUtils.scope-id-mapping.test.js
@@ -14,6 +14,7 @@ describe('registryStoreUtils - Scope ID Mapping', () => {
 
     mockRegistry = {
       store: jest.fn().mockReturnValue(false), // false = no override
+      get: jest.fn().mockReturnValue(undefined), // no existing item
     };
   });
 

--- a/tests/unit/services/componentDefinitionLoader.override.test.js
+++ b/tests/unit/services/componentDefinitionLoader.override.test.js
@@ -294,7 +294,9 @@ describe('ComponentLoader (Sub-Ticket 6.3: Override Behavior)', () => {
     });
     mockRegistry.get.mockImplementation((category, key) => {
       const catMap = internalRegistry.get(category);
-      return catMap ? JSON.parse(JSON.stringify(catMap.get(key))) : undefined;
+      if (!catMap) return undefined;
+      const value = catMap.get(key);
+      return value ? JSON.parse(JSON.stringify(value)) : undefined;
     });
 
     loader = new ComponentLoader(
@@ -355,7 +357,7 @@ describe('ComponentLoader (Sub-Ticket 6.3: Override Behavior)', () => {
   });
 
   // --- Test Case ---
-  it('should override component definition and schema from a later mod', async () => {
+  it('should allow different mods to define components with same base ID without conflict', async () => {
     // --- Arrange ---
     // Configure Fetcher for this specific test
     mockFetcher = createMockDataFetcher({


### PR DESCRIPTION
- Introduced DuplicateContentError to manage attempts to store items with existing keys in the registry.
- Updated storeItemInRegistry function to throw an error when a duplicate is detected instead of logging a warning.
- Modified integration and unit tests to validate the new error handling behavior, ensuring that existing items are not overwritten and appropriate errors are thrown.
- Added a new error module for duplicate content handling.