### PR TITLE
[Agent] enforce mandatory dispatcher

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -17,7 +17,6 @@ import {
   dispatchValidationError,
 } from '../utils/safeDispatchErrorUtils.js';
 import { validateDependency } from '../utils/validationUtils.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 import { targetFormatterMap } from './formatters/targetFormatters.js';
 
@@ -212,12 +211,10 @@ export function formatActionCommand(
     throw new Error('formatActionCommand: logger is required.');
   }
 
-  const dispatcher = safeEventDispatcher || resolveSafeDispatcher(null, logger);
-  if (!dispatcher) {
-    logger.warn(
-      'formatActionCommand: safeEventDispatcher resolution failed; error events may not be dispatched.'
-    );
-  }
+  validateDependency(safeEventDispatcher, 'safeEventDispatcher', logger, {
+    requiredMethods: ['dispatch'],
+  });
+  const dispatcher = safeEventDispatcher;
 
   if (validationMessage) {
     return dispatchValidationError(

--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -3,7 +3,6 @@
 // --- Static Imports ---
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { ICommandProcessor } from './interfaces/ICommandProcessor.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 import { initLogger } from '../utils/index.js';
 import { validateDependency } from '../utils/validationUtils.js';
 import { dispatchSystemErrorEvent } from '../utils/systemErrorDispatchUtils.js';
@@ -33,17 +32,11 @@ class CommandProcessor extends ICommandProcessor {
 
     this.#logger = initLogger('CommandProcessor', logger);
 
-    validateDependency(dispatcher, 'ISafeEventDispatcher', this.#logger, {
+    validateDependency(dispatcher, 'safeEventDispatcher', this.#logger, {
       requiredMethods: ['dispatch'],
     });
 
-    this.#safeEventDispatcher =
-      dispatcher || resolveSafeDispatcher(null, this.#logger);
-    if (!this.#safeEventDispatcher) {
-      this.#logger.warn(
-        'CommandProcessor: safeEventDispatcher resolution failed; some events may not be dispatched.'
-      );
-    }
+    this.#safeEventDispatcher = dispatcher;
 
     this.#logger.debug(
       'CommandProcessor: Instance created and dependencies validated.'

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -12,7 +12,7 @@ import {
 } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 
 /**
  * Provides a stateless view of the world context, deriving information directly
@@ -75,13 +75,10 @@ class WorldContext extends IWorldContext {
         'WorldContext requires a valid ILogger instance with info, error, debug and warn methods.'
       );
     }
-    this.#safeEventDispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, logger);
-    if (!this.#safeEventDispatcher) {
-      logger.warn(
-        'WorldContext: safeEventDispatcher resolution failed; some errors may not be dispatched.'
-      );
-    }
+    validateDependency(safeEventDispatcher, 'safeEventDispatcher', logger, {
+      requiredMethods: ['dispatch'],
+    });
+    this.#safeEventDispatcher = safeEventDispatcher;
     this.#entityManager = entityManager;
     this.#logger = logger;
     this.#logger.debug(

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -4,7 +4,7 @@ import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 import {
   // POSITION_COMPONENT_ID, // No longer directly used for current location logic
   // NAME_COMPONENT_ID, // Handled by EntityDisplayDataProvider
@@ -98,13 +98,10 @@ export class LocationRenderer extends BoundDomRendererBase {
       },
     };
 
-    const resolvedDispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, logger);
-    if (!resolvedDispatcher) {
-      console.warn(
-        '[LocationRenderer] safeEventDispatcher resolution failed; UI errors may not be reported.'
-      );
-    }
+    validateDependency(safeEventDispatcher, 'safeEventDispatcher', logger, {
+      requiredMethods: ['dispatch', 'subscribe', 'unsubscribe'],
+    });
+    const resolvedDispatcher = safeEventDispatcher;
 
     super({
       logger,

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -3,7 +3,7 @@
 import { IPlaytimeTracker } from '../interfaces/IPlaytimeTracker.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -80,13 +80,15 @@ class PlaytimeTracker extends IPlaytimeTracker {
       this.#logger = logger;
     }
 
-    this.#safeEventDispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
-    if (!this.#safeEventDispatcher) {
-      console.warn(
-        'PlaytimeTracker: safeEventDispatcher resolution failed; playtime events may not be emitted.'
-      );
-    }
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      this.#logger,
+      {
+        requiredMethods: ['dispatch'],
+      }
+    );
+    this.#safeEventDispatcher = safeEventDispatcher;
 
     this.#logger.debug('PlaytimeTracker: Instance created.');
   }

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -3,7 +3,7 @@
 
 import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 import { initLogger } from '../utils/index.js';
 import { CLOUD_API_TYPES } from './constants/llmConstants.js';
 import { isValidEnvironmentContext } from './environmentContext.js';
@@ -48,13 +48,15 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
     super();
 
     this.#logger = initLogger('ClientApiKeyProvider', logger);
-    this.#dispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
-    if (!this.#dispatcher) {
-      console.warn(
-        'ClientApiKeyProvider: safeEventDispatcher resolution failed; errors may not be reported.'
-      );
-    }
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      this.#logger,
+      {
+        requiredMethods: ['dispatch'],
+      }
+    );
+    this.#dispatcher = safeEventDispatcher;
     this.#logger.debug('ClientApiKeyProvider: Instance created.');
   }
 

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -8,7 +8,7 @@ import {
   IEnvironmentVariableReader,
 } from '../../llm-proxy-server/src/utils/IServerUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 import { initLogger } from '../utils/index.js';
 import { isValidEnvironmentContext } from './environmentContext.js';
 
@@ -139,13 +139,15 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   }) {
     super();
     this.#logger = initLogger('ServerApiKeyProvider', logger);
-    this.#dispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
-    if (!this.#dispatcher) {
-      console.warn(
-        'ServerApiKeyProvider: safeEventDispatcher resolution failed; key errors may not be reported.'
-      );
-    }
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      this.#logger,
+      {
+        requiredMethods: ['dispatch'],
+      }
+    );
+    this.#dispatcher = safeEventDispatcher;
     if (!fileSystemReader || typeof fileSystemReader.readFile !== 'function') {
       const errorMsg =
         'ServerApiKeyProvider: Constructor requires a valid fileSystemReader instance that implements IFileSystemReader (must have an async readFile method).';

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -1,7 +1,7 @@
 // src/services/browserStorageProvider.js
 import { IStorageProvider } from '../interfaces/IStorageProvider.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
+import { validateDependency } from '../utils/validationUtils.js';
 import { StorageErrorCodes } from './storageErrors.js';
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
@@ -27,13 +27,15 @@ export class BrowserStorageProvider extends IStorageProvider {
       throw new Error(errorMsg);
     }
     this.#logger = logger;
-    this.#safeEventDispatcher =
-      safeEventDispatcher || resolveSafeDispatcher(null, this.#logger);
-    if (!this.#safeEventDispatcher) {
-      console.warn(
-        'BrowserStorageProvider: safeEventDispatcher resolution failed; some errors may go unreported.'
-      );
-    }
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      this.#logger,
+      {
+        requiredMethods: ['dispatch'],
+      }
+    );
+    this.#safeEventDispatcher = safeEventDispatcher;
     this.#logger.debug(
       'BrowserStorageProvider: Initialized. Will use File System Access API with user prompts.'
     );

--- a/tests/unit/actions/actionFormatter.branches.test.js
+++ b/tests/unit/actions/actionFormatter.branches.test.js
@@ -93,15 +93,11 @@ describe('formatActionCommand uncovered branches', () => {
     );
   });
 
-  it('warns when safeEventDispatcher resolution fails', () => {
+  it('throws when safeEventDispatcher is missing', () => {
     const actionDef = { id: 'core:wait', template: 'wait' };
     const context = { type: TARGET_TYPE_NONE };
-    const result = formatActionCommand(actionDef, context, entityManager, {
-      logger,
-    });
-    expect(result).toEqual({ ok: true, value: 'wait' });
-    expect(logger.warn).toHaveBeenCalledWith(
-      'formatActionCommand: safeEventDispatcher resolution failed; error events may not be dispatched.'
-    );
+    expect(() =>
+      formatActionCommand(actionDef, context, entityManager, { logger })
+    ).toThrow('Missing required dependency: safeEventDispatcher.');
   });
 });

--- a/tests/unit/context/worldContext.test.js
+++ b/tests/unit/context/worldContext.test.js
@@ -75,7 +75,11 @@ describe('WorldContext (Stateless)', () => {
   beforeEach(() => {
     mockEntityManager = createMockEntityManager();
     mockLogger = createMockLogger();
-    mockDispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    mockDispatcher = {
+      dispatch: jest.fn().mockResolvedValue(true),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
 
     originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'test';
@@ -140,9 +144,9 @@ describe('WorldContext (Stateless)', () => {
       expect(
         () => new WorldContext(mockEntityManager, {}, mockDispatcher)
       ).toThrow('WorldContext requires a valid ILogger instance');
-      expect(
-        () => new WorldContext(mockEntityManager, mockLogger, null)
-      ).not.toThrow();
+      expect(() =>
+        new WorldContext(mockEntityManager, mockLogger, null)
+      ).toThrow('Missing required dependency: safeEventDispatcher.');
     });
 
     it('should successfully initialize with valid dependencies', () => {

--- a/tests/unit/domUI/locationRenderer.test.js
+++ b/tests/unit/domUI/locationRenderer.test.js
@@ -62,6 +62,7 @@ const createMockDocumentContext = () => {
 const createMockVed = () => ({
   subscribe: jest.fn(() => jest.fn()),
   dispatch: jest.fn(),
+  unsubscribe: jest.fn(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- make dispatcher injection mandatory across services
- require dispatcher validation in tests
- update unit tests with complete dispatcher mocks

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 720 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f74559c3083319b7e86f93ac21fc4