### PR TITLE
[Agent] use trace constants

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -24,6 +24,12 @@ import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { ITargetResolutionService } from '../interfaces/ITargetResolutionService.js';
+import {
+  TRACE_INFO,
+  TRACE_SUCCESS,
+  TRACE_FAILURE,
+  TRACE_STEP,
+} from './tracing/traceContext.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 /**
@@ -175,7 +181,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     }
 
     trace?.addLog(
-      'info',
+      TRACE_INFO,
       `Starting action discovery for actor '${actorEntity.id}'.`,
       'getValidActions',
       { withTrace: shouldTrace }
@@ -223,7 +229,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       `Finished action discovery for actor ${actorEntity.id}. Found ${actions.length} actions from ${candidateDefs.length} candidates.`
     );
     trace?.addLog(
-      'info',
+      TRACE_INFO,
       `Finished discovery. Found ${actions.length} valid actions.`,
       'getValidActions'
     );
@@ -249,7 +255,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   ) {
     const source = 'ActionDiscoveryService.#processCandidateAction';
     trace?.addLog(
-      'step',
+      TRACE_STEP,
       `Processing candidate action: '${actionDef.id}'`,
       source
     );
@@ -257,14 +263,14 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     // STEP 1: Check actor prerequisites
     if (!this.#actorMeetsPrerequisites(actionDef, actorEntity, trace)) {
       trace?.addLog(
-        'failure',
+        TRACE_FAILURE,
         `Action '${actionDef.id}' discarded due to failed actor prerequisites.`,
         source
       );
       return null;
     }
     trace?.addLog(
-      'success',
+      TRACE_SUCCESS,
       `Action '${actionDef.id}' passed actor prerequisite check.`,
       source
     );
@@ -284,7 +290,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       return null;
     }
     trace?.addLog(
-      'info',
+      TRACE_INFO,
       `Scope for action '${actionDef.id}' resolved to ${targetContexts.length} targets.`,
       source,
       { targets: targetContexts.map((t) => t.entityId) }

--- a/src/actions/actionIndex.js
+++ b/src/actions/actionIndex.js
@@ -5,6 +5,11 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('./tracing/traceContext.js').TraceContext} TraceContext */
+import {
+  TRACE_DATA,
+  TRACE_INFO,
+  TRACE_SUCCESS,
+} from './tracing/traceContext.js';
 
 export class ActionIndex {
   /** @type {ILogger} */
@@ -114,14 +119,19 @@ export class ActionIndex {
 
     const actorComponentTypes =
       this.#entityManager.getAllComponentTypesForEntity(actorEntity.id) || [];
-    trace?.addLog('data', `Actor '${actorEntity.id}' has components.`, source, {
-      components: actorComponentTypes.length > 0 ? actorComponentTypes : [],
-    });
+    trace?.addLog(
+      TRACE_DATA,
+      `Actor '${actorEntity.id}' has components.`,
+      source,
+      {
+        components: actorComponentTypes.length > 0 ? actorComponentTypes : [],
+      }
+    );
 
     // Use a Set to automatically handle de-duplication.
     const candidateSet = new Set(this.#noActorRequirement);
     trace?.addLog(
-      'info',
+      TRACE_INFO,
       `Added ${this.#noActorRequirement.length} actions with no actor component requirements.`,
       source
     );
@@ -130,7 +140,7 @@ export class ActionIndex {
       const actionsForComponent = this.#byActorComponent.get(componentType);
       if (actionsForComponent) {
         trace?.addLog(
-          'info',
+          TRACE_INFO,
           `Found ${actionsForComponent.length} actions requiring component '${componentType}'.`,
           source
         );
@@ -142,7 +152,7 @@ export class ActionIndex {
 
     const candidates = Array.from(candidateSet);
     trace?.addLog(
-      'success',
+      TRACE_SUCCESS,
       `Final candidate list contains ${candidates.length} unique actions.`,
       source,
       { actionIds: candidates.map((a) => a.id) }

--- a/src/actions/targetResolutionService.js
+++ b/src/actions/targetResolutionService.js
@@ -19,6 +19,7 @@ import {
 import { parseDslExpression } from '../scopeDsl/parser.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/systemEventIds.js';
+import { TRACE_INFO, TRACE_ERROR } from './tracing/traceContext.js';
 
 export class TargetResolutionService extends ITargetResolutionService {
   #scopeRegistry;
@@ -69,11 +70,11 @@ export class TargetResolutionService extends ITargetResolutionService {
   /** @override */
   async resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
     const source = 'TargetResolutionService.resolveTargets';
-    trace?.addLog('info', `Resolving scope '${scopeName}'.`, source);
+    trace?.addLog(TRACE_INFO, `Resolving scope '${scopeName}'.`, source);
 
     if (scopeName === TARGET_DOMAIN_NONE) {
       trace?.addLog(
-        'info',
+        TRACE_INFO,
         `Scope is 'none'; returning a single no-target context.`,
         source
       );
@@ -82,7 +83,7 @@ export class TargetResolutionService extends ITargetResolutionService {
 
     if (scopeName === TARGET_DOMAIN_SELF) {
       trace?.addLog(
-        'info',
+        TRACE_INFO,
         `Scope is 'self'; returning the actor as the target.`,
         source
       );
@@ -97,7 +98,7 @@ export class TargetResolutionService extends ITargetResolutionService {
     );
 
     trace?.addLog(
-      'info',
+      TRACE_INFO,
       `DSL scope '${scopeName}' resolved to ${targetIds.size} target(s).`,
       source,
       { targetIds: Array.from(targetIds) }
@@ -119,7 +120,11 @@ export class TargetResolutionService extends ITargetResolutionService {
    */
   #resolveScopeToIds(scopeName, actorEntity, discoveryContext, trace = null) {
     const source = 'TargetResolutionService.#resolveScopeToIds';
-    trace?.addLog('info', `Resolving scope '${scopeName}' with DSL.`, source);
+    trace?.addLog(
+      TRACE_INFO,
+      `Resolving scope '${scopeName}' with DSL.`,
+      source
+    );
     const scopeDefinition = this.#scopeRegistry.getScope(scopeName);
 
     if (
@@ -176,7 +181,7 @@ export class TargetResolutionService extends ITargetResolutionService {
     source,
     originalError = null
   ) {
-    trace?.addLog('error', message, source, details);
+    trace?.addLog(TRACE_ERROR, message, source, details);
     originalError
       ? this.#logger.error(message, originalError)
       : this.#logger.warn(message);

--- a/src/actions/tracing/traceContext.js
+++ b/src/actions/tracing/traceContext.js
@@ -3,8 +3,22 @@
  * @see src/actions/tracing/traceContext.js
  */
 
+export const TRACE_INFO = 'info';
+export const TRACE_SUCCESS = 'success';
+export const TRACE_FAILURE = 'failure';
+export const TRACE_STEP = 'step';
+export const TRACE_ERROR = 'error';
+export const TRACE_DATA = 'data';
+
 /**
- * @typedef {'info' | 'success' | 'failure' | 'step' | 'error' | 'data'} LogEntryType
+ * @typedef {(
+ *   typeof TRACE_INFO |
+ *   typeof TRACE_SUCCESS |
+ *   typeof TRACE_FAILURE |
+ *   typeof TRACE_STEP |
+ *   typeof TRACE_ERROR |
+ *   typeof TRACE_DATA
+ * )} LogEntryType
  * 'step' - A major stage in the process.
  * 'data' - Logs a significant data structure (e.g., context, AST).
  */

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -2,6 +2,13 @@
 
 import { BaseService } from '../../utils/serviceBase.js';
 import { resolveReferences } from './conditionReferenceResolver.js';
+import {
+  TRACE_INFO,
+  TRACE_SUCCESS,
+  TRACE_FAILURE,
+  TRACE_ERROR,
+  TRACE_DATA,
+} from '../tracing/traceContext.js';
 
 /* type-only imports */
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
@@ -225,7 +232,7 @@ export class PrerequisiteEvaluationService extends BaseService {
     const source = 'PrerequisiteEvaluationService._evaluatePrerequisite';
     const originalLogic = prereqObject.logic;
 
-    trace?.addLog('info', 'Evaluating rule.', source, {
+    trace?.addLog(TRACE_INFO, 'Evaluating rule.', source, {
       logic: originalLogic || {},
     });
 
@@ -235,7 +242,7 @@ export class PrerequisiteEvaluationService extends BaseService {
     );
 
     if (JSON.stringify(originalLogic) !== JSON.stringify(resolvedLogic)) {
-      trace?.addLog('data', 'Condition reference resolved.', source, {
+      trace?.addLog(TRACE_DATA, 'Condition reference resolved.', source, {
         resolvedLogic: resolvedLogic || {},
       });
     }
@@ -249,7 +256,7 @@ export class PrerequisiteEvaluationService extends BaseService {
     const result = this._executeJsonLogic(resolvedLogic, evaluationContext);
 
     trace?.addLog(
-      result ? 'success' : 'failure',
+      result ? TRACE_SUCCESS : TRACE_FAILURE,
       `Rule evaluation result: ${result}`,
       source,
       { result: Boolean(result) }
@@ -300,7 +307,7 @@ export class PrerequisiteEvaluationService extends BaseService {
       );
     } catch (evalError) {
       trace?.addLog(
-        'error',
+        TRACE_ERROR,
         `Error during rule evaluation: ${evalError.message}`,
         source,
         { error: evalError }
@@ -397,9 +404,14 @@ export class PrerequisiteEvaluationService extends BaseService {
       return false;
     }
 
-    trace?.addLog('data', 'Built prerequisite evaluation context.', source, {
-      context: evaluationContext || {},
-    });
+    trace?.addLog(
+      TRACE_DATA,
+      'Built prerequisite evaluation context.',
+      source,
+      {
+        context: evaluationContext || {},
+      }
+    );
 
     return this.#evaluateRules(
       prerequisites,

--- a/tests/unit/actions/actionDiscoveryService.tracing.test.js
+++ b/tests/unit/actions/actionDiscoveryService.tracing.test.js
@@ -1,6 +1,12 @@
 import { beforeEach, expect, it, jest } from '@jest/globals';
 import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
-import { TraceContext } from '../../../src/actions/tracing/traceContext.js';
+import {
+  TraceContext,
+  TRACE_INFO,
+  TRACE_STEP,
+  TRACE_SUCCESS,
+  TRACE_FAILURE,
+} from '../../../src/actions/tracing/traceContext.js';
 
 jest.mock('../../../src/actions/tracing/traceContext.js', () => ({
   TraceContext: jest
@@ -66,7 +72,7 @@ describeActionDiscoverySuite(
 
         expect(TraceContext).toHaveBeenCalledTimes(1);
         expect(trace.addLog).toHaveBeenCalledWith(
-          'info',
+          TRACE_INFO,
           `Starting action discovery for actor '${actorEntity.id}'.`,
           'getValidActions',
           { withTrace: true }
@@ -101,12 +107,12 @@ describeActionDiscoverySuite(
         );
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'step',
+          TRACE_STEP,
           `Processing candidate action: '${actionDefSimple.id}'`,
           'ActionDiscoveryService.#processCandidateAction'
         );
         expect(trace.addLog).toHaveBeenCalledWith(
-          'step',
+          TRACE_STEP,
           `Processing candidate action: '${actionDefScope.id}'`,
           'ActionDiscoveryService.#processCandidateAction'
         );
@@ -145,7 +151,7 @@ describeActionDiscoverySuite(
         );
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'success',
+          TRACE_SUCCESS,
           `Action '${actionDefPrereq.id}' passed actor prerequisite check.`,
           'ActionDiscoveryService.#processCandidateAction'
         );
@@ -165,7 +171,7 @@ describeActionDiscoverySuite(
         );
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'failure',
+          TRACE_FAILURE,
           `Action '${actionDefPrereq.id}' discarded due to failed actor prerequisites.`,
           'ActionDiscoveryService.#processCandidateAction'
         );

--- a/tests/unit/actions/actionIndex.tracing.test.js
+++ b/tests/unit/actions/actionIndex.tracing.test.js
@@ -7,7 +7,12 @@
 
 import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import { ActionIndex } from '../../../src/actions/actionIndex.js';
-import { TraceContext } from '../../../src/actions/tracing/traceContext.js';
+import {
+  TraceContext,
+  TRACE_DATA,
+  TRACE_INFO,
+  TRACE_SUCCESS,
+} from '../../../src/actions/tracing/traceContext.js';
 import { mock } from 'jest-mock-extended';
 
 // Mock the TraceContext to spy on its methods
@@ -112,7 +117,7 @@ describe('ActionIndex', () => {
         actionIndex.getCandidateActions(actorEntity, trace);
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'data',
+          TRACE_DATA,
           `Actor '${actorEntity.id}' has components.`,
           source,
           { components: components }
@@ -125,7 +130,7 @@ describe('ActionIndex', () => {
         actionIndex.getCandidateActions(actorEntity, trace);
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'info',
+          TRACE_INFO,
           'Added 1 actions with no actor component requirements.',
           source
         );
@@ -140,7 +145,7 @@ describe('ActionIndex', () => {
 
         // action2 and action4 require componentA
         expect(trace.addLog).toHaveBeenCalledWith(
-          'info',
+          TRACE_INFO,
           `Found 2 actions requiring component 'componentA'.`,
           source
         );
@@ -169,7 +174,7 @@ describe('ActionIndex', () => {
         const candidateIds = candidates.map((a) => a.id);
 
         expect(trace.addLog).toHaveBeenCalledWith(
-          'success',
+          TRACE_SUCCESS,
           `Final candidate list contains ${candidates.length} unique actions.`,
           source,
           { actionIds: candidateIds }
@@ -189,16 +194,16 @@ describe('ActionIndex', () => {
 
         const calls = trace.addLog.mock.calls;
         expect(calls).toHaveLength(4);
-        expect(calls[0][0]).toBe('data'); // components
+        expect(calls[0][0]).toBe(TRACE_DATA); // components
         expect(calls[0][1]).toContain('has components');
 
-        expect(calls[1][0]).toBe('info'); // no requirement
+        expect(calls[1][0]).toBe(TRACE_INFO); // no requirement
         expect(calls[1][1]).toContain('no actor component requirements');
 
-        expect(calls[2][0]).toBe('info'); // componentB actions
+        expect(calls[2][0]).toBe(TRACE_INFO); // componentB actions
         expect(calls[2][1]).toContain("requiring component 'componentB'");
 
-        expect(calls[3][0]).toBe('success'); // final list
+        expect(calls[3][0]).toBe(TRACE_SUCCESS); // final list
         expect(calls[3][1]).toContain('Final candidate list');
       });
     });

--- a/tests/unit/actions/traceContext.test.js
+++ b/tests/unit/actions/traceContext.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { TraceContext } from '../../../src/actions/tracing/traceContext.js';
+import {
+  TraceContext,
+  TRACE_INFO,
+  TRACE_ERROR,
+  TRACE_SUCCESS,
+} from '../../../src/actions/tracing/traceContext.js';
 
 describe('TraceContext', () => {
   it('initializes with empty logs', () => {
@@ -10,10 +15,10 @@ describe('TraceContext', () => {
   it('adds a log entry without data', () => {
     const trace = new TraceContext();
     const before = Date.now();
-    trace.addLog('info', 'hello', 'tester');
+    trace.addLog(TRACE_INFO, 'hello', 'tester');
     expect(trace.logs).toHaveLength(1);
     const entry = trace.logs[0];
-    expect(entry.type).toBe('info');
+    expect(entry.type).toBe(TRACE_INFO);
     expect(entry.message).toBe('hello');
     expect(entry.source).toBe('tester');
     expect(entry.timestamp).toBeGreaterThanOrEqual(before);
@@ -23,10 +28,10 @@ describe('TraceContext', () => {
   it('adds a log entry with data when provided', () => {
     const trace = new TraceContext();
     const data = { foo: 'bar' };
-    trace.addLog('error', 'oops', 'tester', data);
+    trace.addLog(TRACE_ERROR, 'oops', 'tester', data);
     expect(trace.logs).toHaveLength(1);
     expect(trace.logs[0]).toMatchObject({
-      type: 'error',
+      type: TRACE_ERROR,
       message: 'oops',
       source: 'tester',
       data,
@@ -35,8 +40,8 @@ describe('TraceContext', () => {
 
   it('preserves log order when multiple entries are added', () => {
     const trace = new TraceContext();
-    trace.addLog('info', 'first', 'src1');
-    trace.addLog('success', 'second', 'src2', { value: 42 });
+    trace.addLog(TRACE_INFO, 'first', 'src1');
+    trace.addLog(TRACE_SUCCESS, 'second', 'src2', { value: 42 });
     expect(trace.logs.map((l) => l.message)).toEqual(['first', 'second']);
   });
 });

--- a/tests/unit/actions/validation/prerequisiteEvaluationService.tracing.test.js
+++ b/tests/unit/actions/validation/prerequisiteEvaluationService.tracing.test.js
@@ -2,6 +2,13 @@
 
 import { jest, describe, beforeEach, expect, it } from '@jest/globals';
 import { PrerequisiteEvaluationService } from '../../../../src/actions/validation/prerequisiteEvaluationService.js';
+import {
+  TRACE_INFO,
+  TRACE_SUCCESS,
+  TRACE_FAILURE,
+  TRACE_ERROR,
+  TRACE_DATA,
+} from '../../../../src/actions/tracing/traceContext.js';
 import { mock } from 'jest-mock-extended';
 
 // Mock dependencies
@@ -121,7 +128,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
       );
 
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'data',
+        TRACE_DATA,
         'Built prerequisite evaluation context.',
         sourceEvaluate,
         { context: mockEvaluationContext }
@@ -141,7 +148,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
       );
 
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'info',
+        TRACE_INFO,
         'Evaluating rule.',
         sourceEvaluatePrerequisite,
         { logic: prerequisites[0].logic }
@@ -161,7 +168,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
       );
 
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'success',
+        TRACE_SUCCESS,
         'Rule evaluation result: true',
         sourceEvaluatePrerequisite,
         { result: true }
@@ -182,7 +189,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
 
       expect(result).toBe(false);
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'failure',
+        TRACE_FAILURE,
         'Rule evaluation result: false',
         sourceEvaluatePrerequisite,
         { result: false }
@@ -205,7 +212,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
 
       // Log original
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'info',
+        TRACE_INFO,
         'Evaluating rule.',
         sourceEvaluatePrerequisite,
         { logic: originalLogic }
@@ -213,7 +220,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
 
       // Log resolved
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'data',
+        TRACE_DATA,
         'Condition reference resolved.',
         sourceEvaluatePrerequisite,
         { resolvedLogic: resolvedLogic }
@@ -263,7 +270,7 @@ describe('PrerequisiteEvaluationService › with Tracing', () => {
 
       expect(result).toBe(false);
       expect(mockTraceContext.addLog).toHaveBeenCalledWith(
-        'error',
+        TRACE_ERROR,
         `Error during rule evaluation: ${evalError.message}`,
         sourceEvaluatePrerequisite,
         { error: evalError }


### PR DESCRIPTION
Summary: added TRACE_INFO and related constants in traceContext.js and replaced string literals in action modules and tests. Updated JSDoc typedef and unit tests to rely on these constants.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685f009cde6c83319c72c4aa10a5f19a