### PR TITLE
[Agent] Add dispatchWithLogging tests

### DIFF
--- a/tests/unit/utils/eventDispatchUtils.test.js
+++ b/tests/unit/utils/eventDispatchUtils.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { dispatchWithLogging } from '../../../src/utils/eventDispatchUtils.js';
+import { createMockLogger } from '../../common/mockFactories/loggerMocks.js';
+import * as loggerUtils from '../../../src/utils/loggerUtils.js';
+
+jest.mock('../../../src/utils/loggerUtils.js');
+
+describe('dispatchWithLogging', () => {
+  it('logs debug message on successful dispatch without identifier', async () => {
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const logger = createMockLogger();
+    loggerUtils.ensureValidLogger.mockReturnValue(logger);
+
+    await dispatchWithLogging(dispatcher, 'evt', { foo: 1 }, logger);
+
+    expect(loggerUtils.ensureValidLogger).toHaveBeenCalledWith(
+      logger,
+      'dispatchWithLogging'
+    );
+    expect(dispatcher.dispatch).toHaveBeenCalledWith('evt', { foo: 1 }, {});
+    expect(logger.debug).toHaveBeenCalledWith("Dispatched 'evt'.");
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs error message on failed dispatch with identifier and options', async () => {
+    const error = new Error('boom');
+    const dispatcher = { dispatch: jest.fn().mockRejectedValue(error) };
+    const logger = createMockLogger();
+    loggerUtils.ensureValidLogger.mockReturnValue(logger);
+    const options = { opt: true };
+
+    await dispatchWithLogging(
+      dispatcher,
+      'evt',
+      { bar: 2 },
+      logger,
+      'ID',
+      options
+    );
+
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      'evt',
+      { bar: 2 },
+      options
+    );
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed dispatching 'evt' event for ID.",
+      error
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added unit tests for the dispatchWithLogging utility covering success and error branches.

Changes Made:
- Created `eventDispatchUtils.test.js` to verify log output and option handling.

Testing Done:
- [x] Code formatted (`npx prettier tests/unit/utils/eventDispatchUtils.test.js -w`)
- [x] Lint passes on new file (`npx eslint tests/unit/utils/eventDispatchUtils.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685ef47b52f483318765608d52ab7602