### PR TITLE
[Agent] Inject directive strategy resolver

### DIFF
--- a/src/turns/interfaces/IDirectiveStrategyResolver.js
+++ b/src/turns/interfaces/IDirectiveStrategyResolver.js
@@ -1,0 +1,22 @@
+// src/turns/interfaces/IDirectiveStrategyResolver.js
+
+/** @typedef {import('./ITurnDirectiveStrategy.js').ITurnDirectiveStrategy} ITurnDirectiveStrategy */
+
+/**
+ * @interface IDirectiveStrategyResolver
+ * @description Provides a method to resolve an {@link ITurnDirectiveStrategy}
+ * implementation for a given directive.
+ */
+export class IDirectiveStrategyResolver {
+  /**
+   * Resolves the strategy for the supplied directive.
+   *
+   * @param {string} directive - Directive requesting a strategy.
+   * @returns {ITurnDirectiveStrategy} The resolved strategy implementation.
+   */
+  resolveStrategy(directive) {
+    throw new Error(
+      'IDirectiveStrategyResolver.resolveStrategy method not implemented.'
+    );
+  }
+}

--- a/src/turns/states/helpers/commandProcessingWorkflow.js
+++ b/src/turns/states/helpers/commandProcessingWorkflow.js
@@ -11,6 +11,7 @@
  * @typedef {import('../../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
  * @typedef {import('../../../../../interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor
  * @typedef {import('../../../../../interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreter
+ * @typedef {import('../../interfaces/IDirectiveStrategyResolver.js').IDirectiveStrategyResolver} IDirectiveStrategyResolver
  */
 
 import {
@@ -30,6 +31,7 @@ export class CommandProcessingWorkflow {
   _exceptionHandler;
   _commandProcessor;
   _commandOutcomeInterpreter;
+  _directiveStrategyResolver;
 
   /**
    * Creates the workflow instance.
@@ -44,10 +46,12 @@ export class CommandProcessingWorkflow {
     exceptionHandler,
     commandProcessor,
     commandOutcomeInterpreter,
+    directiveStrategyResolver,
   }) {
     this._state = state;
     this._commandProcessor = commandProcessor;
     this._commandOutcomeInterpreter = commandOutcomeInterpreter;
+    this._directiveStrategyResolver = directiveStrategyResolver;
 
     if (!this._commandProcessor) {
       throw new Error(
@@ -57,6 +61,11 @@ export class CommandProcessingWorkflow {
     if (!this._commandOutcomeInterpreter) {
       throw new Error(
         'CommandProcessingWorkflow: commandOutcomeInterpreter is required.'
+      );
+    }
+    if (!this._directiveStrategyResolver) {
+      throw new Error(
+        'CommandProcessingWorkflow: directiveStrategyResolver is required.'
       );
     }
 
@@ -181,7 +190,7 @@ export class CommandProcessingWorkflow {
     const actorId = activeTurnCtx.getActor()?.id ?? 'UnknownActor';
 
     const directiveStrategy =
-      this._state._directiveResolver.resolveStrategy(directiveType);
+      this._directiveStrategyResolver.resolveStrategy(directiveType);
     if (!directiveStrategy) {
       const errorMsg = `${this._state.getStateName()}: Could not resolve ITurnDirectiveStrategy for directive '${directiveType}' (actor ${actorId}).`;
       logger.error(errorMsg);

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -182,6 +182,7 @@ export class ProcessingCommandState extends AbstractTurnState {
       exceptionHandler: this._exceptionHandler,
       commandProcessor: this.#commandProcessor,
       commandOutcomeInterpreter: this._commandOutcomeInterpreter,
+      directiveStrategyResolver: this._directiveResolver,
     });
 
     this._logConstruction();


### PR DESCRIPTION
## Summary
- add IDirectiveStrategyResolver interface
- inject directiveStrategyResolver into CommandProcessingWorkflow
- use the resolver inside _executeDirectiveStrategy
- pass the resolver from ProcessingCommandState

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ee5ec0c2c8331879480ad99bc7c6b