### PR TITLE
[Agent] DRY entity tests with shared helpers

### DIFF
--- a/tests/common/entities/definitionBuilders.js
+++ b/tests/common/entities/definitionBuilders.js
@@ -1,0 +1,22 @@
+import EntityDefinition from '../../../src/entities/entityDefinition.js';
+
+/**
+ * @file Helper builders for entity definitions used in integration tests.
+ * @see tests/common/entities/definitionBuilders.js
+ */
+
+/**
+ * Builds a minimal {@link EntityDefinition} instance.
+ *
+ * @param {string} id - Unique definition identifier.
+ * @param {Record<string, any>} components - Component map keyed by ID.
+ * @param {string} [description] - Optional description text.
+ * @returns {EntityDefinition} Newly constructed definition.
+ */
+export function buildEntityDefinition(
+  id,
+  components = {},
+  description = 'Test definition'
+) {
+  return new EntityDefinition(id, { description, components });
+}

--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -5,3 +5,4 @@ export { TestData } from './testData.js';
 export * from './serializationUtils.js';
 export * from './execContext.js';
 export * from './invalidInputHelpers.js';
+export * from './definitionBuilders.js';

--- a/tests/common/mockFactories/index.js
+++ b/tests/common/mockFactories/index.js
@@ -31,3 +31,4 @@ export { createLoaderMocks } from './loaders.js';
 export { createRuleTestDataRegistry } from './entities.js';
 
 export { MockContainer } from './container.js';
+export { createMockSpatialIndexManager } from './spatialIndexManager.js';

--- a/tests/common/mockFactories/spatialIndexManager.js
+++ b/tests/common/mockFactories/spatialIndexManager.js
@@ -1,0 +1,22 @@
+import { createSimpleMock } from './coreServices.js';
+
+/**
+ * @file Factory for SpatialIndexManager mocks used in tests.
+ * @see tests/common/mockFactories/spatialIndexManager.js
+ */
+
+/**
+ * Creates a mock implementation of {@link module:ISpatialIndexManager}.
+ *
+ * @description Provides jest.fn stubs for the basic spatial index methods.
+ * @returns {object} Mocked spatial index manager with jest.fn methods.
+ */
+export function createMockSpatialIndexManager() {
+  return createSimpleMock([
+    'addEntity',
+    'removeEntity',
+    'updateEntityLocation',
+    'clearIndex',
+    'getEntitiesInLocation',
+  ]);
+}

--- a/tests/integration/entityCreationFromDefAndInstance.integration.test.js
+++ b/tests/integration/entityCreationFromDefAndInstance.integration.test.js
@@ -4,16 +4,9 @@
  */
 
 import Entity from '../../src/entities/entity.js';
-import EntityDefinition from '../../src/entities/entityDefinition.js';
+import { buildEntityDefinition } from '../common/entities/index.js';
 import EntityManagerIntegrationTestBed from '../common/entities/entityManagerIntegrationTestBed.js';
 
-// Mocks for constructor dependencies
-const mockSpatialIndexManager = {
-  addEntity: jest.fn(),
-  removeEntity: jest.fn(),
-  updateEntityLocation: jest.fn(),
-  clearIndex: jest.fn(),
-};
 
 describe('EntityManager Integration Tests', () => {
   let entityManager;
@@ -42,17 +35,13 @@ describe('EntityManager Integration Tests', () => {
     const instanceId = 'core:goblin_sentry';
 
     // 1. Create the base EntityDefinition for a goblin
-    const goblinDefinitionData = {
-      id: definitionId,
-      description: 'A standard goblin creature.',
-      components: {
+    const goblinDefinition = buildEntityDefinition(
+      definitionId,
+      {
         'core:name': { name: 'Goblin' },
         'core:health': { max: 15, current: 15 },
       },
-    };
-    const goblinDefinition = new EntityDefinition(
-      definitionId,
-      goblinDefinitionData
+      'A standard goblin creature.'
     );
 
     // 2. Populate the mock DataRegistry to simulate it being loaded

--- a/tests/unit/scopeDsl/engine.additional.test.js
+++ b/tests/unit/scopeDsl/engine.additional.test.js
@@ -8,6 +8,7 @@ import ScopeEngine from '../../../src/scopeDsl/engine.js';
 import { parseDslExpression } from '../../../src/scopeDsl/parser.js';
 import ScopeDepthError from '../../../src/errors/scopeDepthError.js';
 import ScopeCycleError from '../../../src/errors/scopeCycleError.js';
+import { createMockSpatialIndexManager } from '../../common/mockFactories/index.js';
 
 // Mock dependencies
 const mockEntityManager = {
@@ -20,9 +21,7 @@ const mockEntityManager = {
   getEntities: jest.fn(), // For the alternative path in negative component queries
 };
 
-const mockSpatialIndexManager = {
-  getEntitiesInLocation: jest.fn(),
-};
+const mockSpatialIndexManager = createMockSpatialIndexManager();
 
 const mockJsonLogicEval = {
   evaluate: jest.fn(),

--- a/tests/unit/scopeDsl/engine.test.js
+++ b/tests/unit/scopeDsl/engine.test.js
@@ -10,6 +10,7 @@ import ScopeEngine from '../../../src/scopeDsl/engine.js';
 import { parseDslExpression } from '../../../src/scopeDsl/parser.js';
 import ScopeDepthError from '../../../src/errors/scopeDepthError.js';
 import ScopeCycleError from '../../../src/errors/scopeCycleError.js';
+import { createMockSpatialIndexManager } from '../../common/mockFactories/index.js';
 
 // Mock dependencies
 const mockEntityManager = {
@@ -21,9 +22,7 @@ const mockEntityManager = {
   entities: [],
 };
 
-const mockSpatialIndexManager = {
-  getEntitiesInLocation: jest.fn(),
-};
+const mockSpatialIndexManager = createMockSpatialIndexManager();
 
 const mockJsonLogicEval = {
   evaluate: jest.fn(),


### PR DESCRIPTION
Summary: Refactored EntityManager tests to reuse existing mock factories and added utility helpers.

Changes Made:
- Created `createMockSpatialIndexManager` factory and exported from helpers.
- Added `buildEntityDefinition` helper for integration tests.
- Updated test suites to use these helpers and removed inline mocks.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes on modified files (`npx eslint <files>`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test (N/A)


------
https://chatgpt.com/codex/tasks/task_e_685ec59730908331aab546e32f37a79b