### PR TITLE
[Agent] Centralize duplicate error translation

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -404,17 +404,7 @@ class EntityManager extends IEntityManager {
       this.#dispatchEntityCreated(entity);
       return entity;
     } catch (err) {
-      if (err instanceof Error && err.message.startsWith('Entity with ID')) {
-        this.#logger.error(err.message);
-        const match = err.message.match(
-          /Entity with ID '([^']+)' already exists/
-        );
-        if (match) {
-          throw new DuplicateEntityError(match[1], err.message);
-        }
-        throw new DuplicateEntityError('unknown', err.message);
-      }
-      throw err;
+      throw this.#errorTranslator.translate(err);
     }
   }
 

--- a/src/entities/services/errorTranslator.js
+++ b/src/entities/services/errorTranslator.js
@@ -93,6 +93,25 @@ export class ErrorTranslator {
       }
     }
 
+    if (err instanceof DuplicateEntityError) {
+      const msg = err.message.startsWith('EntityManager.')
+        ? err.message
+        : `EntityManager.createEntityInstance: ${err.message}`;
+      this.#logger.error(msg);
+      return new DuplicateEntityError(err.entityId, msg);
+    }
+
+    if (err instanceof Error && err.message.startsWith('Entity with ID')) {
+      const match = err.message.match(
+        /Entity with ID '([^']+)' already exists/
+      );
+      if (match) {
+        const msg = `EntityManager.createEntityInstance: Entity with ID '${match[1]}' already exists.`;
+        this.#logger.error(msg);
+        return new DuplicateEntityError(match[1], msg);
+      }
+    }
+
     return err instanceof Error ? err : new Error(String(err));
   }
 }

--- a/tests/unit/entities/entityManager.creationErrors.test.js
+++ b/tests/unit/entities/entityManager.creationErrors.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import EntityFactory from '../../../src/entities/factories/entityFactory.js';
+import { EntityManagerTestBed, TestData } from '../../common/entities/index.js';
+import { DuplicateEntityError } from '../../../src/errors/duplicateEntityError.js';
+
+describe('EntityManager - Factory Error Translation (create)', () => {
+  it('translates duplicate ID errors to DuplicateEntityError', () => {
+    const bed = new EntityManagerTestBed();
+    const message = "Entity with ID 'dup-1' already exists.";
+    jest.spyOn(EntityFactory.prototype, 'create').mockImplementation(() => {
+      throw new Error(message);
+    });
+    bed.setupTestDefinitions('basic');
+
+    expect(() =>
+      bed.entityManager.createEntityInstance(TestData.DefinitionIDs.BASIC, {
+        instanceId: 'dup-1',
+      })
+    ).toThrow(
+      new DuplicateEntityError(
+        'dup-1',
+        "EntityManager.createEntityInstance: Entity with ID 'dup-1' already exists."
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use ErrorTranslator in `createEntityInstance`
- extend ErrorTranslator with translations for duplicate creation errors
- add unit test verifying translation

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ee589ed088331acd6f163fdd215f0