### PR TITLE
[Fix] update command outcome interface

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -16,6 +16,7 @@ import { validateDependency } from '../utils/validationUtils.js';
 /** @typedef {import('../turns/interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../types/commandResult.js').CommandResult} CommandResult */
 
 /**
  * @description Processes raw command strings from actors.
@@ -77,7 +78,7 @@ class CommandProcessor extends ICommandProcessor {
       await this.#dispatchSystemError(userMsg, internalMsg);
       return {
         success: false,
-        errorResult: this.#_createFailureResult(userMsg, internalMsg),
+        errorResult: this.#createFailureResult(userMsg, internalMsg),
       };
     }
 
@@ -118,7 +119,7 @@ class CommandProcessor extends ICommandProcessor {
         )}`
       );
 
-      const failureResult = this.#_createFailureResult(userMsg, internalMsg);
+      const failureResult = this.#createFailureResult(userMsg, internalMsg);
       failureResult.originalInput = commandString;
       failureResult.actionResult = { actionId: actionDefinitionId };
       return { success: false, errorResult: failureResult };
@@ -127,7 +128,7 @@ class CommandProcessor extends ICommandProcessor {
 
   // --- Private Helper Methods ---
 
-  #_createFailureResult(userError, internalError, turnEnded = true) {
+  #createFailureResult(userError, internalError, turnEnded = true) {
     const result = {
       success: false,
       turnEnded: turnEnded,

--- a/src/commands/interfaces/ICommandOutcomeInterpreter.js
+++ b/src/commands/interfaces/ICommandOutcomeInterpreter.js
@@ -3,6 +3,7 @@
 /** @typedef {import('../../types/commandResult.js').CommandResult} CommandResult */
 // Or a more specific shared type
 /** @typedef {import('../../turns/constants/turnDirectives.js').default} TurnDirective */
+/** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
 
 /**
  * @interface ICommandOutcomeInterpreter
@@ -13,12 +14,12 @@ export class ICommandOutcomeInterpreter {
    * Interprets a CommandResult and returns the appropriate TurnDirective.
    *
    * @async
-   * @param {CommandResult} result - The result object from command processing.
-   * @param {string} actorId - The unique ID of the entity whose command result is being interpreted.
+   * @param {CommandResult} _result - The result object from command processing.
+   * @param {ITurnContext} _turnContext - The active turn context for the actor whose result is being interpreted.
    * @returns {Promise<TurnDirective | string>} A promise resolving to a TurnDirective enum value (string).
-   * @throws {Error} If actorId is invalid or result object is malformed.
+   * @throws {Error} If turnContext or result object is malformed.
    */
-  async interpret(result, actorId) {
+  async interpret(_result, _turnContext) {
     throw new Error(
       'ICommandOutcomeInterpreter.interpret method not implemented.'
     );

--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -11,6 +11,7 @@
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/ICommandOutcomeInterpreter.js').ICommandOutcomeInterpreter} ICommandOutcomeInterpreterType */
 /** @typedef {import('../../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
+/** @typedef {import('../../types/commandResult.js').CommandResult} CommandResult */
 /** @typedef {import('../../entities/entity.js').default} Entity */
 
 // --- Constant Imports ---
@@ -139,6 +140,14 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
     return processedActionId;
   }
 
+  /**
+   * Interpret a command processor result to decide the next turn directive.
+   *
+   * @override
+   * @param {CommandResult} result - Result from the command processor.
+   * @param {ITurnContext} turnContext - Current turn context for the actor.
+   * @returns {Promise<TurnDirective | string>} The resolved turn directive.
+   */
   async interpret(result, turnContext) {
     const actorId = this.#validateTurnContext(turnContext);
     const originalInput = result.originalInput || '';


### PR DESCRIPTION
Summary: Align CommandOutcomeInterpreter interface with implementation and rename a private helper.

Changes Made:
- Updated interpret signature in `ICommandOutcomeInterpreter` to take an `ITurnContext`.
- Added matching JSDoc and override in `CommandOutcomeInterpreter`.
- Added missing typedef and renamed `#_createFailureResult` to `#createFailureResult` in `CommandProcessor`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy) *(fails: existing project issues)*
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test (N/A)

------
https://chatgpt.com/codex/tasks/task_e_685f009151bc8331afcb117e58da5a56