### PR TITLE
[Agent] add location display service

### DIFF
--- a/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
+++ b/src/dependencyInjection/registrations/worldAndEntityRegistrations.js
@@ -28,6 +28,7 @@ import * as closenessCircleService from '../../logic/services/closenessCircleSer
 import { EntityDisplayDataProvider } from '../../entities/entityDisplayDataProvider.js';
 import { SpatialIndexSynchronizer } from '../../entities/spatialIndexSynchronizer.js';
 import { LocationQueryService } from '../../entities/locationQueryService.js';
+import LocationDisplayService from '../../entities/services/locationDisplayService.js';
 
 /**
  * Registers world, entity, and context-related services.
@@ -108,6 +109,7 @@ export function registerWorldAndEntity(container) {
       safeEventDispatcher: /** @type {ISafeEventDispatcher} */ (
         c.resolve(tokens.ISafeEventDispatcher)
       ),
+      locationDisplayService: c.resolve(tokens.LocationDisplayService),
     });
   });
   logger.debug(
@@ -144,6 +146,19 @@ export function registerWorldAndEntity(container) {
   logger.debug(
     `World and Entity Registration: Registered ${String(
       tokens.LocationQueryService
+    )}.`
+  );
+
+  registrar.singletonFactory(tokens.LocationDisplayService, (c) => {
+    return new LocationDisplayService({
+      entityManager: c.resolve(tokens.IEntityManager),
+      logger: c.resolve(tokens.ILogger),
+      safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+    });
+  });
+  logger.debug(
+    `World and Entity Registration: Registered ${String(
+      tokens.LocationDisplayService
     )}.`
   );
 

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -100,6 +100,7 @@ import { freeze } from '../utils';
  * @property {DiToken} EntityDisplayDataProvider - Token for the service providing entity display data.
  * @property {DiToken} AlertRouter - Token for the service that routes alerts to the UI or console.
  * @property {DiToken} LocationQueryService - Token for the service providing location-based entity queries.
+ * @property {DiToken} LocationDisplayService - Token for the service providing display data for locations.
  * @property {DiToken} GameSessionManager - Token for the game session manager.
  * @property {DiToken} PersistenceCoordinator - Token coordinating persistence operations.
  *
@@ -249,6 +250,7 @@ export const tokens = freeze({
   AlertRouter: 'AlertRouter',
   ClosenessCircleService: 'ClosenessCircleService',
   LocationQueryService: 'LocationQueryService',
+  LocationDisplayService: 'LocationDisplayService',
   GameSessionManager: 'GameSessionManager',
   PersistenceCoordinator: 'PersistenceCoordinator',
 

--- a/src/domUI/location/buildLocationDisplayPayload.js
+++ b/src/domUI/location/buildLocationDisplayPayload.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @typedef {import('../../entities/entityDisplayDataProvider.js').ProcessedExit} ProcessedExit
+ * @typedef {import('../../entities/services/locationDisplayService.js').ProcessedExit} ProcessedExit
  * @typedef {import('../../entities/entityDisplayDataProvider.js').CharacterDisplayInfo} CharacterDisplayData
  */
 

--- a/src/entities/services/locationDisplayService.js
+++ b/src/entities/services/locationDisplayService.js
@@ -1,0 +1,295 @@
+// src/entities/services/locationDisplayService.js
+
+import {
+  NAME_COMPONENT_ID,
+  DESCRIPTION_COMPONENT_ID,
+  EXITS_COMPONENT_ID,
+  PORTRAIT_COMPONENT_ID,
+} from '../../constants/componentIds.js';
+import { validateDependency } from '../../utils/validationUtils.js';
+import { ensureValidLogger } from '../../utils/loggerUtils.js';
+import { isNonBlankString } from '../../utils/textUtils.js';
+import { getEntityDisplayName } from '../../utils/entityUtils.js';
+import { buildPortraitInfo } from '../utils/portraitUtils.js';
+import { InvalidEntityIdError } from '../../errors/invalidEntityIdError.js';
+
+/** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger */
+/** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../entity.js').default} Entity */
+/** @typedef {import('../../interfaces/CommonTypes.js').NamespacedId} NamespacedId */
+
+/**
+ * @typedef {object} ProcessedExit
+ * @property {string} description - The direction or description of the exit.
+ * @property {NamespacedId | string | undefined} target - The identifier of the target location.
+ * @property {NamespacedId | string | undefined} [id] - Alias for target.
+ */
+
+/**
+ * @typedef {object} PortraitData
+ * @property {string} imagePath - The full, resolved path to the portrait image.
+ * @property {string | null} altText - The alternative text for the image.
+ */
+
+/**
+ * @class LocationDisplayService
+ * @description Provides display-oriented queries for location entities.
+ */
+export class LocationDisplayService {
+  /** @type {IEntityManager} */
+  #entityManager;
+  /** @type {ILogger} */
+  #logger;
+  /** @type {ISafeEventDispatcher} */
+  #safeEventDispatcher;
+
+  /** @private */
+  _logPrefix = '[LocationDisplayService]';
+
+  /**
+   * @param {object} deps
+   * @param {IEntityManager} deps.entityManager
+   * @param {ILogger} deps.logger
+   * @param {ISafeEventDispatcher} deps.safeEventDispatcher
+   */
+  constructor({ entityManager, logger, safeEventDispatcher }) {
+    validateDependency(logger, 'logger', console, {
+      requiredMethods: ['info', 'warn', 'error', 'debug'],
+    });
+    const effectiveLogger = ensureValidLogger(logger, 'LocationDisplayService');
+
+    validateDependency(entityManager, 'entityManager', effectiveLogger, {
+      requiredMethods: ['getEntityInstance'],
+    });
+
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      effectiveLogger,
+      { requiredMethods: ['dispatch'] }
+    );
+
+    this.#entityManager = entityManager;
+    this.#logger = effectiveLogger;
+    this.#safeEventDispatcher = safeEventDispatcher;
+    this.#logger.debug(`${this._logPrefix} Service instantiated.`);
+  }
+
+  /**
+   * @private
+   * @param {NamespacedId | string} entityId
+   * @returns {Entity}
+   * @throws {InvalidEntityIdError}
+   */
+  #fetchEntity(entityId) {
+    if (!entityId) {
+      throw new InvalidEntityIdError(entityId);
+    }
+    return this.#entityManager.getEntityInstance(entityId);
+  }
+
+  /**
+   * @private
+   * @param {NamespacedId | string} entityId
+   * @param {*} fallback
+   * @param {(entity: Entity) => *} callback
+   * @param {string} [notFoundMsg]
+   * @returns {*}
+   */
+  #withEntity(entityId, fallback, callback, notFoundMsg) {
+    let entity;
+    try {
+      entity = this.#fetchEntity(entityId);
+    } catch (error) {
+      if (error instanceof InvalidEntityIdError) {
+        this.#logger.warn(
+          `${this._logPrefix} fetchEntity called with null or empty entityId.`
+        );
+        return fallback;
+      }
+      throw error;
+    }
+
+    if (!entity) {
+      if (notFoundMsg) {
+        this.#logger.debug(`${this._logPrefix} ${notFoundMsg}`);
+      }
+      return fallback;
+    }
+
+    return callback(entity);
+  }
+
+  /**
+   * @private
+   * @param {NamespacedId | string} entityId
+   * @param {string} [defaultName]
+   * @returns {string}
+   */
+  #getEntityName(entityId, defaultName = 'Unknown Entity') {
+    return this.#withEntity(
+      entityId,
+      defaultName,
+      (entity) => getEntityDisplayName(entity, defaultName, this.#logger),
+      `getEntityName: Entity with ID '${entityId}' not found. Returning default name.`
+    );
+  }
+
+  /**
+   * @private
+   * @param {NamespacedId | string} entityId
+   * @param {string} [defaultDescription]
+   * @returns {string}
+   */
+  #getEntityDescription(entityId, defaultDescription = '') {
+    return this.#withEntity(
+      entityId,
+      defaultDescription,
+      (entity) => {
+        const descriptionComponent = entity.getComponentData(
+          DESCRIPTION_COMPONENT_ID
+        );
+        if (
+          descriptionComponent &&
+          typeof descriptionComponent.text === 'string'
+        ) {
+          return descriptionComponent.text;
+        }
+
+        this.#logger.debug(
+          `${this._logPrefix} getEntityDescription: Entity '${entityId}' found, but no valid DESCRIPTION_COMPONENT_ID data. Returning default description.`
+        );
+        return defaultDescription;
+      },
+      `getEntityDescription: Entity with ID '${entityId}' not found. Returning default description.`
+    );
+  }
+
+  /**
+   * Retrieves detailed display information for a location entity.
+   *
+   * @param {NamespacedId | string} locationEntityId
+   * @returns {{ name: string, description: string, exits: Array<ProcessedExit> } | null}
+   */
+  getLocationDetails(locationEntityId) {
+    if (!locationEntityId) {
+      this.#logger.warn(
+        `${this._logPrefix} getLocationDetails called with null or empty locationEntityId.`
+      );
+      return null;
+    }
+
+    const locationEntity =
+      this.#entityManager.getEntityInstance(locationEntityId);
+    if (!locationEntity) {
+      this.#logger.debug(
+        `${this._logPrefix} getLocationDetails: Location entity with ID '${locationEntityId}' not found.`
+      );
+      return null;
+    }
+
+    const name = this.#getEntityName(locationEntityId, 'Unnamed Location');
+    const description = this.#getEntityDescription(
+      locationEntityId,
+      'No description available.'
+    );
+
+    const exitsComponentData =
+      locationEntity.getComponentData(EXITS_COMPONENT_ID);
+    let processedExits = [];
+
+    if (exitsComponentData && Array.isArray(exitsComponentData)) {
+      processedExits = this._parseLocationExits(
+        exitsComponentData,
+        locationEntityId
+      );
+    } else if (exitsComponentData) {
+      this.#logger.warn(
+        `${this._logPrefix} getLocationDetails: Exits component data for location '${locationEntityId}' is present but not an array.`,
+        { exitsComponentData }
+      );
+    }
+
+    return {
+      name,
+      description,
+      exits: processedExits,
+    };
+  }
+
+  /**
+   * Retrieves portrait data for a location entity.
+   *
+   * @param {NamespacedId | string} locationEntityId
+   * @returns {PortraitData | null}
+   */
+  getLocationPortraitData(locationEntityId) {
+    if (!locationEntityId) {
+      this.#logger.warn(
+        `${this._logPrefix} getLocationPortraitData called with null or empty locationEntityId.`
+      );
+      return null;
+    }
+
+    return this.#withEntity(
+      locationEntityId,
+      null,
+      (entity) => {
+        const info = buildPortraitInfo(
+          entity,
+          'getLocationPortraitData',
+          this.#logger,
+          this.#safeEventDispatcher,
+          this._logPrefix
+        );
+        if (!info) return null;
+        return { imagePath: info.path, altText: info.altText };
+      },
+      `getLocationPortraitData: Location entity with ID '${locationEntityId}' not found.`
+    );
+  }
+
+  /**
+   * @param {Array<*>} exitsComponentData
+   * @param {NamespacedId | string} locationEntityId
+   * @returns {ProcessedExit[]}
+   */
+  _parseLocationExits(exitsComponentData, locationEntityId) {
+    if (!Array.isArray(exitsComponentData)) {
+      return [];
+    }
+    return exitsComponentData
+      .map((exit) => this.#normalizeExit(exit, locationEntityId))
+      .filter((exit) => exit !== null);
+  }
+
+  /**
+   * @param {*} exit
+   * @param {NamespacedId | string} locationEntityId
+   * @returns {ProcessedExit | null}
+   */
+  #normalizeExit(exit, locationEntityId) {
+    if (typeof exit !== 'object' || exit === null) {
+      this.#logger.warn(
+        `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,
+        { exit }
+      );
+      return null;
+    }
+    const exitDescription = isNonBlankString(exit.direction)
+      ? exit.direction.trim()
+      : 'Unspecified Exit';
+    const exitTarget = isNonBlankString(exit.target)
+      ? exit.target.trim()
+      : undefined;
+
+    return {
+      description: exitDescription,
+      target: exitTarget,
+      id: exitTarget,
+    };
+  }
+}
+
+export default LocationDisplayService;

--- a/tests/unit/services/locationDisplayService.test.js
+++ b/tests/unit/services/locationDisplayService.test.js
@@ -1,0 +1,189 @@
+import { jest, describe, beforeEach, it, expect } from '@jest/globals';
+import LocationDisplayService from '../../../src/entities/services/locationDisplayService.js';
+import {
+  NAME_COMPONENT_ID,
+  DESCRIPTION_COMPONENT_ID,
+  EXITS_COMPONENT_ID,
+} from '../../../src/constants/componentIds.js';
+
+describe('LocationDisplayService', () => {
+  let mockEntityManager;
+  let mockLogger;
+  let mockSafeEventDispatcher;
+  let service;
+
+  beforeEach(() => {
+    mockEntityManager = {
+      getEntityInstance: jest.fn(),
+    };
+    mockLogger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    };
+    mockSafeEventDispatcher = { dispatch: jest.fn() };
+    service = new LocationDisplayService({
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+      safeEventDispatcher: mockSafeEventDispatcher,
+    });
+  });
+
+  describe('getLocationDetails', () => {
+    it('should return compiled location details with exits', () => {
+      const mockLocationEntity = {
+        id: 'loc1',
+        getComponentData: jest.fn((componentId) => {
+          if (componentId === NAME_COMPONENT_ID) return { text: 'Grand Hall' };
+          if (componentId === DESCRIPTION_COMPONENT_ID)
+            return { text: 'A vast hall.' };
+          if (componentId === EXITS_COMPONENT_ID)
+            return [
+              { direction: 'north', target: 'loc2' },
+              { direction: 'south', target: 'loc3' },
+              { direction: 'a secret passage', target: 'loc_secret' },
+              { target: 'loc_no_dir' },
+              null,
+              { direction: '  ', target: 'loc_empty_dir' },
+            ];
+          return null;
+        }),
+      };
+      mockEntityManager.getEntityInstance.mockReturnValue(mockLocationEntity);
+
+      const details = service.getLocationDetails('loc1');
+
+      expect(details).toEqual({
+        name: 'Grand Hall',
+        description: 'A vast hall.',
+        exits: [
+          { description: 'north', target: 'loc2', id: 'loc2' },
+          { description: 'south', target: 'loc3', id: 'loc3' },
+          {
+            description: 'a secret passage',
+            target: 'loc_secret',
+            id: 'loc_secret',
+          },
+          {
+            description: 'Unspecified Exit',
+            target: 'loc_no_dir',
+            id: 'loc_no_dir',
+          },
+          {
+            description: 'Unspecified Exit',
+            target: 'loc_empty_dir',
+            id: 'loc_empty_dir',
+          },
+        ],
+      });
+      expect(mockEntityManager.getEntityInstance).toHaveBeenCalledWith('loc1');
+      expect(mockLocationEntity.getComponentData).toHaveBeenCalledWith(
+        NAME_COMPONENT_ID
+      );
+      expect(mockLocationEntity.getComponentData).toHaveBeenCalledWith(
+        DESCRIPTION_COMPONENT_ID
+      );
+      expect(mockLocationEntity.getComponentData).toHaveBeenCalledWith(
+        EXITS_COMPONENT_ID
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Invalid exit item in exits component for location 'loc1'"
+        ),
+        expect.any(Object)
+      );
+    });
+
+    it('should return null if location entity not found', () => {
+      mockEntityManager.getEntityInstance.mockReturnValue(null);
+      expect(service.getLocationDetails('missing')).toBeNull();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Location entity with ID 'missing' not found.")
+      );
+    });
+
+    it('should handle EXITS_COMPONENT_ID data being present but not an array', () => {
+      const mockLocationEntity = {
+        id: 'loc_bad_exits',
+        getComponentData: jest.fn((id) => {
+          if (id === EXITS_COMPONENT_ID) return { not_an_array: 'bad_data' };
+          return null;
+        }),
+      };
+      mockEntityManager.getEntityInstance.mockReturnValue(mockLocationEntity);
+
+      service.getLocationDetails('loc_bad_exits');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Exits component data for location 'loc_bad_exits' is present but not an array."
+        ),
+        expect.any(Object)
+      );
+    });
+
+    it('should return null if locationEntityId is null or empty', () => {
+      expect(service.getLocationDetails(null)).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('called with null or empty locationEntityId')
+      );
+    });
+  });
+
+  describe('getLocationPortraitData', () => {
+    it('should return portrait data with alt text', () => {
+      const mockEntity = {
+        id: 'loc1',
+        definitionId: 'core:loc',
+        getComponentData: jest.fn().mockReturnValue({
+          imagePath: 'images/loc.png',
+          altText: 'Location Alt',
+        }),
+      };
+      mockEntityManager.getEntityInstance.mockReturnValue(mockEntity);
+
+      const result = service.getLocationPortraitData('loc1');
+
+      expect(result).toEqual({
+        imagePath: '/data/mods/core/images/loc.png',
+        altText: 'Location Alt',
+      });
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Constructed portrait path for location 'loc1': /data/mods/core/images/loc.png"
+        )
+      );
+    });
+
+    it('should return null if portrait component missing', () => {
+      const mockEntity = {
+        id: 'loc2',
+        definitionId: 'core:loc',
+        getComponentData: jest.fn().mockReturnValue(null),
+      };
+      mockEntityManager.getEntityInstance.mockReturnValue(mockEntity);
+      const result = service.getLocationPortraitData('loc2');
+      expect(result).toBeNull();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Location entity 'loc2' has no valid PORTRAIT_COMPONENT_ID data or imagePath."
+        )
+      );
+    });
+
+    it('should return null if entity not found', () => {
+      mockEntityManager.getEntityInstance.mockReturnValue(null);
+      expect(service.getLocationPortraitData('missing')).toBeNull();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Location entity with ID 'missing' not found.")
+      );
+    });
+
+    it('should return null if locationEntityId is null or empty', () => {
+      expect(service.getLocationPortraitData(null)).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('called with null or empty locationEntityId')
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `LocationDisplayService` for location-based display queries
- delegate location display methods from `EntityDisplayDataProvider`
- register the new service with DI
- update tokens and payload builder
- add unit tests for new service and update provider tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f07237ea483318805db88e5670886