### PR TITLE
[Agent] clarify EntityManager test bed naming

### DIFF
--- a/tests/common/entities/entityManagerTestBed.js
+++ b/tests/common/entities/entityManagerTestBed.js
@@ -1,8 +1,8 @@
 /**
- * @file This module provides a centralized TestBed helper and standardized test data
+ * @file This module provides a centralized EntityManagerTestBed helper and standardized test data
  * for all EntityManager unit tests. It aims to reduce boilerplate, improve readability,
  * and make the test suite easier to maintain.
- * @see tests/common/entities/testBed.js
+ * @see tests/common/entities/entityManagerTestBed.js
  */
 
 import EntityManager from '../../../src/entities/entityManager.js';
@@ -26,7 +26,7 @@ import { createDescribeTestBedSuite } from '../describeSuite.js';
  * Creates mocks, instantiates the manager, and provides helper methods
  * to streamline test writing.
  */
-export class TestBed extends FactoryTestBed {
+export class EntityManagerTestBed extends FactoryTestBed {
   /**
    * Collection of all mocks for easy access in tests.
    *
@@ -41,7 +41,7 @@ export class TestBed extends FactoryTestBed {
   entityManager;
 
   /**
-   * Creates a new TestBed instance.
+   * Creates a new EntityManagerTestBed instance.
    *
    * @param {object} [overrides] - Optional overrides.
    * @param {object} [overrides.entityManagerOptions] - Options forwarded to the EntityManager constructor.
@@ -104,7 +104,7 @@ export class TestBed extends FactoryTestBed {
   /**
    * Creates a new entity instance from a definition stored in {@link TestData}.
    *
-   * Internally this configures the mock registry via {@link TestBed#setupDefinitions}
+   * Internally this configures the mock registry via {@link EntityManagerTestBed#setupDefinitions}
    * and then delegates to {@link EntityManager#createEntityInstance}.
    *
    * @param {keyof typeof TestData.Definitions} defKey - Key of the test
@@ -133,7 +133,7 @@ export class TestBed extends FactoryTestBed {
   }
 
   /**
-   * Convenience wrapper around {@link TestBed#setupDefinitions} for test
+   * Convenience wrapper around {@link EntityManagerTestBed#setupDefinitions} for test
    * definitions stored in {@link TestData}.
    *
    * @param {...keyof typeof TestData.Definitions} defKeys - Keys of test
@@ -190,7 +190,7 @@ export class TestBed extends FactoryTestBed {
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createEntityWithOverride(
+  createEntityWithOverrides(
     defKey,
     overrides,
     { resetDispatch = false, ...options } = {}
@@ -213,15 +213,15 @@ export class TestBed extends FactoryTestBed {
 }
 
 /**
- * Creates a test suite for {@link EntityManager} utilizing {@link TestBed} for
+ * Creates a test suite for {@link EntityManager} utilizing {@link EntityManagerTestBed} for
  * setup and cleanup. The provided suite function receives a getter that
- * returns the current {@link TestBed} instance.
+ * returns the current {@link EntityManagerTestBed} instance.
  *
  * @param {string} title - Title of the suite passed to `describe`.
- * @param {(getTestBed: () => TestBed) => void} suiteFn - Function containing the
- *   tests. It receives a callback that returns the active {@link TestBed}.
+ * @param {(getTestBed: () => EntityManagerTestBed) => void} suiteFn - Function containing the
+ *   tests. It receives a callback that returns the active {@link EntityManagerTestBed}.
  * @returns {void}
  */
-export const describeEntityManagerSuite = createDescribeTestBedSuite(TestBed);
+export const describeEntityManagerSuite = createDescribeTestBedSuite(EntityManagerTestBed);
 
-export default TestBed;
+export default EntityManagerTestBed;

--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -1,6 +1,6 @@
 export { default as SimpleEntityManager } from './simpleEntityManager.js';
-export { default as TestBed } from './testBed.js';
-export * from './testBed.js';
+export { default as EntityManagerTestBed } from './entityManagerTestBed.js';
+export * from './entityManagerTestBed.js';
 export { TestData } from './testData.js';
 export * from './serializationUtils.js';
 export * from './execContext.js';

--- a/tests/common/entities/invalidInputHelpers.js
+++ b/tests/common/entities/invalidInputHelpers.js
@@ -14,8 +14,8 @@ import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.j
  *   repeating the same `it.each` logic.
  * @param {Array<*>|Array<Array<*>>} values - Invalid values to iterate over.
  * @param {string} message - Test description passed to `it.each`.
- * @param {() => import('./testBed.js').TestBed} getBed - Callback returning the
- *   active {@link TestBed} instance.
+ * @param {() => import('./entityManagerTestBed.js').EntityManagerTestBed} getBed - Callback returning the
+ *   active {@link EntityManagerTestBed} instance.
  * @param {(em: import('../../../src/entities/entityManager.js').default,
  *   ...args: any[]) => any} invoke - Function that calls the method under test
  *   using the provided EntityManager instance.
@@ -36,7 +36,7 @@ function runInvalidCases(values, message, getBed, invoke) {
  *   handling in EntityManager methods.
  * @param {Array<*>|Array<Array<*>>} values - Invalid values passed to `it.each`.
  * @param {string} message - Description used in the generated test.
- * @returns {(getBed: () => import('./testBed.js').TestBed,
+ * @returns {(getBed: () => import('./entityManagerTestBed.js').EntityManagerTestBed,
  *   invoke: (em: import('../../../src/entities/entityManager.js').default,
  *   ...args: any[]) => any) => void} Function executing the parameterized test.
  */
@@ -50,8 +50,8 @@ function createInvalidInputTest(values, message) {
  *
  * @description Helper for entity component methods like addComponent and
  * removeComponent that should throw InvalidArgumentError when called with invalid IDs.
- * @param {() => import('./testBed.js').TestBed} getBed - Callback to retrieve
- *   the active {@link TestBed} instance.
+ * @param {() => import('./entityManagerTestBed.js').EntityManagerTestBed} getBed - Callback to retrieve
+ *   the active {@link EntityManagerTestBed} instance.
  * @param {(em: import('../../../src/entities/entityManager.js').default, instanceId: *, componentId: *) => *} invoke
  *   - Function that invokes the target EntityManager method.
  * @returns {void}
@@ -78,8 +78,8 @@ export function runInvalidIdPairTests(getBed, invoke) {
  * Runs a parameterized test verifying how a method handles invalid entity IDs.
  *
  * @description Helper for entity methods like removeEntityInstance that should throw InvalidArgumentError when called with invalid IDs.
- * @param {() => import('./testBed.js').TestBed} getBed - Callback to retrieve
- *   the active {@link TestBed} instance.
+ * @param {() => import('./entityManagerTestBed.js').EntityManagerTestBed} getBed - Callback to retrieve
+ *   the active {@link EntityManagerTestBed} instance.
  * @param {(em: import('../../../src/entities/entityManager.js').default, instanceId: *) => *} invoke
  *   - Function that invokes the target EntityManager method.
  * @returns {void}
@@ -96,8 +96,8 @@ export function runInvalidEntityIdTests(getBed, invoke) {
  *
  * @description Helper for methods that accept a definitionId and should throw
  * InvalidArgumentError when called with invalid IDs.
- * @param {() => import('./testBed.js').TestBed} getBed - Callback to retrieve
- *   the active {@link TestBed} instance.
+ * @param {() => import('./entityManagerTestBed.js').EntityManagerTestBed} getBed - Callback to retrieve
+ *   the active {@link EntityManagerTestBed} instance.
  * @param {(em: import('../../../src/entities/entityManager.js').default, definitionId: *) => *} invoke
  *   - Function that invokes the target EntityManager method.
  * @returns {void}

--- a/tests/unit/common/entities/testBed.test.js
+++ b/tests/unit/common/entities/testBed.test.js
@@ -5,7 +5,7 @@
 
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 // Corrected the path to be relative to the test file's location as per the logs.
-import { TestBed, TestData } from '../../../common/entities/index.js';
+import { EntityManagerTestBed, TestData } from '../../../common/entities/index.js';
 import EntityManager from '../../../../src/entities/entityManager.js';
 import EntityDefinition from '../../../../src/entities/entityDefinition.js';
 import {
@@ -13,12 +13,12 @@ import {
   POSITION_COMPONENT_ID,
 } from '../../../../src/constants/componentIds.js';
 
-// We only need to mock EntityManager to verify that the TestBed instantiates it correctly.
+// We only need to mock EntityManager to verify that the EntityManagerTestBed instantiates it correctly.
 // EntityDefinition should NOT be mocked, as we need its real implementation to create
 // the test data objects that the system under test relies on.
 jest.mock('../../../../src/entities/entityManager.js');
 
-describe('EntityManager Test Helpers: TestBed & TestData', () => {
+describe('EntityManager Test Helpers: EntityManagerTestBed & TestData', () => {
   describe('TestData Export', () => {
     it('should export a TestData object with the correct structure', () => {
       expect(TestData).toBeDefined();
@@ -54,13 +54,13 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
     });
   });
 
-  describe('TestBed Class', () => {
-    let testBed;
+  describe('EntityManagerTestBed Class', () => {
+    let bed;
 
     beforeEach(() => {
       // Clear any static mocks before each test
       jest.clearAllMocks();
-      testBed = new TestBed();
+      bed = new EntityManagerTestBed();
     });
 
     describe('Constructor & Initialization', () => {
@@ -69,21 +69,21 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
         // FIX: The constructor now receives a 5th `options` argument, which is `{}` by default.
         // We update the test to expect this new argument.
         expect(EntityManager).toHaveBeenCalledWith({
-          registry: testBed.mocks.registry,
-          validator: testBed.mocks.validator,
-          logger: testBed.mocks.logger,
-          dispatcher: testBed.mocks.eventDispatcher,
+          registry: bed.mocks.registry,
+          validator: bed.mocks.validator,
+          logger: bed.mocks.logger,
+          dispatcher: bed.mocks.eventDispatcher,
         });
       });
 
       it('should provide a public property `entityManager` with the SUT instance', () => {
-        expect(testBed.entityManager).toBeDefined();
-        expect(testBed.entityManager).toBeInstanceOf(EntityManager);
+        expect(bed.entityManager).toBeDefined();
+        expect(bed.entityManager).toBeInstanceOf(EntityManager);
       });
 
       it('should provide a public `mocks` property containing all created mocks', () => {
-        expect(testBed.mocks).toBeDefined();
-        const mockKeys = Object.keys(testBed.mocks);
+        expect(bed.mocks).toBeDefined();
+        const mockKeys = Object.keys(bed.mocks);
         expect(mockKeys).toContain('registry');
         expect(mockKeys).toContain('validator');
         expect(mockKeys).toContain('logger');
@@ -92,28 +92,28 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
 
       it('should initialize mocks with jest.fn() spies', () => {
         // Registry
-        expect(testBed.mocks.registry.getEntityDefinition).toBeDefined();
+        expect(bed.mocks.registry.getEntityDefinition).toBeDefined();
         expect(
-          jest.isMockFunction(testBed.mocks.registry.getEntityDefinition)
+          jest.isMockFunction(bed.mocks.registry.getEntityDefinition)
         ).toBe(true);
 
         // Validator
-        expect(testBed.mocks.validator.validate).toBeDefined();
-        expect(jest.isMockFunction(testBed.mocks.validator.validate)).toBe(
+        expect(bed.mocks.validator.validate).toBeDefined();
+        expect(jest.isMockFunction(bed.mocks.validator.validate)).toBe(
           true
         );
         // Check default implementation
-        expect(testBed.mocks.validator.validate()).toEqual({ isValid: true });
+        expect(bed.mocks.validator.validate()).toEqual({ isValid: true });
 
         // Logger
-        expect(jest.isMockFunction(testBed.mocks.logger.info)).toBe(true);
-        expect(jest.isMockFunction(testBed.mocks.logger.warn)).toBe(true);
-        expect(jest.isMockFunction(testBed.mocks.logger.error)).toBe(true);
-        expect(jest.isMockFunction(testBed.mocks.logger.debug)).toBe(true);
+        expect(jest.isMockFunction(bed.mocks.logger.info)).toBe(true);
+        expect(jest.isMockFunction(bed.mocks.logger.warn)).toBe(true);
+        expect(jest.isMockFunction(bed.mocks.logger.error)).toBe(true);
+        expect(jest.isMockFunction(bed.mocks.logger.debug)).toBe(true);
 
         // Event Dispatcher
         expect(
-          jest.isMockFunction(testBed.mocks.eventDispatcher.dispatch)
+          jest.isMockFunction(bed.mocks.eventDispatcher.dispatch)
         ).toBe(true);
       });
     });
@@ -121,9 +121,9 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
     describe('setupDefinitions()', () => {
       it('should configure the mock registry to return specified definitions', () => {
         const { basic, actor } = TestData.Definitions;
-        testBed.setupDefinitions(basic, actor);
+        bed.setupDefinitions(basic, actor);
 
-        const registry = testBed.mocks.registry;
+        const registry = bed.mocks.registry;
         // With the fix, these assertions should now pass as `basic` and `actor` are real objects with an `id`.
         expect(registry.getEntityDefinition(TestData.DefinitionIDs.BASIC)).toBe(
           basic
@@ -135,9 +135,9 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
 
       it('should make the mock registry return undefined for unspecified IDs', () => {
         const { basic } = TestData.Definitions;
-        testBed.setupDefinitions(basic);
+        bed.setupDefinitions(basic);
 
-        const registry = testBed.mocks.registry;
+        const registry = bed.mocks.registry;
         expect(registry.getEntityDefinition(TestData.DefinitionIDs.BASIC)).toBe(
           basic
         );
@@ -148,8 +148,8 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
       });
 
       it('should handle being called with no definitions', () => {
-        testBed.setupDefinitions();
-        const registry = testBed.mocks.registry;
+        bed.setupDefinitions();
+        const registry = bed.mocks.registry;
         expect(
           registry.getEntityDefinition(TestData.DefinitionIDs.BASIC)
         ).toBeUndefined();
@@ -160,19 +160,19 @@ describe('EntityManager Test Helpers: TestBed & TestData', () => {
       it('should call clearAll() on its entityManager instance', async () => {
         // FIX: The entityManager instance from the mocked module already has mock methods.
         // We directly assert on that mock method.
-        const clearAllMethod = testBed.entityManager.clearAll;
+        const clearAllMethod = bed.entityManager.clearAll;
 
-        await testBed.cleanup();
+        await bed.cleanup();
 
         expect(clearAllMethod).toHaveBeenCalledTimes(1);
       });
 
       it('should clear all mocks via jest.clearAllMocks()', async () => {
-        const { logger } = testBed.mocks;
+        const { logger } = bed.mocks;
         logger.info('test call');
         expect(logger.info).toHaveBeenCalledTimes(1);
 
-        await testBed.cleanup();
+        await bed.cleanup();
 
         // jest.clearAllMocks() resets the counter.
         expect(logger.info).toHaveBeenCalledTimes(0);

--- a/tests/unit/entities/entityManager.definitionMutation.test.js
+++ b/tests/unit/entities/entityManager.definitionMutation.test.js
@@ -3,7 +3,7 @@
 import { test, expect } from '@jest/globals';
 import {
   describeEntityManagerSuite,
-  TestBed,
+  EntityManagerTestBed,
 } from '../../common/entities/index.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 
@@ -11,20 +11,20 @@ describeEntityManagerSuite(
   'EntityManager.createEntityInstance does not mutate definitions',
   (getBed) => {
     test('components property remains unchanged when null', () => {
-      const testBed = getBed();
+      const bed = getBed();
       const definition = { id: 'test:nullComps', components: null };
       const regDef = new EntityDefinition(definition.id, {
         components: definition.components,
       });
-      testBed.setupDefinitions(regDef);
+      bed.setupDefinitions(regDef);
 
-      const entity = testBed.entityManager.createEntityInstance(definition.id);
+      const entity = bed.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toBeNull();
     });
 
     test('components property remains unchanged when valid object', () => {
-      const testBed = getBed();
+      const bed = getBed();
       const definition = {
         id: 'test:validComps',
         components: { 'core:name': { value: 'A' } },
@@ -32,9 +32,9 @@ describeEntityManagerSuite(
       const regDef = new EntityDefinition(definition.id, {
         components: definition.components,
       });
-      testBed.setupDefinitions(regDef);
+      bed.setupDefinitions(regDef);
 
-      const entity = testBed.entityManager.createEntityInstance(definition.id);
+      const entity = bed.entityManager.createEntityInstance(definition.id);
       expect(entity).not.toBeNull();
       expect(definition.components).toEqual({ 'core:name': { value: 'A' } });
     });

--- a/tests/unit/entities/entityManager.getComponentData.test.js
+++ b/tests/unit/entities/entityManager.getComponentData.test.js
@@ -28,7 +28,7 @@ describeEntityManagerSuite('EntityManager - getComponentData', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'Override' };
-      getBed().createEntityWithOverride(
+      getBed().createEntityWithOverrides(
         'basic',
         { [NAME_COMPONENT_ID]: overrideData },
         { instanceId: PRIMARY }

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -25,7 +25,7 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
       const { entityManager } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
       if (Object.keys(overrides).length) {
-        getBed().createEntityWithOverride('basic', overrides, {
+        getBed().createEntityWithOverrides('basic', overrides, {
           instanceId: PRIMARY,
         });
       } else {
@@ -61,7 +61,7 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         if (useOverride) {
-          getBed().createEntityWithOverride(
+          getBed().createEntityWithOverrides(
             'basic',
             { [NAME_COMPONENT_ID]: { name: 'Override' } },
             { instanceId: PRIMARY }
@@ -87,7 +87,7 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         if (useOverride) {
-          getBed().createEntityWithOverride(
+          getBed().createEntityWithOverrides(
             'basic',
             { [NAME_COMPONENT_ID]: { name: 'Override' } },
             { instanceId: PRIMARY }

--- a/tests/unit/entities/entityManager.injection.test.js
+++ b/tests/unit/entities/entityManager.injection.test.js
@@ -1,7 +1,7 @@
 /**
  * @file This file consolidates all tests for the EntityManager's automatic injection
  * of default components for actor entities (e.g., goals, notes, stm).
- * It exclusively uses the TestBed helper for all setup to ensure consistency,
+ * It exclusively uses the EntityManagerTestBed helper for all setup to ensure consistency,
  * centralization, and reduce boilerplate.
  * @see src/entities/entityManager.js
  */

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -1,7 +1,7 @@
 /**
  * @file This file consolidates all tests for the EntityManager's core lifecycle methods:
  * constructor, createEntityInstance, reconstructEntity, removeEntityInstance, and clearAll.
- * It exclusively uses the TestBed helper for setup to ensure consistency and reduce boilerplate.
+ * It exclusively uses the EntityManagerTestBed helper for setup to ensure consistency and reduce boilerplate.
  * @see src/entities/entityManager.js
  */
 
@@ -9,7 +9,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   describeEntityManagerSuite,
   TestData,
-  TestBed,
+  EntityManagerTestBed,
 } from '../../common/entities/index.js';
 import {
   runInvalidEntityIdTests,
@@ -32,7 +32,7 @@ describeEntityManagerSuite(
   'EntityManager - Constructor Validation',
   (getBed) => {
     describe('constructor', () => {
-      it('should instantiate successfully via TestBed', () => {
+      it('should instantiate successfully via EntityManagerTestBed', () => {
         // The beforeEach hook already does this. If it fails, the test will crash.
         expect(getBed().entityManager).toBeInstanceOf(
           getBed().entityManager.constructor
@@ -67,11 +67,11 @@ describeEntityManagerSuite(
 
       it('should use the injected idGenerator', () => {
         const mockIdGenerator = jest.fn();
-        const testBed = new TestBed({ idGenerator: mockIdGenerator });
+        const bed = new EntityManagerTestBed({ idGenerator: mockIdGenerator });
         // This test simply checks if the generator is stored,
         // createEntityInstance tests will check if it's *used*.
         // We can't directly access the private field, so we rely on functional tests.
-        expect(testBed.entityManager).toBeDefined();
+        expect(bed.entityManager).toBeDefined();
       });
 
       it('should default to a UUIDv4 generator if none is provided', () => {
@@ -97,9 +97,9 @@ describeEntityManagerSuite('EntityManager - createEntityInstance', (getBed) => {
     it('should create an entity with an ID from the injected generator if no instanceId is provided', () => {
       // Arrange
       const mockIdGenerator = () => 'test-entity-id-123';
-      const testBed = new TestBed({ idGenerator: mockIdGenerator });
+      const bed = new EntityManagerTestBed({ idGenerator: mockIdGenerator });
 
-      const entity = testBed.createBasicEntity();
+      const entity = bed.createBasicEntity();
 
       // Assert
       expect(entity).toBeInstanceOf(Entity);
@@ -110,10 +110,10 @@ describeEntityManagerSuite('EntityManager - createEntityInstance', (getBed) => {
     it('should create an entity with a specific instanceId if provided, ignoring the generator', () => {
       // Arrange
       const mockIdGenerator = jest.fn(() => 'should-not-be-called');
-      const testBed = new TestBed({ idGenerator: mockIdGenerator });
+      const bed = new EntityManagerTestBed({ idGenerator: mockIdGenerator });
       const { PRIMARY } = TestData.InstanceIDs;
 
-      const entity = testBed.createBasicEntity({
+      const entity = bed.createBasicEntity({
         instanceId: PRIMARY,
       });
 
@@ -445,12 +445,12 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
       };
 
       // Arrange
-      const testBed = new TestBed({
+      const bed = new EntityManagerTestBed({
         entityManagerOptions: { repository: stubRepo },
       });
-      const { entityManager, mocks } = testBed;
+      const { entityManager, mocks } = bed;
       const { PRIMARY } = TestData.InstanceIDs;
-      testBed.createBasicEntity({ instanceId: PRIMARY });
+      bed.createBasicEntity({ instanceId: PRIMARY });
 
       // Act & Assert
       expect(() => entityManager.removeEntityInstance(PRIMARY)).toThrow(
@@ -461,7 +461,7 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
           'EntityRepository.remove failed for already retrieved entity'
         )
       );
-      testBed.cleanup();
+      bed.cleanup();
     });
   });
 });

--- a/tests/unit/entities/entityManager.queries.test.js
+++ b/tests/unit/entities/entityManager.queries.test.js
@@ -1,7 +1,7 @@
 /**
  * @file This file consolidates all tests for the EntityManager's entity query and
  * accessor methods, such as getEntityInstance and getEntitiesWithComponent.
- * It exclusively uses the TestBed helper for all setup to ensure consistency and reduce boilerplate.
+ * It exclusively uses the EntityManagerTestBed helper for all setup to ensure consistency and reduce boilerplate.
  * @see tests/unit/entities/entityManager.queries.test.js
  */
 

--- a/tests/unit/entities/entityManager.reconstructionErrors.test.js
+++ b/tests/unit/entities/entityManager.reconstructionErrors.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import EntityFactory from '../../../src/entities/factories/entityFactory.js';
-import { TestBed, TestData } from '../../common/entities/index.js';
+import { EntityManagerTestBed, TestData } from '../../common/entities/index.js';
 import { buildSerializedEntity } from '../../common/entities/index.js';
 import { DuplicateEntityError } from '../../../src/errors/duplicateEntityError.js';
 import { SerializedEntityError } from '../../../src/errors/serializedEntityError.js';
@@ -31,26 +31,26 @@ describe('EntityManager - Factory Error Translation', () => {
   ];
 
   it.each(errorCases)('translates %s', (_, factoryErr, expected) => {
-    const testBed = new TestBed();
+    const bed = new EntityManagerTestBed();
     jest
       .spyOn(EntityFactory.prototype, 'reconstruct')
       .mockImplementation(() => {
         throw factoryErr;
       });
-    testBed.setupTestDefinitions('basic');
+    bed.setupTestDefinitions('basic');
     const serialized = buildSerializedEntity(
       TestData.InstanceIDs.PRIMARY,
       TestData.DefinitionIDs.BASIC,
       {}
     );
 
-    expect(() => testBed.entityManager.reconstructEntity(serialized)).toThrow(
+    expect(() => bed.entityManager.reconstructEntity(serialized)).toThrow(
       expected
     );
   });
 
   it('translates duplicate ID errors to DuplicateEntityError', () => {
-    const testBed = new TestBed();
+    const bed = new EntityManagerTestBed();
     const message =
       "EntityFactory.reconstruct: Entity with ID 'dup-1' already exists. Reconstruction aborted.";
     jest
@@ -58,14 +58,14 @@ describe('EntityManager - Factory Error Translation', () => {
       .mockImplementation(() => {
         throw new Error(message);
       });
-    testBed.setupTestDefinitions('basic');
+    bed.setupTestDefinitions('basic');
     const serialized = buildSerializedEntity(
       'dup-1',
       TestData.DefinitionIDs.BASIC,
       {}
     );
 
-    expect(() => testBed.entityManager.reconstructEntity(serialized)).toThrow(
+    expect(() => bed.entityManager.reconstructEntity(serialized)).toThrow(
       new DuplicateEntityError(
         'dup-1',
         "EntityManager.reconstructEntity: Entity with ID 'dup-1' already exists. Reconstruction aborted."

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -19,7 +19,7 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
 
       // Add component as an override
-      getBed().createEntityWithOverride(
+      getBed().createEntityWithOverrides(
         'basic',
         { [NAME_COMPONENT_ID]: { name: 'Override' } },
         { instanceId: PRIMARY }
@@ -43,7 +43,7 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'ToBeRemoved' };
-      const entity = getBed().createEntityWithOverride(
+      const entity = getBed().createEntityWithOverrides(
         'basic',
         { [NAME_COMPONENT_ID]: overrideData },
         { instanceId: PRIMARY, resetDispatch: true }

--- a/tests/unit/smoke/newCharacterMemory.test.js
+++ b/tests/unit/smoke/newCharacterMemory.test.js
@@ -16,24 +16,24 @@ import {
 import { expect, test } from '@jest/globals';
 import {
   describeEntityManagerSuite,
-  TestBed,
+  EntityManagerTestBed,
 } from '../../common/entities/index.js';
 
 /**
- * Uses {@link TestBed} to verify that the EntityManager injects the
+ * Uses {@link EntityManagerTestBed} to verify that the EntityManager injects the
  * `core:short_term_memory` component when missing from an actor definition.
  */
 describeEntityManagerSuite(
   'Smoke › New Character › Short-Term Memory bootstrap',
   (getBed) => {
     test('EntityManager injects default short-term memory', () => {
-      const testBed = getBed();
+      const bed = getBed();
       const definition = new EntityDefinition('test:alice', {
         components: { [ACTOR_COMPONENT_ID]: {} },
       });
-      testBed.setupDefinitions(definition);
+      bed.setupDefinitions(definition);
 
-      const character = testBed.entityManager.createEntityInstance(
+      const character = bed.entityManager.createEntityInstance(
         definition.id
       );
 


### PR DESCRIPTION
## Summary
- rename `TestBed` to `EntityManagerTestBed`
- rename helper `createEntityWithOverrides`
- update imports and variable names in tests

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ed59a91ac83318676b0c28e11a5f9