### PR TITLE
[Agent] rename exit parsing helpers

### DIFF
--- a/src/entities/services/locationDisplayService.js
+++ b/src/entities/services/locationDisplayService.js
@@ -200,10 +200,7 @@ export class LocationDisplayService {
     let processedExits = [];
 
     if (exitsComponentData && Array.isArray(exitsComponentData)) {
-      processedExits = this._parseLocationExits(
-        exitsComponentData,
-        locationEntityId
-      );
+      processedExits = this.parseRawExits(exitsComponentData, locationEntityId);
     } else if (exitsComponentData) {
       this.#logger.warn(
         `${this._logPrefix} getLocationDetails: Exits component data for location '${locationEntityId}' is present but not an array.`,
@@ -255,12 +252,12 @@ export class LocationDisplayService {
    * @param {NamespacedId | string} locationEntityId
    * @returns {ProcessedExit[]}
    */
-  _parseLocationExits(exitsComponentData, locationEntityId) {
+  parseRawExits(exitsComponentData, locationEntityId) {
     if (!Array.isArray(exitsComponentData)) {
       return [];
     }
     return exitsComponentData
-      .map((exit) => this.#normalizeExit(exit, locationEntityId))
+      .map((exit) => this.#normalizeExitItem(exit, locationEntityId))
       .filter((exit) => exit !== null);
   }
 
@@ -269,7 +266,7 @@ export class LocationDisplayService {
    * @param {NamespacedId | string} locationEntityId
    * @returns {ProcessedExit | null}
    */
-  #normalizeExit(exit, locationEntityId) {
+  #normalizeExitItem(exit, locationEntityId) {
     if (typeof exit !== 'object' || exit === null) {
       this.#logger.warn(
         `${this._logPrefix} getLocationDetails: Invalid exit item in exits component for location '${locationEntityId}'. Skipping.`,


### PR DESCRIPTION
Summary: rename _parseLocationExits to parseRawExits and #normalizeExit to normalizeExitItem in LocationDisplayService, updating all references

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint executed `npm run lint` (fails with known issues)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f667a461c8331b3b5257eda953922