### PR TITLE
[Agent] explicit error assertion helpers

### DIFF
--- a/tests/common/entities/invalidInputHelpers.js
+++ b/tests/common/entities/invalidInputHelpers.js
@@ -3,6 +3,7 @@
  * @see tests/common/entities/invalidInputHelpers.js
  */
 /* eslint-env jest */
+/* global it, expect */
 
 import { TestData } from './index.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
@@ -107,4 +108,55 @@ export function runInvalidDefinitionIdTests(getBed, invoke) {
     TestData.InvalidValues.invalidDefinitionIds,
     'should throw InvalidArgumentError for invalid definitionId %p'
   )(getBed, invoke);
+}
+
+/**
+ * Asserts that invoking {@code fn} throws the expected error type and message.
+ *
+ * @param {Function} fn - Function expected to throw.
+ * @param {new (...args: any[]) => Error} ErrorClass - Expected error constructor.
+ * @param {string|RegExp} message - Message substring or regex expected in the error.
+ * @returns {void}
+ */
+export function expectErrorWithMessage(fn, ErrorClass, message) {
+  let error;
+  try {
+    fn();
+  } catch (err) {
+    error = err;
+  }
+  expect(error).toBeInstanceOf(ErrorClass);
+  if (message instanceof RegExp) {
+    expect(error.message).toMatch(message);
+  } else {
+    expect(error.message).toContain(message);
+  }
+}
+
+/**
+ * Asserts that the provided async function rejects with the expected error type
+ * and message.
+ *
+ * @param {Function} asyncFn - Async function expected to reject.
+ * @param {new (...args: any[]) => Error} ErrorClass - Expected error constructor.
+ * @param {string|RegExp} message - Expected error message substring or regex.
+ * @returns {Promise<void>}
+ */
+export async function expectAsyncErrorWithMessage(
+  asyncFn,
+  ErrorClass,
+  message
+) {
+  let error;
+  try {
+    await asyncFn();
+  } catch (err) {
+    error = err;
+  }
+  expect(error).toBeInstanceOf(ErrorClass);
+  if (message instanceof RegExp) {
+    expect(error.message).toMatch(message);
+  } else {
+    expect(error.message).toContain(message);
+  }
 }

