### PR TITLE
[Agent] validate dispatcher and init logger

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -7,6 +7,8 @@ import {
 } from '../constants/eventIds.js';
 import { ICommandProcessor } from './interfaces/ICommandProcessor.js';
 import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { initLogger } from '../utils/index.js';
+import { validateDependency } from '../utils/validationUtils.js';
 
 // --- Type Imports ---
 /** @typedef {import('../entities/entity.js').default} Entity */
@@ -28,14 +30,18 @@ class CommandProcessor extends ICommandProcessor {
   constructor(options) {
     super();
 
-    const { logger, safeEventDispatcher } = options || {};
+    const { logger, safeEventDispatcher: dispatcher } = options || {};
 
-    this.#logger = logger;
+    this.#logger = initLogger('CommandProcessor', logger);
+
+    validateDependency(dispatcher, 'ISafeEventDispatcher', this.#logger, {
+      requiredMethods: ['dispatch'],
+    });
 
     this.#safeEventDispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
+      dispatcher || resolveSafeDispatcher(null, this.#logger);
     if (!this.#safeEventDispatcher) {
-      console.warn(
+      this.#logger.warn(
         'CommandProcessor: safeEventDispatcher resolution failed; some events may not be dispatched.'
       );
     }

--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -18,6 +18,8 @@ import TurnDirective from '../../turns/constants/turnDirectives.js';
 // --- Interface Imports ---
 import { ICommandOutcomeInterpreter } from '../interfaces/ICommandOutcomeInterpreter.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { initLogger } from '../../utils/index.js';
+import { validateDependency } from '../../utils/validationUtils.js';
 
 /**
  * @class CommandOutcomeInterpreter
@@ -30,19 +32,13 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
 
   constructor({ dispatcher, logger }) {
     super();
-    if (!logger || typeof logger.error !== 'function') {
-      console.error('CommandOutcomeInterpreter Constructor: Invalid logger.');
-      throw new Error('CommandOutcomeInterpreter: Invalid ILogger dependency.');
-    }
-    this.#logger = logger;
-    if (!dispatcher || typeof dispatcher.dispatch !== 'function') {
-      this.#logger.error(
-        'CommandOutcomeInterpreter Constructor: Invalid ISafeEventDispatcher.'
-      );
-      throw new Error(
-        'CommandOutcomeInterpreter: Invalid ISafeEventDispatcher dependency.'
-      );
-    }
+
+    this.#logger = initLogger('CommandOutcomeInterpreter', logger);
+
+    validateDependency(dispatcher, 'ISafeEventDispatcher', this.#logger, {
+      requiredMethods: ['dispatch'],
+    });
+
     this.#dispatcher = dispatcher;
     this.#logger.debug(
       'CommandOutcomeInterpreter: Instance created successfully.'

--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -15,7 +15,12 @@ let turnContext;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  logger = { debug: jest.fn(), error: jest.fn() };
+  logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
   dispatcher = { dispatch: jest.fn() };
   turnContext = {
     getActor: jest.fn(() => ({ id: 'actor-1' })),
@@ -27,17 +32,17 @@ describe('CommandOutcomeInterpreter additional branches', () => {
   it('throws when logger is invalid', () => {
     expect(
       () => new CommandOutcomeInterpreter({ dispatcher, logger: {} })
-    ).toThrow('CommandOutcomeInterpreter: Invalid ILogger dependency.');
+    ).toThrow("Invalid or missing method 'info' on dependency 'logger'.");
   });
 
   it('throws when dispatcher is invalid', () => {
     expect(
       () => new CommandOutcomeInterpreter({ dispatcher: {}, logger })
     ).toThrow(
-      'CommandOutcomeInterpreter: Invalid ISafeEventDispatcher dependency.'
+      "Invalid or missing method 'dispatch' on dependency 'ISafeEventDispatcher'."
     );
     expect(logger.error).toHaveBeenCalledWith(
-      'CommandOutcomeInterpreter Constructor: Invalid ISafeEventDispatcher.'
+      "Invalid or missing method 'dispatch' on dependency 'ISafeEventDispatcher'."
     );
   });
 


### PR DESCRIPTION
Summary: Updated CommandProcessor and CommandOutcomeInterpreter to use shared logger initialization and dependency validation utilities. Tests now expect new validation messages and use complete mock loggers.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685eeeee80d883318c9facd928302cc8