### PR TITLE
[Agent] unify logger and dispatcher helpers

### DIFF
--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -14,12 +14,7 @@
 
 import { ITurnState } from '../interfaces/ITurnState.js';
 import { UNKNOWN_ACTOR_ID } from '../../constants/unknownIds.js';
-import {
-  getLogger,
-  getSafeEventDispatcher,
-  resolveLogger,
-  resolveSafeDispatcher,
-} from './helpers/contextUtils.js';
+import { getLogger } from './helpers/contextUtils.js';
 import { validateContextMethods } from './helpers/validationUtils.js';
 
 /**
@@ -125,12 +120,12 @@ export class AbstractTurnState extends ITurnState {
     try {
       ctx = this._getTurnContext();
     } catch (err) {
-      resolveLogger(null, this._handler).error(err.message);
+      getLogger(null, this._handler).error(err.message);
       await this._resetToIdle(reason);
       return null;
     }
     if (!ctx) {
-      resolveLogger(null, this._handler).error(
+      getLogger(null, this._handler).error(
         `${this.getStateName()}: No ITurnContext available. Resetting to idle.`
       );
       await this._resetToIdle(reason);
@@ -162,7 +157,7 @@ export class AbstractTurnState extends ITurnState {
 
     const missing = validateContextMethods(ctx, requiredMethods);
     if (missing.length) {
-      const logger = resolveLogger(ctx, this._handler);
+      const logger = getLogger(ctx, this._handler);
       const msg = `${this.getStateName()}: ITurnContext missing required methods: ${missing.join(', ')}`;
       logger.error(msg);
 
@@ -182,7 +177,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async enterState(handler, previousState) {
     const turnCtx = this._getTurnContext();
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
 
     let actorIdForLog = 'N/A';
     if (turnCtx && typeof turnCtx.getActor === 'function') {
@@ -204,7 +199,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async exitState(handler, nextState) {
     const turnCtx = this._getTurnContext();
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
 
     let actorIdForLog = 'N/A';
     if (turnCtx && typeof turnCtx.getActor === 'function') {
@@ -226,7 +221,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async startTurn(handler, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const actorIdForLog = actorEntity?.id ?? UNKNOWN_ACTOR_ID;
     const warningMessage = `Method 'startTurn(actorId: ${actorIdForLog})' called on state ${this.getStateName()} where it is not expected or handled.`;
     logger.warn(warningMessage);
@@ -238,7 +233,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleSubmittedCommand(handler, commandString, actorEntity) {
     const turnCtx = this._getTurnContext();
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const contextActorId = turnCtx?.getActor()?.id ?? 'NO_CONTEXT_ACTOR';
     const errorMessage = `Method 'handleSubmittedCommand(command: "${commandString}", entity: ${actorEntity?.id}, contextActor: ${contextActorId})' must be implemented by concrete state ${this.getStateName()}.`;
     logger.error(errorMessage);
@@ -248,7 +243,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleTurnEndedEvent(handler, payload) {
     const turnCtx = this._getTurnContext();
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const warningMessage = `Method 'handleTurnEndedEvent(payloadActorId: ${payload?.entityId})' called on state ${this.getStateName()} where it might not be expected or handled. Current context actor: ${turnCtx?.getActor()?.id ?? 'N/A'}.`;
     logger.warn(warningMessage);
   }
@@ -256,7 +251,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async processCommandResult(handler, actor, cmdProcResult, commandString) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();
     if (actor.id !== contextActor?.id) {
       logger.warn(
@@ -271,7 +266,7 @@ export class AbstractTurnState extends ITurnState {
   /** @override */
   async handleDirective(handler, actor, directive, cmdProcResult) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
