### PR TITLE
[Agent] Allow undefined baseContext in getValidActions

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -166,12 +166,12 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
    * It is simpler, with its complex inner logic delegated to helpers.
    *
    * @param {Entity} actorEntity The entity for whom to find actions.
-   * @param {ActionContext} baseContext The current action context.
+   * @param {ActionContext} [baseContext={}] The current action context.
    * @param {object} [options] Optional settings.
    * @param {boolean} [options.trace] - If true, generates a detailed trace of the discovery process.
    * @returns {Promise<import('../interfaces/IActionDiscoveryService.js').DiscoveredActionsResult>}
    */
-  async getValidActions(actorEntity, baseContext, options = {}) {
+  async getValidActions(actorEntity, baseContext = {}, options = {}) {
     const { trace: shouldTrace = false } = options;
     const trace = shouldTrace ? this.#traceContextFactory() : null;
 

--- a/tests/unit/actions/actionDiscoveryService.baseContextDefault.test.js
+++ b/tests/unit/actions/actionDiscoveryService.baseContextDefault.test.js
@@ -1,0 +1,30 @@
+import { beforeEach, expect, test, jest } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// This test verifies that getValidActions can be called with an undefined
+// baseContext argument without throwing or producing errors.
+describeActionDiscoverySuite(
+  'ActionDiscoveryService baseContext default',
+  (getBed) => {
+    const actor = { id: 'actor-1' };
+
+    beforeEach(() => {
+      const bed = getBed();
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([]);
+      bed.mocks.getActorLocationFn.mockReturnValue({
+        id: 'room1',
+        getComponentData: jest.fn(),
+      });
+    });
+
+    test('handles undefined baseContext without errors', async () => {
+      const bed = getBed();
+      const result = await bed.service.getValidActions(actor, undefined);
+
+      expect(result).toEqual({ actions: [], errors: [], trace: null });
+      expect(bed.mocks.logger.error).not.toHaveBeenCalled();
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- update `getValidActions` signature to default `baseContext` to `{}`
- document the optional parameter in JSDoc
- add unit test for undefined `baseContext`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 722 errors, 2666 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f69e4c0fc8331b02bebe2744870e4