### PR TITLE
[Agent] inject managers into game engine

### DIFF
--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -100,6 +100,8 @@ import { freeze } from '../utils';
  * @property {DiToken} EntityDisplayDataProvider - Token for the service providing entity display data.
  * @property {DiToken} AlertRouter - Token for the service that routes alerts to the UI or console.
  * @property {DiToken} LocationQueryService - Token for the service providing location-based entity queries.
+ * @property {DiToken} GameSessionManager - Token for the game session manager.
+ * @property {DiToken} PersistenceCoordinator - Token coordinating persistence operations.
  *
  * --- Core Service Interfaces ---
  * @property {DiToken} ISafeEventDispatcher - Token for the safe event dispatching utility interface.
@@ -246,6 +248,8 @@ export const tokens = freeze({
   AlertRouter: 'AlertRouter',
   ClosenessCircleService: 'ClosenessCircleService',
   LocationQueryService: 'LocationQueryService',
+  GameSessionManager: 'GameSessionManager',
+  PersistenceCoordinator: 'PersistenceCoordinator',
 
   // Core Service Interfaces
   ISafeEventDispatcher: 'ISafeEventDispatcher',


### PR DESCRIPTION
Summary: Introduced optional dependency injection for the session manager and persistence coordinator in `GameEngine`. Added corresponding tokens so custom implementations can be resolved from the DI container.

Testing Done:
- [x] Code formatted `npx prettier -w src/engine/gameEngine.js src/dependencyInjection/tokens.js`
- [x] Lint passes `npx eslint src/engine/gameEngine.js src/dependencyInjection/tokens.js`
- [x] Root tests `npm test`
- [x] Proxy tests `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed5bc3d1c83319edf72e7cb6b604d