### PR TITLE
[Agent] Cleanup discovery imports

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -9,21 +9,17 @@
 /** @typedef {import('./actionTypes.js').ActionContext} ActionContext */
 /** @typedef {import('../logging/consoleLogger.js').default} ILogger */
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
-/** @typedef {import('../scopeDsl/scopeRegistry.js').default} ScopeRegistry */
 /** @typedef {import('./actionIndex.js').ActionIndex} ActionIndex */
 /** @typedef {import('./tracing/traceContext.js').TraceContext} TraceContext */
 /** @typedef {import('./actionTypes.js').TraceContextFactory} TraceContextFactory */
 
-import { ActionTargetContext } from '../models/actionTargetContext.js';
+/** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
+/** @typedef {import('../interfaces/ITargetResolutionService.js').ITargetResolutionService} ITargetResolutionService */
+
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
-import {
-  TARGET_DOMAIN_SELF,
-  TARGET_DOMAIN_NONE,
-} from '../constants/targetDomains.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
-import { ITargetResolutionService } from '../interfaces/ITargetResolutionService.js';
 import {
   TRACE_INFO,
   TRACE_SUCCESS,


### PR DESCRIPTION
Summary:
- drop unused target domain imports in `ActionDiscoveryService`
- document `ActionTargetContext` and `ITargetResolutionService` via typedefs

Testing Done:
- [x] Lint (`npm run lint`)
- [x] Root tests (`npm run test`)
- [x] Proxy tests (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685f69d8ea9883319f49dc3b4405b471