### PR TITLE
[Agent] Remove unused TraceContext result

### DIFF
--- a/src/actions/tracing/traceContext.js
+++ b/src/actions/tracing/traceContext.js
@@ -26,9 +26,6 @@ export class TraceContext {
   /** @type {TraceLogEntry[]} */
   logs = [];
 
-  /** @type {any | null} */
-  result = null;
-
   /**
    * Adds a log entry to the trace.
    *

--- a/tests/unit/actions/traceContext.test.js
+++ b/tests/unit/actions/traceContext.test.js
@@ -2,10 +2,9 @@ import { describe, it, expect } from '@jest/globals';
 import { TraceContext } from '../../../src/actions/tracing/traceContext.js';
 
 describe('TraceContext', () => {
-  it('initializes with empty logs and null result', () => {
+  it('initializes with empty logs', () => {
     const trace = new TraceContext();
     expect(trace.logs).toEqual([]);
-    expect(trace.result).toBeNull();
   });
 
   it('adds a log entry without data', () => {


### PR DESCRIPTION
## Summary
- remove unused `result` property from `TraceContext`
- update `TraceContext` unit test

## Testing Done
- `npm run format` *(ran on specific files)*
- `npx eslint src/actions/tracing/traceContext.js tests/unit/actions/traceContext.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start` *(manual smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_685ed045852c833196b307dfd9a3708b