### PR TITLE
[Agent] use immutable payload when emitting action decided

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -233,14 +233,14 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
     const payload = {
       actorId: actor.id,
       actorType: determineActorType(actor),
+      ...(extractedData && {
+        extractedData: {
+          ...extractedData,
+          thoughts: extractedData.thoughts ?? '',
+          notes: extractedData.notes ?? [],
+        },
+      }),
     };
-    if (extractedData) {
-      payload.extractedData = {
-        ...extractedData,
-        thoughts: extractedData.thoughts ?? '',
-        notes: extractedData.notes ?? [],
-      };
-    }
 
     const dispatcher = getSafeEventDispatcher(turnContext, this._handler);
     const logger = turnContext.getLogger();


### PR DESCRIPTION
## Summary
- ensure `_emitActionDecided` builds payload immutably
- test that the emitted payload has no unexpected mutations

## Testing Done
- `npm run test`
- `npx eslint src/turns/states/awaitingActorDecisionState.js tests/unit/turns/states/awaitingActorDecisionState.helpers.test.js --fix`
- `npm run test` in `llm-proxy-server`

------
https://chatgpt.com/codex/tasks/task_e_685ebcb8ac4c83319e46bd59c1d7a432