### PR TITLE
[Agent] Add reusable entity helpers and refactor tests

### DIFF
--- a/tests/common/entities/entityFactories.js
+++ b/tests/common/entities/entityFactories.js
@@ -1,0 +1,42 @@
+import Entity from '../../../src/entities/entity.js';
+import EntityDefinition from '../../../src/entities/entityDefinition.js';
+import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
+
+/**
+ * @description Creates an {@link EntityDefinition} with the provided components.
+ * @param {string} id - Unique definition identifier.
+ * @param {Record<string, any>} [components] - Components mapped by ID.
+ * @param {string} [description] - Optional description text.
+ * @returns {EntityDefinition} The constructed definition instance.
+ */
+export function createEntityDefinition(
+  id,
+  components = {},
+  description = 'Test definition'
+) {
+  return new EntityDefinition(id, { description, components });
+}
+
+/**
+ * @description Creates an {@link Entity} instance with optional base components
+ *   and component overrides.
+ * @param {object} params - Parameters for entity creation.
+ * @param {string} params.instanceId - Instance identifier for the entity.
+ * @param {string} [params.definitionId] - Definition identifier.
+ * @param {Record<string, any>} [params.baseComponents] - Components on the definition.
+ * @param {Record<string, any>} [params.overrides] - Component overrides for the instance.
+ * @returns {Entity} Newly created entity instance.
+ */
+export function createEntityInstance({
+  instanceId,
+  definitionId = 'test:def',
+  baseComponents = {},
+  overrides = {},
+}) {
+  const defId = definitionId.includes(':')
+    ? definitionId
+    : `test:${definitionId}`;
+  const definition = createEntityDefinition(defId, baseComponents);
+  const data = new EntityInstanceData(instanceId, definition, overrides);
+  return new Entity(data);
+}

--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -6,3 +6,4 @@ export * from './serializationUtils.js';
 export * from './execContext.js';
 export * from './invalidInputHelpers.js';
 export * from './definitionBuilders.js';
