### PR TITLE
[Agent] add tracing helpers

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -180,8 +180,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       return { actions: [], errors: [], trace: null };
     }
 
-    trace?.addLog(
-      TRACE_INFO,
+    trace?.info(
       `Starting action discovery for actor '${actorEntity.id}'.`,
       'getValidActions',
       { withTrace: shouldTrace }
@@ -228,8 +227,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     this.#logger.debug(
       `Finished action discovery for actor ${actorEntity.id}. Found ${actions.length} actions from ${candidateDefs.length} candidates.`
     );
-    trace?.addLog(
-      TRACE_INFO,
+    trace?.info(
       `Finished discovery. Found ${actions.length} valid actions.`,
       'getValidActions'
     );
@@ -254,23 +252,17 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     trace
   ) {
     const source = 'ActionDiscoveryService.#processCandidateAction';
-    trace?.addLog(
-      TRACE_STEP,
-      `Processing candidate action: '${actionDef.id}'`,
-      source
-    );
+    trace?.step(`Processing candidate action: '${actionDef.id}'`, source);
 
     // STEP 1: Check actor prerequisites
     if (!this.#actorMeetsPrerequisites(actionDef, actorEntity, trace)) {
-      trace?.addLog(
-        TRACE_FAILURE,
+      trace?.failure(
         `Action '${actionDef.id}' discarded due to failed actor prerequisites.`,
         source
       );
       return null;
     }
-    trace?.addLog(
-      TRACE_SUCCESS,
+    trace?.success(
       `Action '${actionDef.id}' passed actor prerequisite check.`,
       source
     );
@@ -289,8 +281,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       );
       return null;
     }
-    trace?.addLog(
-      TRACE_INFO,
+    trace?.info(
       `Scope for action '${actionDef.id}' resolved to ${targetContexts.length} targets.`,
       source,
       { targets: targetContexts.map((t) => t.entityId) }

--- a/src/actions/actionIndex.js
+++ b/src/actions/actionIndex.js
@@ -119,19 +119,13 @@ export class ActionIndex {
 
     const actorComponentTypes =
       this.#entityManager.getAllComponentTypesForEntity(actorEntity.id) || [];
-    trace?.addLog(
-      TRACE_DATA,
-      `Actor '${actorEntity.id}' has components.`,
-      source,
-      {
-        components: actorComponentTypes.length > 0 ? actorComponentTypes : [],
-      }
-    );
+    trace?.data(`Actor '${actorEntity.id}' has components.`, source, {
+      components: actorComponentTypes.length > 0 ? actorComponentTypes : [],
+    });
 
     // Use a Set to automatically handle de-duplication.
     const candidateSet = new Set(this.#noActorRequirement);
-    trace?.addLog(
-      TRACE_INFO,
+    trace?.info(
       `Added ${this.#noActorRequirement.length} actions with no actor component requirements.`,
       source
     );
@@ -139,8 +133,7 @@ export class ActionIndex {
     for (const componentType of actorComponentTypes) {
       const actionsForComponent = this.#byActorComponent.get(componentType);
       if (actionsForComponent) {
-        trace?.addLog(
-          TRACE_INFO,
+        trace?.info(
           `Found ${actionsForComponent.length} actions requiring component '${componentType}'.`,
           source
         );
@@ -151,8 +144,7 @@ export class ActionIndex {
     }
 
     const candidates = Array.from(candidateSet);
-    trace?.addLog(
-      TRACE_SUCCESS,
+    trace?.success(
       `Final candidate list contains ${candidates.length} unique actions.`,
       source,
       { actionIds: candidates.map((a) => a.id) }

--- a/src/actions/targetResolutionService.js
+++ b/src/actions/targetResolutionService.js
@@ -70,11 +70,10 @@ export class TargetResolutionService extends ITargetResolutionService {
   /** @override */
   async resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
     const source = 'TargetResolutionService.resolveTargets';
-    trace?.addLog(TRACE_INFO, `Resolving scope '${scopeName}'.`, source);
+    trace?.info(`Resolving scope '${scopeName}'.`, source);
 
     if (scopeName === TARGET_DOMAIN_NONE) {
-      trace?.addLog(
-        TRACE_INFO,
+      trace?.info(
         `Scope is 'none'; returning a single no-target context.`,
         source
       );
@@ -82,8 +81,7 @@ export class TargetResolutionService extends ITargetResolutionService {
     }
 
     if (scopeName === TARGET_DOMAIN_SELF) {
-      trace?.addLog(
-        TRACE_INFO,
+      trace?.info(
         `Scope is 'self'; returning the actor as the target.`,
         source
       );
@@ -97,8 +95,7 @@ export class TargetResolutionService extends ITargetResolutionService {
       trace
     );
 
-    trace?.addLog(
-      TRACE_INFO,
+    trace?.info(
       `DSL scope '${scopeName}' resolved to ${targetIds.size} target(s).`,
       source,
       { targetIds: Array.from(targetIds) }
@@ -120,11 +117,7 @@ export class TargetResolutionService extends ITargetResolutionService {
    */
   #resolveScopeToIds(scopeName, actorEntity, discoveryContext, trace = null) {
     const source = 'TargetResolutionService.#resolveScopeToIds';
-    trace?.addLog(
-      TRACE_INFO,
-      `Resolving scope '${scopeName}' with DSL.`,
-      source
-    );
+    trace?.info(`Resolving scope '${scopeName}' with DSL.`, source);
     const scopeDefinition = this.#scopeRegistry.getScope(scopeName);
 
     if (
@@ -181,7 +174,7 @@ export class TargetResolutionService extends ITargetResolutionService {
     source,
     originalError = null
   ) {
-    trace?.addLog(TRACE_ERROR, message, source, details);
+    trace?.error(message, source, details);
     originalError
       ? this.#logger.error(message, originalError)
       : this.#logger.warn(message);

--- a/src/actions/tracing/traceContext.js
+++ b/src/actions/tracing/traceContext.js
@@ -63,4 +63,82 @@ export class TraceContext {
 
     this.logs.push(logEntry);
   }
+
+  /**
+   * Convenience wrapper for logging an informational message.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  info(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_INFO, msg, src)
+      : this.addLog(TRACE_INFO, msg, src, data);
+  }
+
+  /**
+   * Convenience wrapper for logging a success event.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  success(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_SUCCESS, msg, src)
+      : this.addLog(TRACE_SUCCESS, msg, src, data);
+  }
+
+  /**
+   * Convenience wrapper for logging a failure event.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  failure(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_FAILURE, msg, src)
+      : this.addLog(TRACE_FAILURE, msg, src, data);
+  }
+
+  /**
+   * Convenience wrapper for logging a high-level step in a process.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  step(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_STEP, msg, src)
+      : this.addLog(TRACE_STEP, msg, src, data);
+  }
+
+  /**
+   * Convenience wrapper for logging an error event.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  error(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_ERROR, msg, src)
+      : this.addLog(TRACE_ERROR, msg, src, data);
+  }
+
+  /**
+   * Convenience wrapper for logging a data payload.
+   *
+   * @param {string} msg The log message.
+   * @param {string} src The source of the log entry.
+   * @param {object} [data] Optional payload.
+   */
+  data(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_DATA, msg, src)
+      : this.addLog(TRACE_DATA, msg, src, data);
+  }
 }

--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -232,7 +232,7 @@ export class PrerequisiteEvaluationService extends BaseService {
     const source = 'PrerequisiteEvaluationService._evaluatePrerequisite';
     const originalLogic = prereqObject.logic;
 
-    trace?.addLog(TRACE_INFO, 'Evaluating rule.', source, {
+    trace?.info('Evaluating rule.', source, {
       logic: originalLogic || {},
     });
 
@@ -242,7 +242,7 @@ export class PrerequisiteEvaluationService extends BaseService {
     );
 
     if (JSON.stringify(originalLogic) !== JSON.stringify(resolvedLogic)) {
-      trace?.addLog(TRACE_DATA, 'Condition reference resolved.', source, {
+      trace?.data('Condition reference resolved.', source, {
         resolvedLogic: resolvedLogic || {},
       });
     }
@@ -255,12 +255,13 @@ export class PrerequisiteEvaluationService extends BaseService {
 
     const result = this._executeJsonLogic(resolvedLogic, evaluationContext);
 
-    trace?.addLog(
-      result ? TRACE_SUCCESS : TRACE_FAILURE,
-      `Rule evaluation result: ${result}`,
-      source,
-      { result: Boolean(result) }
-    );
+    result
+      ? trace?.success(`Rule evaluation result: ${result}`, source, {
+          result: Boolean(result),
+        })
+      : trace?.failure(`Rule evaluation result: ${result}`, source, {
+          result: Boolean(result),
+        });
 
     return result;
   }
@@ -306,8 +307,7 @@ export class PrerequisiteEvaluationService extends BaseService {
         trace
       );
     } catch (evalError) {
-      trace?.addLog(
-        TRACE_ERROR,
+      trace?.error(
         `Error during rule evaluation: ${evalError.message}`,
         source,
         { error: evalError }
@@ -404,14 +404,9 @@ export class PrerequisiteEvaluationService extends BaseService {
       return false;
     }
 
-    trace?.addLog(
-      TRACE_DATA,
-      'Built prerequisite evaluation context.',
-      source,
-      {
-        context: evaluationContext || {},
-      }
-    );
+    trace?.data('Built prerequisite evaluation context.', source, {
+      context: evaluationContext || {},
+    });
 
     return this.#evaluateRules(
       prerequisites,

--- a/tests/unit/actions/actionDiscoveryService.tracing.test.js
+++ b/tests/unit/actions/actionDiscoveryService.tracing.test.js
@@ -8,11 +8,48 @@ import {
   TRACE_FAILURE,
 } from '../../../src/actions/tracing/traceContext.js';
 
-jest.mock('../../../src/actions/tracing/traceContext.js', () => ({
-  TraceContext: jest
-    .fn()
-    .mockImplementation(() => ({ addLog: jest.fn(), logs: [] })),
-}));
+jest.mock('../../../src/actions/tracing/traceContext.js', () => {
+  const actual = jest.requireActual(
+    '../../../src/actions/tracing/traceContext.js'
+  );
+  return {
+    ...actual,
+    TraceContext: jest.fn().mockImplementation(() => ({
+      addLog: jest.fn(),
+      info(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_INFO, msg, src)
+          : this.addLog(actual.TRACE_INFO, msg, src, data);
+      },
+      step(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_STEP, msg, src)
+          : this.addLog(actual.TRACE_STEP, msg, src, data);
+      },
+      success(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_SUCCESS, msg, src)
+          : this.addLog(actual.TRACE_SUCCESS, msg, src, data);
+      },
+      failure(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_FAILURE, msg, src)
+          : this.addLog(actual.TRACE_FAILURE, msg, src, data);
+      },
+      error(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_ERROR, msg, src)
+          : this.addLog(actual.TRACE_ERROR, msg, src, data);
+      },
+      data(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_DATA, msg, src)
+          : this.addLog(actual.TRACE_DATA, msg, src, data);
+      },
+      logs: [],
+    })),
+  };
+});
 
 describeActionDiscoverySuite(
   'ActionDiscoveryService Tracing',

--- a/tests/unit/actions/actionIndex.tracing.test.js
+++ b/tests/unit/actions/actionIndex.tracing.test.js
@@ -17,14 +17,46 @@ import { mock } from 'jest-mock-extended';
 
 // Mock the TraceContext to spy on its methods
 jest.mock('../../../src/actions/tracing/traceContext.js', () => {
+  const actual = jest.requireActual(
+    '../../../src/actions/tracing/traceContext.js'
+  );
   return {
-    TraceContext: jest.fn().mockImplementation(() => {
-      return {
-        addLog: jest.fn(),
-        logs: [],
-        result: null,
-      };
-    }),
+    ...actual,
+    TraceContext: jest.fn().mockImplementation(() => ({
+      addLog: jest.fn(),
+      info(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_INFO, msg, src)
+          : this.addLog(actual.TRACE_INFO, msg, src, data);
+      },
+      success(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_SUCCESS, msg, src)
+          : this.addLog(actual.TRACE_SUCCESS, msg, src, data);
+      },
+      failure(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_FAILURE, msg, src)
+          : this.addLog(actual.TRACE_FAILURE, msg, src, data);
+      },
+      step(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_STEP, msg, src)
+          : this.addLog(actual.TRACE_STEP, msg, src, data);
+      },
+      error(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_ERROR, msg, src)
+          : this.addLog(actual.TRACE_ERROR, msg, src, data);
+      },
+      data(msg, src, data) {
+        data === undefined
+          ? this.addLog(actual.TRACE_DATA, msg, src)
+          : this.addLog(actual.TRACE_DATA, msg, src, data);
+      },
+      logs: [],
+      result: null,
+    })),
   };
 });
 

--- a/tests/unit/actions/traceContext.test.js
+++ b/tests/unit/actions/traceContext.test.js
@@ -4,6 +4,9 @@ import {
   TRACE_INFO,
   TRACE_ERROR,
   TRACE_SUCCESS,
+  TRACE_FAILURE,
+  TRACE_STEP,
+  TRACE_DATA,
 } from '../../../src/actions/tracing/traceContext.js';
 
 describe('TraceContext', () => {
@@ -43,5 +46,24 @@ describe('TraceContext', () => {
     trace.addLog(TRACE_INFO, 'first', 'src1');
     trace.addLog(TRACE_SUCCESS, 'second', 'src2', { value: 42 });
     expect(trace.logs.map((l) => l.message)).toEqual(['first', 'second']);
+  });
+
+  it('exposes helper methods for each log type', () => {
+    const trace = new TraceContext();
+    trace.info('i', 'src');
+    trace.success('s', 'src');
+    trace.failure('f', 'src');
+    trace.step('p', 'src');
+    trace.error('e', 'src');
+    trace.data('d', 'src');
+
+    expect(trace.logs.map((l) => l.type)).toEqual([
+      TRACE_INFO,
+      TRACE_SUCCESS,
+      TRACE_FAILURE,
+      TRACE_STEP,
+      TRACE_ERROR,
+      TRACE_DATA,
+    ]);
   });
 });

--- a/tests/unit/actions/validation/prerequisiteEvaluationService.tracing.test.js
+++ b/tests/unit/actions/validation/prerequisiteEvaluationService.tracing.test.js
@@ -20,6 +20,36 @@ const mockGameDataRepository = mock();
 // Mock TraceContext
 const mockTraceContext = {
   addLog: jest.fn(),
+  info(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_INFO, msg, src)
+      : this.addLog(TRACE_INFO, msg, src, data);
+  },
+  success(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_SUCCESS, msg, src)
+      : this.addLog(TRACE_SUCCESS, msg, src, data);
+  },
+  failure(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_FAILURE, msg, src)
+      : this.addLog(TRACE_FAILURE, msg, src, data);
+  },
+  step(msg, src, data) {
+    data === undefined
+      ? this.addLog('step', msg, src)
+      : this.addLog('step', msg, src, data);
+  },
+  error(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_ERROR, msg, src)
+      : this.addLog(TRACE_ERROR, msg, src, data);
+  },
+  data(msg, src, data) {
+    data === undefined
+      ? this.addLog(TRACE_DATA, msg, src)
+      : this.addLog(TRACE_DATA, msg, src, data);
+  },
 };
 
 // Test data

--- a/tests/unit/scopeDsl/engine.additional.test.js
+++ b/tests/unit/scopeDsl/engine.additional.test.js
@@ -35,6 +35,36 @@ const mockLogger = {
 
 const mockTraceContext = {
   addLog: jest.fn(),
+  info(msg, src, data) {
+    data === undefined
+      ? this.addLog('info', msg, src)
+      : this.addLog('info', msg, src, data);
+  },
+  success(msg, src, data) {
+    data === undefined
+      ? this.addLog('success', msg, src)
+      : this.addLog('success', msg, src, data);
+  },
+  failure(msg, src, data) {
+    data === undefined
+      ? this.addLog('failure', msg, src)
+      : this.addLog('failure', msg, src, data);
+  },
+  step(msg, src, data) {
+    data === undefined
+      ? this.addLog('step', msg, src)
+      : this.addLog('step', msg, src, data);
+  },
+  error(msg, src, data) {
+    data === undefined
+      ? this.addLog('error', msg, src)
+      : this.addLog('error', msg, src, data);
+  },
+  data(msg, src, data) {
+    data === undefined
+      ? this.addLog('data', msg, src)
+      : this.addLog('data', msg, src, data);
+  },
 };
 
 const mockRuntimeCtx = {

--- a/tests/unit/scopeDsl/engine.comprehensive.test.js
+++ b/tests/unit/scopeDsl/engine.comprehensive.test.js
@@ -331,6 +331,36 @@ describe('ScopeEngine - Comprehensive Coverage Tests', () => {
     test('should handle trace context integration', () => {
       const mockTraceContext = {
         addLog: jest.fn(),
+        info(msg, src, data) {
+          data === undefined
+            ? this.addLog('info', msg, src)
+            : this.addLog('info', msg, src, data);
+        },
+        success(msg, src, data) {
+          data === undefined
+            ? this.addLog('success', msg, src)
+            : this.addLog('success', msg, src, data);
+        },
+        failure(msg, src, data) {
+          data === undefined
+            ? this.addLog('failure', msg, src)
+            : this.addLog('failure', msg, src, data);
+        },
+        step(msg, src, data) {
+          data === undefined
+            ? this.addLog('step', msg, src)
+            : this.addLog('step', msg, src, data);
+        },
+        error(msg, src, data) {
+          data === undefined
+            ? this.addLog('error', msg, src)
+            : this.addLog('error', msg, src, data);
+        },
+        data(msg, src, data) {
+          data === undefined
+            ? this.addLog('data', msg, src)
+            : this.addLog('data', msg, src, data);
+        },
       };
 
       const ast = parseDslExpression('location');

--- a/tests/unit/scopeDsl/engine.test.js
+++ b/tests/unit/scopeDsl/engine.test.js
@@ -37,6 +37,36 @@ const mockLogger = {
 // Mock TraceContext for instrumentation tests
 const mockTraceContext = {
   addLog: jest.fn(),
+  info(msg, src, data) {
+    data === undefined
+      ? this.addLog('info', msg, src)
+      : this.addLog('info', msg, src, data);
+  },
+  success(msg, src, data) {
+    data === undefined
+      ? this.addLog('success', msg, src)
+      : this.addLog('success', msg, src, data);
+  },
+  failure(msg, src, data) {
+    data === undefined
+      ? this.addLog('failure', msg, src)
+      : this.addLog('failure', msg, src, data);
+  },
+  step(msg, src, data) {
+    data === undefined
+      ? this.addLog('step', msg, src)
+      : this.addLog('step', msg, src, data);
+  },
+  error(msg, src, data) {
+    data === undefined
+      ? this.addLog('error', msg, src)
+      : this.addLog('error', msg, src, data);
+  },
+  data(msg, src, data) {
+    data === undefined
+      ? this.addLog('data', msg, src)
+      : this.addLog('data', msg, src, data);
+  },
 };
 
 const mockRuntimeCtx = {


### PR DESCRIPTION
## Summary
- expose convenience trace logging methods
- refactor action modules to use the new helpers
- adjust mocks in tracing tests
- add tests for helper methods

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f6651480083319113aa0efbaa3147