### PR TITLE
[Feat] Engine state transition helper

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -17,6 +17,18 @@ class EngineState {
   }
 
   /**
+   * Marks the engine as initialized and running for the provided world.
+   *
+   * @param {string} worldName - Name of the active world.
+   * @returns {void}
+   */
+  setStarted(worldName) {
+    this.isInitialized = true;
+    this.isGameLoopRunning = true;
+    this.activeWorld = worldName;
+  }
+
+  /**
    * Resets all state flags back to their defaults.
    *
    * @returns {void}

--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -161,9 +161,7 @@ class GameEngine {
    * @returns {void}
    */
   #startEngine(worldName) {
-    this.#engineState.isInitialized = true;
-    this.#engineState.isGameLoopRunning = true;
-    this.#engineState.activeWorld = worldName;
+    this.#engineState.setStarted(worldName);
   }
 
   /**


### PR DESCRIPTION
Summary: Encapsulates engine state changes.

Changes Made:
- Added `setStarted` method on `EngineState` for explicit state transitions
- Updated `GameEngine` to use the new method

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685ef40a74108331a2553abfa09e5d4a