+export * from './entityFactories.js';

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -7,48 +7,33 @@ import { runInvalidIdPairTests } from '../../common/entities/index.js';
 
 describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
   describe('hasComponent', () => {
-    it('should return true if the component exists on the definition', () => {
-      // Arrange
-      const { entityManager } = getBed();
-      const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
-      const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createBasicEntity({ instanceId: PRIMARY });
-
-      // Act
-      const result = entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID);
-
-      // Assert
-      expect(result).toBe(true);
-    });
-
-    it('should return true if the component is added as an override', () => {
-      // Arrange
-      const { entityManager } = getBed();
-      const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createEntityWithOverride(
-        'basic',
+    it.each([
+      [
+        'component exists on definition',
+        {},
+        TestData.ComponentIDs.NAME_COMPONENT_ID,
+        true,
+      ],
+      [
+        'component added as override',
         { 'new:component': { data: 'test' } },
-        { instanceId: PRIMARY }
-      );
-
-      // Act
-      const result = entityManager.hasComponent(PRIMARY, 'new:component');
-
-      // Assert
-      expect(result).toBe(true);
-    });
-
-    it('should return false if the component does not exist', () => {
-      // Arrange
+        'new:component',
+        true,
+      ],
+      ['component does not exist', {}, 'non:existent', false],
+    ])('%s', (_desc, overrides, componentId, expected) => {
       const { entityManager } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
-      getBed().createBasicEntity({ instanceId: PRIMARY });
+      if (Object.keys(overrides).length) {
+        getBed().createEntityWithOverride('basic', overrides, {
+          instanceId: PRIMARY,
+        });
+      } else {
+        getBed().createBasicEntity({ instanceId: PRIMARY });
+      }
 
-      // Act
-      const result = entityManager.hasComponent(PRIMARY, 'non:existent');
-
-      // Assert
-      expect(result).toBe(false);
+      const result = entityManager.hasComponent(PRIMARY, componentId);
+      expect(result).toBe(expected);
     });
 
     it('should return false for a non-existent entity instance', () => {
@@ -68,84 +53,53 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
     );
 
     describe('with checkOverrideOnly flag', () => {
-      it('should return false if component is only on definition', () => {
-        // Arrange
+      it.each([
+        ['component only on definition', false],
+        ['component as override', true],
+      ])('should handle %s', (_desc, useOverride) => {
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createBasicEntity({ instanceId: PRIMARY });
-
-        // Act
+        if (useOverride) {
+          getBed().createEntityWithOverride(
+            'basic',
+            { [NAME_COMPONENT_ID]: { name: 'Override' } },
+            { instanceId: PRIMARY }
+          );
+        } else {
+          getBed().createBasicEntity({ instanceId: PRIMARY });
+        }
         const result = entityManager.hasComponent(
           PRIMARY,
           NAME_COMPONENT_ID,
           true
         );
-
-        // Assert
-        expect(result).toBe(false);
-      });
-
-      it('should return true if component is an override', () => {
-        // Arrange
-        const { entityManager } = getBed();
-        const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
-        const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntityWithOverride(
-          'basic',
-          { [NAME_COMPONENT_ID]: { name: 'Override' } },
-          { instanceId: PRIMARY }
-        );
-
-        // Act
-        const result = entityManager.hasComponent(
-          PRIMARY,
-          NAME_COMPONENT_ID,
-          true
-        );
-
-        // Assert
-        expect(result).toBe(true);
+        expect(result).toBe(useOverride);
       });
     });
 
     describe('hasComponentOverride', () => {
-      it('should return false if component is only on definition', () => {
-        // Arrange
+      it.each([
+        ['component only on definition', false],
+        ['component as override', true],
+      ])('should handle %s', (_desc, useOverride) => {
         const { entityManager } = getBed();
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createBasicEntity({ instanceId: PRIMARY });
-
-        // Act
+        if (useOverride) {
+          getBed().createEntityWithOverride(
+            'basic',
+            { [NAME_COMPONENT_ID]: { name: 'Override' } },
+            { instanceId: PRIMARY }
+          );
+        } else {
+          getBed().createBasicEntity({ instanceId: PRIMARY });
+        }
         const result = entityManager.hasComponentOverride(
           PRIMARY,
           NAME_COMPONENT_ID
         );
-
-        // Assert
-        expect(result).toBe(false);
-      });
-
-      it('should return true if component is an override', () => {
-        // Arrange
-        const { entityManager } = getBed();
-        const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
-        const { PRIMARY } = TestData.InstanceIDs;
-        getBed().createEntityWithOverride(
-          'basic',
-          { [NAME_COMPONENT_ID]: { name: 'Override' } },
-          { instanceId: PRIMARY }
-        );
-
-        // Act
-        const result = entityManager.hasComponentOverride(
-          PRIMARY,
-          NAME_COMPONENT_ID
-        );
-
-        // Assert
-        expect(result).toBe(true);
+        expect(result).toBe(useOverride);
       });
 
       it('should return false for a non-existent entity instance', () => {

--- a/tests/unit/logic/contextAssembler.more.test.js
+++ b/tests/unit/logic/contextAssembler.more.test.js
@@ -12,6 +12,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 // Import Entity type for creating mock entity structure
 import Entity from '../../../src/entities/entity.js'; // Adjust path if necessary
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -44,7 +45,6 @@ const mockEntityManager = {
  * @param {string | number} id - Identifier for the entity.
  * @returns {Partial<Entity>} A mock entity object with an ID.
  */
-const createMockEntity = (id) => ({ id: id });
 
 // --- Test Suite ---
 
@@ -64,8 +64,8 @@ describe('Ticket 8: createJsonLogicContext (contextAssembler.js)', () => {
     baseEvent = { type: 'DEFAULT_EVENT', payload: { value: 1 } };
     actorId = 'player-123';
     targetId = 'enemy-abc';
-    mockActorEntity = createMockEntity(actorId);
-    mockTargetEntity = createMockEntity(targetId);
+    mockActorEntity = createEntityInstance({ instanceId: actorId });
+    mockTargetEntity = createEntityInstance({ instanceId: targetId });
     mockEntityManager.getEntityInstance.mockReturnValue(undefined);
     mockEntityManager.getComponentData.mockReset();
     mockEntityManager.hasComponent.mockReset();

--- a/tests/unit/logic/contextAssembler.test.js
+++ b/tests/unit/logic/contextAssembler.test.js
@@ -13,6 +13,7 @@ import {
 } from '@jest/globals';
 // Import ONLY createJsonLogicContext
 import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js'; // Import the function under test
+import { createEntityInstance } from '../../common/entities/index.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 
 // --- JSDoc Imports for Type Hinting ---
@@ -40,9 +41,6 @@ const mockEntityManager = {
   hasComponent: jest.fn(),
 };
 
-// Helper to create mock entity instance
-const createMockEntity = (id) => ({ id });
-
 // --- Test Suite ---
 
 describe('createJsonLogicContext (contextAssembler.js)', () => {
@@ -61,8 +59,8 @@ describe('createJsonLogicContext (contextAssembler.js)', () => {
     baseEvent = { type: 'TEST_EVENT', payload: { data: 'sample' } };
     actorId = 'player:1';
     targetId = 'npc:mob';
-    mockActorEntity = createMockEntity(actorId);
-    mockTargetEntity = createMockEntity(targetId);
+    mockActorEntity = createEntityInstance({ instanceId: actorId });
+    mockTargetEntity = createEntityInstance({ instanceId: targetId });
 
     // Default mock behavior: Entities NOT found
     mockEntityManager.getEntityInstance.mockReturnValue(undefined);

--- a/tests/unit/logic/jsonLogicComponentAccess.e2e.test.js
+++ b/tests/unit/logic/jsonLogicComponentAccess.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path - Needed for mock setup
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -50,36 +51,14 @@ const mockEntityManager = {
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-json-logic';
 
-// Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
-
 // --- Test Suite ---
 
 describe('JsonLogic Component Accessor Behavior (TEST-103)', () => {
   let service;
   const actorId = 'testActor:1';
   const targetId = 'testTarget:1';
-  const mockActor = createMockEntity(actorId);
-  const mockTarget = createMockEntity(targetId);
+  const mockActor = createEntityInstance({ instanceId: actorId });
+  const mockTarget = createEntityInstance({ instanceId: targetId });
   const compAId = 'compA';
   const compBId = 'compB'; // This component will typically be mocked as missing
   const compCId = 'ns:compC'; // Namespaced component ID

--- a/tests/unit/logic/jsonLogicEvaluationService.actorComponentAccess.test.js
+++ b/tests/unit/logic/jsonLogicEvaluationService.actorComponentAccess.test.js
@@ -26,6 +26,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path as needed
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */ // Adjust path as needed
@@ -64,28 +65,6 @@ const mockEntityManager = {
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-actor-access';
 
-// Helper to create a simple mock entity instance for testing
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
-
 // Define a base event structure for context creation
 /** @type {GameEvent} */
 const baseEvent = { type: 'TEST_EVENT', payload: {} };
@@ -105,7 +84,7 @@ describe('JsonLogicEvaluationService - Actor Component Access Tests ([PARENT_ID]
   const namespacedComponentId = 'ns:stats';
   const missingComponentId = 'missingComp';
   const missingPropertyId = 'missingProp';
-  const mockActor = createMockEntity(actorId);
+  const mockActor = createEntityInstance({ instanceId: actorId });
 
   // --- Test Setup & Teardown ---
   beforeEach(() => {

--- a/tests/unit/logic/jsonLogicEvaluationService.complex.e2e.test.js
+++ b/tests/unit/logic/jsonLogicEvaluationService.complex.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path - Needed for mock setup
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../core/interfaces/coreServices.js').ILogger} ILogger */
@@ -53,28 +54,6 @@ const mockEntityManager = {
 };
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-complex-e2e';
-
-// Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
 
 // --- Test Suite for Complex End-to-End Evaluation ---
 
@@ -124,7 +103,7 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
     };
     const actorId = 'player:1';
     const statsComponentId = 'Stats';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
 
     beforeEach(() => {
       // Common setup: Actor entity exists
@@ -346,7 +325,7 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
       '==': [{ var: 'actor.components.NonExistentComponent.value' }, null],
     };
     const actorId = 'player:2';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
     const missingComponentId = 'NonExistentComponent';
     /** @type {GameEvent} */
     const event = { type: 'CHECK', payload: {} };
@@ -443,7 +422,7 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
       '==': [{ var: 'target.components.Inventory.items[0].id' }, 'item:key'],
     };
     const targetId = 'chest:1';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const inventoryComponentId = 'Inventory';
     /** @type {GameEvent} */
     const event = { type: 'INTERACT', payload: {} };
@@ -603,7 +582,8 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
     test('should return true when actor.id is in the list ("player1")', () => {
       const actorId = 'player1';
       mockEntityManager.getEntityInstance.mockImplementation((id) => {
-        if (id === actorId) return createMockEntity(actorId);
+        if (id === actorId)
+          return createEntityInstance({ instanceId: actorId });
         return undefined;
       });
       const context = createJsonLogicContext(
@@ -623,7 +603,8 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
     test('should return true when actor.id is in the list ("player2")', () => {
       const actorId = 'player2';
       mockEntityManager.getEntityInstance.mockImplementation((id) => {
-        if (id === actorId) return createMockEntity(actorId);
+        if (id === actorId)
+          return createEntityInstance({ instanceId: actorId });
         return undefined;
       });
       const context = createJsonLogicContext(
@@ -643,7 +624,8 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
     test('should return false when actor.id is not in the list ("npc1")', () => {
       const actorId = 'npc1';
       mockEntityManager.getEntityInstance.mockImplementation((id) => {
-        if (id === actorId) return createMockEntity(actorId);
+        if (id === actorId)
+          return createEntityInstance({ instanceId: actorId });
         return undefined;
       });
       const context = createJsonLogicContext(
@@ -685,7 +667,7 @@ describe('JsonLogicEvaluationService - Complex E2E Tests (Ticket 2.6.4)', () => 
   describe('Target Component Presence Rule: { "==": [ { "var": "target.components.Shield" }, null ] }', () => {
     const rule = { '==': [{ var: 'target.components.Shield' }, null] }; // Rule is true if Shield component is missing
     const targetId = 'guard:1';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const shieldComponentId = 'Shield';
     /** @type {GameEvent} */
     const event = { type: 'ATTACK', payload: {} };

--- a/tests/unit/logic/jsonLogicEvaluationService.deepPath.e2e.test.js
+++ b/tests/unit/logic/jsonLogicEvaluationService.deepPath.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path if needed
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 // No longer need direct import of jsonLogic here if only using service.evaluate
 
 // --- JSDoc Imports for Type Hinting ---
@@ -45,30 +46,6 @@ const mockEntityManager = {
   activeEntities: new Map(),
   // Add mocks for new EntityManager properties/methods if necessary for these tests
   _definitionCache: new Map(), // Mock internal for safety, though likely not directly used by these tests
-};
-
-// Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = 'test:dummydef',
-  initialComponents = {}
-) => {
-  // A generic definition used for mock entities in this test file
-  // Ensure the definitionId has a colon, or EntityDefinition.modId might be undefined.
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  }); // Base components can be passed if needed
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
 };
 
 // --- Test Suite for Isolated Deep Path Evaluation ---
@@ -109,7 +86,7 @@ describe('JsonLogicEvaluationService - Isolated Deep Path E2E Test', () => {
       '==': [{ var: 'target.components.Inventory.items.0.id' }, 'item:key'],
     };
     const targetId = 'chest:1';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const inventoryComponentId = 'Inventory';
     /** @type {GameEvent} */
     const event = { type: 'INTERACT', payload: {} };

--- a/tests/unit/logic/jsonLogicEvaluationService.targetComponentAccess.test.js
+++ b/tests/unit/logic/jsonLogicEvaluationService.targetComponentAccess.test.js
@@ -19,6 +19,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path as needed
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */ // Adjust path as needed
@@ -54,27 +55,8 @@ const mockEntityManager = {
   activeEntities: new Map(),
 };
 
-// Helper to create a simple mock entity instance for testing
+// Helper constant for default definition id used by test entities
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-eval-target-access';
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
 
 // Define a base event structure for context creation
 /** @type {GameEvent} */
@@ -96,8 +78,8 @@ describe('JsonLogicEvaluationService - Target Component Access Tests ([PARENT_ID
   const namespacedComponentId = 'game:state'; // Example namespaced component
   const missingComponentId = 'missingComp';
   const missingPropertyId = 'missingProp';
-  const mockTarget = createMockEntity(targetId);
-  const mockActor = createMockEntity(actorId); // Actor entity might be needed by context creator
+  const mockTarget = createEntityInstance({ instanceId: targetId });
+  const mockActor = createEntityInstance({ instanceId: actorId }); // Actor entity might be needed by context creator
 
   // --- Test Setup & Teardown ---
   beforeEach(() => {

--- a/tests/unit/logic/jsonLogicEvaluationService.test.js
+++ b/tests/unit/logic/jsonLogicEvaluationService.test.js
@@ -20,6 +20,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -209,27 +210,7 @@ describe('JsonLogicEvaluationService', () => {
   // and that the context is built and used as expected.
   describe('evaluate() method (End-to-End with REAL jsonLogic.apply)', () => {
     // Helper to create simple mock entity instance for these tests
-    // Updated createMockEntity
     const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-eval-service';
-    const createMockEntity = (
-      instanceId,
-      definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-      initialComponents = {}
-    ) => {
-      const defIdToUse = definitionId.includes(':')
-        ? definitionId
-        : `test:${definitionId}`;
-      const genericDefinition = new EntityDefinition(defIdToUse, {
-        components: {},
-      });
-      const instanceData = new EntityInstanceData(
-        instanceId,
-        genericDefinition,
-        initialComponents
-      );
-      const entity = new Entity(instanceData);
-      return entity;
-    };
 
     // --- Test cases using createJsonLogicContext and actual jsonLogic.apply ---
     // Example: Test with actor component access
@@ -242,7 +223,7 @@ describe('JsonLogicEvaluationService', () => {
       };
       /** @type {GameEvent} */
       const event = { type: 'CHECK_HEALTH', payload: {} };
-      const mockActor = createMockEntity(actorId); // Using the updated helper
+      const mockActor = createEntityInstance({ instanceId: actorId });
       const healthComponentData = { current: 100, max: 100 };
 
       // Setup EntityManager mocks for this specific test
@@ -312,7 +293,7 @@ describe('JsonLogicEvaluationService', () => {
       };
       /** @type {GameEvent} */
       const event = { type: 'INTERACT', payload: {} };
-      const mockTarget = createMockEntity(targetId); // Using updated helper
+      const mockTarget = createEntityInstance({ instanceId: targetId });
       const statusComponentData = { mood: 'happy', condition: 'normal' };
 
       mockEntityManager.getEntityInstance.mockImplementation((id) => {
@@ -376,8 +357,8 @@ describe('JsonLogicEvaluationService', () => {
         type: 'ATTACK',
         payload: { damage_type: 'fire' },
       };
-      const mockActor = createMockEntity(actorId); // Updated
-      const mockTarget = createMockEntity(targetId); // Updated
+      const mockActor = createEntityInstance({ instanceId: actorId });
+      const mockTarget = createEntityInstance({ instanceId: targetId });
 
       const actorInventoryData = { has_key: true, items: ['sword'] };
       const targetVulnerabilityData = { type: 'fire', level: 2 };
@@ -449,7 +430,7 @@ describe('JsonLogicEvaluationService', () => {
       // So `actor.id` is the standard.
       const rule = { '==': [{ var: 'actor.id' }, actorId] };
       const event = { type: 'ANY_EVENT', payload: {} };
-      const mockActor = createMockEntity(actorId); // Updated
+      const mockActor = createEntityInstance({ instanceId: actorId });
 
       mockEntityManager.getEntityInstance.mockImplementation((id) =>
         id === actorId ? mockActor : undefined

--- a/tests/unit/logic/jsonLogicPatterns.component.e2e.test.js
+++ b/tests/unit/logic/jsonLogicPatterns.component.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path - Needed for mock setup
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -56,26 +57,6 @@ const mockEntityManager = {
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-component-patterns';
 
 // Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
 
 // --- Test Suite ---
 
@@ -83,8 +64,8 @@ describe('JsonLogicEvaluationService - Component Patterns (TEST-105)', () => {
   let service;
   const actorId = 'testActor:p1';
   const targetId = 'testTarget:p1';
-  const mockActor = createMockEntity(actorId);
-  const mockTarget = createMockEntity(targetId);
+  const mockActor = createEntityInstance({ instanceId: actorId });
+  const mockTarget = createEntityInstance({ instanceId: targetId });
   const compAId = 'compA'; // Generic component for tests
   const compBId = 'compB'; // Another generic component
 

--- a/tests/unit/logic/jsonLogicPatterns.compound.e2e.test.js
+++ b/tests/unit/logic/jsonLogicPatterns.compound.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path if needed for mock creation
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */ // Adjusted path
@@ -56,26 +57,6 @@ const mockEntityManager = {
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-compound';
 
 // Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
 
 // --- Test Suite ---
 
@@ -116,7 +97,7 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     };
     const targetId = 'door:1';
     const componentId = 'game:lockable';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const lockedState = { state: 'locked' };
     const unlockedState = { state: 'unlocked' };
 
@@ -277,9 +258,9 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     const actorKeyComp = 'game:quest_item_key';
     const targetLockComp = 'game:lockable';
 
-    const mockActor = createMockEntity(actorId);
-    const mockTargetDoor = createMockEntity(targetId);
-    const mockOtherDoor = createMockEntity(otherTargetId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
+    const mockTargetDoor = createEntityInstance({ instanceId: targetId });
+    const mockOtherDoor = createEntityInstance({ instanceId: otherTargetId });
     const lockedState = { state: 'locked' };
     const unlockedState = { state: 'unlocked' };
 
@@ -548,7 +529,7 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     const actorId = 'core:player';
     const poisonComp = 'effect:poison';
     const diseaseComp = 'effect:disease';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
 
     test('should evaluate TRUE if actor has poison component ONLY', () => {
       // Arrange
@@ -707,7 +688,7 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     };
     const targetId = 'chest:1';
     const componentId = 'game:lockable';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const lockedState = { state: 'locked' };
     const unlockedState = { state: 'unlocked' };
     const jammedState = { state: 'jammed' };
@@ -856,7 +837,7 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     // Variables and states defined as in AC4...
     const targetId = 'chest:1';
     const componentId = 'game:lockable';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
     const lockedState = { state: 'locked' };
     const unlockedState = { state: 'unlocked' };
     const jammedState = { state: 'jammed' };
@@ -1004,7 +985,7 @@ describe('TEST-109: Validate JSON-LOGIC-PATTERNS.MD - Compound Logic (Patterns 1
     };
     const actorId = 'npc:mule';
     const componentId = 'status:burdened';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
     const componentData = { weightFactor: 1.5 };
 
     test('should evaluate TRUE when component is missing', () => {

--- a/tests/unit/logic/jsonLogicPatterns.contextVar.e2e.test.js
+++ b/tests/unit/logic/jsonLogicPatterns.contextVar.e2e.test.js
@@ -45,9 +45,6 @@ const mockEntityManager = {
   activeEntities: new Map(),
 };
 
-// Helper to create mock entity instance (mainly for satisfying EM mock types if needed)
-const createMockEntity = (id) => new Entity(id);
-
 // --- Test Suite ---
 
 describe('TEST-107: JSON Logic Context Variable Patterns (8-9)', () => {

--- a/tests/unit/logic/jsonLogicPatterns.entityState.e2e.test.js
+++ b/tests/unit/logic/jsonLogicPatterns.entityState.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path if needed for mock creation
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */ // Adjusted path
@@ -50,28 +51,6 @@ const mockEntityManager = {
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-entity-state';
 
-// Helper to create mock entity instance for tests
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
-
 // --- Test Suite ---
 
 describe('TEST-108: Validate JSON-LOGIC-PATTERNS.MD - Entity/Context State Patterns (10-11)', () => {
@@ -107,8 +86,8 @@ describe('TEST-108: Validate JSON-LOGIC-PATTERNS.MD - Entity/Context State Patte
     const rule = { '==': [{ var: 'target.id' }, 'npc:shopkeeper'] };
     const targetId = 'npc:shopkeeper';
     const otherTargetId = 'npc:guard';
-    const mockShopkeeper = createMockEntity(targetId);
-    const mockGuard = createMockEntity(otherTargetId);
+    const mockShopkeeper = createEntityInstance({ instanceId: targetId });
+    const mockGuard = createEntityInstance({ instanceId: otherTargetId });
 
     test('should evaluate true when targetId matches and entity exists', () => {
       // Arrange: EM finds the specific target
@@ -211,8 +190,8 @@ describe('TEST-108: Validate JSON-LOGIC-PATTERNS.MD - Entity/Context State Patte
     const rule = { '==': [{ var: 'actor.id' }, 'core:player'] };
     const actorId = 'core:player';
     const otherActorId = 'npc:ally';
-    const mockPlayer = createMockEntity(actorId);
-    const mockAlly = createMockEntity(otherActorId);
+    const mockPlayer = createEntityInstance({ instanceId: actorId });
+    const mockAlly = createEntityInstance({ instanceId: otherActorId });
 
     test('should evaluate true when actorId matches and entity exists', () => {
       // Arrange: EM finds the specific actor
@@ -310,7 +289,7 @@ describe('TEST-108: Validate JSON-LOGIC-PATTERNS.MD - Entity/Context State Patte
   describe('AC3: Pattern 11 - Target Existence Check {"!=": [{"var": "target"}, null]}', () => {
     const rule = { '!=': [{ var: 'target' }, null] };
     const targetId = 'item:chest';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
 
     test('should evaluate true when targetId resolves to an entity', () => {
       // Arrange: EM finds the target
@@ -385,7 +364,7 @@ describe('TEST-108: Validate JSON-LOGIC-PATTERNS.MD - Entity/Context State Patte
   describe('AC4: Pattern 11 - Actor Existence Check {"!=": [{"var": "actor"}, null]}', () => {
     const rule = { '!=': [{ var: 'actor' }, null] };
     const actorId = 'core:player';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
 
     test('should evaluate true when actorId resolves to an entity', () => {
       // Arrange: EM finds the actor

--- a/tests/unit/logic/jsonLogicPatterns.legacyQuest.e2e.test.js
+++ b/tests/unit/logic/jsonLogicPatterns.legacyQuest.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path as needed
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */
@@ -48,28 +49,6 @@ const mockEntityManager = {
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-legacy-quest';
 
-// Helper to create mock entity instance
-// Updated createMockEntity
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
-
 // --- Test Suite ---
 
 describe('TEST-110: Validate JSON-LOGIC-PATTERNS.MD - Legacy Quest State (Pattern 15)', () => {
@@ -79,7 +58,7 @@ describe('TEST-110: Validate JSON-LOGIC-PATTERNS.MD - Legacy Quest State (Patter
   const baseEvent = { type: 'test_event', payload: {} };
   const actorId = 'player:1';
   const questLogComponentId = 'core:quest_log'; // Component ID from pattern example
-  const mockActor = createMockEntity(actorId);
+  const mockActor = createEntityInstance({ instanceId: actorId });
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/unit/logic/jsonLogicUsageDoc.e2e.test.js
+++ b/tests/unit/logic/jsonLogicUsageDoc.e2e.test.js
@@ -9,6 +9,7 @@ import { createJsonLogicContext } from '../../../src/logic/contextAssembler.js';
 import Entity from '../../../src/entities/entity.js'; // Adjust path if needed for mock creation
 import EntityDefinition from '../../../src/entities/entityDefinition.js'; // Added
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js'; // Added
+import { createEntityInstance } from '../../common/entities/index.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../src/interfaces/coreServices.js').ILogger} ILogger */ // Adjusted path
@@ -45,27 +46,6 @@ const mockEntityManager = {
 };
 
 const DUMMY_DEFINITION_ID_FOR_MOCKS = 'def:mock-json-logic';
-
-// Helper to create mock entity instance for tests
-const createMockEntity = (
-  instanceId,
-  definitionId = DUMMY_DEFINITION_ID_FOR_MOCKS,
-  initialComponents = {}
-) => {
-  const defIdToUse = definitionId.includes(':')
-    ? definitionId
-    : `test:${definitionId}`;
-  const genericDefinition = new EntityDefinition(defIdToUse, {
-    components: {},
-  });
-  const instanceData = new EntityInstanceData(
-    instanceId,
-    genericDefinition,
-    initialComponents
-  );
-  const entity = new Entity(instanceData);
-  return entity;
-};
 
 // --- Test Suite for JSON-LOGIC-USAGE.MD Claims ---
 
@@ -187,7 +167,7 @@ describe('TEST-104: Validate JSON-LOGIC-USAGE.MD Specific Claims (E2E)', () => {
   describe('AC3: Direct Actor ID Access', () => {
     const rule = { '==': [{ var: 'actor.id' }, 'actor-1'] };
     const actorId = 'actor-1';
-    const mockActor = createMockEntity(actorId);
+    const mockActor = createEntityInstance({ instanceId: actorId });
 
     test('should evaluate true when actor exists and ID matches', () => {
       // Arrange: Make EM find the actor
@@ -261,7 +241,7 @@ describe('TEST-104: Validate JSON-LOGIC-USAGE.MD Specific Claims (E2E)', () => {
   describe('AC4: Direct Target ID Access', () => {
     const rule = { '==': [{ var: 'target.id' }, 'target-1'] };
     const targetId = 'target-1';
-    const mockTarget = createMockEntity(targetId);
+    const mockTarget = createEntityInstance({ instanceId: targetId });
 
     test('should evaluate true when target exists and ID matches', () => {
       // Arrange: Make EM find the target
@@ -458,7 +438,7 @@ describe('TEST-104: Validate JSON-LOGIC-USAGE.MD Specific Claims (E2E)', () => {
     test('should evaluate false when actor exists', () => {
       // Arrange: Actor exists
       const actorId = 'actor-present';
-      const mockActor = createMockEntity(actorId);
+      const mockActor = createEntityInstance({ instanceId: actorId });
       mockEntityManager.getEntityInstance.mockImplementation((id) => {
         if (id === actorId) return mockActor;
         return undefined;


### PR DESCRIPTION
## Summary
- add `createEntityDefinition` and `createEntityInstance` helpers
- refactor logic tests to use new helpers and `it.each`
- update entityManager hasComponent tests to reduce duplication

## Testing Done
- `npm run lint` *(fails: 705 errors, 2606 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ecf1b12b48331b99e89a93902d22c