### PR TITLE
[Agent] Cover remaining ActionDiscoveryService functions

### DIFF
--- a/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
+++ b/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
@@ -1,0 +1,80 @@
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// Additional coverage tests for ActionDiscoveryService
+
+describeActionDiscoverySuite(
+  'ActionDiscoveryService additional coverage',
+  (getBed) => {
+    beforeEach(() => {
+      const bed = getBed();
+      bed.mocks.getActorLocationFn.mockReturnValue('room1');
+    });
+
+    it('returns empty result when actor entity is null', async () => {
+      const bed = getBed();
+
+      const result = await bed.service.getValidActions(null, {});
+
+      expect(result).toEqual({ actions: [], errors: [], trace: null });
+      expect(bed.mocks.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Actor entity is null; returning empty result.')
+      );
+    });
+
+    it('provides a discovery context with getActor helper', async () => {
+      const bed = getBed();
+      const actor = { id: 'actor1' };
+
+      const def = { id: 'noop', commandVerb: 'wait', scope: 'none' };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+      bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
+        (scope, entity, ctx) => {
+          // invoke getActor to ensure the arrow function is executed
+          expect(ctx.getActor()).toBe(actor);
+          return [{ type: 'none', entityId: null }];
+        }
+      );
+      bed.mocks.formatActionCommandFn.mockReturnValue({
+        ok: true,
+        value: 'wait',
+      });
+
+      await bed.service.getValidActions(actor, {});
+    });
+
+    it('collects formatting errors returned by formatActionCommandFn', async () => {
+      const bed = getBed();
+      const actor = { id: 'actor1' };
+
+      const def = { id: 'bad', commandVerb: 'bad', scope: 'target' };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+        { type: 'entity', entityId: 't1' },
+      ]);
+      bed.mocks.formatActionCommandFn.mockReturnValue({
+        ok: false,
+        error: new Error('nope'),
+        details: { reason: 'bad' },
+      });
+
+      const result = await bed.service.getValidActions(actor, {});
+
+      expect(result.actions).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        actionId: 'bad',
+        targetId: 't1',
+        error: expect.any(Error),
+        details: { reason: 'bad' },
+      });
+      expect(bed.mocks.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Failed to format command for action 'bad' with target 't1'."
+        )
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- add new tests for ActionDiscoveryService to cover uncovered branches

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f6cd1113883318cf8b3de08182519