### PR TITLE
[Test] Refactor wait action test to use test bed

### DIFF
--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment node
  */
@@ -5,195 +6,152 @@
 import coreWaitActionDefinition from '../../../data/mods/core/actions/wait.action.json';
 
 // --- System Under Test ---
-import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
 
 // --- Core Dependencies to Mock ---
-import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
-import EntityManager from '../../../src/entities/entityManager.js';
-import { PrerequisiteEvaluationService } from '../../../src/actions/validation/prerequisiteEvaluationService.js';
-import ConsoleLogger from '../../../src/logging/consoleLogger.js';
-import { formatActionCommand as formatActionCommandFn } from '../../../src/actions/actionFormatter.js';
-import { createMockScopeEngine } from '../../common/mockFactories';
 
 // --- Helper Mocks/Types ---
 import Entity from '../../../src/entities/entity.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, expect, it } from '@jest/globals';
 /** @typedef {import('../../../src/logging/consoleLogger.js').default} ILogger */
 
-// --- Mocking Dependencies ---
-jest.mock('../../../src/data/gameDataRepository.js');
-jest.mock('../../../src/entities/entityManager.js');
-jest.mock(
-  '../../../src/actions/validation/prerequisiteEvaluationService.js'
-);
-jest.mock('../../../src/logging/consoleLogger.js');
-jest.mock('../../../src/actions/actionFormatter.js');
+// No explicit jest.mock calls needed; mocks are provided by the test bed
 
 // --- Test Suite ---
