### PR TITLE
Implement depth guard utility for stateless depth checking

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(npm run test:*)",
       "Bash(npx jest:*)",
       "Bash(./node_modules/.bin/eslint src/logic/operationHandlers/modifyContextArrayHandler.js)",
-      "Bash(npm run format:*)"
+      "Bash(npm run format:*)",
+      "Bash(rg:*)"
     ],
     "deny": []
   }

--- a/src/scopeDsl/core/depthGuard.js
+++ b/src/scopeDsl/core/depthGuard.js
@@ -1,0 +1,21 @@
+import ScopeDepthError from '../../errors/scopeDepthError.js';
+
+/**
+ * Creates a depth guard that ensures expression depth does not exceed the specified maximum
+ *
+ * @param {number} maxDepth - The maximum allowed depth
+ * @returns {{ensure: Function}} Object with ensure method for depth validation
+ */
+export default function createDepthGuard(maxDepth) {
+  return {
+    ensure(level) {
+      if (level > maxDepth) {
+        throw new ScopeDepthError(
+          `Depth ${level} exceeds ${maxDepth}`,
+          level,
+          maxDepth
+        );
+      }
+    }
+  };
+}

--- a/tests/unit/scopeDsl/core/depthGuard.test.js
+++ b/tests/unit/scopeDsl/core/depthGuard.test.js
@@ -1,0 +1,56 @@
+import createDepthGuard from '../../../../src/scopeDsl/core/depthGuard.js';
+import ScopeDepthError from '../../../../src/errors/scopeDepthError.js';
+
+describe('depthGuard', () => {
+  describe('ensure', () => {
+    it('does not throw when level is less than max', () => {
+      const guard = createDepthGuard(4);
+      
+      expect(() => guard.ensure(0)).not.toThrow();
+      expect(() => guard.ensure(1)).not.toThrow();
+      expect(() => guard.ensure(3)).not.toThrow();
+    });
+
+    it('does not throw when level equals max', () => {
+      const guard = createDepthGuard(4);
+      
+      expect(() => guard.ensure(4)).not.toThrow();
+    });
+
+    it('throws ScopeDepthError when level exceeds max', () => {
+      const guard = createDepthGuard(4);
+      
+      expect(() => guard.ensure(5)).toThrow(ScopeDepthError);
+    });
+
+    it('throws error with correct message and properties', () => {
+      const guard = createDepthGuard(4);
+      
+      try {
+        guard.ensure(5);
+        fail('Expected ScopeDepthError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ScopeDepthError);
+        expect(error.message).toBe('Depth 5 exceeds 4');
+        expect(error.depth).toBe(5);
+        expect(error.maxDepth).toBe(4);
+      }
+    });
+
+    it('works with different max depth values', () => {
+      const guard1 = createDepthGuard(1);
+      expect(() => guard1.ensure(1)).not.toThrow();
+      expect(() => guard1.ensure(2)).toThrow(ScopeDepthError);
+
+      const guard10 = createDepthGuard(10);
+      expect(() => guard10.ensure(10)).not.toThrow();
+      expect(() => guard10.ensure(11)).toThrow(ScopeDepthError);
+    });
+
+    it('handles edge case of max depth 0', () => {
+      const guard = createDepthGuard(0);
+      expect(() => guard.ensure(0)).not.toThrow();
+      expect(() => guard.ensure(1)).toThrow(ScopeDepthError);
+    });
+  });
+});

--- a/ticket.txt
+++ b/ticket.txt
@@ -1,12 +1,35 @@
-1. In `src/logic/operationHandlers/modifyArrayFieldHandler.js`, extract:
+-03 Depth Guard Utility
+Goal – Extract stateless depth checking.
 
-   * `validateParams()` – return normalized params or `null`.
-   * `fetchTargetArray()` (existing) – keep.
-   * `applyModification()` (existing) – keep.
-   * `commitChanges()` (existing) – keep.
-   * Update `execute` to orchestrate these helpers with early returns.
-2. Repeat in `modifyContextArrayHandler.js`:
+Files
 
-   * Create `validateParams()` and `resolveArray()` helpers.
-   * Keep or refactor existing modification logic into reusable functions.
-3. Ensure all extracted helpers are private and covered by unit tests.
+scopeDsl/core/depthGuard.js
+
+tests/unit/scopeDsl/core/depthGuard.test.js
+
+Implementation
+
+import ScopeDepthError from '../../errors/scopeDepthError.js';
+export default function createDepthGuard(maxDepth) {
+return {
+ensure(level) {
+if (level > maxDepth) {
+throw new ScopeDepthError(
+Depth ${level} exceeds ${maxDepth}, level, maxDepth
+);
+}
+}
+};
+}
+
+Tests
+
+ensure does not throw when level ≤ max.
+
+Throws exact error instance when level > max.
+
+Acceptance
+
+Utility has 100 % statement coverage.
+
+No change in public behaviour (engine still uses inline checks for now).


### PR DESCRIPTION
- Added `createDepthGuard` function to enforce maximum depth constraints.
- Introduced unit tests to ensure functionality and error handling.
- Updated local settings to include new test command for depth guard utility.