### PR TITLE
[Agent] Refactor EntityManager to use only entity repository

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -97,8 +97,6 @@ class EntityManager extends IEntityManager {
   #eventDispatcher;
   /** @type {function(): string} @private */
   #idGenerator;
-  /** @type {IEntityRepository} @private */
-  #repository;
   /** @type {IComponentCloner} @private */
   #cloner;
   /** @type {IDefaultComponentPolicy} @private */
@@ -147,8 +145,6 @@ class EntityManager extends IEntityManager {
    *   provided as an instance or a zero-argument factory function. Any omitted
    *   dependency will use the default from {@link createDefaultDeps}.
    * @param {IDataRegistry}        deps.registry - Data registry for definitions.
-   * @param {IEntityRepository}    [deps.repository] - Repository for active entities.
-   * @param {Function}             [deps.repositoryFactory] - Factory for the repository.
    * @param {ISchemaValidator}     deps.validator - Schema validator instance.
    * @param {ILogger}              deps.logger - Logger implementation.
    * @param {ISafeEventDispatcher} deps.dispatcher - Event dispatcher.
@@ -168,8 +164,6 @@ class EntityManager extends IEntityManager {
    */
   constructor({
     registry,
-    repository,
-    repositoryFactory,
     validator,
     logger,
     dispatcher,
@@ -189,7 +183,6 @@ class EntityManager extends IEntityManager {
     super();
 
     const defaults = createDefaultDeps({
-      repositoryFactory,
       idGeneratorFactory,
       clonerFactory,
       defaultPolicyFactory,
@@ -202,7 +195,6 @@ class EntityManager extends IEntityManager {
       return dep;
     };
 
-    repository = resolveDep(repository, defaults.repository);
     idGenerator = resolveDep(idGenerator, defaults.idGenerator);
     cloner = resolveDep(cloner, defaults.cloner);
     defaultPolicy = resolveDep(defaultPolicy, defaults.defaultPolicy);
@@ -215,9 +207,6 @@ class EntityManager extends IEntityManager {
 
     validateDependency(registry, 'IDataRegistry', this.#logger, {
       requiredMethods: ['getEntityDefinition'],
-    });
-    validateDependency(repository, 'IEntityRepository', this.#logger, {
-      requiredMethods: ['add', 'get', 'has', 'remove', 'clear', 'entities'],
     });
     validateDependency(validator, 'ISchemaValidator', this.#logger, {
       requiredMethods: ['validate'],
@@ -237,7 +226,6 @@ class EntityManager extends IEntityManager {
     });
 
     this.#registry = registry;
-    this.#repository = repository;
     this.#validator = validator;
     this.#logger = ensureValidLogger(logger, 'EntityManager');
     this.#eventDispatcher = dispatcher;
@@ -253,7 +241,6 @@ class EntityManager extends IEntityManager {
       idGenerator: this.#idGenerator,
       cloner: this.#cloner,
       defaultPolicy: this.#defaultPolicy,
-      repository: this.#repository,
     });
 
     this.#entityRepository = resolveDep(

--- a/src/entities/services/entityLifecycleManager.js
+++ b/src/entities/services/entityLifecycleManager.js
@@ -41,8 +41,6 @@ export class EntityLifecycleManager {
   #logger;
   /** @type {ISafeEventDispatcher} @private */
   #eventDispatcher;
-  /** @type {IEntityRepository|null} @private */
-  #repository;
   /** @type {EntityRepositoryAdapter} @private */
   #entityRepository;
   /** @type {EntityFactory} @private */
@@ -57,7 +55,6 @@ export class EntityLifecycleManager {
    * @param {IDataRegistry} deps.registry - Data registry for definitions.
    * @param {ILogger} deps.logger - Logger instance.
    * @param {ISafeEventDispatcher} deps.eventDispatcher - Event dispatcher.
-   * @param {IEntityRepository} [deps.repository] - Optional backing repository.
    * @param {EntityRepositoryAdapter} deps.entityRepository - Internal entity repository.
    * @param {EntityFactory} deps.factory - EntityFactory instance.
    * @param {ErrorTranslator} deps.errorTranslator - Error translator.
@@ -67,7 +64,6 @@ export class EntityLifecycleManager {
     registry,
     logger,
     eventDispatcher,
-    repository = null,
     entityRepository,
     factory,
     errorTranslator,
@@ -89,11 +85,6 @@ export class EntityLifecycleManager {
         requiredMethods: ['add', 'get', 'has', 'remove', 'clear', 'entities'],
       }
     );
-    if (repository) {
-      validateDependency(repository, 'IEntityRepository', this.#logger, {
-        requiredMethods: ['add', 'get', 'has', 'remove', 'clear', 'entities'],
-      });
-    }
     validateDependency(eventDispatcher, 'ISafeEventDispatcher', this.#logger, {
       requiredMethods: ['dispatch'],
     });
@@ -108,7 +99,6 @@ export class EntityLifecycleManager {
     });
 
     this.#registry = registry;
-    this.#repository = repository;
     this.#eventDispatcher = eventDispatcher;
     this.#entityRepository = entityRepository;
     this.#factory = factory;
@@ -278,9 +268,6 @@ export class EntityLifecycleManager {
 
     try {
       this.#entityRepository.remove(entityToRemove.id);
-      if (this.#repository && typeof this.#repository.remove === 'function') {
-        this.#repository.remove(entityToRemove.id);
-      }
       this.#logger.info(
         `Entity instance ${entityToRemove.id} removed from EntityManager.`
       );
@@ -292,7 +279,7 @@ export class EntityLifecycleManager {
         `EntityManager.removeEntityInstance: EntityRepository.remove failed for already retrieved entity '${instanceId}'. This indicates a serious internal inconsistency.`
       );
       throw new Error(
-        `Internal error: Failed to remove entity '${instanceId}' from repository despite entity being found.`
+        `Internal error: Failed to remove entity '${instanceId}' from entity repository despite entity being found.`
       );
     }
   }

--- a/src/entities/utils/createDefaultDeps.js
+++ b/src/entities/utils/createDefaultDeps.js
@@ -1,6 +1,5 @@
 // src/entities/utils/createDefaultDeps.js
 
-import InMemoryEntityRepository from '../../adapters/InMemoryEntityRepository.js';
 import UuidGenerator from '../../adapters/UuidGenerator.js';
 import LodashCloner from '../../adapters/LodashCloner.js';
 import DefaultComponentPolicy from '../../adapters/DefaultComponentPolicy.js';
@@ -9,25 +8,21 @@ import DefaultComponentPolicy from '../../adapters/DefaultComponentPolicy.js';
  * Create default dependencies for {@link EntityManager}.
  *
  * @param {object} [factories]
- * @param {Function} [factories.repositoryFactory] Factory for the entity repository.
  * @param {Function} [factories.idGeneratorFactory] Factory for the ID generator function.
  * @param {Function} [factories.clonerFactory] Factory for the component cloner.
  * @param {Function} [factories.defaultPolicyFactory] Factory for the default component policy.
  * @returns {{
- *   repository: import('../../ports/IEntityRepository.js').IEntityRepository,
  *   idGenerator: import('../../ports/IIdGenerator.js').IIdGenerator,
  *   cloner: import('../../ports/IComponentCloner.js').IComponentCloner,
  *   defaultPolicy: import('../../ports/IDefaultComponentPolicy.js').IDefaultComponentPolicy,
  * }} Object containing default implementations.
  */
 export function createDefaultDeps({
-  repositoryFactory = () => new InMemoryEntityRepository(),
   idGeneratorFactory = () => UuidGenerator,
   clonerFactory = () => LodashCloner,
   defaultPolicyFactory = () => new DefaultComponentPolicy(),
 } = {}) {
   return {
-    repository: repositoryFactory(),
     idGenerator: idGeneratorFactory(),
     cloner: clonerFactory(),
     defaultPolicy: defaultPolicyFactory(),

--- a/src/entities/utils/createDefaultServices.js
+++ b/src/entities/utils/createDefaultServices.js
@@ -29,7 +29,6 @@ import EntityLifecycleManager from '../services/entityLifecycleManager.js';
  * @param {import('../../ports/IIdGenerator.js').IIdGenerator} deps.idGenerator
  * @param {import('../../ports/IComponentCloner.js').IComponentCloner} deps.cloner
  * @param {import('../../ports/IDefaultComponentPolicy.js').IDefaultComponentPolicy} deps.defaultPolicy
- * @param {import('../../ports/IEntityRepository.js').IEntityRepository} [deps.repository]
  * @returns {{
  *   entityRepository: EntityRepositoryAdapter,
  *   componentMutationService: ComponentMutationService,
@@ -46,7 +45,6 @@ export function createDefaultServices({
   idGenerator,
   cloner,
   defaultPolicy,
-  repository = null,
 }) {
   const entityRepository = new EntityRepositoryAdapter({ logger });
   const componentMutationService = new ComponentMutationService({
@@ -69,7 +67,6 @@ export function createDefaultServices({
     registry,
     logger,
     eventDispatcher,
-    repository,
     entityRepository,
     factory: entityFactory,
     errorTranslator,

--- a/tests/common/entities/entityManagerTestBed.js
+++ b/tests/common/entities/entityManagerTestBed.js
@@ -46,8 +46,6 @@ export class EntityManagerTestBed extends FactoryTestBed {
    * @param {object} [overrides] - Optional overrides.
    * @param {object} [overrides.entityManagerOptions] - Options forwarded to the EntityManager constructor.
    * @param {Function} [overrides.idGenerator] - Legacy shortcut for entityManagerOptions.idGenerator.
-   * @param {import('../../../src/ports/IEntityRepository.js').IEntityRepository} [overrides.entityManagerOptions.repository]
-   *   - Repository implementation used by the EntityManager.
    */
   constructor(overrides = {}) {
     const { entityManagerOptions = {}, ...legacyOptions } = overrides;

--- a/tests/unit/entities/entityManager.lifecycle.test.js
+++ b/tests/unit/entities/entityManager.lifecycle.test.js
@@ -430,39 +430,6 @@ describeEntityManagerSuite('EntityManager - removeEntityInstance', (getBed) => {
     runInvalidEntityIdTests(getBed, (em, instanceId) =>
       em.removeEntityInstance(instanceId)
     );
-
-    it('should throw an error if EntityRepository fails internally', () => {
-      // This is a tricky test for a defensive code path.
-      const stubRepo = {
-        add: jest.fn(),
-        get: jest.fn(),
-        has: jest.fn(() => true),
-        remove: jest.fn(() => {
-          throw new Error('Test repository failure');
-        }),
-        clear: jest.fn(),
-        entities: jest.fn(() => [].values()),
-      };
-
-      // Arrange
-      const bed = new EntityManagerTestBed({
-        entityManagerOptions: { repository: stubRepo },
-      });
-      const { entityManager, mocks } = bed;
-      const { PRIMARY } = TestData.InstanceIDs;
-      bed.createBasicEntity({ instanceId: PRIMARY });
-
-      // Act & Assert
-      expect(() => entityManager.removeEntityInstance(PRIMARY)).toThrow(
-        "Internal error: Failed to remove entity 'test-instance-01' from repository despite entity being found."
-      );
-      expect(mocks.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'EntityRepository.remove failed for already retrieved entity'
-        )
-      );
-      bed.cleanup();
-    });
   });
 });
 

--- a/tests/unit/entities/utils/createDefaultDeps.test.js
+++ b/tests/unit/entities/utils/createDefaultDeps.test.js
@@ -1,26 +1,22 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { createDefaultDeps } from '../../../../src/entities/utils/createDefaultDeps.js';
-import InMemoryEntityRepository from '../../../../src/adapters/InMemoryEntityRepository.js';
 import UuidGenerator from '../../../../src/adapters/UuidGenerator.js';
 import LodashCloner from '../../../../src/adapters/LodashCloner.js';
 import DefaultComponentPolicy from '../../../../src/adapters/DefaultComponentPolicy.js';
 
-class FakeRepo {}
-
 describe('createDefaultDeps', () => {
   it('returns default implementations when no overrides are provided', () => {
     const deps = createDefaultDeps();
-    expect(deps.repository).toBeInstanceOf(InMemoryEntityRepository);
     expect(deps.idGenerator).toBe(UuidGenerator);
     expect(deps.cloner).toBe(LodashCloner);
     expect(deps.defaultPolicy).toBeInstanceOf(DefaultComponentPolicy);
   });
 
   it('uses factory overrides when supplied', () => {
-    const repo = new FakeRepo();
-    const repoFactory = jest.fn(() => repo);
-    const deps = createDefaultDeps({ repositoryFactory: repoFactory });
-    expect(deps.repository).toBe(repo);
-    expect(repoFactory).toHaveBeenCalled();
+    const customId = () => 'custom';
+    const idFactory = jest.fn(() => customId);
+    const deps = createDefaultDeps({ idGeneratorFactory: idFactory });
+    expect(deps.idGenerator).toBe(customId);
+    expect(idFactory).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- simplify `EntityManager` and `EntityLifecycleManager` by removing optional repository
- clean up default dependency utilities and tests
- adjust EntityManager lifecycle tests and testbed

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 721 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f04e31d288331b17026a010178673