### PR TITLE
[Agent] Cover additional TargetResolutionService branches

### DIFF
--- a/tests/unit/actions/targetResolutionService.branches.test.js
+++ b/tests/unit/actions/targetResolutionService.branches.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
+import {
+  TARGET_DOMAIN_SELF,
+  TARGET_DOMAIN_NONE,
+} from '../../../src/constants/targetDomains.js';
+import { ActionTargetContext } from '../../../src/models/actionTargetContext.js';
+
+// Reuse simple mocks similar to scope-loading tests
+
+describe('TargetResolutionService - additional branches', () => {
+  let service;
+  let mockScopeRegistry;
+  let mockScopeEngine;
+  let mockEntityManager;
+  let mockLogger;
+  let mockSafeDispatcher;
+  let mockJsonLogic;
+
+  beforeEach(() => {
+    mockScopeRegistry = { getScope: jest.fn() };
+    mockScopeEngine = { resolve: jest.fn() };
+    mockEntityManager = {};
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    mockSafeDispatcher = { dispatch: jest.fn() };
+    mockJsonLogic = { evaluate: jest.fn() };
+
+    service = new TargetResolutionService({
+      scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+      safeEventDispatcher: mockSafeDispatcher,
+      jsonLogicEvaluationService: mockJsonLogic,
+    });
+  });
+
+  it('returns a no target context when scope is none', async () => {
+    const actor = { id: 'hero' };
+    const result = await service.resolveTargets(TARGET_DOMAIN_NONE, actor, {});
+    expect(result).toEqual([ActionTargetContext.noTarget()]);
+    expect(mockScopeRegistry.getScope).not.toHaveBeenCalled();
+    expect(mockScopeEngine.resolve).not.toHaveBeenCalled();
+    expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns the actor as target when scope is self', async () => {
+    const actor = { id: 'hero' };
+    const result = await service.resolveTargets(TARGET_DOMAIN_SELF, actor, {});
+    expect(result).toEqual([ActionTargetContext.forEntity('hero')]);
+    expect(mockScopeRegistry.getScope).not.toHaveBeenCalled();
+    expect(mockScopeEngine.resolve).not.toHaveBeenCalled();
+    expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('handles undefined scope resolution result gracefully', async () => {
+    const def = {
+      name: 'core:test',
+      expr: 'actor',
+      modId: 'core',
+      source: 'file',
+    };
+    mockScopeRegistry.getScope.mockReturnValue(def);
+    mockScopeEngine.resolve.mockReturnValue(undefined);
+
+    const actor = { id: 'hero' };
+    const result = await service.resolveTargets('core:test', actor, {});
+
+    expect(result).toEqual([]);
+    expect(mockScopeEngine.resolve).toHaveBeenCalled();
+    expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `TargetResolutionService` to cover `none`, `self` and undefined scope resolution

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 719 errors, 2674 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f6d26e7308331a482b614144c2d1e