-    const logger = resolveLogger(turnCtx, handler);
+    const logger = getLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();
     if (actor.id !== contextActor?.id) {
       logger.warn(

--- a/src/turns/states/helpers/commandProcessingWorkflow.js
+++ b/src/turns/states/helpers/commandProcessingWorkflow.js
@@ -20,7 +20,7 @@ import {
 } from './getServiceFromContext.js';
 import { ProcessingExceptionHandler } from './processingExceptionHandler.js';
 import { finishProcessing } from './processingErrorUtils.js';
-import { resolveLogger } from './contextUtils.js';
+import { getLogger } from './contextUtils.js';
 
 /**
  * @class CommandProcessingWorkflow
@@ -73,7 +73,7 @@ export class CommandProcessingWorkflow {
     // Use the state's own robust logger resolution for the default handler.
     this._exceptionHandler =
       exceptionHandler ||
-      new ProcessingExceptionHandler(resolveLogger(null, this._state._handler));
+      new ProcessingExceptionHandler(getLogger(null, this._state._handler));
   }
 
   /**

--- a/src/turns/states/helpers/contextUtils.js
+++ b/src/turns/states/helpers/contextUtils.js
@@ -10,7 +10,7 @@
  */
 
 /**
- * Resolves a logger using the provided context or handler.
+ * Retrieves a logger from the given turn context or handler.
  * Falls back to the console when unavailable.
  *
  * @param {ITurnContext|null} turnContext - The current ITurnContext, if any.
@@ -50,8 +50,8 @@ export function getLogger(turnContext, handler) {
 }
 
 /**
- * Safely resolves a SafeEventDispatcher using the provided context or handler.
- * Falls back to handler.getSafeEventDispatcher() when necessary.
+ * Retrieves a SafeEventDispatcher from the given context or handler.
+ * Falls back to `handler.getSafeEventDispatcher()` when necessary.
  *
  * @param {ITurnContext|null} turnContext - The current ITurnContext, if any.
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
@@ -104,9 +104,12 @@ export function getSafeEventDispatcher(turnContext, handler) {
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
  * @returns {Logger} The resolved logger.
  */
-export function resolveLogger(turnContext, handler) {
-  return getLogger(turnContext, handler);
-}
+/**
+ * Backwards compatible alias for {@link getLogger}.
+ *
+ * @deprecated Use {@link getLogger} instead.
+ */
+export const resolveLogger = getLogger;
 
 /**
  * Safely resolves a SafeEventDispatcher using the provided context or handler.
@@ -117,6 +120,9 @@ export function resolveLogger(turnContext, handler) {
  * @param {BaseTurnHandler} [handler] - Optional handler fallback.
  * @returns {ISafeEventDispatcher|null} The resolved dispatcher or null.
  */
-export function resolveSafeDispatcher(turnContext, handler) {
-  return getSafeEventDispatcher(turnContext, handler);
-}
+/**
+ * Backwards compatible alias for {@link getSafeEventDispatcher}.
+ *
+ * @deprecated Use {@link getSafeEventDispatcher} instead.
+ */
+export const resolveSafeDispatcher = getSafeEventDispatcher;

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -22,11 +22,7 @@ import { ProcessingExceptionHandler } from './helpers/processingExceptionHandler
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
-import {
-  getLogger,
-  getSafeEventDispatcher,
-  resolveLogger,
-} from './helpers/contextUtils.js';
+import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 import turnDirectiveResolverAdapter from '../adapters/turnDirectiveResolverAdapter.js';
 import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js';
 import {
@@ -115,7 +111,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @throws {Error}
    */
   _throwConstructionError(message) {
-    const logger = resolveLogger(null, this._handler);
+    const logger = getLogger(null, this._handler);
     const fullMessage = `${this.getStateName()} Constructor: ${message}`;
     logger.error(fullMessage);
     throw new Error(fullMessage);
@@ -193,7 +189,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @description Logs information about the state's construction.
    */
   _logConstruction() {
-    const logger = resolveLogger(null, this._handler);
+    const logger = getLogger(null, this._handler);
     // Use #commandStringForLog and #turnActionToProcess which are set in the constructor
     const commandStringForLog = this.#commandStringForLog;
     const turnActionIdForLog = this.#turnActionToProcess?.actionDefinitionId;

--- a/tests/unit/turns/states/abstractTurnState.test.js
+++ b/tests/unit/turns/states/abstractTurnState.test.js
@@ -1,8 +1,8 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { AbstractTurnState } from '../../../../src/turns/states/abstractTurnState.js';
 import {
-  resolveLogger,
-  resolveSafeDispatcher,
+  getLogger,
+  getSafeEventDispatcher,
 } from '../../../../src/turns/states/helpers/contextUtils.js';
 
 class TestState extends AbstractTurnState {}
@@ -28,7 +28,7 @@ const makeInvalidHandler = (logger = makeLogger()) => ({
   requestIdleStateTransition: jest.fn().mockResolvedValue(undefined),
 });
 
-describe('resolveLogger helper', () => {
+describe('getLogger helper', () => {
   let logger;
   let handler;
 
@@ -44,7 +44,7 @@ describe('resolveLogger helper', () => {
     const consoleSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    const result = resolveLogger(ctx, handler);
+    const result = getLogger(ctx, handler);
     expect(result).toBe(ctxLogger);
     expect(ctx.getLogger).toHaveBeenCalled();
     expect(consoleSpy).not.toHaveBeenCalled();
@@ -60,7 +60,7 @@ describe('resolveLogger helper', () => {
     const consoleSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    const result = resolveLogger(ctx, handler);
+    const result = getLogger(ctx, handler);
     expect(result).toBe(logger);
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(consoleSpy.mock.calls[0][0]).toMatch(
@@ -81,7 +81,7 @@ describe('resolveLogger helper', () => {
     const consoleSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    const result = resolveLogger(ctx, handler);
+    const result = getLogger(ctx, handler);
     expect(result).toBe(console);
     expect(consoleSpy).toHaveBeenCalledTimes(2);
     expect(consoleSpy.mock.calls[1][0]).toMatch(
@@ -91,7 +91,7 @@ describe('resolveLogger helper', () => {
   });
 });
 
-describe('resolveSafeDispatcher helper', () => {
+describe('getSafeEventDispatcher helper', () => {
   let logger;
   let handler;
 
@@ -107,7 +107,7 @@ describe('resolveSafeDispatcher helper', () => {
       getLogger: jest.fn(() => logger),
       getSafeEventDispatcher: jest.fn(() => dispatcher),
     };
-    const result = resolveSafeDispatcher(ctx, handler);
+    const result = getSafeEventDispatcher(ctx, handler);
     expect(result).toBe(dispatcher);
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
@@ -121,7 +121,7 @@ describe('resolveSafeDispatcher helper', () => {
       getLogger: jest.fn(() => logger),
       getSafeEventDispatcher: jest.fn(() => null),
     };
-    const result = resolveSafeDispatcher(ctx, handler);
+    const result = getSafeEventDispatcher(ctx, handler);
     expect(result).toBe(dispatcher);
     expect(handler.getSafeEventDispatcher).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -137,7 +137,7 @@ describe('resolveSafeDispatcher helper', () => {
         throw new Error('boom');
       }),
     };
-    const result = resolveSafeDispatcher(ctx, handler);
+    const result = getSafeEventDispatcher(ctx, handler);
     expect(result).toBe(dispatcher);
     expect(handler.getSafeEventDispatcher).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledTimes(1);
@@ -149,7 +149,7 @@ describe('resolveSafeDispatcher helper', () => {
       getLogger: jest.fn(() => logger),
       getSafeEventDispatcher: jest.fn(() => null),
     };
-    const result = resolveSafeDispatcher(ctx, handler);
+    const result = getSafeEventDispatcher(ctx, handler);
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn.mock.calls[0][0]).toMatch(/unavailable/);


### PR DESCRIPTION
Summary: Simplified logger/dispatcher helpers for turn states. `resolveLogger`/`resolveSafeDispatcher` are now deprecated aliases for `getLogger` and `getSafeEventDispatcher`. Updated imports and tests accordingly.

Testing Done:
- [x] Code formatted (`npx prettier` on modified files)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_685ef6506204833180a68684bc5bf479