### PR TITLE
[Agent] add logger to EntityInstanceData

### DIFF
--- a/src/entities/entityInstanceData.js
+++ b/src/entities/entityInstanceData.js
@@ -7,6 +7,8 @@ import { cloneDeep } from 'lodash';
 import { freeze } from '../utils/cloneUtils.js';
 import EntityDefinition from './entityDefinition.js';
 
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+
 /**
  * Represents the mutable, runtime data for a unique instance of an entity.
  * It holds a reference to its EntityDefinition and any per-instance component overrides.
@@ -14,6 +16,13 @@ import EntityDefinition from './entityDefinition.js';
  * @module core/entities/entityInstanceData
  */
 class EntityInstanceData {
+  /**
+   * Logger used for warnings and debug output.
+   *
+   * @type {ILogger}
+   * @private
+   */
+  #logger;
   /**
    * The unique runtime identifier for this entity instance (e.g., a UUID).
    *
@@ -47,10 +56,11 @@ class EntityInstanceData {
    * @param {string} instanceId - The unique runtime identifier for this instance.
    * @param {EntityDefinition} definition - The EntityDefinition this instance is based on.
    * @param {Record<string, object>} [initialOverrides] - Optional initial component overrides.
+   * @param {ILogger} [logger] - Logger for warnings and diagnostics.
    * @throws {Error} If instanceId is not a valid string.
    * @throws {Error} If definition is not an instance of EntityDefinition.
    */
-  constructor(instanceId, definition, initialOverrides = {}) {
+  constructor(instanceId, definition, initialOverrides = {}, logger = console) {
     if (typeof instanceId !== 'string' || !instanceId.trim()) {
       throw new Error('EntityInstanceData requires a valid string instanceId.');
     }
@@ -62,6 +72,7 @@ class EntityInstanceData {
 
     this.instanceId = instanceId;
     this.definition = definition;
+    this.#logger = logger;
     // Use cloneDeep for initialOverrides to ensure deep copy and freeze to
     // discourage external mutation.
     this.overrides = freeze(
@@ -163,8 +174,7 @@ class EntityInstanceData {
    */
   hasComponent(componentTypeId, checkOverrideOnly = false) {
     if (arguments.length === 2) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      this.#logger.warn(
         'EntityInstanceData.hasComponent: The checkOverrideOnly flag is deprecated. Use hasComponentOverride(componentTypeId) instead.'
       );
       if (checkOverrideOnly) {

--- a/src/entities/factories/entityFactory.js
+++ b/src/entities/factories/entityFactory.js
@@ -291,7 +291,8 @@ class EntityFactory {
     const entityInstanceDataObject = new EntityInstanceData(
       actualInstanceId,
       entityDefinition,
-      validatedOverrides
+      validatedOverrides,
+      this.#logger
     );
     // Create Entity with just the instance data
     const entity = new Entity(entityInstanceDataObject);
@@ -371,7 +372,8 @@ class EntityFactory {
     const instanceDataForReconstruction = new EntityInstanceData(
       instanceId, // Corrected: instanceId first
       definitionToUse,
-      validatedComponents
+      validatedComponents,
+      this.#logger
     );
     // Create Entity with just the instance data
     const entity = new Entity(instanceDataForReconstruction);

--- a/tests/common/entities/entityFactories.js
+++ b/tests/common/entities/entityFactories.js
@@ -25,6 +25,7 @@ export function createEntityDefinition(
  * @param {string} [params.definitionId] - Definition identifier.
  * @param {Record<string, any>} [params.baseComponents] - Components on the definition.
  * @param {Record<string, any>} [params.overrides] - Component overrides for the instance.
+ * @param {object} [params.logger] - Logger for EntityInstanceData.
  * @returns {Entity} Newly created entity instance.
  */
 export function createEntityInstance({
@@ -32,11 +33,17 @@ export function createEntityInstance({
   definitionId = 'test:def',
   baseComponents = {},
   overrides = {},
+  logger = console,
 }) {
   const defId = definitionId.includes(':')
     ? definitionId
     : `test:${definitionId}`;
   const definition = createEntityDefinition(defId, baseComponents);
-  const data = new EntityInstanceData(instanceId, definition, overrides);
+  const data = new EntityInstanceData(
+    instanceId,
+    definition,
+    overrides,
+    logger
+  );
   return new Entity(data);
 }

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -40,7 +40,8 @@ const createTestEntity = (
   instanceId,
   definitionId,
   defComponents = {},
-  instanceOverrides = {}
+  instanceOverrides = {},
+  logger = console
 ) => {
   const definition = new EntityDefinition(definitionId, {
     description: `Test Definition ${definitionId}`,
@@ -49,7 +50,8 @@ const createTestEntity = (
   const instanceData = new EntityInstanceData(
     instanceId,
     definition,
-    instanceOverrides
+    instanceOverrides,
+    logger
   );
   return new Entity(instanceData);
 };

--- a/tests/unit/adapters/coreAdapters.test.js
+++ b/tests/unit/adapters/coreAdapters.test.js
@@ -66,7 +66,7 @@ describe('DefaultComponentPolicy', () => {
     const def = new EntityDefinition('actor', {
       components: { [ACTOR_COMPONENT_ID]: {} },
     });
-    const data = new EntityInstanceData('e1', def);
+    const data = new EntityInstanceData('e1', def, {}, logger);
     const entity = new Entity(data);
 
     const policy = new DefaultComponentPolicy();
@@ -98,7 +98,7 @@ describe('DefaultComponentPolicy', () => {
         [GOALS_COMPONENT_ID]: { goals: [{ text: 'x' }] },
       },
     });
-    const data = new EntityInstanceData('e2', def);
+    const data = new EntityInstanceData('e2', def, {}, logger);
     const entity = new Entity(data);
 
     const policy = new DefaultComponentPolicy();
@@ -117,7 +117,7 @@ describe('DefaultComponentPolicy', () => {
     const validator = createMockSchemaValidator();
     const logger = createMockLogger();
     const def = new EntityDefinition('basic', { components: {} });
-    const data = new EntityInstanceData('e3', def);
+    const data = new EntityInstanceData('e3', def, {}, logger);
     const entity = new Entity(data);
 
     const policy = new DefaultComponentPolicy();

--- a/tests/unit/adapters/defaultComponentPolicy.errorHandling.test.js
+++ b/tests/unit/adapters/defaultComponentPolicy.errorHandling.test.js
@@ -24,7 +24,7 @@ describe('DefaultComponentPolicy error handling', () => {
     const def = new EntityDefinition('actor', {
       components: { [ACTOR_COMPONENT_ID]: {} },
     });
-    const data = new EntityInstanceData('e1', def);
+    const data = new EntityInstanceData('e1', def, {}, logger);
     const entity = new Entity(data);
 
     const policy = new DefaultComponentPolicy();
@@ -53,7 +53,7 @@ describe('DefaultComponentPolicy error handling', () => {
     const def = new EntityDefinition('actor', {
       components: { [ACTOR_COMPONENT_ID]: {} },
     });
-    const data = new EntityInstanceData('e2', def);
+    const data = new EntityInstanceData('e2', def, {}, logger);
     const entity = new Entity(data);
 
     const policy = new DefaultComponentPolicy();

--- a/tests/unit/context/worldContext.edgeCases.test.js
+++ b/tests/unit/context/worldContext.edgeCases.test.js
@@ -40,7 +40,6 @@ import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 describe('WorldContext Edge Cases', () => {
   let worldContext;
   let logger;
-  let loggerErrorSpy;
   let loggerWarnSpy;
   let dispatcher;
   let originalNodeEnv; // Variable to store original NODE_ENV
@@ -50,7 +49,8 @@ describe('WorldContext Edge Cases', () => {
     instanceId,
     definitionId,
     defComponents = {},
-    instanceOverrides = {}
+    instanceOverrides = {},
+    logger = console
   ) => {
     const definition = new EntityDefinition(definitionId, {
       description: `Test Definition ${definitionId}`,
@@ -59,7 +59,8 @@ describe('WorldContext Edge Cases', () => {
     const instanceData = new EntityInstanceData(
       instanceId,
       definition,
-      instanceOverrides
+      instanceOverrides,
+      logger
     );
     return new Entity(instanceData);
   };
@@ -74,7 +75,6 @@ describe('WorldContext Edge Cases', () => {
 
     logger = new ConsoleLogger(); // Use the actual logger to spy on it
     // Suppress actual console output for errors and warnings during tests
-    loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
     loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
     // Also mock info/debug if necessary to suppress console noise during tests
     jest.spyOn(logger, 'info').mockImplementation(() => {});

--- a/tests/unit/context/worldContext.test.js
+++ b/tests/unit/context/worldContext.test.js
@@ -13,10 +13,7 @@ import WorldContext from '../../../src/context/worldContext.js';
 import Entity from '../../../src/entities/entity.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../../src/entities/entityInstanceData.js';
-import {
-  POSITION_COMPONENT_ID,
-  CURRENT_ACTOR_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
+import { POSITION_COMPONENT_ID } from '../../../src/constants/componentIds.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 
 const createMockEntityManager = () => ({
@@ -38,7 +35,8 @@ const createTestEntity = (
   instanceId,
   definitionId,
   defComponents = {},
-  instanceOverrides = {}
+  instanceOverrides = {},
+  logger = console
 ) => {
   const definition = new EntityDefinition(definitionId, {
     description: `Test Definition ${definitionId}`,
@@ -47,7 +45,8 @@ const createTestEntity = (
   const instanceData = new EntityInstanceData(
     instanceId,
     definition,
-    instanceOverrides
+    instanceOverrides,
+    logger
   );
   return new Entity(instanceData);
 };

--- a/tests/unit/entities/EntityInstanceData.test.js
+++ b/tests/unit/entities/EntityInstanceData.test.js
@@ -19,7 +19,12 @@ describe('EntityInstanceData', () => {
   const validInstanceId = 'instance-123';
 
   it('should be creatable with valid instanceId and EntityDefinition', () => {
-    const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+    const instanceData = new EntityInstanceData(
+      validInstanceId,
+      entityDef,
+      {},
+      console
+    );
     expect(instanceData).toBeInstanceOf(EntityInstanceData);
     expect(instanceData.instanceId).toBe(validInstanceId);
     expect(instanceData.definition).toBe(entityDef);
@@ -34,7 +39,8 @@ describe('EntityInstanceData', () => {
     const instanceData = new EntityInstanceData(
       validInstanceId,
       entityDef,
-      initialOverrides
+      initialOverrides,
+      console
     );
     expect(instanceData.overrides['core:health'].current).toBe(40);
     // Check that it does not affect the original initialOverrides object
@@ -47,23 +53,28 @@ describe('EntityInstanceData', () => {
   });
 
   it('should throw an error if instanceId is invalid', () => {
-    expect(() => new EntityInstanceData(null, entityDef)).toThrow(
+    expect(() => new EntityInstanceData(null, entityDef, {}, console)).toThrow(
       'EntityInstanceData requires a valid string instanceId.'
     );
-    expect(() => new EntityInstanceData('', entityDef)).toThrow(
+    expect(() => new EntityInstanceData('', entityDef, {}, console)).toThrow(
       'EntityInstanceData requires a valid string instanceId.'
     );
   });
 
   it('should throw an error if definition is not an EntityDefinition', () => {
-    expect(() => new EntityInstanceData(validInstanceId, {})).toThrow(
-      'EntityInstanceData requires a valid EntityDefinition object.'
-    );
+    expect(
+      () => new EntityInstanceData(validInstanceId, {}, {}, console)
+    ).toThrow('EntityInstanceData requires a valid EntityDefinition object.');
   });
 
   describe('getComponentData', () => {
     it('should return data from definition if no override exists', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       const health = instanceData.getComponentData('core:health');
       expect(health).toEqual({ current: 50, max: 50, regen: 1 });
       // Ensure it's a clone and not the definition's object
@@ -71,9 +82,14 @@ describe('EntityInstanceData', () => {
     });
 
     it('should return overridden data if an override exists', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': { current: 30, max: 45 },
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': { current: 30, max: 45 },
+        },
+        console
+      );
       const health = instanceData.getComponentData('core:health');
       // Should now only return the override, not a merge
       expect(health).toEqual({ current: 30, max: 45 });
@@ -82,29 +98,49 @@ describe('EntityInstanceData', () => {
     it('should merge object properties: override wins over definition', () => {
       // This test title is now a misnomer, as it no longer merges.
       // The behavior is that override replaces.
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': { current: 25 }, // Only current is overridden
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': { current: 25 }, // Only current is overridden
+        },
+        console
+      );
       const health = instanceData.getComponentData('core:health');
       expect(health).toEqual({ current: 25 }); // Only the override data should be present
     });
 
     it('should return a clone of the override if definition does not have the component', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'custom:status': { effect: 'poisoned' },
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'custom:status': { effect: 'poisoned' },
+        },
+        console
+      );
       const status = instanceData.getComponentData('custom:status');
       expect(status).toEqual({ effect: 'poisoned' });
       expect(status).not.toBe(instanceData.overrides['custom:status']);
     });
 
     it('should return undefined if component is not in definition or overrides', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(instanceData.getComponentData('non:existent')).toBeUndefined();
     });
 
     it('should throw a TypeError if override data is null', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(() =>
         instanceData.setComponentOverride('core:health', null)
       ).toThrow(TypeError);
@@ -112,9 +148,14 @@ describe('EntityInstanceData', () => {
 
     it('should return a clone, not the original override object, when override is an object', () => {
       const overrideData = { current: 10 };
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': overrideData,
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': overrideData,
+        },
+        console
+      );
       const health = instanceData.getComponentData('core:health');
       expect(health).not.toBe(overrideData); // Should be a new object due to merging or cloning
       health.current = 5;
@@ -122,7 +163,12 @@ describe('EntityInstanceData', () => {
     });
 
     it('should return a clone, not the original definition object, when no override and definition data is an object', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       const nameComp = instanceData.getComponentData('core:name');
       expect(nameComp).not.toBe(entityDef.components['core:name']);
       nameComp.name = 'Changed Name';
@@ -132,7 +178,12 @@ describe('EntityInstanceData', () => {
 
   describe('setComponentOverride', () => {
     it('should add a new override', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       const inventoryData = { items: ['sword'] };
       instanceData.setComponentOverride('custom:inventory', inventoryData);
       expect(instanceData.overrides['custom:inventory']).toEqual(inventoryData);
@@ -142,9 +193,14 @@ describe('EntityInstanceData', () => {
     });
 
     it('should update an existing override', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': { current: 30 },
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': { current: 30 },
+        },
+        console
+      );
       instanceData.setComponentOverride('core:health', {
         current: 20,
         max: 40,
@@ -156,14 +212,24 @@ describe('EntityInstanceData', () => {
     });
 
     it('should throw if componentTypeId is invalid', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(() => instanceData.setComponentOverride('', {})).toThrow(
         'Invalid componentTypeId for setComponentOverride.'
       );
     });
 
     it('should throw a TypeError if componentData is not an object', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(() =>
         instanceData.setComponentOverride('core:health', 42)
       ).toThrow(TypeError);
@@ -172,15 +238,25 @@ describe('EntityInstanceData', () => {
 
   describe('removeComponentOverride', () => {
     it('should remove an existing override', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': { current: 30 },
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': { current: 30 },
+        },
+        console
+      );
       expect(instanceData.removeComponentOverride('core:health')).toBe(true);
       expect(instanceData.overrides['core:health']).toBeUndefined();
     });
 
     it('should return false if override does not exist', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(instanceData.removeComponentOverride('core:health')).toBe(false);
     });
 
@@ -196,7 +272,12 @@ describe('EntityInstanceData', () => {
 
   describe('hasComponent', () => {
     it('should return true if component is in definition', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(instanceData.hasComponent('core:health')).toBe(true);
     });
 
@@ -208,12 +289,22 @@ describe('EntityInstanceData', () => {
     });
 
     it('should return false if component is in neither', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(instanceData.hasComponent('non:existent')).toBe(false);
     });
 
     it('should throw a TypeError when attempting to set a null override', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       expect(() =>
         instanceData.setComponentOverride('core:health', null)
       ).toThrow(TypeError);
@@ -222,7 +313,12 @@ describe('EntityInstanceData', () => {
 
   describe('allComponentTypeIds', () => {
     it('should return keys from definition if no overrides', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef);
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {},
+        console
+      );
       const ids = instanceData.allComponentTypeIds;
       expect(ids).toEqual(
         expect.arrayContaining(['core:health', 'core:name', 'custom:mana'])
@@ -231,10 +327,15 @@ describe('EntityInstanceData', () => {
     });
 
     it('should return a combined set of keys from definition and overrides', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:health': { current: 10 }, // Overlap
-        'new:ability': { name: 'fly' }, // New
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:health': { current: 10 }, // Overlap
+          'new:ability': { name: 'fly' }, // New
+        },
+        console
+      );
       const ids = instanceData.allComponentTypeIds;
       expect(ids).toEqual(
         expect.arrayContaining([
@@ -248,10 +349,15 @@ describe('EntityInstanceData', () => {
     });
 
     it('should include keys of overrides that are set to null', () => {
-      const instanceData = new EntityInstanceData(validInstanceId, entityDef, {
-        'core:name': null, // Nullify existing
-        'new:aura': null, // New but nullified
-      });
+      const instanceData = new EntityInstanceData(
+        validInstanceId,
+        entityDef,
+        {
+          'core:name': null, // Nullify existing
+          'new:aura': null, // New but nullified
+        },
+        console
+      );
       const ids = instanceData.allComponentTypeIds;
       expect(ids).toEqual(
         expect.arrayContaining([

--- a/tests/unit/entities/entity.test.js
+++ b/tests/unit/entities/entity.test.js
@@ -32,7 +32,8 @@ describe('Entity Class', () => {
     mockInstanceData = new EntityInstanceData(
       testInstanceId,
       mockDefinition,
-      {}
+      {},
+      console
     );
 
     entity = new Entity(mockInstanceData);
@@ -107,9 +108,14 @@ describe('Entity Class', () => {
           'core:health': { current: 100, max: 100 },
         },
       });
-      const instanceData = new EntityInstanceData('test-id', def, {
-        'core:health': { current: 50 }, // Override only current
-      });
+      const instanceData = new EntityInstanceData(
+        'test-id',
+        def,
+        {
+          'core:health': { current: 50 }, // Override only current
+        },
+        console
+      );
       const entity = new Entity(instanceData);
 
       const healthData = entity.getComponentData('core:health');
@@ -247,7 +253,8 @@ describe('Entity Class', () => {
         {
           'core:health': { current: 50 }, // Override only current health
           'custom:inventory': { items: ['potion'] },
-        }
+        },
+        console
       );
       const entity = new Entity(instanceData);
 
@@ -285,7 +292,8 @@ describe('Entity Class', () => {
         {
           'core:health': { current: 75 }, // Override only current health
           'custom:stamina': { value: 30 },
-        }
+        },
+        console
       );
       const entity = new Entity(instanceData);
 
@@ -313,8 +321,6 @@ describe('Entity Class', () => {
   describe('toString', () => {
     it('should return a string representation of the entity including its ID, DefID and component types', () => {
       mockInstanceData.setComponentOverride('custom:mana', { current: 10 });
-      const expectedString = `Entity[${testInstanceId} (Def: ${testDefinitionId})] Components: core:name, core:health, custom:mana`;
-      // Order might vary, so check parts or use a regex/matcher
       const str = entity.toString();
       expect(str).toContain(
         `Entity[${testInstanceId} (Def: ${testDefinitionId})]`
@@ -326,7 +332,12 @@ describe('Entity Class', () => {
 
     it('should display "None" if no components are present', () => {
       const emptyDef = new EntityDefinition('empty:def', { components: {} });
-      const emptyInstanceData = new EntityInstanceData('emptyInst', emptyDef);
+      const emptyInstanceData = new EntityInstanceData(
+        'emptyInst',
+        emptyDef,
+        {},
+        console
+      );
       const emptyEntity = new Entity(emptyInstanceData);
 
       const expectedString =

--- a/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
+++ b/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
@@ -28,7 +28,12 @@ describe('EntityInstanceData', () => {
   describe('constructor', () => {
     it('should initialize correctly with a definition and no overrides', () => {
       // Act
-      const instance = new EntityInstanceData('instance-1', baseDefinition);
+      const instance = new EntityInstanceData(
+        'instance-1',
+        baseDefinition,
+        {},
+        console
+      );
 
       // Assert
       expect(instance.instanceId).toBe('instance-1');
@@ -46,7 +51,8 @@ describe('EntityInstanceData', () => {
       const instance = new EntityInstanceData(
         'instance-1',
         baseDefinition,
-        initialOverrides
+        initialOverrides,
+        console
       );
 
       // Assert
@@ -66,10 +72,15 @@ describe('EntityInstanceData', () => {
 
     beforeEach(() => {
       // Arrange: Create an instance with a mix of overrides for each test.
-      instance = new EntityInstanceData('instance-1', baseDefinition, {
-        ...positionComponent,
-        ...inventoryComponent,
-      });
+      instance = new EntityInstanceData(
+        'instance-1',
+        baseDefinition,
+        {
+          ...positionComponent,
+          ...inventoryComponent,
+        },
+        console
+      );
     });
 
     it('should remove an existing component override and return true', () => {

--- a/tests/unit/services/turnHandlerResolver.test.js
+++ b/tests/unit/services/turnHandlerResolver.test.js
@@ -26,7 +26,8 @@ const createTestEntity = (
   instanceId,
   definitionId,
   defComponents = {},
-  instanceOverrides = {}
+  instanceOverrides = {},
+  logger = console
 ) => {
   const definition = new EntityDefinition(definitionId, {
     components: defComponents,
@@ -34,7 +35,8 @@ const createTestEntity = (
   const instanceData = new EntityInstanceData(
     instanceId,
     definition,
-    instanceOverrides
+    instanceOverrides,
+    logger
   );
   return new Entity(instanceData);
 };

--- a/tests/unit/turns/prompting/actionContextBuilder.test.js
+++ b/tests/unit/turns/prompting/actionContextBuilder.test.js
@@ -37,7 +37,8 @@ const createTestEntity = (
   instanceId,
   definitionId,
   defComponents = {},
-  instanceOverrides = {}
+  instanceOverrides = {},
+  logger = console
 ) => {
   const definition = new EntityDefinition(definitionId, {
     description: `Test Definition ${definitionId}`,
@@ -46,7 +47,8 @@ const createTestEntity = (
   const instanceData = new EntityInstanceData(
     instanceId,
     definition,
-    instanceOverrides
+    instanceOverrides,
+    logger
   );
   return new Entity(instanceData);
 };


### PR DESCRIPTION
## Summary
- add logger field and constructor param with default console
- route warnings through the new logger
- pass logger when creating EntityInstanceData
- update affected tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing issues)*
- `npm test`
- `cd llm-proxy-server && npm test`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685f669c21108331916d080178d64d75