### PR TITLE
[Agent] add dispatchValidationError helper

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -12,7 +12,10 @@
 
 // --- Dependency Imports ---
 import { getEntityDisplayName } from '../utils/entityUtils.js';
-import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import {
+  safeDispatchError,
+  dispatchValidationError,
+} from '../utils/safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { TARGET_DOMAIN_NONE } from '../constants/targetDomains.js';
 import {
@@ -36,18 +39,6 @@ import {
 /**
  * @typedef {FormatActionOk | FormatActionError} FormatActionCommandResult
  */
-
-/**
- * @description Helper for reporting argument validation errors.
- * @param {ISafeEventDispatcher} dispatcher - Dispatcher for error events.
- * @param {string} message - Error message to send.
- * @param {object} [detail] - Optional error detail payload.
- * @returns {FormatActionError} Result object representing the failure.
- */
-function reportValidationError(dispatcher, message, detail) {
-  safeDispatchError(dispatcher, message, detail);
-  return { ok: false, error: message };
-}
 
 /**
  * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => FormatActionCommandResult>} TargetFormatterMap
@@ -146,41 +137,31 @@ function validateFormatInputs(
     throw new Error('formatActionCommand: logger is required.');
   }
   if (!actionDefinition || !actionDefinition.template) {
-    return reportValidationError(
+    return dispatchValidationError(
       dispatcher,
       'formatActionCommand: Invalid or missing actionDefinition or template.',
       { actionDefinition }
     );
   }
   if (!targetContext) {
-    return reportValidationError(
+    return dispatchValidationError(
       dispatcher,
       'formatActionCommand: Invalid or missing targetContext.',
       { targetContext }
     );
   }
   if (!entityManager || typeof entityManager.getEntityInstance !== 'function') {
-    safeDispatchError(
+    return dispatchValidationError(
       dispatcher,
       'formatActionCommand: Invalid or missing entityManager.',
       { entityManager }
     );
-    return {
-      ok: false,
-      error:
-        'formatActionCommand: entityManager parameter must be a valid EntityManager instance.',
-    };
   }
   if (typeof displayNameFn !== 'function') {
-    safeDispatchError(
+    return dispatchValidationError(
       dispatcher,
       'formatActionCommand: getEntityDisplayName utility function is not available.'
     );
-    return {
-      ok: false,
-      error:
-        'formatActionCommand: getEntityDisplayName parameter must be a function.',
-    };
   }
 
   return null;

--- a/src/utils/safeDispatchErrorUtils.js
+++ b/src/utils/safeDispatchErrorUtils.js
@@ -55,4 +55,20 @@ export function safeDispatchError(dispatcher, message, details = {}, logger) {
   dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });
 }
 
+/**
+ * @description Dispatches a validation error and returns a standardized result object.
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
+ * @param {string} message - Human readable error message.
+ * @param {object} [details] - Additional structured details for debugging.
+ * @param {ILogger} [logger] - Optional logger for error logging. When omitted, a
+ * console-based fallback is used.
+ * @returns {{ ok: false, error: string, details?: object }} Result object for validation failures.
+ */
+export function dispatchValidationError(dispatcher, message, details, logger) {
+  safeDispatchError(dispatcher, message, details, logger);
+  return details !== undefined
+    ? { ok: false, error: message, details }
+    : { ok: false, error: message };
+}
+
 // --- FILE END ---

--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -94,6 +94,7 @@ describe('formatActionCommand', () => {
       ok: false,
       error:
         'formatActionCommand: Invalid or missing actionDefinition or template.',
+      details: { actionDefinition: { id: 'bad' } },
     });
     expect(dispatcher.dispatch).toHaveBeenCalledWith(
       SYSTEM_ERROR_OCCURRED_ID,
@@ -114,8 +115,8 @@ describe('formatActionCommand', () => {
     );
     expect(result).toEqual({
       ok: false,
-      error:
-        'formatActionCommand: entityManager parameter must be a valid EntityManager instance.',
+      error: 'formatActionCommand: Invalid or missing entityManager.',
+      details: { entityManager: {} },
     });
   });
 

--- a/tests/unit/utils/safeDispatchErrorUtils.test.js
+++ b/tests/unit/utils/safeDispatchErrorUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
   safeDispatchError,
+  dispatchValidationError,
   InvalidDispatcherError,
 } from '../../../src/utils/safeDispatchErrorUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
@@ -28,5 +29,27 @@ describe('safeDispatchError', () => {
       "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
     );
     expect(error.details).toEqual({ functionName: 'safeDispatchError' });
+  });
+});
+
+describe('dispatchValidationError', () => {
+  it('dispatches the error and returns result with details', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const result = dispatchValidationError(dispatcher, 'bad', { foo: 1 });
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
+      message: 'bad',
+      details: { foo: 1 },
+    });
+    expect(result).toEqual({ ok: false, error: 'bad', details: { foo: 1 } });
+  });
+
+  it('omits details when none provided', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const result = dispatchValidationError(dispatcher, 'oops');
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
+      message: 'oops',
+      details: {},
+    });
+    expect(result).toEqual({ ok: false, error: 'oops' });
   });
 });


### PR DESCRIPTION
## Summary
- add shared `dispatchValidationError` helper
- use `dispatchValidationError` in `formatActionCommand`
- update unit tests

## Testing Done
- `npm run lint` *(warnings only)*
- `npm test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ec64689108331b3761bbc9d786021