### PR TITLE
[Agent] centralize minimal entity helper

### DIFF
--- a/tests/common/mockFactories/entities.js
+++ b/tests/common/mockFactories/entities.js
@@ -207,3 +207,19 @@ export const createMockActor = (
     getComponent: jest.fn((compId) => compMap.get(compId)),
   };
 };
+
+/**
+ * Creates a minimal test entity with component map access.
+ *
+ * @description Provides an object with `id`, `components` and
+ *   `getComponentData` for simple unit tests.
+ * @param {string} instanceId - Entity instance ID.
+ * @param {Record<string, any>} [components] - Components keyed by id.
+ * @returns {{id: string, components: Record<string, any>, getComponentData: (id: string) => any}}
+ *   Minimal entity stub.
+ */
+export const createTestEntity = (instanceId, components = {}) => ({
+  id: instanceId,
+  components,
+  getComponentData: (id) => components[id] ?? null,
+});

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -17,6 +17,7 @@ import {
   EXITS_COMPONENT_ID,
   POSITION_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
+import { createTestEntity } from '../../common/mockFactories/index.js';
 
 // We create manual mocks instead of using jest.mock() to have finer control.
 
@@ -26,12 +27,6 @@ describeActionDiscoverySuite(
     const HERO_INSTANCE_ID = 'hero-instance-uuid-integration-1';
     const GUILD_INSTANCE_ID = 'guild-instance-uuid-integration-1';
     const TOWN_INSTANCE_ID = 'town-instance-uuid-integration-1';
-
-    const createTestEntity = (instanceId, components = {}) => ({
-      id: instanceId,
-      components: components,
-      getComponentData: (id) => components[id] || null,
-    });
 
     const heroEntityInitialComponents = {
       [POSITION_COMPONENT_ID]: { locationId: GUILD_INSTANCE_ID },

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -11,10 +11,8 @@ import { describeActionDiscoverySuite } from '../../common/actions/actionDiscove
 // --- Core Dependencies to Mock ---
 
 // --- Helper Mocks/Types ---
-import Entity from '../../../src/entities/entity.js';
-import EntityDefinition from '../../../src/entities/entityDefinition.js';
-import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
 import { beforeEach, expect, it } from '@jest/globals';
+import { createTestEntity } from '../../common/mockFactories/index.js';
 /** @typedef {import('../../../src/logging/consoleLogger.js').default} ILogger */
 
 // No explicit jest.mock calls needed; mocks are provided by the test bed
@@ -24,23 +22,13 @@ describeActionDiscoverySuite(
   'ActionDiscoveryService - Wait Action Tests',
   (getBed) => {
     const ACTOR_INSTANCE_ID = 'actor1-instance-wait';
-    const DUMMY_DEFINITION_ID = 'def:dummy-wait-test';
-
-    const createTestEntity = (instanceId, definitionId) => {
-      const definition = new EntityDefinition(definitionId, {});
-      const instanceData = new EntityInstanceData(instanceId, definition, {});
-      return new Entity(instanceData);
-    };
 
     let mockActorEntity;
 
     beforeEach(() => {
       const bed = getBed();
 
-      mockActorEntity = createTestEntity(
-        ACTOR_INSTANCE_ID,
-        DUMMY_DEFINITION_ID
-      );
+      mockActorEntity = createTestEntity(ACTOR_INSTANCE_ID);
 
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
 


### PR DESCRIPTION
## Summary
- add `createTestEntity` to common mock factories
- reuse `createTestEntity` in ActionDiscoverySystem tests

## Testing
- `npx eslint tests/common/mockFactories/entities.js tests/unit/actions/actionDiscoverySystem.go.test.js tests/unit/actions/actionDiscoverySystem.wait.test.js --fix`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ec6522f048331a9b9484dc72e7c1a