### PR TITLE
[Agent] add dependency validation helpers

### DIFF
--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -30,6 +30,11 @@ import {
 } from '../../errors/InitializationError.js';
 import { validateWorldName, buildActionIndex } from './initHelpers.js';
 import ContentDependencyValidator from './contentDependencyValidator.js';
+import {
+  assertFunction,
+  assertMethods,
+  assertPresent,
+} from '../../utils/dependencyValidators.js';
 
 /**
  * Service responsible for orchestrating the entire game initialization sequence.
@@ -99,109 +104,99 @@ class InitializationService extends IInitializationService {
   }) {
     super();
 
-    if (
-      !logger ||
-      typeof logger.error !== 'function' ||
-      typeof logger.debug !== 'function'
-    ) {
-      const errorMsg =
-        "InitializationService: Missing or invalid required dependency 'logger'.";
-      throw new SystemInitializationError(errorMsg);
-    }
+    assertMethods(
+      logger,
+      ['error', 'debug'],
+      "InitializationService: Missing or invalid required dependency 'logger'.",
+      SystemInitializationError
+    );
 
     this.#logger = logger;
 
-    // FIX: Check for the correct 'dispatch' method name
-    if (
-      !validatedEventDispatcher ||
-      typeof validatedEventDispatcher.dispatch !== 'function'
-    ) {
-      const errorMsg =
-        "InitializationService: Missing or invalid required dependency 'validatedEventDispatcher'.";
-      this.#logger.error(errorMsg);
-      throw new SystemInitializationError(errorMsg);
-    }
+    assertFunction(
+      validatedEventDispatcher,
+      'dispatch',
+      "InitializationService: Missing or invalid required dependency 'validatedEventDispatcher'.",
+      SystemInitializationError,
+      this.#logger
+    );
 
-    if (!modsLoader || typeof modsLoader.loadMods !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'modsLoader'."
-      );
-    }
-    if (!scopeRegistry || typeof scopeRegistry.initialize !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'scopeRegistry'."
-      );
-    }
-    if (!dataRegistry || typeof dataRegistry.getAll !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'dataRegistry'."
-      );
-    }
-    if (
-      !systemInitializer ||
-      typeof systemInitializer.initializeAll !== 'function'
-    ) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'systemInitializer'."
-      );
-    }
-    if (
-      !worldInitializer ||
-      typeof worldInitializer.initializeWorldEntities !== 'function'
-    ) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'worldInitializer'."
-      );
-    }
-    if (
-      !safeEventDispatcher ||
-      typeof safeEventDispatcher.subscribe !== 'function'
-    ) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'safeEventDispatcher'."
-      );
-    }
-    if (!entityManager) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing required dependency 'entityManager'."
-      );
-    }
-    if (!actionIndex || typeof actionIndex.buildIndex !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'actionIndex'."
-      );
-    }
-    if (
-      !gameDataRepository ||
-      typeof gameDataRepository.getAllActionDefinitions !== 'function'
-    ) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'gameDataRepository'."
-      );
-    }
-    if (!domUiFacade) {
-      throw new SystemInitializationError(
-        'InitializationService requires a domUiFacade dependency'
-      );
-    }
-    if (!thoughtListener || typeof thoughtListener.handleEvent !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'thoughtListener'."
-      );
-    }
-    if (!notesListener || typeof notesListener.handleEvent !== 'function') {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'notesListener'."
-      );
-    }
-    if (
-      !spatialIndexManager ||
-      typeof spatialIndexManager.buildIndex !== 'function'
-    ) {
-      throw new SystemInitializationError(
-        "InitializationService: Missing or invalid required dependency 'spatialIndexManager'."
-      );
-    }
+    assertFunction(
+      modsLoader,
+      'loadMods',
+      "InitializationService: Missing or invalid required dependency 'modsLoader'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      scopeRegistry,
+      'initialize',
+      "InitializationService: Missing or invalid required dependency 'scopeRegistry'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      dataRegistry,
+      'getAll',
+      "InitializationService: Missing or invalid required dependency 'dataRegistry'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      systemInitializer,
+      'initializeAll',
+      "InitializationService: Missing or invalid required dependency 'systemInitializer'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      worldInitializer,
+      'initializeWorldEntities',
+      "InitializationService: Missing or invalid required dependency 'worldInitializer'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      safeEventDispatcher,
+      'subscribe',
+      "InitializationService: Missing or invalid required dependency 'safeEventDispatcher'.",
+      SystemInitializationError
+    );
+    assertPresent(
+      entityManager,
+      "InitializationService: Missing required dependency 'entityManager'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      actionIndex,
+      'buildIndex',
+      "InitializationService: Missing or invalid required dependency 'actionIndex'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      gameDataRepository,
+      'getAllActionDefinitions',
+      "InitializationService: Missing or invalid required dependency 'gameDataRepository'.",
+      SystemInitializationError
+    );
+    assertPresent(
+      domUiFacade,
+      'InitializationService requires a domUiFacade dependency',
+      SystemInitializationError
+    );
+    assertFunction(
+      thoughtListener,
+      'handleEvent',
+      "InitializationService: Missing or invalid required dependency 'thoughtListener'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      notesListener,
+      'handleEvent',
+      "InitializationService: Missing or invalid required dependency 'notesListener'.",
+      SystemInitializationError
+    );
+    assertFunction(
+      spatialIndexManager,
+      'buildIndex',
+      "InitializationService: Missing or invalid required dependency 'spatialIndexManager'.",
+      SystemInitializationError
+    );
     this.#validatedEventDispatcher = validatedEventDispatcher;
     this.#modsLoader = modsLoader;
     this.#scopeRegistry = scopeRegistry;

--- a/src/initializers/systemInitializer.js
+++ b/src/initializers/systemInitializer.js
@@ -10,6 +10,10 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */ // Corrected path
 import { dispatchWithLogging } from '../utils/eventDispatchUtils.js';
