### PR TITLE
[Feat] centralize turn action handling

### DIFF
--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -54,6 +54,16 @@ export class ProcessingCommandState extends AbstractTurnState {
   _processingWorkflowFactory;
 
   /**
+   * @description Updates the turn action to process.
+   * @private
+   * @param {ITurnAction|null} action - Action to process.
+   * @returns {void}
+   */
+  _setTurnAction(action) {
+    this.#turnActionToProcess = action;
+  }
+
+  /**
    * @description Internal setter used by ProcessingGuard.
    * @param {boolean} val - New processing state.
    * @returns {void}
@@ -163,7 +173,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     this.#commandProcessor = commandProcessor;
     this._commandOutcomeInterpreter = commandOutcomeInterpreter;
     this.#commandStringForLog = commandString;
-    this.#turnActionToProcess = turnAction;
+    this._setTurnAction(turnAction);
     this._directiveResolver = directiveResolver;
 
     this._processingGuard = new ProcessingGuard(this);
@@ -210,7 +220,7 @@ export class ProcessingCommandState extends AbstractTurnState {
       this.#commandStringForLog,
       this.#turnActionToProcess,
       (a) => {
-        this.#turnActionToProcess = a;
+        this._setTurnAction(a);
       },
       this._exceptionHandler
     );

--- a/tests/unit/turns/states/processingCommandState.setTurnAction.test.js
+++ b/tests/unit/turns/states/processingCommandState.setTurnAction.test.js
@@ -1,0 +1,49 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { ProcessingCommandState } from '../../../../src/turns/states/processingCommandState.js';
+import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+
+describe('ProcessingCommandState _setTurnAction usage', () => {
+  test('action updates occur via _setTurnAction', async () => {
+    const setTurnActionSpy = jest.spyOn(
+      ProcessingCommandState.prototype,
+      '_setTurnAction'
+    );
+
+    const handler = {
+      getLogger: () => ({
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
+    };
+    const commandProcessor = { dispatchAction: jest.fn() };
+    const commandOutcomeInterpreter = { interpret: jest.fn() };
+
+    const initialAction = { actionDefinitionId: 'init', commandString: 'cmd' };
+    const updatedAction = {
+      actionDefinitionId: 'update',
+      commandString: 'new',
+    };
+
+    const processingWorkflowFactory = (state, cmd, action, setAction) => {
+      setAction(updatedAction);
+      return { run: jest.fn().mockResolvedValue(undefined) };
+    };
+
+    const state = new ProcessingCommandState({
+      handler,
+      commandProcessor,
+      commandOutcomeInterpreter,
+      commandString: initialAction.commandString,
+      turnAction: initialAction,
+      directiveResolver: TurnDirectiveStrategyResolver.default,
+      processingWorkflowFactory,
+    });
+
+    await state.enterState(handler, null);
+
+    expect(setTurnActionSpy).toHaveBeenNthCalledWith(1, initialAction);
+    expect(setTurnActionSpy).toHaveBeenNthCalledWith(2, updatedAction);
+    expect(setTurnActionSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Summary: Introduces `_setTurnAction` method for `ProcessingCommandState` and ensures all updates to the turn action go through this method. Added a unit test confirming it gets called from the workflow.

Changes Made:
- Added `_setTurnAction` private method and used it in constructor and workflow.
- Created new unit test verifying the setter usage.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685efd285aa08331925f3a37a9eb0790