### PR TITLE
[Agent] Refactor initialization service config

### DIFF
--- a/src/dependencyInjection/registrations/orchestrationRegistrations.js
+++ b/src/dependencyInjection/registrations/orchestrationRegistrations.js
@@ -83,23 +83,25 @@ export function registerOrchestration(container) {
     });
     const spatialIndexManager = c.resolve(tokens.ISpatialIndexManager);
     return new InitializationService({
-      logger: initLogger,
-      validatedEventDispatcher: initDispatcher,
-      modsLoader,
-      scopeRegistry,
-      dataRegistry,
-      llmAdapter,
-      llmConfigLoader,
-      systemInitializer,
-      worldInitializer,
-      safeEventDispatcher,
-      entityManager,
-      domUiFacade,
-      actionIndex,
-      gameDataRepository,
-      thoughtListener,
-      notesListener,
-      spatialIndexManager,
+      log: { logger: initLogger },
+      events: { validatedEventDispatcher: initDispatcher, safeEventDispatcher },
+      llm: { llmAdapter, llmConfigLoader },
+      persistence: {
+        entityManager,
+        domUiFacade,
+        actionIndex,
+        gameDataRepository,
+        thoughtListener,
+        notesListener,
+        spatialIndexManager,
+      },
+      coreSystems: {
+        modsLoader,
+        scopeRegistry,
+        dataRegistry,
+        systemInitializer,
+        worldInitializer,
+      },
     });
   });
   logger.debug(

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -63,45 +63,42 @@ class InitializationService extends IInitializationService {
   /**
    * Creates a new InitializationService instance.
    *
-   * @param {object} deps
-   * @param {ILogger} deps.logger
-   * @param {IValidatedEventDispatcher} deps.validatedEventDispatcher
-   * @param {IModsLoader} deps.modsLoader
-   * @param {import('../../interfaces/IScopeRegistry.js').IScopeRegistry} dependencies.scopeRegistry - Registry of scopes.
-   * @param {import('../../data/inMemoryDataRegistry.js').DataRegistry} dependencies.dataRegistry - Data registry instance.
-   * @param {import('../../turns/interfaces/ILLMAdapter.js').ILLMAdapter & {init?: Function, isInitialized?: Function, isOperational?: Function}} dependencies.llmAdapter - LLM adapter instance.
-   * @param {LlmConfigLoader} dependencies.llmConfigLoader - Loader for LLM configuration.
-   * @param {SystemInitializer} dependencies.systemInitializer - Initializes tagged systems.
-   * @param {WorldInitializer} dependencies.worldInitializer - Initializes the game world.
-   * @param {ISafeEventDispatcher} dependencies.safeEventDispatcher - Event dispatcher for safe events.
-   * @param {IEntityManager} dependencies.entityManager - Entity manager instance.
-   * @param {import('../../domUI/domUiFacade.js').DomUiFacade} dependencies.domUiFacade - UI facade instance.
-   * @param {ActionIndex} dependencies.actionIndex - Action index for optimized action discovery.
-   * @param {import('../../interfaces/IGameDataRepository.js').IGameDataRepository} dependencies.gameDataRepository - Game data repository instance.
-   * @param {IThoughtListener} deps.thoughtListener
-   * @param {INotesListener} deps.notesListener
-   * @param {ISpatialIndexManager} deps.spatialIndexManager
+   * @param {object} config - Grouped dependencies.
+   * @param {{ logger: ILogger }} config.log - Logging utilities.
+   * @param {{ validatedEventDispatcher: IValidatedEventDispatcher, safeEventDispatcher: ISafeEventDispatcher }} config.events - Event dispatchers.
+   * @param {{ llmAdapter: import('../../turns/interfaces/ILLMAdapter.js').ILLMAdapter & {init?: Function, isInitialized?: Function, isOperational?: Function}, llmConfigLoader: LlmConfigLoader }} config.llm - LLM services.
+   * @param {{
+   *   entityManager: IEntityManager,
+   *   domUiFacade: import('../../domUI/domUiFacade.js').DomUiFacade,
+   *   actionIndex: ActionIndex,
+   *   gameDataRepository: import('../../interfaces/IGameDataRepository.js').IGameDataRepository,
+   *   thoughtListener: IThoughtListener,
+   *   notesListener: INotesListener,
+   *   spatialIndexManager: ISpatialIndexManager,
+   * }} config.persistence - Persistence related services.
+   * @param {{
+   *   modsLoader: IModsLoader,
+   *   scopeRegistry: import('../../interfaces/IScopeRegistry.js').IScopeRegistry,
+   *   dataRegistry: import('../../data/inMemoryDataRegistry.js').DataRegistry,
+   *   systemInitializer: SystemInitializer,
+   *   worldInitializer: WorldInitializer,
+   * }} config.coreSystems - Core engine systems.
    * @description Initializes the complete game system.
    */
-  constructor({
-    logger,
-    validatedEventDispatcher,
-    modsLoader,
-    scopeRegistry,
-    dataRegistry,
-    llmAdapter,
-    llmConfigLoader,
-    systemInitializer,
-    worldInitializer,
-    safeEventDispatcher,
-    entityManager,
-    domUiFacade,
-    actionIndex,
-    gameDataRepository,
-    thoughtListener,
-    notesListener,
-    spatialIndexManager,
-  }) {
+  constructor({ log = {}, events = {}, llm = {}, persistence = {}, coreSystems = {} } = {}) {
+    const { logger } = log;
+    const { validatedEventDispatcher, safeEventDispatcher } = events;
+    const { llmAdapter, llmConfigLoader } = llm;
+    const {
+      entityManager,
+      domUiFacade,
+      actionIndex,
+      gameDataRepository,
+      thoughtListener,
+      notesListener,
+      spatialIndexManager,
+    } = persistence;
+    const { modsLoader, scopeRegistry, dataRegistry, systemInitializer, worldInitializer } = coreSystems;
     super();
 
     assertMethods(

--- a/tests/unit/initializers/services/initializationService.constructor.test.js
+++ b/tests/unit/initializers/services/initializationService.constructor.test.js
@@ -42,19 +42,12 @@ beforeEach(() => {
 
 describe('InitializationService constructor', () => {
   it('creates instance with valid dependencies', () => {
-    expect(
-      () =>
-        new InitializationService({
-          logger,
-          validatedEventDispatcher: dispatcher,
-          modsLoader,
-          scopeRegistry,
-          dataRegistry,
-          llmAdapter,
-          llmConfigLoader,
-          systemInitializer,
-          worldInitializer,
-          safeEventDispatcher,
+    expect(() =>
+      new InitializationService({
+        log: { logger },
+        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
           entityManager,
           domUiFacade,
           actionIndex,
@@ -62,29 +55,39 @@ describe('InitializationService constructor', () => {
           thoughtListener,
           notesListener,
           spatialIndexManager,
-        })
+        },
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+        },
+      })
     ).not.toThrow();
   });
 
   it('throws if logger is missing', () => {
     const create = () =>
       new InitializationService({
-        validatedEventDispatcher: dispatcher,
-        modsLoader,
-        scopeRegistry,
-        dataRegistry,
-        llmAdapter,
-        llmConfigLoader,
-        systemInitializer,
-        worldInitializer,
-        safeEventDispatcher,
-        entityManager,
-        domUiFacade,
-        actionIndex,
-        gameDataRepository,
-        thoughtListener,
-        notesListener,
-        spatialIndexManager,
+        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
+          entityManager,
+          domUiFacade,
+          actionIndex,
+          gameDataRepository,
+          thoughtListener,
+          notesListener,
+          spatialIndexManager,
+        },
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+        },
       });
     expect(create).toThrow(SystemInitializationError);
     expect(create).toThrow(/logger/);
@@ -93,22 +96,25 @@ describe('InitializationService constructor', () => {
   it('throws if validatedEventDispatcher is missing', () => {
     const createVD = () =>
       new InitializationService({
-        logger,
-        modsLoader,
-        scopeRegistry,
-        dataRegistry,
-        llmAdapter,
-        llmConfigLoader,
-        systemInitializer,
-        worldInitializer,
-        safeEventDispatcher,
-        entityManager,
-        domUiFacade,
-        actionIndex,
-        gameDataRepository,
-        thoughtListener,
-        notesListener,
-        spatialIndexManager,
+        log: { logger },
+        events: { safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
+          entityManager,
+          domUiFacade,
+          actionIndex,
+          gameDataRepository,
+          thoughtListener,
+          notesListener,
+          spatialIndexManager,
+        },
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+        },
       });
     expect(createVD).toThrow(SystemInitializationError);
     expect(createVD).toThrow(/validatedEventDispatcher/);

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -44,46 +44,51 @@ describe('InitializationService DomUiFacade handling', () => {
   it('throws when DomUiFacade is missing', () => {
     expect(() => {
       const svc = new InitializationService({
-        logger,
-        validatedEventDispatcher: dispatcher,
-        modsLoader,
-        scopeRegistry,
-        dataRegistry,
-        llmAdapter,
-        llmConfigLoader,
-        systemInitializer,
-        worldInitializer,
-        safeEventDispatcher,
-        entityManager,
-        actionIndex: { buildIndex: jest.fn() },
-        gameDataRepository: {
-          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        log: { logger },
+        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
+          entityManager,
+          actionIndex: { buildIndex: jest.fn() },
+          gameDataRepository: {
+            getAllActionDefinitions: jest.fn().mockReturnValue([]),
+          },
+          thoughtListener,
+          notesListener,
+          // domUiFacade omitted
         },
-        thoughtListener,
-        notesListener,
-        // domUiFacade: domUiFacade, // Intentionally omitted
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+          // spatialIndexManager intentionally missing for this test
+        },
       });
     }).toThrow(SystemInitializationError);
     expect(() => {
       const svc = new InitializationService({
-        logger,
-        validatedEventDispatcher: dispatcher,
-        modsLoader,
-        scopeRegistry,
-        dataRegistry,
-        llmAdapter,
-        llmConfigLoader,
-        systemInitializer,
-        worldInitializer,
-        safeEventDispatcher,
-        entityManager,
-        actionIndex: { buildIndex: jest.fn() },
-        gameDataRepository: {
-          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        log: { logger },
+        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
+          entityManager,
+          actionIndex: { buildIndex: jest.fn() },
+          gameDataRepository: {
+            getAllActionDefinitions: jest.fn().mockReturnValue([]),
+          },
+          thoughtListener,
+          notesListener,
+          // domUiFacade omitted
         },
-        thoughtListener,
-        notesListener,
-        // domUiFacade: domUiFacade, // Intentionally omitted
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+        },
       });
     }).toThrow('InitializationService requires a domUiFacade dependency');
   });

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -39,25 +39,27 @@ describe('InitializationService invalid world name handling', () => {
     'returns failure for %p',
     async (bad) => {
       const service = new InitializationService({
-        logger,
-        validatedEventDispatcher: dispatcher,
-        modsLoader,
-        scopeRegistry,
-        dataRegistry,
-        llmAdapter,
-        llmConfigLoader,
-        systemInitializer,
-        worldInitializer,
-        safeEventDispatcher,
-        entityManager,
-        domUiFacade,
-        actionIndex: { buildIndex: jest.fn() },
-        gameDataRepository: {
-          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        log: { logger },
+        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+        llm: { llmAdapter, llmConfigLoader },
+        persistence: {
+          entityManager,
+          domUiFacade,
+          actionIndex: { buildIndex: jest.fn() },
+          gameDataRepository: {
+            getAllActionDefinitions: jest.fn().mockReturnValue([]),
+          },
+          thoughtListener,
+          notesListener,
+          spatialIndexManager: { buildIndex: jest.fn() },
         },
-        thoughtListener,
-        notesListener,
-        spatialIndexManager: { buildIndex: jest.fn() },
+        coreSystems: {
+          modsLoader,
+          scopeRegistry,
+          dataRegistry,
+          systemInitializer,
+          worldInitializer,
+        },
       });
 
       const result = await service.runInitializationSequence(bad);

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -48,25 +48,27 @@ describe('InitializationService LLM adapter rejection', () => {
     llmAdapter.init.mockRejectedValueOnce(error);
 
     const svc = new InitializationService({
-      logger,
-      validatedEventDispatcher: dispatcher,
-      modsLoader,
-      scopeRegistry,
-      dataRegistry,
-      llmAdapter,
-      llmConfigLoader,
-      systemInitializer,
-      worldInitializer,
-      safeEventDispatcher,
-      entityManager,
-      domUiFacade,
-      actionIndex: { buildIndex: jest.fn() },
-      gameDataRepository: {
-        getAllActionDefinitions: jest.fn().mockReturnValue([]),
+      log: { logger },
+      events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+      llm: { llmAdapter, llmConfigLoader },
+      persistence: {
+        entityManager,
+        domUiFacade,
+        actionIndex: { buildIndex: jest.fn() },
+        gameDataRepository: {
+          getAllActionDefinitions: jest.fn().mockReturnValue([]),
+        },
+        thoughtListener,
+        notesListener,
+        spatialIndexManager: { buildIndex: jest.fn() },
       },
-      thoughtListener,
-      notesListener,
-      spatialIndexManager: { buildIndex: jest.fn() },
+      coreSystems: {
+        modsLoader,
+        scopeRegistry,
+        dataRegistry,
+        systemInitializer,
+        worldInitializer,
+      },
     });
 
     const result = await svc.runInitializationSequence(WORLD);

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -56,23 +56,25 @@ beforeEach(() => {
 describe('InitializationService success path', () => {
   it('runs the initialization sequence successfully', async () => {
     const service = new InitializationService({
-      logger,
-      validatedEventDispatcher: dispatcher,
-      modsLoader,
-      scopeRegistry,
-      dataRegistry,
-      llmAdapter,
-      llmConfigLoader,
-      systemInitializer,
-      worldInitializer,
-      safeEventDispatcher,
-      entityManager,
-      domUiFacade,
-      actionIndex,
-      gameDataRepository,
-      thoughtListener,
-      notesListener,
-      spatialIndexManager: { buildIndex: jest.fn() },
+      log: { logger },
+      events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+      llm: { llmAdapter, llmConfigLoader },
+      persistence: {
+        entityManager,
+        domUiFacade,
+        actionIndex,
+        gameDataRepository,
+        thoughtListener,
+        notesListener,
+        spatialIndexManager: { buildIndex: jest.fn() },
+      },
+      coreSystems: {
+        modsLoader,
+        scopeRegistry,
+        dataRegistry,
+        systemInitializer,
+        worldInitializer,
+      },
     });
 
     const result = await service.runInitializationSequence(MOCK_WORLD);


### PR DESCRIPTION
Summary: Refactored `InitializationService` to take grouped configuration objects and updated all usages and tests accordingly.

Changes Made:
- Updated constructor to accept `{log, events, llm, persistence, coreSystems}`
- Adjusted orchestration registration to build new config
- Modified unit tests to use new grouped config structure

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685ef69e451083319d4f8a3f3ba34f6d