### PR TITLE
[Agent] add scheduler tests and increase repair coverage

### DIFF
--- a/tests/scheduling/realScheduler.spec.js
+++ b/tests/scheduling/realScheduler.spec.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { RealScheduler } from '../../src/scheduling/index.js';
+
+describe('RealScheduler', () => {
+  it('delegates setTimeout to globalThis.setTimeout', () => {
+    const spy = jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation(() => 'id');
+    const fn = jest.fn();
+    const scheduler = new RealScheduler();
+    const result = scheduler.setTimeout(fn, 50);
+    expect(spy).toHaveBeenCalledWith(fn, 50);
+    expect(result).toBe('id');
+    spy.mockRestore();
+  });
+
+  it('delegates clearTimeout to globalThis.clearTimeout', () => {
+    const spy = jest
+      .spyOn(globalThis, 'clearTimeout')
+      .mockImplementation(() => {});
+    const scheduler = new RealScheduler();
+    scheduler.clearTimeout('id');
+    expect(spy).toHaveBeenCalledWith('id');
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/logic/services/closenessCircleService.test.js
+++ b/tests/unit/logic/services/closenessCircleService.test.js
@@ -84,6 +84,12 @@ describe('ClosenessCircleService', () => {
     test('should handle an array with one element', () => {
       expect(repair(['a'])).toEqual(['a']);
     });
+
+    test('should return an empty array for non-array inputs', () => {
+      expect(repair(null)).toEqual([]);
+      expect(repair(undefined)).toEqual([]);
+      expect(repair({})).toEqual([]);
+    });
   });
 
   describe('Usage Scenarios', () => {


### PR DESCRIPTION
## Summary
- test that RealScheduler delegates to the global environment
- cover non-array input branch in closenessCircleService.repair

## Testing Done
- `npx prettier --write tests/unit/logic/services/closenessCircleService.test.js tests/scheduling/realScheduler.spec.js`
- `npx eslint tests/unit/logic/services/closenessCircleService.test.js tests/scheduling/realScheduler.spec.js --fix`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685eeacc48188331bb5feccfaaa6992a