### PR TITLE
[Refactor] remove public scope init from WorldInitializer

### DIFF
--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -18,7 +18,6 @@ import {
   WORLDINIT_ENTITY_INSTANTIATED_ID,
   WORLDINIT_ENTITY_INSTANTIATION_FAILED_ID,
 } from '../constants/eventIds.js';
-import loadAndInitScopes from './services/scopeRegistryUtils.js';
 
 // --- Utility Imports ---
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
@@ -60,20 +59,6 @@ class WorldInitializer {
    */
   getWorldContext() {
     return this.#worldContext;
-  }
-
-  /**
-   * Initializes the ScopeRegistry with loaded scopes from the data registry.
-   * This should be called after mods are loaded but before world entities are initialized.
-   *
-   * @returns {Promise<void>}
-   */
-  async initializeScopeRegistry() {
-    await loadAndInitScopes({
-      dataSource: this.#repository.get.bind(this.#repository),
-      scopeRegistry: this.#scopeRegistry,
-      logger: this.#logger,
-    });
   }
 
   /**

--- a/tests/unit/initializers/worldInitializer.initialization-sequence.test.js
+++ b/tests/unit/initializers/worldInitializer.initialization-sequence.test.js
@@ -91,18 +91,15 @@ describe('WorldInitializer - Initialization Sequence', () => {
       mockEntityManager.createEntityInstance.mockReturnValue(mockEntity);
     });
 
-    it('should NOT call initializeScopeRegistry during initializeWorldEntities', async () => {
+    it('should NOT call loadAndInitScopes during initializeWorldEntities', async () => {
       // Spy on the loadAndInitScopes helper
-      const initializeScopeRegistrySpy = jest.spyOn(
-        scopeRegistryUtils,
-        'default'
-      );
+      const loadAndInitScopesSpy = jest.spyOn(scopeRegistryUtils, 'default');
 
       await worldInitializer.initializeWorldEntities('test:world');
 
       // This is the key assertion: scope registry initialization should NOT be called
       // during initializeWorldEntities because it's handled by InitializationService
-      expect(initializeScopeRegistrySpy).not.toHaveBeenCalled();
+      expect(loadAndInitScopesSpy).not.toHaveBeenCalled();
     });
 
     it('should log that scope registry initialization is handled externally', async () => {
@@ -137,7 +134,7 @@ describe('WorldInitializer - Initialization Sequence', () => {
     });
   });
 
-  describe('initializeScopeRegistry standalone behavior', () => {
+  describe('loadAndInitScopes standalone behavior', () => {
     it('should properly initialize scope registry when called directly', async () => {
       const mockScopes = {
         followers: { expr: 'actor.core:leading.followers[]', modId: 'core' },
@@ -268,10 +265,7 @@ describe('WorldInitializer - Initialization Sequence', () => {
     it('should prevent double initialization of scope registry', async () => {
       // This test ensures we don't accidentally re-introduce the double initialization bug
 
-      const initializeScopeRegistrySpy = jest.spyOn(
-        scopeRegistryUtils,
-        'default'
-      );
+      const loadAndInitScopesSpy = jest.spyOn(scopeRegistryUtils, 'default');
 
       // Call both methods that could potentially initialize scope registry
       await scopeRegistryUtils.default({
@@ -281,20 +275,17 @@ describe('WorldInitializer - Initialization Sequence', () => {
       });
       await worldInitializer.initializeWorldEntities('test:world');
 
-      // initializeScopeRegistry should only be called once (the direct call)
-      expect(initializeScopeRegistrySpy).toHaveBeenCalledTimes(1);
+      // loadAndInitScopes should only be called once (the direct call)
+      expect(loadAndInitScopesSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should maintain separation of concerns between scope and entity initialization', async () => {
-      const initializeScopeRegistrySpy = jest.spyOn(
-        scopeRegistryUtils,
-        'default'
-      );
+      const loadAndInitScopesSpy = jest.spyOn(scopeRegistryUtils, 'default');
 
       // Entity initialization should not trigger scope initialization
       await worldInitializer.initializeWorldEntities('test:world');
 
-      expect(initializeScopeRegistrySpy).not.toHaveBeenCalled();
+      expect(loadAndInitScopesSpy).not.toHaveBeenCalled();
 
       // But scope initialization should still work independently
       await scopeRegistryUtils.default({
@@ -303,7 +294,7 @@ describe('WorldInitializer - Initialization Sequence', () => {
         logger: mockLogger,
       });
 
-      expect(initializeScopeRegistrySpy).toHaveBeenCalledTimes(1);
+      expect(loadAndInitScopesSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/initializers/worldInitializer.scopeRegistry.integration.test.js
+++ b/tests/unit/initializers/worldInitializer.scopeRegistry.integration.test.js
@@ -75,7 +75,7 @@ describe('WorldInitializer - ScopeRegistry Integration', () => {
     });
   });
 
-  describe('initializeScopeRegistry integration', () => {
+  describe('loadAndInitScopes integration', () => {
     it('should successfully initialize ScopeRegistry with scopes from GameDataRepository', async () => {
       const mockScopes = {
         'core:all_characters': 'actor',

--- a/tests/unit/initializers/worldInitializer.test.js
+++ b/tests/unit/initializers/worldInitializer.test.js
@@ -611,7 +611,7 @@ describe('WorldInitializer', () => {
     });
   });
 
-  describe('initializeScopeRegistry', () => {
+  describe('loadAndInitScopes helper', () => {
     it('should call scopeRegistry.initialize with scopes from repository', async () => {
       const mockScopes = { 'core:testScope': 'actor' };
       mockGameDataRepository.get = jest.fn().mockReturnValue(mockScopes);


### PR DESCRIPTION
Summary: WorldInitializer no longer exposes a separate scope initialization method. The helper `loadAndInitScopes` is now used by tests and InitializationService. Tests were updated accordingly and references removed.

Changes Made:
- deleted `initializeScopeRegistry` from `WorldInitializer` and removed helper import
- renamed test suites and spies to use `loadAndInitScopes`
- updated integration tests to match new helper names

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685f666166d483319fd82c6b13976063