### PR TITLE
[Agent] add helper test coverage

### DIFF
--- a/tests/unit/turns/helpers/getServiceFromContext.test.js
+++ b/tests/unit/turns/helpers/getServiceFromContext.test.js
@@ -1,0 +1,94 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import {
+  getServiceFromContext,
+  ServiceLookupError,
+} from '../../../../src/turns/states/helpers/getServiceFromContext.js';
+import { safeDispatchError } from '../../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+/**
+ * Creates a minimal state object with mocked handler and finishProcessing.
+ *
+ * @param logger
+ * @param dispatcher
+ * @returns {object} Mock state
+ */
+const createState = (logger, dispatcher) => {
+  const state = {
+    getStateName: () => 'TestState',
+    _handler: {
+      getLogger: jest.fn(() => logger),
+      getSafeEventDispatcher: jest.fn(() => dispatcher),
+    },
+    _exceptionHandler: { handle: jest.fn().mockResolvedValue(undefined) },
+    isProcessing: false,
+    finishProcessing: jest.fn(() => {
+      state.isProcessing = false;
+    }),
+  };
+  return state;
+};
+
+describe('getServiceFromContext', () => {
+  let logger;
+  let dispatcher;
+  let state;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = { error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+    dispatcher = { dispatch: jest.fn() };
+    state = createState(logger, dispatcher);
+  });
+
+  test('returns service when context provides it', async () => {
+    const service = {};
+    const turnCtx = {
+      getLogger: () => logger,
+      getCommandProcessor: jest.fn(() => service),
+    };
+
+    const result = await getServiceFromContext(
+      state,
+      turnCtx,
+      'getCommandProcessor',
+      'ICommandProcessor',
+      'actor1'
+    );
+
+    expect(result).toBe(service);
+    expect(turnCtx.getCommandProcessor).toHaveBeenCalled();
+    expect(state.finishProcessing).not.toHaveBeenCalled();
+  });
+
+  test('throws ServiceLookupError and finishes processing on failure', async () => {
+    state.isProcessing = true;
+    const turnCtx = {
+      getLogger: () => logger,
+      getSafeEventDispatcher: () => dispatcher,
+      // method missing
+    };
+
+    await expect(
+      getServiceFromContext(
+        state,
+        turnCtx,
+        'getCommandProcessor',
+        'ICommandProcessor',
+        'actor2'
+      )
+    ).rejects.toBeInstanceOf(ServiceLookupError);
+
+    expect(state.finishProcessing).toHaveBeenCalled();
+    expect(state.isProcessing).toBe(false);
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.any(String),
+      expect.any(Object),
+      logger
+    );
+  });
+});

--- a/tests/unit/turns/helpers/processingExceptionHandler.handle.test.js
+++ b/tests/unit/turns/helpers/processingExceptionHandler.handle.test.js
@@ -1,0 +1,41 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { ProcessingExceptionHandler } from '../../../../src/turns/states/helpers/processingExceptionHandler.js';
+
+const createState = (logger, dispatcher) => {
+  const state = {
+    getStateName: () => 'TestState',
+    isProcessing: true,
+    finishProcessing: jest.fn(() => {
+      state.isProcessing = false;
+    }),
+    _handler: {
+      getLogger: jest.fn(() => logger),
+      getSafeEventDispatcher: jest.fn(() => dispatcher),
+    },
+  };
+  return state;
+};
+
+describe('ProcessingExceptionHandler.handle', () => {
+  test('resets processing flags and ends the turn', async () => {
+    const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const dispatcher = { dispatch: jest.fn() };
+    const turnCtx = {
+      getLogger: jest.fn(() => logger),
+      getSafeEventDispatcher: jest.fn(() => dispatcher),
+      endTurn: jest.fn().mockResolvedValue(undefined),
+      isAwaitingExternalEvent: jest.fn(() => true),
+      setAwaitingExternalEvent: jest.fn(),
+      getActor: jest.fn(() => ({ id: 'actor1' })),
+    };
+
+    const state = createState(logger, dispatcher);
+    const handler = new ProcessingExceptionHandler(state);
+
+    await handler.handle(turnCtx, new Error('boom'), 'actor1');
+
+    expect(state.isProcessing).toBe(false);
+    expect(state.finishProcessing).toHaveBeenCalled();
+    expect(turnCtx.endTurn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Add unit tests for helper utilities under turns.

Changes Made:
- Added getServiceFromContext success and failure tests.
- Added ProcessingExceptionHandler.handle test ensuring flags reset and turn ends.

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_685f09ae694483318686d5f895186ad5