### PR TITLE
[Agent] Refactor entity creation and exits parsing

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -381,27 +381,36 @@ export class EntityDisplayDataProvider {
       return [];
     }
     return exitsComponentData
-      .map((exit) => {
-        if (typeof exit !== 'object' || exit === null) {
-          this.#logger.warn(
-            `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,
-            { exit }
-          );
-          return null;
-        }
-        const exitDescription = isNonBlankString(exit.direction)
-          ? exit.direction.trim()
-          : 'Unspecified Exit';
-        const exitTarget = isNonBlankString(exit.target)
-          ? exit.target.trim()
-          : undefined;
-
-        return {
-          description: exitDescription,
-          target: exitTarget,
-          id: exitTarget,
-        };
-      })
+      .map((exit) => this.#normalizeExit(exit, locationEntityId))
       .filter((exit) => exit !== null);
+  }
+
+  /**
+   * @description Normalizes a single raw exit object.
+   * @private
+   * @param {*} exit - Raw exit data from component.
+   * @param {NamespacedId | string} locationEntityId - Location ID for logging context.
+   * @returns {ProcessedExit | null} Normalized exit or null if invalid.
+   */
+  #normalizeExit(exit, locationEntityId) {
+    if (typeof exit !== 'object' || exit === null) {
+      this.#logger.warn(
+        `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,
+        { exit }
+      );
+      return null;
+    }
+    const exitDescription = isNonBlankString(exit.direction)
+      ? exit.direction.trim()
+      : 'Unspecified Exit';
+    const exitTarget = isNonBlankString(exit.target)
+      ? exit.target.trim()
+      : undefined;
+
+    return {
+      description: exitDescription,
+      target: exitTarget,
+      id: exitTarget,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- simplify createEntityInstance with helper methods
- normalize exit parsing in EntityDisplayDataProvider

## Testing
- `npm run test`
- `cd llm-proxy-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ecf2ccd488331826f9a48c6ff1cb8