### PR TITLE
[Fix] update command outcome interface return type

### DIFF
--- a/src/commands/interfaces/ICommandOutcomeInterpreter.js
+++ b/src/commands/interfaces/ICommandOutcomeInterpreter.js
@@ -16,7 +16,7 @@ export class ICommandOutcomeInterpreter {
    * @async
    * @param {CommandResult} _result - The result object from command processing.
    * @param {ITurnContext} _turnContext - The active turn context for the actor whose result is being interpreted.
-   * @returns {Promise<TurnDirective | string>} A promise resolving to a TurnDirective enum value (string).
+   * @returns {Promise<TurnDirective>} A promise resolving to a TurnDirective enum value.
    * @throws {Error} If turnContext or result object is malformed.
    */
   async interpret(_result, _turnContext) {

--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -146,7 +146,7 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
    * @override
    * @param {CommandResult} result - Result from the command processor.
    * @param {ITurnContext} turnContext - Current turn context for the actor.
-   * @returns {Promise<TurnDirective | string>} The resolved turn directive.
+   * @returns {Promise<TurnDirective>} The resolved turn directive.
    */
   async interpret(result, turnContext) {
     const actorId = this.#validateTurnContext(turnContext);


### PR DESCRIPTION
Summary: Align ICommandOutcomeInterpreter and its implementation with Promise<TurnDirective> return type.

Changes Made:
- Updated JSDoc in ICommandOutcomeInterpreter to return `Promise<TurnDirective>`.
- Updated CommandOutcomeInterpreter implementation JSDoc accordingly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (not executed)


------
https://chatgpt.com/codex/tasks/task_e_685f05060e8c833180a49db2ebbd63ea