### PR TITLE
[Feat] add error target id extraction helper

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -162,7 +162,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
    * It is simpler, with its complex inner logic delegated to helpers.
    *
    * @param {Entity} actorEntity The entity for whom to find actions.
-   * @param {ActionContext} [baseContext={}] The current action context.
+   * @param {ActionContext} [baseContext] The current action context.
    * @param {object} [options] Optional settings.
    * @param {boolean} [options.trace] - If true, generates a detailed trace of the discovery process.
    * @returns {Promise<import('../interfaces/IActionDiscoveryService.js').DiscoveredActionsResult>}
@@ -209,8 +209,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       } catch (err) {
         errors.push({
           actionId: actionDef.id,
-          targetId:
-            err?.targetId ?? err?.target?.entityId ?? err?.entityId ?? null,
+          targetId: this.#extractTargetId(err),
           error: err,
         });
         this.#logger.error(
@@ -229,6 +228,18 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     );
 
     return { actions, errors, trace };
+  }
+
+  /**
+   * @description Extracts a target entity ID from various error shapes.
+   * @param {Error} error - The error thrown during action processing.
+   * @returns {string|null} The resolved target entity ID or null if not present.
+   * @private
+   */
+  #extractTargetId(error) {
+    return (
+      error?.targetId ?? error?.target?.entityId ?? error?.entityId ?? null
+    );
   }
 
   /**

--- a/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
+++ b/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, expect, it } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// Tests for targetId extraction from errors thrown during candidate processing
+
+describeActionDiscoverySuite(
+  'ActionDiscoveryService error target extraction',
+  (getBed) => {
+    beforeEach(() => {
+      const bed = getBed();
+      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+        { type: 'none', entityId: null },
+      ]);
+      bed.mocks.getActorLocationFn.mockReturnValue('room1');
+      bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+    });
+
+    it('extracts targetId from error.target.entityId', async () => {
+      const bed = getBed();
+      const def = { id: 'bad', commandVerb: 'bad', scope: 'none' };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
+      bed.mocks.formatActionCommandFn.mockImplementation(() => {
+        const err = new Error('boom');
+        err.target = { entityId: 'target-123' };
+        throw err;
+      });
+
+      const result = await bed.service.getValidActions({ id: 'actor' }, {});
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        actionId: 'bad',
+        targetId: 'target-123',
+      });
+    });
+
+    it('extracts targetId from error.entityId', async () => {
+      const bed = getBed();
+      const def = { id: 'bad', commandVerb: 'bad', scope: 'none' };
+      bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
+      bed.mocks.formatActionCommandFn.mockImplementation(() => {
+        const err = new Error('boom');
+        err.entityId = 'target-456';
+        throw err;
+      });
+
+      const result = await bed.service.getValidActions({ id: 'actor' }, {});
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        actionId: 'bad',
+        targetId: 'target-456',
+      });
+    });
+  }
+);


### PR DESCRIPTION
Summary: Adds a new helper method to `ActionDiscoveryService` for pulling a target ID from different error shapes. Tests cover new helper usage.

Changes Made:
- Implemented `#extractTargetId` private method and updated error handling in `getValidActions`.
- Added unit tests verifying target ID extraction from `error.target.entityId` and `error.entityId`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_685f73f7cc9c8331aa42f8b3b05dceb9