### PR TITLE
[Agent] refine formatter error handling

### DIFF
--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -137,6 +137,25 @@ describe('formatActionCommand', () => {
     );
   });
 
+  it('warns and returns template when formatter is missing in map', () => {
+    const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
+    const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
+    const customMap = {};
+    const result = formatActionCommand(
+      actionDef,
+      context,
+      entityManager,
+      { logger, safeEventDispatcher: dispatcher },
+      displayNameFn,
+      customMap
+    );
+
+    expect(result).toEqual({ ok: true, value: 'inspect {target}' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown targetContext type')
+    );
+  });
+
   it('throws if logger is missing', () => {
     const actionDef = { id: 'core:wait', template: 'wait' };
     const context = { type: TARGET_TYPE_NONE };


### PR DESCRIPTION
## Summary
- add helper to normalize formatter results
- exit early when target formatter is missing
- update tests for missing formatter branch

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3397 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f746184808331a64ff0fbfdd5d802