### PR TITLE
[Agent] remove deprecated world name validator

### DIFF
--- a/src/initializers/services/initHelpers.js
+++ b/src/initializers/services/initHelpers.js
@@ -4,22 +4,6 @@
 /** @typedef {import('../../actions/actionIndex.js').ActionIndex} ActionIndex */
 
 /**
- * Validates that a world name is a non-empty string.
- *
- * @param {string} worldName - Name of the world to validate.
- * @param {ILogger} logger - Logger for reporting validation errors.
- * @returns {void}
- * @throws {TypeError} If the world name is missing or blank.
- */
-export function validateWorldName(worldName, logger) {
-  const msg = 'InitializationService requires a valid non-empty worldName.';
-  if (!worldName || typeof worldName !== 'string' || worldName.trim() === '') {
-    logger?.error(msg);
-    throw new TypeError(msg);
-  }
-}
-
-/**
  * Builds the ActionIndex from definitions provided by the repository.
  *
  * @param {ActionIndex} actionIndex - Index instance to populate.

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -28,7 +28,9 @@ import {
   WorldInitializationError,
   InitializationError,
 } from '../../errors/InitializationError.js';
-import { validateWorldName, buildActionIndex } from './initHelpers.js';
+import { buildActionIndex } from './initHelpers.js';
+import { assertNonBlankString } from '../../utils/parameterGuards.js';
+import { InvalidArgumentError } from '../../errors/invalidArgumentError.js';
 import ContentDependencyValidator from './contentDependencyValidator.js';
 import {
   assertFunction,
@@ -253,7 +255,12 @@ class InitializationService extends IInitializationService {
       `InitializationService: Starting runInitializationSequence for world: ${worldName}.`
     );
     try {
-      validateWorldName(worldName, this.#logger);
+      assertNonBlankString(
+        worldName,
+        'worldName',
+        'InitializationService',
+        this.#logger
+      );
       await this.#loadMods(worldName);
       await this.#contentDependencyValidator.validate(worldName);
       await this.#initializeScopeRegistry();
@@ -287,11 +294,7 @@ class InitializationService extends IInitializationService {
         details: { message: `World '${worldName}' initialized.` },
       };
     } catch (error) {
-      if (
-        error instanceof TypeError &&
-        error.message ===
-          'InitializationService requires a valid non-empty worldName.'
-      ) {
+      if (error instanceof InvalidArgumentError) {
         return { success: false, error };
       }
       await this.#reportFatalError(error, worldName);

--- a/tests/unit/initializers/services/initializationHelpers.test.js
+++ b/tests/unit/initializers/services/initializationHelpers.test.js
@@ -1,27 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import {
-  validateWorldName,
-  buildActionIndex,
-} from '../../../../src/initializers/services/initHelpers.js';
+import { buildActionIndex } from '../../../../src/initializers/services/initHelpers.js';
 
 describe('InitializationService helper functions', () => {
-  describe('validateWorldName', () => {
-    let logger;
-    beforeEach(() => {
-      logger = { error: jest.fn() };
-    });
-
-    it('does nothing for a valid name', () => {
-      expect(() => validateWorldName('world', logger)).not.toThrow();
-      expect(logger.error).not.toHaveBeenCalled();
-    });
-
-    it.each([[null], [undefined], [''], ['   ']])('throws for %p', (bad) => {
-      expect(() => validateWorldName(bad, logger)).toThrow(TypeError);
-      expect(logger.error).toHaveBeenCalled();
-    });
-  });
-
   describe('buildActionIndex', () => {
     let logger;
     let repo;

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -1,6 +1,7 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
+import { InvalidArgumentError } from '../../../../src/errors/invalidArgumentError.js';
 
 let logger;
 let dispatcher;
@@ -69,7 +70,7 @@ describe('InitializationService invalid world name handling', () => {
 
       const result = await service.runInitializationSequence(bad);
       expect(result.success).toBe(false);
-      expect(result.error).toBeInstanceOf(TypeError);
+      expect(result.error).toBeInstanceOf(InvalidArgumentError);
       expect(modsLoader.loadMods).not.toHaveBeenCalled();
       expectNoDispatch(dispatcher.dispatch);
     }


### PR DESCRIPTION
## Summary
- drop `validateWorldName` helper
- switch InitializationService to `assertNonBlankString`
- adjust invalid world name test expectations
- clean up initialization helper tests

## Testing Done
- `npm run lint` *(fails: 3343 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f096dfbd483318a7e888bcfbbb6e9