### PR TITLE
[Agent] handle llm adapter initialization failure

### DIFF
--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import { UI_SHOW_FATAL_ERROR_ID } from '../../../../src/constants/eventIds.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const WORLD = 'world';
@@ -42,7 +43,7 @@ beforeEach(() => {
 });
 
 describe('InitializationService LLM adapter rejection', () => {
-  it('continues when llmAdapter.init rejects', async () => {
+  it('fails when llmAdapter.init rejects', async () => {
     const error = new Error('adapter');
     llmAdapter.init.mockRejectedValueOnce(error);
 
@@ -73,6 +74,10 @@ describe('InitializationService LLM adapter rejection', () => {
       `InitializationService: CRITICAL error during ConfigurableLLMAdapter.init(): ${error.message}`,
       expect.objectContaining({ errorName: error.name })
     );
-    expect(result.success).toBe(true);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      UI_SHOW_FATAL_ERROR_ID,
+      expect.any(Object)
+    );
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- detect and handle LLM adapter initialization failure
- treat adapter init failures as fatal in initialization sequence
- adjust LLM adapter rejection test for new behaviour

## Testing Done
- `npm run lint` *(fails: 699 errors, 2623 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685eef9e216c8331b2f37ef7a2978088