### PR TITLE
[Agent] validate location ID in LocationQueryService

### DIFF
--- a/src/entities/locationQueryService.js
+++ b/src/entities/locationQueryService.js
@@ -3,21 +3,27 @@
  * @see src/entities/locationQueryService.js
  */
 
+import { assertValidId } from '../utils/parameterGuards.js';
+import { InvalidArgumentError } from '../errors/invalidArgumentError.js';
+
 /**
  * @typedef {import('../interfaces/coreServices.js').ISpatialIndexManager} ISpatialIndexManager
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  */
 
 /**
- * @description Service for querying entities by location.
+ * Service for querying entities by location.
  * This service provides location-based entity queries by delegating to the spatial index manager.
+ *
  * @class LocationQueryService
  */
 export class LocationQueryService {
   /**
-   * @param {object} dependencies
-   * @param {ISpatialIndexManager} dependencies.spatialIndexManager
-   * @param {ILogger} dependencies.logger
+   * Create a new LocationQueryService.
+   *
+   * @param {object} dependencies - Constructor dependencies.
+   * @param {ISpatialIndexManager} dependencies.spatialIndexManager - Spatial index manager used for lookups.
+   * @param {ILogger} dependencies.logger - Logger instance.
    */
   constructor({ spatialIndexManager, logger }) {
     /** @private */
@@ -37,12 +43,23 @@ export class LocationQueryService {
    */
   getEntitiesInLocation(locationId) {
     try {
+      assertValidId(
+        locationId,
+        'LocationQueryService.getEntitiesInLocation',
+        this.logger
+      );
       return this.spatialIndexManager.getEntitiesInLocation(locationId);
     } catch (error) {
-      this.logger.error(
-        `LocationQueryService.getEntitiesInLocation: Error querying spatial index for location '${locationId}':`,
-        error
-      );
+      if (error instanceof InvalidArgumentError) {
+        this.logger.warn(
+          `LocationQueryService.getEntitiesInLocation called with invalid locationId: '${locationId}'`
+        );
+      } else {
+        this.logger.error(
+          `LocationQueryService.getEntitiesInLocation: Error querying spatial index for location '${locationId}':`,
+          error
+        );
+      }
       return new Set();
     }
   }

--- a/tests/unit/entities/locationQueryService.test.js
+++ b/tests/unit/entities/locationQueryService.test.js
@@ -1,0 +1,38 @@
+import { describe, it, beforeEach, expect } from '@jest/globals';
+import { LocationQueryService } from '../../../src/entities/locationQueryService.js';
+import { createMockSpatialIndexManager } from '../../common/mockFactories/spatialIndexManager.js';
+import { createMockLogger } from '../../common/mockFactories/loggerMocks.js';
+
+describe('LocationQueryService', () => {
+  let spatialIndexManager;
+  let logger;
+  let service;
+
+  beforeEach(() => {
+    spatialIndexManager = createMockSpatialIndexManager();
+    logger = createMockLogger();
+    service = new LocationQueryService({ spatialIndexManager, logger });
+  });
+
+  it('delegates queries to the spatial index manager for valid IDs', () => {
+    const set = new Set(['a']);
+    spatialIndexManager.getEntitiesInLocation.mockReturnValue(set);
+
+    const result = service.getEntitiesInLocation('loc1');
+
+    expect(spatialIndexManager.getEntitiesInLocation).toHaveBeenCalledWith(
+      'loc1'
+    );
+    expect(result).toBe(set);
+  });
+
+  it('returns an empty set and warns when ID is invalid', () => {
+    const result = service.getEntitiesInLocation('');
+
+    expect(spatialIndexManager.getEntitiesInLocation).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "LocationQueryService.getEntitiesInLocation called with invalid locationId: ''"
+    );
+    expect(result).toEqual(new Set());
+  });
+});


### PR DESCRIPTION
## Summary
- use `assertValidId` inside `LocationQueryService.getEntitiesInLocation`
- warn and return empty set when ID is invalid
- add unit tests for `LocationQueryService`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f66acd7588331bd7362a8e833dbeb