### PR TITLE
[Agent] Inject logger and document into InputHandler

### DIFF
--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -377,7 +377,11 @@ export function registerLegacyInputHandler(registrar, logger) {
       new InputHandler(
         c.resolve(tokens.inputElement),
         undefined,
-        c.resolve(tokens.IValidatedEventDispatcher)
+        c.resolve(tokens.IValidatedEventDispatcher),
+        {
+          document: c.resolve(tokens.WindowDocument),
+          logger: c.resolve(tokens.ILogger),
+        }
       )
   );
   logger.debug(


### PR DESCRIPTION
## Summary
- inject document and logger dependencies into `InputHandler`
- use logger for warnings, errors and debug messages
- register legacy input handler with document and logger
- update tests for new constructor behavior

## Testing Done
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685ef61db7988331921abb2e689760a2