### PR TITLE
[Agent] refactor string validation

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -12,6 +12,7 @@ import {
 import EngineState from './engineState.js';
 import GameSessionManager from './gameSessionManager.js';
 import PersistenceCoordinator from './persistenceCoordinator.js';
+import { assertNonBlankString } from '../utils/parameterGuards.js';
 
 // --- JSDoc Type Imports ---
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -171,11 +172,9 @@ class GameEngine {
    * @private
    * @description Sets initialization, loop and world values to inactive.
    * @returns {void}
-   */
+  */
   #resetEngineState() {
-    this.#engineState.isInitialized = false;
-    this.#engineState.isGameLoopRunning = false;
-    this.#engineState.activeWorld = null;
+    this.#engineState.reset();
   }
 
   async _executeInitializationSequence(worldName) {
@@ -244,16 +243,12 @@ class GameEngine {
   }
 
   async startNewGame(worldName) {
-    if (
-      !worldName ||
-      typeof worldName !== 'string' ||
-      worldName.trim() === ''
-    ) {
-      const errorMsg =
-        'GameEngine.startNewGame: worldName must be a non-empty string.';
-      this.#logger.error(errorMsg);
-      throw new TypeError(errorMsg);
-    }
+    assertNonBlankString(
+      worldName,
+      'worldName',
+      'GameEngine.startNewGame',
+      this.#logger,
+    );
     this.#logger.debug(
       `GameEngine: startNewGame called for world "${worldName}".`
     );
@@ -355,16 +350,12 @@ class GameEngine {
   }
 
   async loadGame(saveIdentifier) {
-    if (
-      !saveIdentifier ||
-      typeof saveIdentifier !== 'string' ||
-      saveIdentifier.trim() === ''
-    ) {
-      const errorMsg =
-        'GameEngine.loadGame: saveIdentifier must be a non-empty string.';
-      this.#logger.error(errorMsg);
-      throw new TypeError(errorMsg);
-    }
+    assertNonBlankString(
+      saveIdentifier,
+      'saveIdentifier',
+      'GameEngine.loadGame',
+      this.#logger,
+    );
     return this.#persistenceCoordinator.loadGame(saveIdentifier);
   }
 

--- a/tests/unit/engine/loadGame.test.js
+++ b/tests/unit/engine/loadGame.test.js
@@ -169,13 +169,14 @@ describeEngineSuite('GameEngine', (context) => {
       'should reject invalid save identifiers: %p',
       async (badId) => {
         const expectedMessage =
-          'GameEngine.loadGame: saveIdentifier must be a non-empty string.';
+          `GameEngine.loadGame: Invalid saveIdentifier '${badId}'. Expected non-blank string.`;
 
         await expect(context.engine.loadGame(badId)).rejects.toThrow(
           expectedMessage
         );
         expect(context.bed.getLogger().error).toHaveBeenCalledWith(
-          expectedMessage
+          expectedMessage,
+          expect.any(Object)
         );
       }
     );

--- a/tests/unit/engine/startNewGame.test.js
+++ b/tests/unit/engine/startNewGame.test.js
@@ -99,14 +99,15 @@ describeEngineSuite('GameEngine', (context) => {
       'should reject invalid world names: %p',
       async (badName) => {
         const expectedMessage =
-          'GameEngine.startNewGame: worldName must be a non-empty string.';
+          `GameEngine.startNewGame: Invalid worldName '${badName}'. Expected non-blank string.`;
 
         await expect(context.engine.startNewGame(badName)).rejects.toThrow(
           expectedMessage
         );
 
         expect(context.bed.getLogger().error).toHaveBeenCalledWith(
-          expectedMessage
+          expectedMessage,
+          expect.any(Object)
         );
         expectEngineStopped(context.engine);
       }


### PR DESCRIPTION
## Summary
- reuse `assertNonBlankString` in GameEngine
- delegate engine state reset to EngineState
- update tests for new validation errors

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ede0b701883318127adb8a071dbec