+import {
+  assertFunction,
+  assertPresent,
+} from '../utils/dependencyValidators.js';
 
 /**
  * Service responsible for initializing essential systems of the application.
@@ -41,20 +45,17 @@ class SystemInitializer {
     validatedEventDispatcher,
     initializationTag,
   }) {
-    // Simplified validation for brevity, assume checks pass
-    if (!resolver || typeof resolver.resolveByTag !== 'function')
-      throw new Error(
-        "SystemInitializer requires a valid IServiceResolver with 'resolveByTag'."
-      );
-    if (!logger)
-      throw new Error('SystemInitializer requires an ILogger instance.');
-    if (
-      !validatedEventDispatcher ||
-      typeof validatedEventDispatcher.dispatch !== 'function'
-    )
-      throw new Error(
-        'SystemInitializer requires a valid ValidatedEventDispatcher.'
-      );
+    assertFunction(
+      resolver,
+      'resolveByTag',
+      "SystemInitializer requires a valid IServiceResolver with 'resolveByTag'."
+    );
+    assertPresent(logger, 'SystemInitializer requires an ILogger instance.');
+    assertFunction(
+      validatedEventDispatcher,
+      'dispatch',
+      'SystemInitializer requires a valid ValidatedEventDispatcher.'
+    );
     if (
       !initializationTag ||
       typeof initializationTag !== 'string' ||

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -24,6 +24,11 @@ import { SCOPES_KEY } from '../constants/dataRegistryKeys.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { dispatchWithLogging } from '../utils/eventDispatchUtils.js';
 import { WorldInitializationError } from '../errors/InitializationError.js';
+import {
+  assertFunction,
+  assertPresent,
+  assertMethods,
+} from '../utils/dependencyValidators.js';
 
 /**
  * Service responsible for instantiating entities defined
@@ -105,41 +110,41 @@ class WorldInitializer {
     logger,
     scopeRegistry,
   }) {
-    if (
-      !entityManager ||
-      typeof entityManager.createEntityInstance !== 'function'
-    )
-      throw new WorldInitializationError(
-        'WorldInitializer requires an IEntityManager with createEntityInstance().'
-      );
-    if (!worldContext)
-      throw new WorldInitializationError(
-        'WorldInitializer requires a WorldContext.'
-      );
-    if (
-      !gameDataRepository ||
-      typeof gameDataRepository.getWorld !== 'function' ||
-      typeof gameDataRepository.getEntityInstanceDefinition !== 'function' ||
-      typeof gameDataRepository.get !== 'function'
-    )
-      throw new WorldInitializationError(
-        'WorldInitializer requires an IGameDataRepository with getWorld(), getEntityInstanceDefinition(), and get().'
-      );
-    if (
-      !validatedEventDispatcher ||
-      typeof validatedEventDispatcher.dispatch !== 'function'
-    )
-      throw new WorldInitializationError(
-        'WorldInitializer requires a ValidatedEventDispatcher with dispatch().'
-      );
-    if (!logger || typeof logger.debug !== 'function')
-      throw new WorldInitializationError(
-        'WorldInitializer requires an ILogger.'
-      );
-    if (!scopeRegistry || typeof scopeRegistry.initialize !== 'function')
-      throw new WorldInitializationError(
-        'WorldInitializer requires an IScopeRegistry with initialize().'
-      );
+    assertFunction(
+      entityManager,
+      'createEntityInstance',
+      'WorldInitializer requires an IEntityManager with createEntityInstance().',
+      WorldInitializationError
+    );
+    assertPresent(
+      worldContext,
+      'WorldInitializer requires a WorldContext.',
+      WorldInitializationError
+    );
+    assertMethods(
+      gameDataRepository,
+      ['getWorld', 'getEntityInstanceDefinition', 'get'],
+      'WorldInitializer requires an IGameDataRepository with getWorld(), getEntityInstanceDefinition(), and get().',
+      WorldInitializationError
+    );
+    assertFunction(
+      validatedEventDispatcher,
+      'dispatch',
+      'WorldInitializer requires a ValidatedEventDispatcher with dispatch().',
+      WorldInitializationError
+    );
+    assertFunction(
+      logger,
+      'debug',
+      'WorldInitializer requires an ILogger.',
+      WorldInitializationError
+    );
+    assertFunction(
+      scopeRegistry,
+      'initialize',
+      'WorldInitializer requires an IScopeRegistry with initialize().',
+      WorldInitializationError
+    );
 
     this.#entityManager = entityManager;
     this.#worldContext = worldContext;

--- a/src/utils/dependencyValidators.js
+++ b/src/utils/dependencyValidators.js
@@ -1,0 +1,76 @@
+// src/utils/dependencyValidators.js
+/**
+ * Small assertion helpers for validating dependencies.
+ *
+ * @module dependencyValidators
+ */
+
+/**
+ * Asserts that an object is present (not null or undefined).
+ *
+ * @param {*} value - Dependency value to check.
+ * @param {string} message - Error message for missing dependency.
+ * @param {Function} [ErrorType] - Error constructor to use when throwing.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for error output.
+ * @throws {Error} When the dependency is missing.
+ * @returns {void}
+ */
+export function assertPresent(value, message, ErrorType = Error, logger) {
+  if (value === undefined || value === null) {
+    if (logger && typeof logger.error === 'function') {
+      logger.error(message);
+    }
+    throw new ErrorType(message);
+  }
+}
+
+/**
+ * Asserts that an object's property is a function.
+ *
+ * @param {object} obj - The object being validated.
+ * @param {string} fnName - Name of the property expected to be a function.
+ * @param {string} message - Error message used if validation fails.
+ * @param {Function} [ErrorType] - Error constructor used when throwing.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for error output.
+ * @throws {Error} When the function is missing or invalid.
+ * @returns {void}
+ */
+export function assertFunction(
+  obj,
+  fnName,
+  message,
+  ErrorType = Error,
+  logger
+) {
+  if (!obj || typeof obj[fnName] !== 'function') {
+    if (logger && typeof logger.error === 'function') {
+      logger.error(message);
+    }
+    throw new ErrorType(message);
+  }
+}
+
+/**
+ * Asserts that all specified method names exist on an object and are functions.
+ *
+ * @param {object} obj - The object being validated.
+ * @param {string[]} methods - Method names that must exist.
+ * @param {string} message - Error message used if validation fails.
+ * @param {Function} [ErrorType] - Error constructor used when throwing.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Optional logger for error output.
+ * @throws {Error} When any method is missing or not a function.
+ * @returns {void}
+ */
+export function assertMethods(
+  obj,
+  methods,
+  message,
+  ErrorType = Error,
+  logger
+) {
+  for (const m of methods) {
+    assertFunction(obj, m, message, ErrorType, logger);
+  }
+}
+
+// --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,3 +20,4 @@ export * from './jsonCleaning.js';
 export * from './jsonRepair.js';
 export * from './evaluationContextUtils.js';
 export * from './eventDispatchUtils.js';
+export * from './dependencyValidators.js';


### PR DESCRIPTION
Summary:
- add a dependencyValidators utility with helper assertions
- refactor SystemInitializer, WorldInitializer, and InitializationService constructors to use the helpers
- re-export new helpers from utils index

Testing Done:
- `npx prettier --write src/initializers/systemInitializer.js src/initializers/worldInitializer.js src/initializers/services/initializationService.js src/utils/index.js src/utils/dependencyValidators.js`
- `npx eslint src/initializers/systemInitializer.js src/initializers/worldInitializer.js src/initializers/services/initializationService.js src/utils/index.js src/utils/dependencyValidators.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ed5e13c1483319519c01e0a4ba687