### PR TITLE
[Agent] populate failure results

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -85,7 +85,12 @@ class CommandProcessor extends ICommandProcessor {
       );
       return {
         success: false,
-        errorResult: this.#createFailureResult(userMsg, internalMsg),
+        errorResult: this.#createFailureResult(
+          userMsg,
+          internalMsg,
+          commandString,
+          undefined
+        ),
       };
     }
 
@@ -132,22 +137,31 @@ class CommandProcessor extends ICommandProcessor {
         this.#logger
       );
 
-      const failureResult = this.#createFailureResult(userMsg, internalMsg);
-      failureResult.originalInput = commandString;
-      failureResult.actionResult = { actionId: actionDefinitionId };
+      const failureResult = this.#createFailureResult(
+        userMsg,
+        internalMsg,
+        commandString,
+        actionDefinitionId
+      );
       return { success: false, errorResult: failureResult };
     }
   }
 
   // --- Private Helper Methods ---
 
-  #createFailureResult(userError, internalError, turnEnded = true) {
+  #createFailureResult(
+    userError,
+    internalError,
+    originalInput,
+    actionId,
+    turnEnded = true
+  ) {
     const result = {
       success: false,
       turnEnded: turnEnded,
       internalError: internalError,
-      originalInput: undefined,
-      actionResult: undefined,
+      originalInput,
+      actionResult: actionId ? { actionId } : undefined,
     };
     if (userError !== undefined) {
       result.error = userError;


### PR DESCRIPTION
Summary: Expanded CommandProcessor failure creation to include original command input and actionId. dispatchAction now passes these when failures occur, returning fully populated CommandResult objects.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685f6f4a895883319735d9147d2b56e4