### PR TITLE
[Agent] clarify component presence checks

### DIFF
--- a/src/entities/entity.js
+++ b/src/entities/entity.js
@@ -98,12 +98,31 @@ class Entity {
    * considering both its definition and instance overrides.
    *
    * @param {string} componentTypeId - The unique string identifier for the component type.
-   * @param {boolean} [checkOverrideOnly] - If true, only checks instance overrides.
+   * @param {boolean} [checkOverrideOnly] - DEPRECATED. If true, only checks
+   * instance overrides.
    * @returns {boolean} True if the entity has data for this component type, false otherwise.
    */
   hasComponent(componentTypeId, checkOverrideOnly = false) {
-    // Added checkOverrideOnly parameter
-    return this.#data.hasComponent(componentTypeId, checkOverrideOnly); // Use #data and pass parameter
+    if (arguments.length === 2) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Entity.hasComponent: The checkOverrideOnly flag is deprecated. Use hasComponentOverride(componentTypeId) instead.'
+      );
+      if (checkOverrideOnly) {
+        return this.hasComponentOverride(componentTypeId);
+      }
+    }
+    return this.#data.hasComponent(componentTypeId); // Use #data
+  }
+
+  /**
+   * Checks if this entity has a non-null override for the given component type.
+   *
+   * @param {string} componentTypeId - The unique component type ID.
+   * @returns {boolean} True if an override exists and is not null.
+   */
+  hasComponentOverride(componentTypeId) {
+    return this.#data.hasComponentOverride(componentTypeId);
   }
 
   /**

--- a/src/entities/entityInstanceData.js
+++ b/src/entities/entityInstanceData.js
@@ -145,10 +145,21 @@ class EntityInstanceData {
    * A component explicitly overridden with `null` is considered not present for this instance via the override.
    *
    * @param {string} componentTypeId - The unique string identifier for the component type.
-   * @param {boolean} [checkOverrideOnly] - If true, only checks if a non-null override exists for this instance.
+   * @param {boolean} [checkOverrideOnly] - DEPRECATED. If true, only checks if
+   * a non-null override exists for this instance.
    * @returns {boolean} True if the instance has data for this component type under the specified condition.
    */
   hasComponent(componentTypeId, checkOverrideOnly = false) {
+    if (arguments.length === 2) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'EntityInstanceData.hasComponent: The checkOverrideOnly flag is deprecated. Use hasComponentOverride(componentTypeId) instead.'
+      );
+      if (checkOverrideOnly) {
+        return this.hasComponentOverride(componentTypeId);
+      }
+    }
+
     if (typeof componentTypeId !== 'string' || !componentTypeId.trim()) {
       return false;
     }
@@ -158,19 +169,33 @@ class EntityInstanceData {
       componentTypeId
     );
 
-    if (checkOverrideOnly) {
-      // For an override to count, it must exist and not be null.
-      return overrideExists && this.overrides[componentTypeId] !== null;
-    }
-
     if (overrideExists) {
-      // FIXED: If an override key exists, the component is considered present,
-      // even if its value is null. This aligns with the final test's expectation.
+      // If an override key exists, the component is considered present,
+      // even if its value is null. This aligns with legacy expectations.
       return true;
     }
 
     // If no override, presence is determined by the definition.
     return this.definition.hasComponent(componentTypeId);
