### PR TITLE
[Agent] Handle lookup errors in DefinitionCache

### DIFF
--- a/src/entities/services/definitionCache.js
+++ b/src/entities/services/definitionCache.js
@@ -25,6 +25,8 @@ export class DefinitionCache {
   #logger;
 
   /**
+   * Construct a new DefinitionCache with registry and logger.
+   *
    * @param {object} deps - Dependencies
    * @param {IDataRegistry} deps.registry - Data registry for definitions
    * @param {ILogger} deps.logger - Logger instance
@@ -58,7 +60,8 @@ export class DefinitionCache {
       const def = lookupDefinition(definitionId, this.#registry, this.#logger);
       this.#cache.set(definitionId, def);
       return def;
-    } catch {
+    } catch (err) {
+      this.#logger.warn(err.message);
       return null;
     }
   }

--- a/tests/unit/entities/services/definitionCache.test.js
+++ b/tests/unit/entities/services/definitionCache.test.js
@@ -33,5 +33,14 @@ describe('DefinitionCache', () => {
 
     const result = cache.get('missing');
     expect(result).toBeNull();
+    const warnMsgs = logger.warn.mock.calls.map((c) => c[0]).join('\n');
+    expect(warnMsgs).toContain('Entity definition not found');
+  });
+
+  it('logs a warning when given an invalid ID', () => {
+    const result = cache.get('');
+    expect(result).toBeNull();
+    const warnMsgs = logger.warn.mock.calls.map((c) => c[0]).join('\n');
+    expect(warnMsgs).toContain('Invalid ID');
   });
 });


### PR DESCRIPTION
## Summary
- warn on lookup failures in `DefinitionCache.get`
- test warnings for missing/invalid definition IDs

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3386 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f66be3a2883318b7e614d8595755d