### PR TITLE
[Agent] centralize context method lists

### DIFF
--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -19,6 +19,7 @@ import { destroyCleanupStrategy } from './helpers/destroyCleanupStrategy.js';
 import {
   validateActorInContext,
   retrieveStrategyFromContext,
+  AWAITING_DECISION_CONTEXT_METHODS,
 } from './helpers/validationUtils.js';
 
 /**
@@ -60,16 +61,13 @@ export class AwaitingActorDecisionState extends AbstractTurnState {
    *   valid, otherwise null.
    */
   async _ensureContext(reason) {
-    const required = [
-      'getActor',
-      'getLogger',
-      'getStrategy',
-      'requestProcessingCommandStateTransition',
-      'endTurn',
-    ];
-    const ctx = await this._ensureContextWithMethods(reason, required, {
-      endTurnOnFail: true,
-    });
+    const ctx = await this._ensureContextWithMethods(
+      reason,
+      AWAITING_DECISION_CONTEXT_METHODS,
+      {
+        endTurnOnFail: true,
+      }
+    );
     return /** @type {AwaitingActorDecisionStateContext | null} */ (ctx);
   }
 

--- a/src/turns/states/helpers/validationUtils.js
+++ b/src/turns/states/helpers/validationUtils.js
@@ -9,6 +9,33 @@
 import { UNKNOWN_ENTITY_ID } from '../../../constants/unknownIds.js';
 
 /**
+ * @description Method names required on an ITurnContext when used by the
+ * AwaitingActorDecisionState. The state relies on these methods to validate the
+ * actor, obtain its strategy and transition to the processing state.
+ * @type {string[]}
+ */
+export const AWAITING_DECISION_CONTEXT_METHODS = Object.freeze([
+  'getActor',
+  'getLogger',
+  'getStrategy',
+  'requestProcessingCommandStateTransition',
+  'endTurn',
+]);
+
+/**
+ * @description Method names required on an ITurnContext when used by the
+ * ProcessingCommandState. These methods allow the state to retrieve the actor
+ * and chosen action, obtain a logger and dispatch events safely.
+ * @type {string[]}
+ */
+export const PROCESSING_CONTEXT_METHODS = Object.freeze([
+  'getActor',
+  'getLogger',
+  'getChosenAction',
+  'getSafeEventDispatcher',
+]);
+
+/**
  * Ensures the provided actor is valid.
  *
  * @param {Entity} actor - Actor entity to validate.

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -28,6 +28,7 @@ import { ITurnDirectiveResolver } from '../interfaces/ITurnDirectiveResolver.js'
 import {
   validateTurnAction,
   validateCommandString,
+  PROCESSING_CONTEXT_METHODS,
 } from './helpers/validationUtils.js';
 
 /**
@@ -103,15 +104,13 @@ export class ProcessingCommandState extends AbstractTurnState {
    *   cast to ProcessingCommandStateContext or null on failure.
    */
   async _ensureContext(reason) {
-    const required = [
-      'getActor',
-      'getLogger',
-      'getChosenAction',
-      'getSafeEventDispatcher',
-    ];
-    const ctx = await this._ensureContextWithMethods(reason, required, {
-      endTurnOnFail: false,
-    });
+    const ctx = await this._ensureContextWithMethods(
+      reason,
+      PROCESSING_CONTEXT_METHODS,
+      {
+        endTurnOnFail: false,
+      }
+    );
     return /** @type {ProcessingCommandStateContext | null} */ (ctx);
   }
 


### PR DESCRIPTION
## Summary
- define constant method lists in `validationUtils`
- reuse these constants across turn states

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f054cc6a48331937c6cd09e9d9467