### PR TITLE
[Refactor] DRY payload normalization and validation

### DIFF
--- a/src/entities/services/componentMutationService.js
+++ b/src/entities/services/componentMutationService.js
@@ -102,40 +102,6 @@ export class ComponentMutationService {
   }
 
   /**
-   * Validate parameters for addComponent.
-   *
-   * @private
-   * @param {string} instanceId - Entity instance ID.
-   * @param {string} componentTypeId - Component type ID.
-   * @param {object} componentData - Raw component data.
-   * @throws {InvalidArgumentError} If parameters are invalid.
-   */
-  #validateAddComponentParams(instanceId, componentTypeId, componentData) {
-    validateAddComponentParamsUtil(
-      instanceId,
-      componentTypeId,
-      componentData,
-      this.#logger
-    );
-  }
-
-  /**
-   * Validate parameters for removeComponent.
-   *
-   * @private
-   * @param {string} instanceId - Entity instance ID.
-   * @param {string} componentTypeId - Component type ID.
-   * @throws {InvalidArgumentError} If parameters are invalid.
-   */
-  #validateRemoveComponentParams(instanceId, componentTypeId) {
-    validateRemoveComponentParamsUtil(
-      instanceId,
-      componentTypeId,
-      this.#logger
-    );
-  }
-
-  /**
    * Adds or updates a component on an existing entity instance.
    *
    * @param {string} instanceId - The ID of the entity instance.
@@ -146,10 +112,12 @@ export class ComponentMutationService {
    * @throws {ValidationError} If component data validation fails.
    */
   addComponent(instanceId, componentTypeId, componentData) {
-    this.#validateAddComponentParams(
+    validateAddComponentParamsUtil(
       instanceId,
       componentTypeId,
-      componentData
+      componentData,
+      this.#logger,
+      'ComponentMutationService.addComponent'
     );
 
     const entity = this.#entityRepository.get(instanceId);
@@ -219,7 +187,12 @@ export class ComponentMutationService {
    * @throws {Error} If component override does not exist or removal fails.
    */
   removeComponent(instanceId, componentTypeId) {
-    this.#validateRemoveComponentParams(instanceId, componentTypeId);
+    validateRemoveComponentParamsUtil(
+      instanceId,
+      componentTypeId,
+      this.#logger,
+      'ComponentMutationService.removeComponent'
+    );
 
     const entity = this.#entityRepository.get(instanceId);
     if (!entity) {

--- a/src/entities/utils/parameterValidators.js
+++ b/src/entities/utils/parameterValidators.js
@@ -25,15 +25,10 @@ import { InvalidInstanceIdError } from '../../errors/invalidInstanceIdError.js';
  * @returns {void}
  * @private
  */
-function _assertIds(methodName, instanceId, componentTypeId, logger) {
+function _assertIds(context, instanceId, componentTypeId, logger) {
   try {
-    assertValidId(instanceId, methodName, logger);
-    assertNonBlankString(
-      componentTypeId,
-      'componentTypeId',
-      methodName,
-      logger
-    );
+    assertValidId(instanceId, context, logger);
+    assertNonBlankString(componentTypeId, 'componentTypeId', context, logger);
   } catch (err) {
     logger.error(err);
     throw new InvalidArgumentError(`Invalid ID: ${err.message}`);
@@ -47,18 +42,20 @@ function _assertIds(methodName, instanceId, componentTypeId, logger) {
  * @param {string} componentTypeId - Component type ID.
  * @param {object} componentData - Raw component data.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for reporting issues.
+ * @param {string} [context='EntityManager.addComponent'] - Method context for error messages.
  * @throws {InvalidArgumentError} If parameters are invalid.
  */
 export function validateAddComponentParams(
   instanceId,
   componentTypeId,
   componentData,
-  logger
+  logger,
+  context = 'EntityManager.addComponent'
 ) {
-  _assertIds('EntityManager.addComponent', instanceId, componentTypeId, logger);
+  _assertIds(context, instanceId, componentTypeId, logger);
 
   if (componentData === null) {
-    const errorMsg = `EntityManager.addComponent: componentData cannot be null for ${componentTypeId} on ${instanceId}`;
+    const errorMsg = `${context}: componentData cannot be null for ${componentTypeId} on ${instanceId}`;
     logger.error(errorMsg, {
       componentTypeId,
       instanceId,
@@ -68,7 +65,7 @@ export function validateAddComponentParams(
 
   if (componentData !== undefined && typeof componentData !== 'object') {
     const receivedType = typeof componentData;
-    const errorMsg = `EntityManager.addComponent: componentData for ${componentTypeId} on ${instanceId} must be an object. Received: ${receivedType}`;
+    const errorMsg = `${context}: componentData for ${componentTypeId} on ${instanceId} must be an object. Received: ${receivedType}`;
     logger.error(errorMsg, {
       componentTypeId,
       instanceId,
@@ -84,19 +81,16 @@ export function validateAddComponentParams(
  * @param {string} instanceId - Entity instance ID.
  * @param {string} componentTypeId - Component type ID.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for reporting issues.
+ * @param {string} [context='EntityManager.removeComponent'] - Method context for error messages.
  * @throws {InvalidArgumentError} If parameters are invalid.
  */
 export function validateRemoveComponentParams(
   instanceId,
   componentTypeId,
-  logger
+  logger,
+  context = 'EntityManager.removeComponent'
 ) {
-  _assertIds(
-    'EntityManager.removeComponent',
-    instanceId,
-    componentTypeId,
-    logger
-  );
+  _assertIds(context, instanceId, componentTypeId, logger);
 }
 
 /**


### PR DESCRIPTION
Summary: Introduced a private `#normalizePayload` helper in `SpatialIndexSynchronizer` to consolidate event payload extraction. Parameter validation utilities now accept a context for reuse across services, and `ComponentMutationService` uses them directly.

Changes Made:
- Added `#normalizePayload` method and updated event handlers.
- Extended parameter validators with optional `context` argument.
- Simplified `ComponentMutationService` by removing redundant validation wrappers.

Testing Done:
- [x] Code formatted (`prettier`)
- [x] Lint warnings only (`eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685ec58c8a408331a445060476df24d9