### PR TITLE
[Agent] inject content dependency validator

### DIFF
--- a/src/initializers/services/contentDependencyValidator.js
+++ b/src/initializers/services/contentDependencyValidator.js
@@ -8,7 +8,9 @@
  * entity instances reference existing definitions and that exit targets and
  * blockers correspond to spawned instances.
  */
-class ContentDependencyValidator {
+import IContentDependencyValidator from '../../interfaces/IContentDependencyValidator.js';
+
+class ContentDependencyValidator extends IContentDependencyValidator {
   /** @type {ILogger} */
   #logger;
   /** @type {IGameDataRepository} */
@@ -21,7 +23,8 @@ class ContentDependencyValidator {
    * @param {IGameDataRepository} deps.gameDataRepository - Repository providing entity and world data.
    * @param {ILogger} deps.logger - Logger for debug and error output.
    */
-  constructor({ gameDataRepository, logger }) {
+  constructor({ gameDataRepository, logger } = {}) {
+    super();
     this.#gameDataRepository = gameDataRepository;
     this.#logger = logger;
   }

--- a/src/interfaces/IContentDependencyValidator.js
+++ b/src/interfaces/IContentDependencyValidator.js
@@ -1,0 +1,25 @@
+/**
+ * @file Defines the interface for validating content dependencies.
+ */
+
+/**
+ * @interface IContentDependencyValidator
+ * @description Contract for validating entity and world content dependencies.
+ */
+export class IContentDependencyValidator {
+  /**
+   * Validates content dependencies for a specified world.
+   *
+   * @param {string} worldName - Identifier of the world to validate.
+   * @returns {Promise<void>} Resolves when validation is complete.
+   * @throws {Error} If not implemented by a subclass.
+   */
+  async validate(worldName) {
+    const _worldName = worldName; // suppress unused param lint
+    throw new Error(
+      'IContentDependencyValidator.validate method not implemented.'
+    );
+  }
+}
+
+export default IContentDependencyValidator;

--- a/tests/unit/initializers/services/initializationService.constructor.test.js
+++ b/tests/unit/initializers/services/initializationService.constructor.test.js
@@ -19,6 +19,7 @@ let gameDataRepository;
 let thoughtListener;
 let notesListener;
 let spatialIndexManager;
+let contentDependencyValidator;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -38,32 +39,37 @@ beforeEach(() => {
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
   spatialIndexManager = { buildIndex: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
 describe('InitializationService constructor', () => {
   it('creates instance with valid dependencies', () => {
-    expect(() =>
-      new InitializationService({
-        log: { logger },
-        events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
-        llm: { llmAdapter, llmConfigLoader },
-        persistence: {
-          entityManager,
-          domUiFacade,
-          actionIndex,
-          gameDataRepository,
-          thoughtListener,
-          notesListener,
-          spatialIndexManager,
-        },
-        coreSystems: {
-          modsLoader,
-          scopeRegistry,
-          dataRegistry,
-          systemInitializer,
-          worldInitializer,
-        },
-      })
+    expect(
+      () =>
+        new InitializationService({
+          log: { logger },
+          events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+          llm: { llmAdapter, llmConfigLoader },
+          persistence: {
+            entityManager,
+            domUiFacade,
+            actionIndex,
+            gameDataRepository,
+            thoughtListener,
+            notesListener,
+            spatialIndexManager,
+          },
+          coreSystems: {
+            modsLoader,
+            scopeRegistry,
+            dataRegistry,
+            systemInitializer,
+            worldInitializer,
+            contentDependencyValidator,
+          },
+        })
     ).not.toThrow();
   });
 
@@ -87,6 +93,7 @@ describe('InitializationService constructor', () => {
           dataRegistry,
           systemInitializer,
           worldInitializer,
+          contentDependencyValidator,
         },
       });
     expect(create).toThrow(SystemInitializationError);
@@ -114,6 +121,7 @@ describe('InitializationService constructor', () => {
           dataRegistry,
           systemInitializer,
           worldInitializer,
+          contentDependencyValidator,
         },
       });
     expect(createVD).toThrow(SystemInitializationError);

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -16,6 +16,7 @@ let entityManager;
 let domUiFacade;
 let thoughtListener;
 let notesListener;
+let contentDependencyValidator;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -38,6 +39,9 @@ beforeEach(() => {
   domUiFacade = {};
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
 describe('InitializationService DomUiFacade handling', () => {
@@ -63,6 +67,7 @@ describe('InitializationService DomUiFacade handling', () => {
           dataRegistry,
           systemInitializer,
           worldInitializer,
+          contentDependencyValidator,
           // spatialIndexManager intentionally missing for this test
         },
       });
@@ -88,6 +93,7 @@ describe('InitializationService DomUiFacade handling', () => {
           dataRegistry,
           systemInitializer,
           worldInitializer,
+          contentDependencyValidator,
         },
       });
     }).toThrow('InitializationService requires a domUiFacade dependency');

--- a/tests/unit/initializers/services/initializationService.failureScenarios.test.js
+++ b/tests/unit/initializers/services/initializationService.failureScenarios.test.js
@@ -58,6 +58,9 @@ describe('InitializationService failure scenarios', () => {
         dataRegistry: { getAll: jest.fn().mockReturnValue([]) },
         systemInitializer: { initializeAll: jest.fn() },
         worldInitializer: { initializeWorldEntities: jest.fn() },
+        contentDependencyValidator: {
+          validate: jest.fn().mockResolvedValue(undefined),
+        },
       },
       llm: {
         llmAdapter: { init: jest.fn() },

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -16,6 +16,7 @@ let entityManager;
 let domUiFacade;
 let thoughtListener;
 let notesListener;
+let contentDependencyValidator;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -32,6 +33,9 @@ beforeEach(() => {
   domUiFacade = {};
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
 describe('InitializationService invalid world name handling', () => {
@@ -59,6 +63,7 @@ describe('InitializationService invalid world name handling', () => {
           dataRegistry,
           systemInitializer,
           worldInitializer,
+          contentDependencyValidator,
         },
       });
 

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -18,6 +18,7 @@ let entityManager;
 let domUiFacade;
 let thoughtListener;
 let notesListener;
+let contentDependencyValidator;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -40,6 +41,9 @@ beforeEach(() => {
   domUiFacade = {};
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
 describe('InitializationService LLM adapter rejection', () => {
@@ -68,6 +72,7 @@ describe('InitializationService LLM adapter rejection', () => {
         dataRegistry,
         systemInitializer,
         worldInitializer,
+        contentDependencyValidator,
       },
     });
 

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -19,6 +19,7 @@ let actionIndex;
 let gameDataRepository;
 let thoughtListener;
 let notesListener;
+let contentDependencyValidator;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -51,6 +52,9 @@ beforeEach(() => {
   };
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
 describe('InitializationService success path', () => {
@@ -74,6 +78,7 @@ describe('InitializationService success path', () => {
         dataRegistry,
         systemInitializer,
         worldInitializer,
+        contentDependencyValidator,
       },
     });
 


### PR DESCRIPTION
## Summary
- add interface `IContentDependencyValidator`
- implement interface in `ContentDependencyValidator`
- allow `InitializationService` to receive a content validator dependency
- use injected validator during initialization
- pass mocked validator in InitializationService tests

## Testing Done
- [x] `npm run format`
- [ ] `npm run lint` *(fails: 721 errors, 2609 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run format`
- [x] `npm run lint` in proxy
- [x] `npm run test` in proxy


------
https://chatgpt.com/codex/tasks/task_e_685f04cef2c48331baa55adedd848913