--- a/tests/unit/entities/EntityDefinition.test.js
+++ b/tests/unit/entities/EntityDefinition.test.js
@@ -1,4 +1,5 @@
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
+import { expectErrorWithMessage } from '../../common/entities/index.js';
 
 describe('EntityDefinition', () => {
   const validDefinitionData = {
@@ -22,28 +23,40 @@ describe('EntityDefinition', () => {
   });
 
   it('should throw an error if ID is invalid', () => {
-    expect(() => new EntityDefinition(null, validDefinitionData)).toThrow(
+    expectErrorWithMessage(
+      () => new EntityDefinition(null, validDefinitionData),
+      Error,
       'EntityDefinition requires a valid string id.'
     );
-    expect(() => new EntityDefinition('', validDefinitionData)).toThrow(
+    expectErrorWithMessage(
+      () => new EntityDefinition('', validDefinitionData),
+      Error,
       'EntityDefinition requires a valid string id.'
     );
-    expect(() => new EntityDefinition('  ', validDefinitionData)).toThrow(
+    expectErrorWithMessage(
+      () => new EntityDefinition('  ', validDefinitionData),
+      Error,
       'EntityDefinition requires a valid string id.'
     );
   });
 
   describe('definitionData and components handling', () => {
     it('should throw an error if definitionData itself is invalid', () => {
-      expect(() => new EntityDefinition(validDefinitionId, null)).toThrow(
+      expectErrorWithMessage(
+        () => new EntityDefinition(validDefinitionId, null),
+        Error,
         'EntityDefinition requires definitionData to be an object.'
       );
-      expect(() => new EntityDefinition(validDefinitionId, undefined)).toThrow(
+      expectErrorWithMessage(
+        () => new EntityDefinition(validDefinitionId, undefined),
+        Error,
         'EntityDefinition requires definitionData to be an object.'
       );
-      expect(
-        () => new EntityDefinition(validDefinitionId, 'not-an-object-at-all')
-      ).toThrow('EntityDefinition requires definitionData to be an object.');
+      expectErrorWithMessage(
+        () => new EntityDefinition(validDefinitionId, 'not-an-object-at-all'),
+        Error,
+        'EntityDefinition requires definitionData to be an object.'
+      );
     });
 
     it('should default to empty components if definitionData.components is missing', () => {

--- a/tests/unit/entities/factories/entityFactory.test.js
+++ b/tests/unit/entities/factories/entityFactory.test.js
@@ -22,6 +22,7 @@ import {
   createMockSchemaValidator,
   createSimpleMockDataRegistry,
 } from '../../../common/mockFactories.js';
+import { expectErrorWithMessage } from '../../../common/entities/index.js';
 import {
   ACTOR_COMPONENT_ID,
   SHORT_TERM_MEMORY_COMPONENT_ID,
@@ -67,63 +68,78 @@ describe('EntityFactory', () => {
     });
 
     it('should throw an error if validator is missing', () => {
-      expect(() => {
-        new EntityFactory({
-          validator: null,
-          logger: mocks.logger,
-          idGenerator: mockIdGenerator,
-          cloner: mockCloner,
-          defaultPolicy: mockDefaultPolicy,
-        });
-      }).toThrow('Missing required dependency: ISchemaValidator.');
+      expectErrorWithMessage(
+        () =>
+          new EntityFactory({
+            validator: null,
+            logger: mocks.logger,
+            idGenerator: mockIdGenerator,
+            cloner: mockCloner,
+            defaultPolicy: mockDefaultPolicy,
+          }),
+        Error,
+        'Missing required dependency: ISchemaValidator.'
+      );
     });
 
     it('should throw an error if logger is missing', () => {
-      expect(() => {
-        new EntityFactory({
-          validator: mocks.validator,
-          logger: null,
-          idGenerator: mockIdGenerator,
-          cloner: mockCloner,
-          defaultPolicy: mockDefaultPolicy,
-        });
-      }).toThrow('Missing required dependency: ILogger.');
+      expectErrorWithMessage(
+        () =>
+          new EntityFactory({
+            validator: mocks.validator,
+            logger: null,
+            idGenerator: mockIdGenerator,
+            cloner: mockCloner,
+            defaultPolicy: mockDefaultPolicy,
+          }),
+        Error,
+        'Missing required dependency: ILogger.'
+      );
     });
 
     it('should throw an error if idGenerator is not a function', () => {
-      expect(() => {
-        new EntityFactory({
-          validator: mocks.validator,
-          logger: mocks.logger,
-          idGenerator: 'not-a-function',
-          cloner: mockCloner,
-          defaultPolicy: mockDefaultPolicy,
-        });
-      }).toThrow('idGenerator must be a function');
+      expectErrorWithMessage(
+        () =>
+          new EntityFactory({
+            validator: mocks.validator,
+            logger: mocks.logger,
+            idGenerator: 'not-a-function',
+            cloner: mockCloner,
+            defaultPolicy: mockDefaultPolicy,
+          }),
+        Error,
+        'idGenerator must be a function'
+      );
     });
 
     it('should throw an error if cloner is not a function', () => {
-      expect(() => {
-        new EntityFactory({
-          validator: mocks.validator,
-          logger: mocks.logger,
-          idGenerator: mockIdGenerator,
-          cloner: 'not-a-function',
-          defaultPolicy: mockDefaultPolicy,
-        });
-      }).toThrow('cloner must be a function');
+      expectErrorWithMessage(
+        () =>
+          new EntityFactory({
+            validator: mocks.validator,
+            logger: mocks.logger,
+            idGenerator: mockIdGenerator,
+            cloner: 'not-a-function',
+            defaultPolicy: mockDefaultPolicy,
+          }),
+        Error,
+        'cloner must be a function'
+      );
     });
 
     it('should throw an error if defaultPolicy is not an object', () => {
-      expect(() => {
-        new EntityFactory({
-          validator: mocks.validator,
-          logger: mocks.logger,
-          idGenerator: mockIdGenerator,
-          cloner: mockCloner,
-          defaultPolicy: 'not-an-object',
-        });
-      }).toThrow('defaultPolicy must be an object');
+      expectErrorWithMessage(
+        () =>
+          new EntityFactory({
+            validator: mocks.validator,
+            logger: mocks.logger,
+            idGenerator: mockIdGenerator,
+            cloner: mockCloner,
+            defaultPolicy: 'not-an-object',
+          }),
+        Error,
+        'defaultPolicy must be an object'
+      );
     });
   });
 
@@ -180,51 +196,62 @@ describe('EntityFactory', () => {
     });
 
     it('should throw TypeError if definitionId is not a string', () => {
-      expect(() => {
-        factory.create(null, {}, mocks.registry, { has: () => false }, null);
-      }).toThrow('definitionId must be a non-empty string.');
+      expectErrorWithMessage(
+        () =>
+          factory.create(null, {}, mocks.registry, { has: () => false }, null),
+        TypeError,
+        'definitionId must be a non-empty string.'
+      );
 
-      expect(() => {
-        factory.create(
-          undefined,
-          {},
-          mocks.registry,
-          { has: () => false },
-          null
-        );
-      }).toThrow('definitionId must be a non-empty string.');
+      expectErrorWithMessage(
+        () =>
+          factory.create(
+            undefined,
+            {},
+            mocks.registry,
+            { has: () => false },
+            null
+          ),
+        TypeError,
+        'definitionId must be a non-empty string.'
+      );
 
-      expect(() => {
-        factory.create(123, {}, mocks.registry, { has: () => false }, null);
-      }).toThrow('definitionId must be a non-empty string.');
+      expectErrorWithMessage(
+        () =>
+          factory.create(123, {}, mocks.registry, { has: () => false }, null),
+        TypeError,
+        'definitionId must be a non-empty string.'
+      );
     });
 
     it('should throw DefinitionNotFoundError if definition not found', () => {
       mocks.registry.getEntityDefinition.mockReturnValue(null);
 
-      expect(() => {
+      expect(() =>
         factory.create(
           'non-existent',
           {},
           mocks.registry,
           { has: () => false },
           null
-        );
-      }).toThrow(new DefinitionNotFoundError('non-existent'));
+        )
+      ).toThrow(new DefinitionNotFoundError('non-existent'));
     });
 
     it('should throw error if entity with same ID already exists', () => {
       const repository = { has: jest.fn(() => true) };
-
-      expect(() => {
-        factory.create(
-          'test-def:basic',
-          { instanceId: 'existing-id' },
-          mocks.registry,
-          repository,
-          null
-        );
-      }).toThrow("Entity with ID 'existing-id' already exists.");
+      expectErrorWithMessage(
+        () =>
+          factory.create(
+            'test-def:basic',
+            { instanceId: 'existing-id' },
+            mocks.registry,
+            repository,
+            null
+          ),
+        Error,
+        "Entity with ID 'existing-id' already exists."
+      );
     });
 
     it('should apply component overrides correctly', () => {


### PR DESCRIPTION
Summary: Added helper functions for error assertions and refactored tests to use them.

Changes Made:
- Created `expectErrorWithMessage` and `expectAsyncErrorWithMessage` in `tests/common/entities/invalidInputHelpers.js`.
- Updated `EntityDefinition` and `EntityFactory` tests to assert error types using the new helpers.

Testing Done:
- [x] Code formatted (`npx prettier -w` on changed files)
- [x] Lint passes on changed files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_685ee5aaef4c8331b8da69e549273e03