### PR TITLE
[Agent] add helper for invalid input reporting

### DIFF
--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -97,4 +97,37 @@ describe('CommandOutcomeInterpreter additional branches', () => {
       "CommandOutcomeInterpreter: actor actor-1: result.actionResult.actionId ('undefined') invalid/missing. Using action identifier: 'core:unknown_action'."
     );
   });
+
+  it('dispatches error when turnContext is missing getActor', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    await expect(interpreter.interpret({}, {})).rejects.toThrow(
+      'CommandOutcomeInterpreter: Invalid turnContext provided.'
+    );
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'CommandOutcomeInterpreter: Invalid turnContext provided.',
+      expect.any(Object)
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'CommandOutcomeInterpreter: Invalid turnContext provided.',
+      expect.any(Object)
+    );
+  });
+
+  it('dispatches error when actor is invalid', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    turnContext.getActor.mockReturnValue({});
+    await expect(interpreter.interpret({}, turnContext)).rejects.toThrow(
+      'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+    );
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.',
+      expect.any(Object)
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.',
+      expect.any(Object)
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `#reportInvalidInput` helper on `CommandOutcomeInterpreter`
- refactor validation methods to use the new helper
- extend tests for new error reporting behavior

## Testing Done
- `npm run lint` *(fails: 703 errors, 2623 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ef62bbccc83318ffe7443fefa4e3e