### PR TITLE
[Test] Add DefinitionCache caching test

### DIFF
--- a/tests/unit/entities/definitionCache.test.js
+++ b/tests/unit/entities/definitionCache.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import DefinitionCache from '../../../src/entities/services/definitionCache.js';
+import {
+  createSimpleMockDataRegistry,
+  createMockLogger,
+} from '../../common/mockFactories/index.js';
+
+describe('DefinitionCache (root path)', () => {
+  let registry;
+  let logger;
+  let cache;
+
+  beforeEach(() => {
+    registry = createSimpleMockDataRegistry();
+    logger = createMockLogger();
+    cache = new DefinitionCache({ registry, logger });
+  });
+
+  it('caches definitions after first lookup', () => {
+    const def = { id: 'foo' };
+    registry.getEntityDefinition.mockReturnValue(def);
+
+    const first = cache.get('foo');
+    const second = cache.get('foo');
+
+    expect(first).toBe(def);
+    expect(second).toBe(def);
+    expect(registry.getEntityDefinition).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and logs when definition lookup fails', () => {
+    registry.getEntityDefinition.mockReturnValue(undefined);
+
+    const result = cache.get('missing');
+    expect(result).toBeNull();
+    const warnMsgs = logger.warn.mock.calls.map((c) => c[0]).join('\n');
+    expect(warnMsgs).toContain('Entity definition not found');
+  });
+
+  it('logs a warning when given an invalid ID', () => {
+    const result = cache.get('');
+    expect(result).toBeNull();
+    const warnMsgs = logger.warn.mock.calls.map((c) => c[0]).join('\n');
+    expect(warnMsgs).toContain('Invalid ID');
+  });
+});


### PR DESCRIPTION
Summary: Add new unit tests verifying that DefinitionCache caches entity definitions and logs warnings when lookups fail or when IDs are invalid.

Changes Made:
- Created `tests/unit/entities/definitionCache.test.js` with caching and logging assertions.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685f6f96bd788331995d2138957617e3