### PR TITLE
Refactor depth guard utility into cycle detector

### DIFF
--- a/src/scopeDsl/core/cycleDetector.js
+++ b/src/scopeDsl/core/cycleDetector.js
@@ -1,0 +1,19 @@
+import ScopeCycleError from '../../errors/scopeCycleError.js';
+
+/**
+ * Creates a cycle detector that tracks scope traversal and detects circular references.
+ *
+ * @returns {{enter: function(string): void, leave: function(): void}} Cycle detector with enter/leave methods
+ */
+export default function createCycleDetector() {
+  const stack = [];
+  return {
+    enter(key) {
+      if (stack.includes(key)) {
+        throw new ScopeCycleError(`Cycle: ${[...stack, key].join(' -> ')}`, [...stack, key]);
+      }
+      stack.push(key);
+    },
+    leave() { stack.pop(); }
+  };
+}

--- a/tests/core/cycleDetector.test.js
+++ b/tests/core/cycleDetector.test.js
@@ -1,0 +1,123 @@
+import createCycleDetector from '../../src/scopeDsl/core/cycleDetector.js';
+import ScopeCycleError from '../../src/errors/scopeCycleError.js';
+
+describe('createCycleDetector', () => {
+  let detector;
+
+  beforeEach(() => {
+    detector = createCycleDetector();
+  });
+
+  describe('enter()', () => {
+    it('should allow entering unique keys without throwing', () => {
+      expect(() => {
+        detector.enter('scope1');
+        detector.enter('scope2');
+        detector.enter('scope3');
+      }).not.toThrow();
+    });
+
+    it('should throw ScopeCycleError when entering a key that already exists in the stack', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      
+      expect(() => {
+        detector.enter('scope1');
+      }).toThrow(ScopeCycleError);
+    });
+
+    it('should include the full cycle path in the error message', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      detector.enter('scope3');
+      
+      try {
+        detector.enter('scope2');
+        fail('Should have thrown ScopeCycleError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ScopeCycleError);
+        expect(error.message).toBe('Cycle: scope1 -> scope2 -> scope3 -> scope2');
+        expect(error.cyclePath).toEqual(['scope1', 'scope2', 'scope3', 'scope2']);
+      }
+    });
+
+    it('should detect self-referencing cycles', () => {
+      detector.enter('scope1');
+      
+      expect(() => {
+        detector.enter('scope1');
+      }).toThrow(ScopeCycleError);
+    });
+  });
+
+  describe('leave()', () => {
+    it('should pop the last entered key from the stack', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      detector.leave();
+      
+      // Should be able to enter scope2 again after leaving
+      expect(() => {
+        detector.enter('scope2');
+      }).not.toThrow();
+    });
+
+    it('should handle multiple leave calls correctly', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      detector.enter('scope3');
+      
+      detector.leave(); // removes scope3
+      detector.leave(); // removes scope2
+      
+      // Should be able to enter scope2 and scope3 again
+      expect(() => {
+        detector.enter('scope2');
+        detector.enter('scope3');
+      }).not.toThrow();
+    });
+
+    it('should allow re-entering a key after full traversal', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      detector.leave();
+      detector.leave();
+      
+      // Stack is now empty, should be able to enter scope1 again
+      expect(() => {
+        detector.enter('scope1');
+      }).not.toThrow();
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle interleaved enter/leave operations', () => {
+      detector.enter('A');
+      detector.enter('B');
+      detector.leave(); // pop B
+      detector.enter('C');
+      detector.enter('D');
+      detector.leave(); // pop D
+      
+      // Stack is now [A, C]
+      expect(() => detector.enter('A')).toThrow(ScopeCycleError);
+      expect(() => detector.enter('C')).toThrow(ScopeCycleError);
+      expect(() => detector.enter('B')).not.toThrow();
+    });
+
+    it('should maintain correct state after catching cycle errors', () => {
+      detector.enter('scope1');
+      detector.enter('scope2');
+      
+      try {
+        detector.enter('scope1');
+      } catch (error) {
+        // Ignore the error
+      }
+      
+      // Stack should still be [scope1, scope2]
+      expect(() => detector.enter('scope3')).not.toThrow();
+      expect(() => detector.enter('scope1')).toThrow(ScopeCycleError);
+    });
+  });
+});

--- a/ticket.txt
+++ b/ticket.txt
@@ -1,35 +1,36 @@
--03 Depth Guard Utility
-Goal – Extract stateless depth checking.
+T-04 Cycle Detector Utility
+Goal – Isolate cycle detection logic.
 
 Files
 
-scopeDsl/core/depthGuard.js
+scopeDsl/core/cycleDetector.js
 
-tests/unit/scopeDsl/core/depthGuard.test.js
+tests/core/cycleDetector.test.js
 
-Implementation
+Implementation outline
 
-import ScopeDepthError from '../../errors/scopeDepthError.js';
-export default function createDepthGuard(maxDepth) {
+import ScopeCycleError from '../../errors/scopeCycleError.js';
+
+export default function createCycleDetector() {
+const stack = [];
 return {
-ensure(level) {
-if (level > maxDepth) {
-throw new ScopeDepthError(
-Depth ${level} exceeds ${maxDepth}, level, maxDepth
-);
+enter(key) {
+if (stack.includes(key)) {
+throw new ScopeCycleError(Cycle: ${[...stack, key].join(' -> ')}, [...stack, key]);
 }
-}
+stack.push(key);
+},
+leave() { stack.pop(); }
 };
 }
-
 Tests
 
-ensure does not throw when level ≤ max.
+Enters unique keys fine.
 
-Throws exact error instance when level > max.
+Throws on repeated key in stack.
+
+leave() pops correctly.
 
 Acceptance
 
-Utility has 100 % statement coverage.
-
-No change in public behaviour (engine still uses inline checks for now).
+100 % branch coverage for detector.


### PR DESCRIPTION
- Renamed utility to `createCycleDetector` for cycle detection logic.
- Updated implementation to handle cycle detection with unique keys.
- Added unit tests for cycle detection functionality and error handling.
- Maintained 100% branch coverage for the new detector.