### PR TITLE
[Agent] centralize system error dispatch

### DIFF
--- a/src/utils/systemErrorDispatchUtils.js
+++ b/src/utils/systemErrorDispatchUtils.js
@@ -1,0 +1,27 @@
+// src/utils/systemErrorDispatchUtils.js
+
+/**
+ * @file Helper wrapper for dispatching system error events.
+ */
+
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+
+/**
+ * @description Dispatches a `SYSTEM_ERROR_OCCURRED_ID` event using the provided dispatcher.
+ * @param {ISafeEventDispatcher} safeDispatcher - Dispatcher used to emit the event.
+ * @param {string} message - Human readable error message.
+ * @param {object} [details] - Additional structured details for debugging.
+ * @param {ILogger} [logger] - Optional logger for the dispatch.
+ * @returns {void}
+ */
+export function dispatchSystemErrorEvent(
+  safeDispatcher,
+  message,
+  details,
+  logger
+) {
+  safeDispatchError(safeDispatcher, message, details, logger);
+}

--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -1,9 +1,11 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import CommandProcessor from '../../../src/commands/commandProcessor.js';
-import {
-  ATTEMPT_ACTION_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
-} from '../../../src/constants/eventIds.js';
+import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
+import { dispatchSystemErrorEvent } from '../../../src/utils/systemErrorDispatchUtils.js';
+
+jest.mock('../../../src/utils/systemErrorDispatchUtils.js', () => ({
+  dispatchSystemErrorEvent: jest.fn(),
+}));
 
 const mkLogger = () => ({
   debug: jest.fn(),
@@ -63,12 +65,12 @@ describe('CommandProcessor.dispatchAction', () => {
         internalError: expect.stringContaining('missing actionDefinitionId'),
       })
     );
-    expect(safeEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-    expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        message: 'Internal error: Malformed action prevented execution.',
-      })
+    expect(dispatchSystemErrorEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchSystemErrorEvent).toHaveBeenCalledWith(
+      safeEventDispatcher,
+      'Internal error: Malformed action prevented execution.',
+      expect.any(Object),
+      logger
     );
   });
 
@@ -90,12 +92,11 @@ describe('CommandProcessor.dispatchAction', () => {
       ATTEMPT_ACTION_ID,
       expect.any(Object)
     );
-    expect(safeEventDispatcher.dispatch).toHaveBeenNthCalledWith(
-      2,
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        message: 'Internal error: Failed to initiate action.',
-      })
+    expect(dispatchSystemErrorEvent).toHaveBeenCalledWith(
+      safeEventDispatcher,
+      'Internal error: Failed to initiate action.',
+      expect.any(Object),
+      logger
     );
   });
 
@@ -118,19 +119,17 @@ describe('CommandProcessor.dispatchAction', () => {
       ATTEMPT_ACTION_ID,
       expect.any(Object)
     );
-    expect(safeEventDispatcher.dispatch).toHaveBeenNthCalledWith(
-      2,
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        message: 'System error during event dispatch.',
-      })
+    expect(dispatchSystemErrorEvent).toHaveBeenCalledWith(
+      safeEventDispatcher,
+      'System error during event dispatch.',
+      expect.any(Object),
+      logger
     );
-    expect(safeEventDispatcher.dispatch).toHaveBeenNthCalledWith(
-      3,
-      SYSTEM_ERROR_OCCURRED_ID,
-      expect.objectContaining({
-        message: 'Internal error: Failed to initiate action.',
-      })
+    expect(dispatchSystemErrorEvent).toHaveBeenCalledWith(
+      safeEventDispatcher,
+      'Internal error: Failed to initiate action.',
+      expect.any(Object),
+      logger
     );
   });
 });


### PR DESCRIPTION
## Summary
- add `dispatchSystemErrorEvent` helper
- use helper in `CommandProcessor`
- update command processor tests to expect helper call

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f69fd7244833191b71da28bd6b886