+  }
+
+  /**
+   * Checks if this instance has a non-null component override for the
+   * specified type.
+   *
+   * @param {string} componentTypeId - The unique component type ID.
+   * @returns {boolean} True if an override exists and is not null.
+   */
+  hasComponentOverride(componentTypeId) {
+    if (typeof componentTypeId !== 'string' || !componentTypeId.trim()) {
+      return false;
+    }
+
+    const overrideExists = Object.prototype.hasOwnProperty.call(
+      this.overrides,
+      componentTypeId
+    );
+    return overrideExists && this.overrides[componentTypeId] !== null;
   }
 
   /**

--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -584,7 +584,7 @@ class EntityManager extends IEntityManager {
       this.#logger
     );
     const entity = this.#getEntityById(instanceId);
-    return entity ? entity.hasComponent(componentTypeId, true) : false;
+    return entity ? entity.hasComponentOverride(componentTypeId) : false;
   }
 
   /**

--- a/src/entities/services/componentMutationService.js
+++ b/src/entities/services/componentMutationService.js
@@ -203,7 +203,7 @@ export class ComponentMutationService {
     }
 
     // Check if the component to be removed exists as an override.
-    if (!entity.hasComponent(componentTypeId, true)) {
+    if (!entity.hasComponentOverride(componentTypeId)) {
       this.#logger.debug(
         `ComponentMutationService.removeComponent: Component '${componentTypeId}' not found as an override on entity '${instanceId}'. Nothing to remove at instance level.`
       );

--- a/tests/unit/entities/entity.test.js
+++ b/tests/unit/entities/entity.test.js
@@ -145,7 +145,7 @@ describe('Entity Class', () => {
       const spy = jest.spyOn(mockInstanceData, 'hasComponent');
       const result = entity.hasComponent(componentTypeId);
 
-      expect(spy).toHaveBeenCalledWith(componentTypeId, false); // Added false as second argument
+      expect(spy).toHaveBeenCalledWith(componentTypeId);
       expect(result).toBe(true);
       spy.mockRestore();
     });
@@ -155,7 +155,7 @@ describe('Entity Class', () => {
       const spy = jest.spyOn(mockInstanceData, 'hasComponent');
       const result = entity.hasComponent(componentTypeId);
 
-      expect(spy).toHaveBeenCalledWith(componentTypeId, false);
+      expect(spy).toHaveBeenCalledWith(componentTypeId);
       expect(result).toBe(true);
       spy.mockRestore();
     });

--- a/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
+++ b/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
@@ -146,15 +146,15 @@ describe('EntityInstanceData', () => {
       );
     });
 
-    it('should cause hasComponent(id, true) to return false after removal', () => {
+    it('should cause hasComponentOverride(id) to return false after removal', () => {
       // Pre-condition check
-      expect(instance.hasComponent('core:position', true)).toBe(true);
+      expect(instance.hasComponentOverride('core:position')).toBe(true);
 
       // Act
       instance.removeComponentOverride('core:position');
 
       // Assert
-      expect(instance.hasComponent('core:position', true)).toBe(false);
+      expect(instance.hasComponentOverride('core:position')).toBe(false);
     });
 
     it('should not affect hasComponent(id, false) if the component exists on the definition', () => {
@@ -163,14 +163,14 @@ describe('EntityInstanceData', () => {
 
       // Pre-condition checks
       expect(instance.hasComponent('core:health', false)).toBe(true); // From override
-      expect(instance.hasComponent('core:health', true)).toBe(true); // From override
+      expect(instance.hasComponentOverride('core:health')).toBe(true); // From override
 
       // Act
       instance.removeComponentOverride('core:health');
 
       // Assert
       expect(instance.hasComponent('core:health', false)).toBe(true); // Falls back to definition
-      expect(instance.hasComponent('core:health', true)).toBe(false); // Override is gone
+      expect(instance.hasComponentOverride('core:health')).toBe(false); // Override is gone
     });
   });
 });

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -69,10 +69,9 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         } else {
           getBed().createBasicEntity({ instanceId: PRIMARY });
         }
-        const result = entityManager.hasComponent(
+        const result = entityManager.hasComponentOverride(
           PRIMARY,
-          NAME_COMPONENT_ID,
-          true
+          NAME_COMPONENT_ID
         );
         expect(result).toBe(useOverride);
       });

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -24,17 +24,17 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
         { [NAME_COMPONENT_ID]: { name: 'Override' } },
         { instanceId: PRIMARY }
       );
-      expect(entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID, true)).toBe(
-        true
-      );
+      expect(
+        entityManager.hasComponentOverride(PRIMARY, NAME_COMPONENT_ID)
+      ).toBe(true);
 
       // Act
       entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);
 
       // Assert
-      expect(entityManager.hasComponent(PRIMARY, NAME_COMPONENT_ID, true)).toBe(
-        false
-      );
+      expect(
+        entityManager.hasComponentOverride(PRIMARY, NAME_COMPONENT_ID)
+      ).toBe(false);
     });
 
     it('should dispatch a COMPONENT_REMOVED event with the old data', () => {


### PR DESCRIPTION
## Summary
- deprecate boolean flag in `Entity.hasComponent` and delegate to new `hasComponentOverride`
- mirror override check in `EntityInstanceData`
- update callers in `EntityManager` and `ComponentMutationService`
- adjust unit tests for explicit override checks

## Testing Done
- `npm run lint` *(fails: 704 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ed5913f348331a9571b97518447d8