### PR TITLE
[Agent] Implement global key handler

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -10,6 +10,7 @@
 import { tokens } from '../tokens.js';
 import { Registrar } from '../registrarHelpers.js';
 import InputHandler from '../../input/inputHandler.js'; // Legacy Input Handler (Updated Dependency)
+import GlobalKeyHandler from '../../input/globalKeyHandler.js';
 import AlertRouter from '../../alerting/alertRouter.js';
 
 // --- NEW DOM UI Component Imports ---
@@ -187,7 +188,9 @@ export function registerRenderers(registrar, logger) {
         domElementFactory: c.resolve(tokens.DomElementFactory),
       })
   );
-  logger.debug(`UI Registrations: Registered ${tokens.EntityLifecycleMonitor}.`);
+  logger.debug(
+    `UI Registrations: Registered ${tokens.EntityLifecycleMonitor}.`
+  );
 
   registrar.singletonFactory(
     tokens.SaveGameService,
@@ -301,6 +304,16 @@ export function registerControllers(registrar, logger) {
   logger.debug(`UI Registrations: Registered ${tokens.InputStateController}.`);
 
   registrar.singletonFactory(
+    tokens.GlobalKeyHandler,
+    (c) =>
+      new GlobalKeyHandler(
+        c.resolve(tokens.WindowDocument),
+        c.resolve(tokens.IValidatedEventDispatcher)
+      )
+  );
+  logger.debug(`UI Registrations: Registered ${tokens.GlobalKeyHandler}.`);
+
+  registrar.singletonFactory(
     tokens.ProcessingIndicatorController,
     (c) =>
       new ProcessingIndicatorController({
@@ -411,6 +424,11 @@ export function registerUI(
   container.resolve(tokens.ActionResultRenderer);
   logger.debug(
     `UI Registrations: Eagerly instantiated ${tokens.ActionResultRenderer}.`
+  );
+
+  container.resolve(tokens.GlobalKeyHandler);
+  logger.debug(
+    `UI Registrations: Eagerly instantiated ${tokens.GlobalKeyHandler}.`
   );
 
   logger.debug('UI Registrations: Complete.');

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -113,6 +113,7 @@ import { freeze } from '../utils';
  * @property {DiToken} IActionDiscoveryService - Token for the action discovery system interface.
  * @property {DiToken} ITargetResolutionService - Token for the target resolution service interface.
  * @property {DiToken} IInputHandler - Token for handling player input interface.
+ * @property {DiToken} GlobalKeyHandler - Token for listening to global keyboard events.
  * @property {DiToken} ITurnOrderService - Token for the turn order management service interface.
  * @property {DiToken} ITurnManager - Token for the turn management service interface.
  * @property {DiToken} ITurnContext - Token for accessing context specific to the current turn. // <<< ENSURED THIS IS PRESENT AND NOT COMMENTED
@@ -263,6 +264,7 @@ export const tokens = freeze({
   ITargetResolutionService: 'ITargetResolutionService',
   ActionIndex: 'ActionIndex',
   IInputHandler: 'IInputHandler',
+  GlobalKeyHandler: 'GlobalKeyHandler',
   ITurnOrderService: 'ITurnOrderService',
   ITurnManager: 'ITurnManager',
   ITurnContext: 'ITurnContext',

--- a/src/input/globalKeyHandler.js
+++ b/src/input/globalKeyHandler.js
@@ -1,0 +1,74 @@
+/**
+ * @file GlobalKeyHandler class
+ * @description Listens to global keydown events and dispatches UI-related events.
+ */
+
+/** @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher */
+
+/**
+ * Handles global keyboard shortcuts and dispatches corresponding UI events.
+ */
+class GlobalKeyHandler {
+  /** @type {Document} */
+  #document;
+  /** @type {IValidatedEventDispatcher} */
+  #validatedEventDispatcher;
+  /** @type {(e: KeyboardEvent) => void} */
+  #boundListener;
+
+  /**
+   * @param {Document} document - The DOM document to listen on.
+   * @param {IValidatedEventDispatcher} validatedEventDispatcher - Dispatcher for UI events.
+   */
+  constructor(document, validatedEventDispatcher) {
+    if (!document || typeof document.addEventListener !== 'function') {
+      throw new Error('GlobalKeyHandler requires a valid Document.');
+    }
+    if (
+      !validatedEventDispatcher ||
+      typeof validatedEventDispatcher.dispatch !== 'function'
+    ) {
+      throw new Error(
+        'GlobalKeyHandler requires a valid IValidatedEventDispatcher instance.'
+      );
+    }
+
+    this.#document = document;
+    this.#validatedEventDispatcher = validatedEventDispatcher;
+
+    this.#boundListener = this.#handleKeyDown.bind(this);
+    this.#document.addEventListener('keydown', this.#boundListener);
+  }
+
+  /**
+   * Handles keydown events and dispatches matching UI events.
+   *
+   * @param {KeyboardEvent} event - The keydown event.
+   * @private
+   */
+  #handleKeyDown(event) {
+    if (
+      event.key.toLowerCase() === 'i' &&
+      !(event.target instanceof HTMLInputElement)
+    ) {
+      event.preventDefault();
+      this.#validatedEventDispatcher
+        .dispatch('ui:toggle_inventory', {})
+        .catch((err) =>
+          console.error(
+            "GlobalKeyHandler: Failed to dispatch 'ui:toggle_inventory'",
+            err
+          )
+        );
+    }
+  }
+
+  /**
+   * Removes listeners and cleans up resources.
+   */
+  dispose() {
+    this.#document.removeEventListener('keydown', this.#boundListener);
+  }
+}
+
+export default GlobalKeyHandler;

--- a/src/input/inputHandler.js
+++ b/src/input/inputHandler.js
@@ -79,7 +79,6 @@ class InputHandler extends IInputHandler {
       'keydown',
       this._handleInputKeyDown.bind(this)
     );
-    document.addEventListener('keydown', this._handleGlobalKeyDown.bind(this));
     if (this.#inputElement.form) {
       this.#inputElement.form.addEventListener('submit', (e) =>
         e.preventDefault()
@@ -130,25 +129,6 @@ class InputHandler extends IInputHandler {
       }
     }
     // Other non-Enter key specific logic for this input could remain if any.
-  }
-
-  /**
-   * Handles keydown events globally on the document (for UI toggles, etc.).
-   *
-   * @param {KeyboardEvent} event
-   * @private
-   */
-  _handleGlobalKeyDown(event) {
-    // Avoid capturing 'i' if typed into the input field itself
-    /*if (event.key.toLowerCase() === 'i' && event.target !== this.#inputElement) {
-            event.preventDefault();
-            console.log("InputHandler: Detected 'I' key press. Dispatching ui:toggle_inventory.");
-            // Use the new dispatcher
-            this.#validatedEventDispatcher.dispatch('ui:toggle_inventory', {})
-                .catch(err => console.error("InputHandler: Failed to dispatch 'ui:toggle_inventory'", err));
-        }
-        */
-    // Add other global key operationHandlers here
   }
 
   /**

--- a/tests/integration/bootstrap.test.js
+++ b/tests/integration/bootstrap.test.js
@@ -35,6 +35,7 @@ describe('Application Bootstrap Integration Test', () => {
         outputDiv: mockOutputDiv,
         inputElement: mockInputElement,
         titleElement: mockTitleElement,
+        document,
       });
     }).not.toThrow();
 
@@ -52,6 +53,7 @@ describe('Application Bootstrap Integration Test', () => {
       outputDiv: mockOutputDiv,
       inputElement: mockInputElement,
       titleElement: mockTitleElement,
+      document,
     });
 
     const allTokenKeys = Object.keys(tokens);
@@ -85,6 +87,7 @@ describe('Application Bootstrap Integration Test', () => {
       outputDiv: mockOutputDiv,
       inputElement: mockInputElement,
       titleElement: mockTitleElement,
+      document,
     });
 
     // --- Act & Assert ---
@@ -118,6 +121,7 @@ describe('Application Bootstrap Integration Test', () => {
       outputDiv: mockOutputDiv,
       inputElement: mockInputElement,
       titleElement: mockTitleElement, // Now passes the correct h1 element
+      document,
     });
 
     // Resolve the initializer *after* configuration

--- a/tests/unit/config/registrations/uiRegistrations.test.js
+++ b/tests/unit/config/registrations/uiRegistrations.test.js
@@ -118,6 +118,13 @@ describe('registerUI', () => {
     );
   });
 
+  it('should register GlobalKeyHandler via registrar.singletonFactory()', () => {
+    expect(mockSingletonFactory).toHaveBeenCalledWith(
+      tokens.GlobalKeyHandler,
+      expect.any(Function)
+    );
+  });
+
   it('should register all other UI components', () => {
     // Spot-check a few other key registrations to ensure they are still present
     expect(mockSingletonFactory).toHaveBeenCalledWith(
@@ -157,5 +164,9 @@ describe('registerUI', () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith(
       tokens.ChatAlertRenderer
     );
+  });
+
+  it('should eagerly instantiate GlobalKeyHandler', () => {
+    expect(mockContainer.resolve).toHaveBeenCalledWith(tokens.GlobalKeyHandler);
   });
 });

--- a/tests/unit/input/globalKeyHandler.test.js
+++ b/tests/unit/input/globalKeyHandler.test.js
@@ -1,0 +1,59 @@
+import {
+  describe,
+  beforeEach,
+  afterEach,
+  test,
+  expect,
+  jest,
+} from '@jest/globals';
+import GlobalKeyHandler from '../../../src/input/globalKeyHandler.js';
+import ValidatedEventDispatcher from '../../../src/events/validatedEventDispatcher.js';
+
+jest.mock('../../../src/events/validatedEventDispatcher.js');
+
+describe('GlobalKeyHandler', () => {
+  let document;
+  let ved;
+  let handler;
+
+  beforeEach(() => {
+    document = global.document;
+    document.body.innerHTML = '<div id="root"></div><input id="txt" />';
+    ved = new ValidatedEventDispatcher();
+    ved.dispatch = jest.fn(() => Promise.resolve(true));
+    handler = new GlobalKeyHandler(document, ved);
+  });
+
+  afterEach(() => {
+    handler.dispose();
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('constructor validates dependencies', () => {
+    expect(() => new GlobalKeyHandler(null, ved)).toThrow(
+      'GlobalKeyHandler requires a valid Document.'
+    );
+    expect(() => new GlobalKeyHandler(document, {})).toThrow(
+      'GlobalKeyHandler requires a valid IValidatedEventDispatcher instance.'
+    );
+  });
+
+  test("pressing 'i' outside inputs dispatches toggle event", () => {
+    const event = new window.KeyboardEvent('keydown', { key: 'i' });
+    Object.defineProperty(event, 'target', {
+      value: document.getElementById('root'),
+    });
+    document.dispatchEvent(event);
+    expect(ved.dispatch).toHaveBeenCalledWith('ui:toggle_inventory', {});
+  });
+
+  test("pressing 'i' inside input does not dispatch", () => {
+    const event = new window.KeyboardEvent('keydown', { key: 'i' });
+    Object.defineProperty(event, 'target', {
+      value: document.getElementById('txt'),
+    });
+    document.dispatchEvent(event);
+    expect(ved.dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add GlobalKeyHandler class listening for document keydown events
- register GlobalKeyHandler in DI container
- remove global key logic from InputHandler
- update dependency tokens and registrations
- test GlobalKeyHandler and update existing tests

## Testing Done
- `npm run lint` *(fails: 699 errors, 2623 warnings)*
- `npx eslint src/input/globalKeyHandler.js src/input/inputHandler.js tests/unit/input/globalKeyHandler.test.js tests/unit/config/registrations/uiRegistrations.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685eee9413888331ab1101f1dfc029e3