### PR TITLE
[Feat] Return status from tryEndTurn

### DIFF
--- a/tests/unit/turns/states/helpers/processingExceptionHandler.test.js
+++ b/tests/unit/turns/states/helpers/processingExceptionHandler.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { ProcessingExceptionHandler } from '../../../../../src/turns/states/helpers/processingExceptionHandler.js';
+
+/**
+ * Creates a basic state object with optional handler.
+ *
+ * @param {object} [handler]
+ */
+const makeState = (handler = {}) => ({
+  getStateName: () => 'TestState',
+  _handler: handler,
+});
+
+describe('ProcessingExceptionHandler.tryEndTurn', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  });
+
+  test('returns true when endTurn succeeds', async () => {
+    const turnCtx = { endTurn: jest.fn().mockResolvedValue(undefined) };
+    const handler = new ProcessingExceptionHandler(makeState());
+    const result = await handler.tryEndTurn(turnCtx, new Error('boom'), logger);
+    expect(turnCtx.endTurn).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  test('returns true when endTurn fails but handler resets', async () => {
+    const turnCtx = { endTurn: jest.fn().mockRejectedValue(new Error('fail')) };
+    const state = makeState({
+      resetStateAndResources: jest.fn().mockResolvedValue(undefined),
+      requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
+    });
+    const handler = new ProcessingExceptionHandler(state);
+    const result = await handler.tryEndTurn(turnCtx, new Error('boom'), logger);
+    expect(turnCtx.endTurn).toHaveBeenCalled();
+    expect(state._handler.resetStateAndResources).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});
+
+describe('ProcessingExceptionHandler.handle', () => {
+  test('logs warning when end turn and reset both fail', async () => {
+    const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const turnCtx = {
+      getLogger: () => logger,
+      getSafeEventDispatcher: () => ({ dispatch: jest.fn() }),
+    };
+    const state = makeState();
+    const handler = new ProcessingExceptionHandler(state);
+    await handler.handle(turnCtx, new Error('boom'), 'actor1', true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to end turn and handler reset was not performed'
+      )
+    );
+  });
+});


### PR DESCRIPTION
Summary: Modified ProcessingExceptionHandler.tryEndTurn to return a boolean indicating if the turn was ended or handler reset. Added logging in handle when neither action succeeds. Added unit tests for the new behavior.

Changes Made:
- Updated tryEndTurn to return success flag and adapted handle to warn on failure.
- New unit test covering tryEndTurn return values and handle warning.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685ec66fd7dc8331840475b678f98851