### PR TITLE
[Agent] standardize entity creation helper options

### DIFF
--- a/tests/common/entities/entityManagerTestBed.js
+++ b/tests/common/entities/entityManagerTestBed.js
@@ -111,21 +111,24 @@ export class EntityManagerTestBed extends FactoryTestBed {
    *   definition to use.
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
+   * @param {Record<string, object>} [options.overrides] - Component data
+   *   overrides applied during creation.
+   * @param {string} [options.instanceId] - Specific instance ID to use.
    * @param {boolean} [options.resetDispatch] - If true, resets the event
    *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
    *   entity instance.
    */
-  createEntity(defKey, { resetDispatch = false, ...options } = {}) {
+  createEntity(defKey, { overrides, instanceId, resetDispatch = false } = {}) {
     const definition = TestData.Definitions[defKey];
     if (!definition) {
       throw new Error(`Unknown test definition key: ${defKey}`);
     }
     this.setupDefinitions(definition);
-    const entity = this.entityManager.createEntityInstance(
-      definition.id,
-      options
-    );
+    const entity = this.entityManager.createEntityInstance(definition.id, {
+      instanceId,
+      componentOverrides: overrides,
+    });
     if (resetDispatch) {
       this.resetDispatchMock();
     }
@@ -181,10 +184,11 @@ export class EntityManagerTestBed extends FactoryTestBed {
    *   provided component overrides applied.
    * @param {keyof typeof TestData.Definitions} defKey - Key of the test
    *   definition to use.
-   * @param {Record<string, object>} overrides - Map of component IDs to override
-   *   data.
    * @param {object} [options] - Options forwarded to
    *   {@link EntityManager#createEntityInstance}.
+   * @param {Record<string, object>} [options.overrides] - Component overrides
+   *   applied during creation.
+   * @param {string} [options.instanceId] - Specific instance ID to use.
    * @param {boolean} [options.resetDispatch] - If true, resets the event
    *   dispatch mock after creation.
    * @returns {import('../../../src/entities/entity.js').default} The created
@@ -192,12 +196,11 @@ export class EntityManagerTestBed extends FactoryTestBed {
    */
   createEntityWithOverrides(
     defKey,
-    overrides,
-    { resetDispatch = false, ...options } = {}
+    { overrides = {}, instanceId, resetDispatch = false } = {}
   ) {
     return this.createEntity(defKey, {
-      ...options,
-      componentOverrides: overrides,
+      overrides,
+      instanceId,
       resetDispatch,
     });
   }
@@ -222,6 +225,7 @@ export class EntityManagerTestBed extends FactoryTestBed {
  *   tests. It receives a callback that returns the active {@link EntityManagerTestBed}.
  * @returns {void}
  */
-export const describeEntityManagerSuite = createDescribeTestBedSuite(EntityManagerTestBed);
+export const describeEntityManagerSuite =
+  createDescribeTestBedSuite(EntityManagerTestBed);
 
 export default EntityManagerTestBed;

--- a/tests/common/entities/index.js
+++ b/tests/common/entities/index.js
@@ -7,3 +7,4 @@ export * from './execContext.js';
 export * from './invalidInputHelpers.js';
 export * from './definitionBuilders.js';
 export * from './entityFactories.js';
+export * from './testBed.js';

--- a/tests/common/entities/testBed.js
+++ b/tests/common/entities/testBed.js
@@ -1,0 +1,13 @@
+/**
+ * @file Documentation of standardized entity creation helper options.
+ * @typedef {object} CreateEntityOptions
+ * @property {Record<string, object>} [overrides] Component overrides applied to the instance.
+ * @property {string} [instanceId] Explicit instance ID to assign.
+ * @property {boolean} [resetDispatch] If true, resets the event dispatcher mock after creation.
+ *
+ * The helper functions {@link EntityManagerTestBed#createEntity},
+ * {@link EntityManagerTestBed#createBasicEntity},
+ * {@link EntityManagerTestBed#createActorEntity} and
+ * {@link EntityManagerTestBed#createEntityWithOverrides} all accept a
+ * {@link CreateEntityOptions} object as their second argument.
+ */

--- a/tests/unit/entities/entityManager.getComponentData.test.js
+++ b/tests/unit/entities/entityManager.getComponentData.test.js
@@ -28,11 +28,10 @@ describeEntityManagerSuite('EntityManager - getComponentData', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'Override' };
-      getBed().createEntityWithOverrides(
-        'basic',
-        { [NAME_COMPONENT_ID]: overrideData },
-        { instanceId: PRIMARY }
-      );
+      getBed().createEntityWithOverrides('basic', {
+        overrides: { [NAME_COMPONENT_ID]: overrideData },
+        instanceId: PRIMARY,
+      });
 
       // Act
       const data = entityManager.getComponentData(PRIMARY, NAME_COMPONENT_ID);

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -25,7 +25,8 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
       const { entityManager } = getBed();
       const { PRIMARY } = TestData.InstanceIDs;
       if (Object.keys(overrides).length) {
-        getBed().createEntityWithOverrides('basic', overrides, {
+        getBed().createEntityWithOverrides('basic', {
+          overrides,
           instanceId: PRIMARY,
         });
       } else {
@@ -61,11 +62,10 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         if (useOverride) {
-          getBed().createEntityWithOverrides(
-            'basic',
-            { [NAME_COMPONENT_ID]: { name: 'Override' } },
-            { instanceId: PRIMARY }
-          );
+          getBed().createEntityWithOverrides('basic', {
+            overrides: { [NAME_COMPONENT_ID]: { name: 'Override' } },
+            instanceId: PRIMARY,
+          });
         } else {
           getBed().createBasicEntity({ instanceId: PRIMARY });
         }
@@ -86,11 +86,10 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
         const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
         const { PRIMARY } = TestData.InstanceIDs;
         if (useOverride) {
-          getBed().createEntityWithOverrides(
-            'basic',
-            { [NAME_COMPONENT_ID]: { name: 'Override' } },
-            { instanceId: PRIMARY }
-          );
+          getBed().createEntityWithOverrides('basic', {
+            overrides: { [NAME_COMPONENT_ID]: { name: 'Override' } },
+            instanceId: PRIMARY,
+          });
         } else {
           getBed().createBasicEntity({ instanceId: PRIMARY });
         }

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -191,7 +191,7 @@ describeEntityManagerSuite('EntityManager - createEntityInstance', (getBed) => {
 
       // Act
       const entity = getBed().createBasicEntity({
-        componentOverrides: overrides,
+        overrides,
       });
 
       // Assert

--- a/tests/unit/entities/entityManager.queries.test.js
+++ b/tests/unit/entities/entityManager.queries.test.js
@@ -85,7 +85,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         getBed().createBasicEntity({
-          componentOverrides: { [COMPONENT_B]: { val: 1 } },
+          overrides: { [COMPONENT_B]: { val: 1 } },
         });
 
         // Act
@@ -100,15 +100,15 @@ describeEntityManagerSuite(
         const { entityManager } = getBed();
         const entity1 = getBed().createBasicEntity({
           instanceId: 'instance-1',
-          componentOverrides: { [COMPONENT_A]: { val: 1 } },
+          overrides: { [COMPONENT_A]: { val: 1 } },
         });
         const entity2 = getBed().createBasicEntity({
           instanceId: 'instance-2',
-          componentOverrides: { [COMPONENT_B]: { val: 2 } },
+          overrides: { [COMPONENT_B]: { val: 2 } },
         });
         const entity3 = getBed().createBasicEntity({
           instanceId: 'instance-3',
-          componentOverrides: {
+          overrides: {
             [COMPONENT_A]: { val: 3 },
             [COMPONENT_B]: { val: 4 },
           },
@@ -166,7 +166,7 @@ describeEntityManagerSuite(
         // Arrange
         const { entityManager } = getBed();
         const entity1 = getBed().createBasicEntity({
-          componentOverrides: { [COMPONENT_A]: { val: 1 } },
+          overrides: { [COMPONENT_A]: { val: 1 } },
         });
 
         // Act
@@ -175,7 +175,7 @@ describeEntityManagerSuite(
 
         // Modify the state by adding another entity with the component
         const entity2 = getBed().createBasicEntity({
-          componentOverrides: { [COMPONENT_A]: { val: 2 } },
+          overrides: { [COMPONENT_A]: { val: 2 } },
         });
 
         const results2 = entityManager.getEntitiesWithComponent(COMPONENT_A);

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -19,11 +19,10 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { PRIMARY } = TestData.InstanceIDs;
 
       // Add component as an override
-      getBed().createEntityWithOverrides(
-        'basic',
-        { [NAME_COMPONENT_ID]: { name: 'Override' } },
-        { instanceId: PRIMARY }
-      );
+      getBed().createEntityWithOverrides('basic', {
+        overrides: { [NAME_COMPONENT_ID]: { name: 'Override' } },
+        instanceId: PRIMARY,
+      });
       expect(
         entityManager.hasComponentOverride(PRIMARY, NAME_COMPONENT_ID)
       ).toBe(true);
@@ -43,11 +42,11 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       const { NAME_COMPONENT_ID } = TestData.ComponentIDs;
       const { PRIMARY } = TestData.InstanceIDs;
       const overrideData = { name: 'ToBeRemoved' };
-      const entity = getBed().createEntityWithOverrides(
-        'basic',
-        { [NAME_COMPONENT_ID]: overrideData },
-        { instanceId: PRIMARY, resetDispatch: true }
-      );
+      const entity = getBed().createEntityWithOverrides('basic', {
+        overrides: { [NAME_COMPONENT_ID]: overrideData },
+        instanceId: PRIMARY,
+        resetDispatch: true,
+      });
 
       // Act
       entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID);


### PR DESCRIPTION
## Summary
- update EntityManagerTestBed helpers to use `overrides`, `instanceId`, and `resetDispatch` in a single options object
- document helper options in `tests/common/entities/testBed.js`
- adjust unit tests for new helper API

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many pre-existing warnings and errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685eef1d23e4833182c6b89a15f3abd0