### PR TITLE
[Docs] add interfaces for initialization dependencies

### DIFF
--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -3,13 +3,16 @@
 // --- Type Imports ---
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
-/** @typedef {import('../../loaders/modsLoader.js').default} ModsLoader */
+/** @typedef {import('../../interfaces/IModsLoader.js').IModsLoader} IModsLoader */
 /** @typedef {import('../systemInitializer.js').default} SystemInitializer */
 /** @typedef {import('../worldInitializer.js').default} WorldInitializer */
 /** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('../../llms/services/llmConfigLoader.js').LlmConfigLoader} LlmConfigLoader */
 /** @typedef {import('../../events/safeEventDispatcher.js').default} ISafeEventDispatcher */
 /** @typedef {import('../../actions/actionIndex.js').ActionIndex} ActionIndex */
+/** @typedef {import('../../interfaces/IThoughtListener.js').IThoughtListener} IThoughtListener */
+/** @typedef {import('../../interfaces/INotesListener.js').INotesListener} INotesListener */
+/** @typedef {import('../../interfaces/ISpatialIndexManager.js').ISpatialIndexManager} ISpatialIndexManager */
 
 // --- Interface Imports for JSDoc & `extends` ---
 /** @typedef {import('../../interfaces/IInitializationService.js').InitializationResult} InitializationResult */
@@ -58,7 +61,7 @@ class InitializationService extends IInitializationService {
    * @param {object} deps
    * @param {ILogger} deps.logger
    * @param {IValidatedEventDispatcher} deps.validatedEventDispatcher
-   * @param {ModsLoader} deps.modsLoader
+   * @param {IModsLoader} deps.modsLoader
    * @param {import('../../interfaces/IScopeRegistry.js').IScopeRegistry} dependencies.scopeRegistry - Registry of scopes.
    * @param {import('../../data/inMemoryDataRegistry.js').DataRegistry} dependencies.dataRegistry - Data registry instance.
    * @param {import('../../turns/interfaces/ILLMAdapter.js').ILLMAdapter & {init?: Function, isInitialized?: Function, isOperational?: Function}} dependencies.llmAdapter - LLM adapter instance.
@@ -70,8 +73,8 @@ class InitializationService extends IInitializationService {
    * @param {import('../../domUI/domUiFacade.js').DomUiFacade} dependencies.domUiFacade - UI facade instance.
    * @param {ActionIndex} dependencies.actionIndex - Action index for optimized action discovery.
    * @param {import('../../interfaces/IGameDataRepository.js').IGameDataRepository} dependencies.gameDataRepository - Game data repository instance.
-   * @param {ThoughtPersistenceListener} deps.thoughtListener
-   * @param {NotesPersistenceListener} deps.notesListener
+   * @param {IThoughtListener} deps.thoughtListener
+   * @param {INotesListener} deps.notesListener
    * @param {ISpatialIndexManager} deps.spatialIndexManager
    * @description Initializes the complete game system.
    */

--- a/src/interfaces/IModsLoader.js
+++ b/src/interfaces/IModsLoader.js
@@ -1,0 +1,11 @@
+/**
+ * @file Defines the contract for a service that loads mods for a world.
+ */
+
+/**
+ * @typedef {object} IModsLoader
+ * @property {(worldName: string, requestedModIds?: string[]) => Promise<import('./loadContracts.js').LoadReport>} loadMods
+ * Loads mods for the specified world and returns a load report.
+ */
+
+export {};

--- a/src/interfaces/INotesListener.js
+++ b/src/interfaces/INotesListener.js
@@ -1,0 +1,11 @@
+/**
+ * @file Defines the interface for listeners that persist generated notes.
+ */
+
+/**
+ * @typedef {object} INotesListener
+ * @property {(event: { type: string, payload: any }) => void} handleEvent
+ * Handles an ACTION_DECIDED_ID event and persists notes.
+ */
+
+export {};

--- a/src/interfaces/ISpatialIndexManager.js
+++ b/src/interfaces/ISpatialIndexManager.js
@@ -1,4 +1,24 @@
 /**
+ * @file Defines the spatial index management interface used by engine services.
+ */
+
+/**
+ * @typedef {object} ISpatialIndexManager
+ * @property {(entityId: string, locationId: (string|null|undefined)) => void} addEntity
+ * Adds or updates an entity's presence in the index for a given location.
+ * @property {(entityId: string, locationId: (string|null|undefined)) => void} removeEntity
+ * Removes an entity from the index.
+ * @property {(entityId: string, oldLocationId: (string|null|undefined), newLocationId: (string|null|undefined)) => void} updateEntityLocation
+ * Updates an entity's location from an old location to a new one.
+ * @property {(locationId: string) => Set<string>} getEntitiesInLocation
+ * Retrieves a set of all entity IDs currently registered in the specified location.
+ * @property {(entityManager: { activeEntities: Array<any> }) => void} buildIndex
+ * Builds or rebuilds the entire spatial index based on the current state of entities.
+ * @property {() => void} clearIndex
+ * Clears all entries from the spatial index.
+ */
+
+/**
  * @interface ISpatialIndexManager
  * @description
  * Defines the contract for managing a spatial index of entities based on their location.

--- a/src/interfaces/IThoughtListener.js
+++ b/src/interfaces/IThoughtListener.js
@@ -1,0 +1,11 @@
+/**
+ * @file Defines the interface for listeners that persist AI thoughts.
+ */
+
+/**
+ * @typedef {object} IThoughtListener
+ * @property {(event: { type: string, payload: any }) => void} handleEvent
+ * Handles an ACTION_DECIDED_ID event and persists thoughts.
+ */
+
+export {};


### PR DESCRIPTION
Summary: Added JSDoc typedef interfaces for initialization dependencies and updated constructor docs.

Changes Made:
- Created new typedef files for `IModsLoader`, `IThoughtListener`, and `INotesListener` in `src/interfaces`.
- Added detailed typedef to existing `ISpatialIndexManager`.
- Updated `InitializationService` constructor JSDoc to use these interfaces.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685ed02a36e88331957c88d772f93ed7