### PR TITLE
[Agent] handle candidate processing errors

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -193,16 +193,29 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     );
 
     for (const actionDef of candidateDefs) {
-      const result = await this.#processCandidateAction(
-        actionDef,
-        actorEntity,
-        discoveryContext,
-        trace
-      );
+      try {
+        const result = await this.#processCandidateAction(
+          actionDef,
+          actorEntity,
+          discoveryContext,
+          trace
+        );
 
-      if (result) {
-        actions.push(...result.actions);
-        errors.push(...result.errors);
+        if (result) {
+          actions.push(...result.actions);
+          errors.push(...result.errors);
+        }
+      } catch (err) {
+        errors.push({
+          actionId: actionDef.id,
+          targetId:
+            err?.targetId ?? err?.target?.entityId ?? err?.entityId ?? null,
+          error: err,
+        });
+        this.#logger.error(
+          `Error processing candidate action '${actionDef.id}': ${err.message}`,
+          err
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- improve error handling when discovering actions
- test that failed candidates don't halt discovery

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ed0523da48331ba502aaa8f6690e3