### PR TITLE
[Feat] add component override not found error

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -428,7 +428,8 @@ class EntityManager extends IEntityManager {
    * @param {string} componentTypeId - The unique ID of the component type to remove.
    * @throws {EntityNotFoundError} If entity not found.
    * @throws {InvalidArgumentError} If parameters are invalid.
-   * @throws {Error} If component override does not exist or removal fails.
+   * @throws {ComponentOverrideNotFoundError} If component override does not exist.
+   * @throws {Error} If removal fails.
    */
   removeComponent(instanceId, componentTypeId) {
     this.#componentMutationService.removeComponent(instanceId, componentTypeId);

--- a/src/entities/services/componentMutationService.js
+++ b/src/entities/services/componentMutationService.js
@@ -8,6 +8,7 @@ import { validateDependency } from '../../utils/validationUtils.js';
 import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { EntityNotFoundError } from '../../errors/entityNotFoundError.js';
 import { ValidationError } from '../../errors/validationError.js';
+import { ComponentOverrideNotFoundError } from '../../errors/componentOverrideNotFoundError.js';
 import createValidateAndClone from '../utils/createValidateAndClone.js';
 import {
   validateAddComponentParams as validateAddComponentParamsUtil,
@@ -171,7 +172,8 @@ export class ComponentMutationService {
    * @param {string} componentTypeId - The unique ID of the component type to remove.
    * @throws {EntityNotFoundError} If entity not found.
    * @throws {InvalidArgumentError} If parameters are invalid.
-   * @throws {Error} If component override does not exist or removal fails.
+   * @throws {ComponentOverrideNotFoundError} If component override does not exist.
+   * @throws {Error} If removal fails.
    */
   removeComponent(instanceId, componentTypeId) {
     validateRemoveComponentParamsUtil(
@@ -194,9 +196,7 @@ export class ComponentMutationService {
       this.#logger.debug(
         `ComponentMutationService.removeComponent: Component '${componentTypeId}' not found as an override on entity '${instanceId}'. Nothing to remove at instance level.`
       );
-      throw new Error(
-        `Component '${componentTypeId}' not found as an override on entity '${instanceId}'. Nothing to remove at instance level.`
-      );
+      throw new ComponentOverrideNotFoundError(instanceId, componentTypeId);
     }
 
     // Capture the state of the component *before* it is removed.

--- a/src/errors/componentOverrideNotFoundError.js
+++ b/src/errors/componentOverrideNotFoundError.js
@@ -1,0 +1,29 @@
+/**
+ * @file Error thrown when attempting to remove a component override that does not exist.
+ */
+
+/**
+ * Error thrown when an entity does not have the requested component override.
+ *
+ * @class ComponentOverrideNotFoundError
+ * @augments {Error}
+ */
+export class ComponentOverrideNotFoundError extends Error {
+  /**
+   * @param {string} instanceId - The ID of the entity instance.
+   * @param {string} componentTypeId - The component type that was not found as an override.
+   */
+  constructor(instanceId, componentTypeId) {
+    super(
+      `Component '${componentTypeId}' not found as an override on entity '${instanceId}'. Nothing to remove at instance level.`
+    );
+    this.name = 'ComponentOverrideNotFoundError';
+    this.instanceId = instanceId;
+    this.componentTypeId = componentTypeId;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ComponentOverrideNotFoundError);
+    }
+  }
+}
+
+export default ComponentOverrideNotFoundError;

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -9,3 +9,4 @@ export * from './invalidActorEntityError.js';
 export * from './duplicateContentError.js';
 export * from './unknownAstNodeError.js';
 export * from './repositoryConsistencyError.js';
+export * from './componentOverrideNotFoundError.js';

--- a/tests/unit/entities/entityManager.removeComponent.test.js
+++ b/tests/unit/entities/entityManager.removeComponent.test.js
@@ -5,6 +5,7 @@ import {
 } from '../../common/entities/index.js';
 import { runInvalidIdPairTests } from '../../common/entities/index.js';
 import { EntityNotFoundError } from '../../../src/errors/entityNotFoundError.js';
+import { ComponentOverrideNotFoundError } from '../../../src/errors/componentOverrideNotFoundError.js';
 import {
   expectComponentRemovedDispatch,
   expectNoDispatch,
@@ -74,9 +75,7 @@ describeEntityManagerSuite('EntityManager - removeComponent', (getBed) => {
       // Act & Assert
       expect(() =>
         entityManager.removeComponent(PRIMARY, NAME_COMPONENT_ID)
-      ).toThrow(
-        "Component 'core:name' not found as an override on entity 'test-instance-01'. Nothing to remove at instance level."
-      );
+      ).toThrow(ComponentOverrideNotFoundError);
       expectNoDispatch(mocks.eventDispatcher.dispatch);
     });
 

--- a/tests/unit/errors/errorClasses.test.js
+++ b/tests/unit/errors/errorClasses.test.js
@@ -4,6 +4,7 @@ import { ActorMismatchError } from '../../../src/errors/actorMismatchError.js';
 import ModDependencyError from '../../../src/errors/modDependencyError.js';
 import ModsLoaderError from '../../../src/errors/modsLoaderError.js';
 import PromptTooLongError from '../../../src/errors/promptTooLongError.js';
+import { ComponentOverrideNotFoundError } from '../../../src/errors/componentOverrideNotFoundError.js';
 import {
   LLMInteractionError,
   ApiKeyError,
@@ -80,5 +81,13 @@ describe('custom error classes', () => {
       expect(e).toBeInstanceOf(LLMInteractionError);
       expect(e.name).toBe(Cls.name);
     }
+  });
+
+  it('ComponentOverrideNotFoundError sets properties', () => {
+    const err = new ComponentOverrideNotFoundError('i1', 'c:t');
+    expect(err.name).toBe('ComponentOverrideNotFoundError');
+    expect(err.instanceId).toBe('i1');
+    expect(err.componentTypeId).toBe('c:t');
+    expect(err.message).toContain("Component 'c:t'");
   });
 });


### PR DESCRIPTION
Summary: Introduces a specific error class for removing absent component overrides and updates the component mutation workflow.

Changes Made:
- Added `ComponentOverrideNotFoundError` with export.
- Updated `ComponentMutationService.removeComponent` to throw the new error.
- Documented the new error in `EntityManager` and adjusted logic accordingly.
- Updated related unit tests and added coverage for the new class.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_685f66b3b8408331ae042cfa702a67ba