### PR TITLE
[Agent] unify startup error helpers

### DIFF
--- a/src/utils/errorUtils.js
+++ b/src/utils/errorUtils.js
@@ -8,66 +8,6 @@ import { StartupErrorHandler } from './startupErrorHandler.js';
  */
 
 /**
- * Sets an error message in a DOM element and makes it visible.
- *
- * @description Sets an error message in a DOM element and makes it visible.
- * @param {HTMLElement | null | undefined} targetEl - Element to display the message in.
- * @param {string} msg - Message to show.
- * @param {import('../interfaces/DomAdapter.js').DomAdapter} dom - DOM adapter instance.
- * @returns {boolean} True if the message was displayed.
- */
-export function showErrorInElement(targetEl, msg, dom) {
-  if (!targetEl || !(targetEl instanceof HTMLElement)) {
-    return false;
-  }
-  dom.setTextContent(targetEl, msg);
-  dom.setStyle(targetEl, 'display', 'block');
-  return true;
-}
-
-/**
- * Creates a temporary error element after the provided base element.
- *
- * @description Creates a temporary error element after the provided base element.
- * @param {HTMLElement | null | undefined} baseEl - Element to insert after.
- * @param {string} msg - Message for the new element.
- * @param {import('../interfaces/DomAdapter.js').DomAdapter} dom - DOM adapter instance.
- * @returns {HTMLElement | null} The created element, or null if not created.
- */
-export function createTemporaryErrorElement(baseEl, msg, dom) {
-  if (!baseEl || !(baseEl instanceof HTMLElement)) {
-    return null;
-  }
-  const temporaryErrorElement = dom.createElement('div');
-  temporaryErrorElement.id = 'temp-startup-error';
-  dom.setTextContent(temporaryErrorElement, msg);
-  dom.setStyle(temporaryErrorElement, 'color', 'red');
-  dom.setStyle(temporaryErrorElement, 'padding', '10px');
-  dom.setStyle(temporaryErrorElement, 'border', '1px solid red');
-  dom.setStyle(temporaryErrorElement, 'marginTop', '10px');
-  dom.insertAfter(baseEl, temporaryErrorElement);
-  return temporaryErrorElement;
-}
-
-/**
- * Disables an input element and sets a placeholder.
- *
- * @description Disables an input element and sets a placeholder.
- * @param {HTMLInputElement | null | undefined} el - Input to disable.
- * @param {string} placeholder - Placeholder text to set.
- * @param {import('../interfaces/DomAdapter.js').DomAdapter} dom - DOM adapter instance.
- * @returns {boolean} True if the element was updated.
- */
-export function disableInput(el, placeholder) {
-  if (!el || !(el instanceof HTMLInputElement)) {
-    return false;
-  }
-  el.disabled = true;
-  el.placeholder = placeholder;
-  return true;
-}
-
-/**
  * Displays a fatal startup error to the user, logs it, and updates UI elements.
  *
  * @param {FatalErrorUIElements} uiElements - References to key UI elements.

--- a/src/utils/startupErrorHandler.js
+++ b/src/utils/startupErrorHandler.js
@@ -4,6 +4,62 @@ import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 
 /**
+ * Displays an error message inside a DOM element.
+ *
+ * @param {HTMLElement | null | undefined} targetEl - Element to display the message in.
+ * @param {string} msg - Message to show.
+ * @param {DomAdapter} dom - DOM adapter instance.
+ * @returns {boolean} True if the message was displayed.
+ */
+export function showErrorInElement(targetEl, msg, dom) {
+  if (!targetEl || !(targetEl instanceof HTMLElement)) {
+    return false;
+  }
+  dom.setTextContent(targetEl, msg);
+  dom.setStyle(targetEl, 'display', 'block');
+  return true;
+}
+
+/**
+ * Creates a temporary error element after the provided base element.
+ *
+ * @param {HTMLElement | null | undefined} baseEl - Element to insert after.
+ * @param {string} msg - Message for the new element.
+ * @param {DomAdapter} dom - DOM adapter instance.
+ * @returns {HTMLElement | null} The created element, or null if not created.
+ */
+export function createTemporaryErrorElement(baseEl, msg, dom) {
+  if (!baseEl || !(baseEl instanceof HTMLElement)) {
+    return null;
+  }
+  const temporaryErrorElement = dom.createElement('div');
+  temporaryErrorElement.id = 'temp-startup-error';
+  dom.setTextContent(temporaryErrorElement, msg);
+  dom.setStyle(temporaryErrorElement, 'color', 'red');
+  dom.setStyle(temporaryErrorElement, 'padding', '10px');
+  dom.setStyle(temporaryErrorElement, 'border', '1px solid red');
+  dom.setStyle(temporaryErrorElement, 'marginTop', '10px');
+  dom.insertAfter(baseEl, temporaryErrorElement);
+  return temporaryErrorElement;
+}
+
+/**
+ * Disables an input element and sets a placeholder.
+ *
+ * @param {HTMLInputElement | null | undefined} el - Input to disable.
+ * @param {string} placeholder - Placeholder text to set.
+ * @returns {boolean} True if the element was updated.
+ */
+export function disableInput(el, placeholder) {
+  if (!el || !(el instanceof HTMLInputElement)) {
+    return false;
+  }
+  el.disabled = true;
+  el.placeholder = placeholder;
+  return true;
+}
+
+/**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../interfaces/DomAdapter.js').DomAdapter} DomAdapter
  * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
@@ -60,12 +116,7 @@ export class StartupErrorHandler {
    * @returns {boolean} True if message displayed.
    */
   showErrorInElement(targetEl, msg) {
-    if (!targetEl || !(targetEl instanceof HTMLElement)) {
-      return false;
-    }
-    this.dom.setTextContent(targetEl, msg);
-    this.dom.setStyle(targetEl, 'display', 'block');
-    return true;
+    return showErrorInElement(targetEl, msg, this.dom);
   }
 
   /**
@@ -76,18 +127,7 @@ export class StartupErrorHandler {
    * @returns {HTMLElement | null} The created element or null.
    */
   createTemporaryErrorElement(baseEl, msg) {
-    if (!baseEl || !(baseEl instanceof HTMLElement)) {
-      return null;
-    }
-    const el = this.dom.createElement('div');
-    el.id = 'temp-startup-error';
-    this.dom.setTextContent(el, msg);
-    this.dom.setStyle(el, 'color', 'red');
-    this.dom.setStyle(el, 'padding', '10px');
-    this.dom.setStyle(el, 'border', '1px solid red');
-    this.dom.setStyle(el, 'marginTop', '10px');
-    this.dom.insertAfter(baseEl, el);
-    return el;
+    return createTemporaryErrorElement(baseEl, msg, this.dom);
   }
 
   /**
@@ -98,12 +138,7 @@ export class StartupErrorHandler {
    * @returns {boolean} True if updated.
    */
   disableInput(el, placeholder) {
-    if (!el || !(el instanceof HTMLInputElement)) {
-      return false;
-    }
-    el.disabled = true;
-    el.placeholder = placeholder;
-    return true;
+    return disableInput(el, placeholder);
   }
 
   /**

--- a/tests/unit/utils/errorUtils.basic.test.js
+++ b/tests/unit/utils/errorUtils.basic.test.js
@@ -1,13 +1,15 @@
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { displayFatalStartupError } from '../../../src/utils/errorUtils.js';
 import {
   showErrorInElement,
   createTemporaryErrorElement,
   disableInput,
-  displayFatalStartupError,
-} from '../../../src/utils/errorUtils.js';
+} from '../../../src/utils/startupErrorHandler.js';
 
 jest.mock('../../../src/utils/startupErrorHandler.js', () => {
+  const actual = jest.requireActual('../../../src/utils/startupErrorHandler.js');
   return {
+    ...actual,
     StartupErrorHandler: jest.fn().mockImplementation(() => ({
       displayFatalStartupError: jest.fn(() => ({ displayed: true })),
     })),


### PR DESCRIPTION
## Summary
- remove showErrorInElement, createTemporaryErrorElement and disableInput from errorUtils
- export these helpers from startupErrorHandler and use them internally
- update tests to import new helper locations

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f785a7ea0833180c8c504e2957140