-describe('ActionDiscoveryService - Wait Action Tests', () => {
-  let actionDiscoveryService;
-  let mockGameDataRepo;
-  let mockEntityManager;
-  let mockValidationService;
-  let mockPrereqService;
-  let mockLogger;
-  let mockFormatActionCommandFn;
-  let mockActionIndex;
+describeActionDiscoverySuite(
+  'ActionDiscoveryService - Wait Action Tests',
+  (getBed) => {
+    const ACTOR_INSTANCE_ID = 'actor1-instance-wait';
+    const DUMMY_DEFINITION_ID = 'def:dummy-wait-test';
 
-  const ACTOR_INSTANCE_ID = 'actor1-instance-wait';
-  const LOCATION_INSTANCE_ID = 'location1-instance-wait';
-  const DUMMY_DEFINITION_ID = 'def:dummy-wait-test';
-
-  const createTestEntity = (instanceId, definitionId) => {
-    const definition = new EntityDefinition(definitionId, {});
-    const instanceData = new EntityInstanceData(instanceId, definition, {});
-    return new Entity(instanceData);
-  };
-
-  let mockActorEntity;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockGameDataRepo = new GameDataRepository();
-    mockEntityManager = new EntityManager();
-    mockPrereqService = new PrerequisiteEvaluationService();
-    mockPrereqService.evaluate.mockReturnValue(true);
-
-    mockLogger = new ConsoleLogger();
-    mockLogger.debug = jest.fn();
-    mockLogger.info = jest.fn();
-    mockLogger.warn = jest.fn();
-    mockLogger.error = jest.fn();
-
-    mockFormatActionCommandFn = formatActionCommandFn;
-    const mockSafeEventDispatcher = { dispatch: jest.fn() };
-    const mockTargetResolutionService = {
-      resolveTargets: jest.fn().mockImplementation(async (scopeName) => {
-        if (scopeName === 'none') return [{ type: 'none', entityId: null }];
-        if (scopeName === 'self') return [{ type: 'entity', entityId: mockActorEntity.id }];
-        return [];
-      })
+    const createTestEntity = (instanceId, definitionId) => {
+      const definition = new EntityDefinition(definitionId, {});
+      const instanceData = new EntityInstanceData(instanceId, definition, {});
+      return new Entity(instanceData);
     };
 
-    mockActorEntity = createTestEntity(ACTOR_INSTANCE_ID, DUMMY_DEFINITION_ID);
+    let mockActorEntity;
 
-    mockFormatActionCommandFn.mockImplementation((actionDef) => {
-      if (actionDef.id === 'core:wait') {
-        return { ok: true, value: 'wait' };
-      }
-      return { ok: false, error: 'invalid' };
+    beforeEach(() => {
+      const bed = getBed();
+
+      mockActorEntity = createTestEntity(
+        ACTOR_INSTANCE_ID,
+        DUMMY_DEFINITION_ID
+      );
+
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+
+      bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
+        async (scopeName) => {
+          if (scopeName === 'none') return [{ type: 'none', entityId: null }];
+          if (scopeName === 'self')
+            return [{ type: 'entity', entityId: mockActorEntity.id }];
+          return [];
+        }
+      );
+
+      bed.mocks.formatActionCommandFn.mockImplementation((actionDef) => {
+        if (actionDef.id === 'core:wait') {
+          return { ok: true, value: 'wait' };
+        }
+        return { ok: false, error: 'invalid' };
+      });
+
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+        coreWaitActionDefinition,
+      ]);
     });
 
-    mockActionIndex = {
-      getCandidateActions: jest
-        .fn()
-        .mockImplementation(() =>
-          mockGameDataRepo.getAllActionDefinitions()
-        ),
-    };
+    it('should return structured action info [{id, name, command, description, params}] when core:wait is available and valid', async () => {
+      const bed = getBed();
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+        coreWaitActionDefinition,
+      ]);
+      const result = await bed.service.getValidActions(mockActorEntity, {});
 
-    actionDiscoveryService = new ActionDiscoveryService({
-      gameDataRepository: mockGameDataRepo,
-      entityManager: mockEntityManager,
-      prerequisiteEvaluationService: mockPrereqService,
-      logger: mockLogger,
-      formatActionCommandFn: mockFormatActionCommandFn,
-      safeEventDispatcher: mockSafeEventDispatcher,
-      targetResolutionService: mockTargetResolutionService,
-      traceContextFactory: jest.fn(() => ({ addLog: jest.fn(), logs: [] })),
-      actionIndex: mockActionIndex,
-    });
-  });
+      expect(result.actions).toEqual([
+        {
+          id: 'core:wait',
+          name: 'Wait',
+          command: 'wait',
+          description: 'Wait for a moment, doing nothing.',
+          params: { targetId: null },
+        },
+      ]);
 
-  it('should return structured action info [{id, name, command, description, params}] when core:wait is available and valid', async () => {
-    mockGameDataRepo.getAllActionDefinitions.mockReturnValue([
-      coreWaitActionDefinition,
-    ]);
-    const result = await actionDiscoveryService.getValidActions(
-      mockActorEntity,
-      {}
-    );
-
-    expect(result.actions).toEqual([
-      {
-        id: 'core:wait',
-        name: 'Wait',
-        command: 'wait',
-        description: 'Wait for a moment, doing nothing.',
-        params: { targetId: null },
-      },
-    ]);
-
-    expect(mockActionIndex.getCandidateActions).toHaveBeenCalledTimes(1);
-    // FIX: The `wait` action has no prerequisites, so evaluate should NOT be called.
-    expect(mockPrereqService.evaluate).not.toHaveBeenCalled();
-    expect(mockFormatActionCommandFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return an empty array if core:wait action prerequisites fail', async () => {
-    // FIX: Create a custom action def with prerequisites to properly test the failure case.
-    const waitActionWithPrereqs = {
-      ...coreWaitActionDefinition,
-      prerequisites: [{ logic: { some_condition: true } }],
-    };
-    mockGameDataRepo.getAllActionDefinitions.mockReturnValue([
-      waitActionWithPrereqs,
-    ]);
-    mockPrereqService.evaluate.mockReturnValue(false);
-
-    const result = await actionDiscoveryService.getValidActions(
-      mockActorEntity,
-      {}
-    );
-
-    // FIX: Now that `evaluate` is called and returns false, the actions array should be empty.
-    expect(result.actions).toEqual([]);
-    expect(mockFormatActionCommandFn).not.toHaveBeenCalled();
-    expect(mockPrereqService.evaluate).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return an empty array if core:wait action definition is not provided', async () => {
-    mockGameDataRepo.getAllActionDefinitions.mockReturnValue([]);
-
-    const result = await actionDiscoveryService.getValidActions(
-      mockActorEntity,
-      {}
-    );
-
-    expect(result.actions).toEqual([]);
-    expect(mockPrereqService.evaluate).not.toHaveBeenCalled();
-    expect(mockFormatActionCommandFn).not.toHaveBeenCalled();
-  });
-
-  it('should return structured info for core:wait even if other invalid actions are present', async () => {
-    const invalidActionDef = {
-      id: 'other:action',
-      name: 'Other',
-      scope: 'none',
-      prerequisites: [{ logic: { '==': [1, 2] } }], // A failing prereq
-    };
-    mockGameDataRepo.getAllActionDefinitions.mockReturnValue([
-      coreWaitActionDefinition, // This has no prereqs
-      invalidActionDef,       // This has prereqs
-    ]);
-
-    mockPrereqService.evaluate.mockImplementation((prereqs, actionDef) => {
-      // This will only be called for invalidActionDef. Make it fail.
-      return actionDef.id !== 'other:action';
+      expect(bed.mocks.actionIndex.getCandidateActions).toHaveBeenCalledTimes(
+        1
+      );
+      // FIX: The `wait` action has no prerequisites, so evaluate should NOT be called.
+      expect(
+        bed.mocks.prerequisiteEvaluationService.evaluate
+      ).not.toHaveBeenCalled();
+      expect(bed.mocks.formatActionCommandFn).toHaveBeenCalledTimes(1);
     });
 
-    const result = await actionDiscoveryService.getValidActions(
-      mockActorEntity,
-      {}
-    );
+    it('should return an empty array if core:wait action prerequisites fail', async () => {
+      const bed = getBed();
+      const waitActionWithPrereqs = {
+        ...coreWaitActionDefinition,
+        prerequisites: [{ logic: { some_condition: true } }],
+      };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+        waitActionWithPrereqs,
+      ]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(false);
 
-    expect(result.actions).toHaveLength(1);
-    expect(result.actions[0].id).toBe('core:wait');
-    // FIX: `evaluate` is only called for the one action that HAS prerequisites.
-    expect(mockPrereqService.evaluate).toHaveBeenCalledTimes(1);
-    expect(mockFormatActionCommandFn).toHaveBeenCalledTimes(1);
-  });
-});
+      const result = await bed.service.getValidActions(mockActorEntity, {});
+
+      // FIX: Now that `evaluate` is called and returns false, the actions array should be empty.
+      expect(result.actions).toEqual([]);
+      expect(bed.mocks.formatActionCommandFn).not.toHaveBeenCalled();
+      expect(
+        bed.mocks.prerequisiteEvaluationService.evaluate
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return an empty array if core:wait action definition is not provided', async () => {
+      const bed = getBed();
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([]);
+
+      const result = await bed.service.getValidActions(mockActorEntity, {});
+
+      expect(result.actions).toEqual([]);
+      expect(
+        bed.mocks.prerequisiteEvaluationService.evaluate
+      ).not.toHaveBeenCalled();
+      expect(bed.mocks.formatActionCommandFn).not.toHaveBeenCalled();
+    });
+
+    it('should return structured info for core:wait even if other invalid actions are present', async () => {
+      const bed = getBed();
+      const invalidActionDef = {
+        id: 'other:action',
+        name: 'Other',
+        scope: 'none',
+        prerequisites: [{ logic: { '==': [1, 2] } }], // A failing prereq
+      };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
+        coreWaitActionDefinition, // This has no prereqs
+        invalidActionDef, // This has prereqs
+      ]);
+
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockImplementation(
+        (prereqs, actionDef) => actionDef.id !== 'other:action'
+      );
+
+      const result = await bed.service.getValidActions(mockActorEntity, {});
+
+      expect(result.actions).toHaveLength(1);
+      expect(result.actions[0].id).toBe('core:wait');
+      // FIX: `evaluate` is only called for the one action that HAS prerequisites.
+      expect(
+        bed.mocks.prerequisiteEvaluationService.evaluate
+      ).toHaveBeenCalledTimes(1);
+      expect(bed.mocks.formatActionCommandFn).toHaveBeenCalledTimes(1);
+    });
+  }
+);


### PR DESCRIPTION
Summary: Updated wait action discovery test to use `describeActionDiscoverySuite` and mocks provided by the ActionDiscoveryService test bed. Removed manual service setup and unused imports.

Changes Made:
- Switched imports to `describeActionDiscoverySuite` and dropped unused mocks.
- Created bed-based `beforeEach` configuring mock behaviors.
- Updated tests to call `bed.service` and `bed.mocks`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` - fails due to existing repo issues)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_685ebc97c1c48331a7a718bc2484891f