### PR TITLE
[Agent] implement TurnManager FSM

### DIFF
--- a/src/turns/TMState.js
+++ b/src/turns/TMState.js
@@ -1,0 +1,6 @@
+export const TMState = Object.freeze({
+  Idle: 0,
+  AwaitingActor: 1,
+  AwaitingTurnEnd: 2,
+  Stopped: 3,
+});

--- a/src/turns/turnManager.js
+++ b/src/turns/turnManager.js
@@ -1,28 +1,13 @@
-// src/turns/turnManager.js
-// --- FILE START ---
-
-/** @typedef {import('../entities/entity.js').default} Entity */
-/** @typedef {import('./interfaces/ITurnOrderService.js').ITurnOrderService} ITurnOrderService */
-/** @typedef {import('../entities/entityManager.js').default} EntityManager */
-/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} IValidatedEventDispatcher */
-/** @typedef {import('./interfaces/ITurnHandlerResolver.js').ITurnHandlerResolver} ITurnHandlerResolver */
-/** @typedef {import('./interfaces/ITurnHandler.js').ITurnHandler} ITurnHandler */
-/** @typedef {import('../types/eventTypes.js').SystemEventPayloads} SystemEventPayloads */
-
-/** @typedef {import('./interfaces/ITurnManager.js').ITurnManager} ITurnManagerInterface */
-
-// Import the necessary component ID constants
 import {
-  ACTOR_COMPONENT_ID,
   PLAYER_COMPONENT_ID,
   PLAYER_TYPE_COMPONENT_ID,
 } from '../constants/componentIds.js';
 import {
   TURN_ENDED_ID,
-  SYSTEM_ERROR_OCCURRED_ID,
+  TURN_STARTED_ID,
   TURN_PROCESSING_STARTED,
   TURN_PROCESSING_ENDED,
+  SYSTEM_ERROR_OCCURRED_ID,
 } from '../constants/eventIds.js';
 import { ITurnManager } from './interfaces/ITurnManager.js';
 import RoundManager from './roundManager.js';
@@ -30,61 +15,42 @@ import TurnCycle from './turnCycle.js';
 import TurnEventSubscription from './turnEventSubscription.js';
 import { RealScheduler } from '../scheduling/index.js';
 import { safeDispatch } from '../utils/eventHelpers.js';
-import { logStart, logEnd, logError } from '../utils/logHelpers.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { logStart, logEnd, logError } from '../utils/logHelpers.js';
+import { TMState } from './TMState.js';
 
 /**
  * @class TurnManager
+ * @description Finite state machine controlling turn progression.
  * @implements {ITurnManager}
- * @classdesc Manages the overall turn lifecycle. Determines the next actor,
- * initiates their turn via the appropriate handler, and waits for a turn completion
- * event (`core:turn_ended`) before advancing to the next turn or round.
- * Dispatches semantic events like 'core:turn_started' and SYSTEM_ERROR_OCCURRED_ID.
- * Includes logic to stop if a round completes with no successful turns.
  */
-class TurnManager extends ITurnManager {
-  /** @type {ITurnOrderService} */
-  #turnOrderService;
-  /** @type {EntityManager} */
-  #entityManager;
-  /** @type {ILogger} */
+export default class TurnManager extends ITurnManager {
   #logger;
-  /** @type {IValidatedEventDispatcher} */
   #dispatcher;
-  /** @type {ITurnHandlerResolver} */
-  #turnHandlerResolver;
-  /** @type {RoundManager} */
-  #roundManager;
-  /** @type {TurnCycle} */
-  #turnCycle;
-  /** @type {import('../scheduling').IScheduler} */
+  #resolver;
+  #roundMgr;
+  #cycle;
+  #eventSub;
   #scheduler;
-
-  /** @type {boolean} */
-  #isRunning = false;
-  /** @type {Entity | null} */
+  #state = TMState.Idle;
   #currentActor = null;
-  /** @type {ITurnHandler | null} */
   #currentHandler = null;
-  /** @type {import('./turnEventSubscription.js').default} */
-  #eventSubscription;
+  #error = null;
 
   /**
-   * Creates an instance of TurnManager.
-   *
-   * @param {object} options - The dependencies for the TurnManager.
-   * @param {ITurnOrderService} options.turnOrderService - Service for managing turn order within a round.
-   * @param {EntityManager} options.entityManager - Service for managing entities.
-   * @param {ILogger} options.logger - Logging service.
-   * @param {IValidatedEventDispatcher} options.dispatcher - Service for dispatching events AND subscribing.
-   * @param {ITurnHandlerResolver} options.turnHandlerResolver - Service to resolve the correct turn handler.
-   * @param {RoundManager} [options.roundManager] - Optional RoundManager instance for testing.
-   * @param {import('../scheduling').IScheduler} [options.scheduler] - Scheduler implementation for timeouts.
-   * @throws {Error} If any required dependency is missing or invalid.
+   * @param {object} opts - Constructor options.
+   * @param {import('./interfaces/ITurnOrderService.js').ITurnOrderService} opts.turnOrderService - Service for actor ordering.
+   * @param {import('../entities/entityManager.js').default} opts.entityManager - Entity manager.
+   * @param {import('../interfaces/coreServices.js').ILogger} opts.logger - Logger instance.
+   * @param {import('../interfaces/IValidatedEventDispatcher.js').IValidatedEventDispatcher} opts.dispatcher - Event bus.
+   * @param {import('./interfaces/ITurnHandlerResolver.js').ITurnHandlerResolver} opts.turnHandlerResolver - Resolves handlers.
+   * @param {RoundManager} [opts.roundManager] - Optional round manager.
+   * @param {TurnCycle} [opts.turnCycle] - Optional turn cycle wrapper.
+   * @param {TurnEventSubscription} [opts.eventSub] - Optional event subscription helper.
+   * @param {import('../scheduling').IScheduler} [opts.scheduler] - Scheduler to use.
    */
-  constructor(options) {
+  constructor(opts = {}) {
     super();
-
     const {
       turnOrderService,
       entityManager,
@@ -92,581 +58,202 @@ class TurnManager extends ITurnManager {
       dispatcher,
       turnHandlerResolver,
       roundManager,
+      turnCycle,
+      eventSub,
       scheduler = new RealScheduler(),
-    } = options || {};
-    const className = this.constructor.name;
+    } = opts;
+    if (!turnOrderService?.clearCurrentRound) throw new Error('TurnManager requires ITurnOrderService');
+    if (!entityManager?.getEntityInstance) throw new Error('TurnManager requires EntityManager');
+    if (!logger?.debug) throw new Error('TurnManager requires ILogger');
+    if (!dispatcher?.dispatch || !dispatcher.subscribe) throw new Error('TurnManager requires IValidatedEventDispatcher');
+    if (!turnHandlerResolver?.resolveHandler) throw new Error('TurnManager requires ITurnHandlerResolver');
 
-    // --- Dependency Validation (unchanged) ---
-    if (
-      !turnOrderService ||
-      typeof turnOrderService.clearCurrentRound !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid ITurnOrderService instance.`;
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    if (
-      !entityManager ||
-      typeof entityManager.getEntityInstance !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid EntityManager instance.`;
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    if (
-      !logger ||
-      typeof logger.warn !== 'function' ||
-      typeof logger.error !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid ILogger instance.`;
-      console.error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    if (
-      !dispatcher ||
-      typeof dispatcher.dispatch !== 'function' ||
-      typeof dispatcher.subscribe !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid IValidatedEventDispatcher instance (with dispatch and subscribe methods).`;
-      (logger || console).error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    if (
-      !turnHandlerResolver ||
-      typeof turnHandlerResolver.resolveHandler !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid ITurnHandlerResolver instance (with resolveHandler method).`;
-      (logger || console).error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    if (
-      !scheduler ||
-      typeof scheduler.setTimeout !== 'function' ||
-      typeof scheduler.clearTimeout !== 'function'
-    ) {
-      const errorMsg = `${className} requires a valid IScheduler instance.`;
-      (logger || console).error(errorMsg);
-      throw new Error(errorMsg);
-    }
-    // --- End Dependency Validation ---
-
-    this.#turnOrderService = turnOrderService;
-    this.#entityManager = entityManager;
     this.#logger = logger;
     this.#dispatcher = dispatcher;
-    this.#turnHandlerResolver = turnHandlerResolver;
-    this.#roundManager =
-      roundManager || new RoundManager(turnOrderService, entityManager, logger);
-    this.#turnCycle = new TurnCycle(turnOrderService, logger);
+    this.#resolver = turnHandlerResolver;
+    this.#roundMgr = roundManager || new RoundManager(turnOrderService, entityManager, logger);
+    this.#cycle = turnCycle || new TurnCycle(turnOrderService, logger);
     this.#scheduler = scheduler;
-    this.#eventSubscription = new TurnEventSubscription(
-      dispatcher,
-      logger,
-      scheduler
-    );
-
-    // --- State Initialization (reset flags) ---
-    this.#isRunning = false;
-    this.#currentActor = null;
-    this.#currentHandler = null;
-    // --- End State Initialization ---
-
-    logStart(this.#logger, 'TurnManager initialized successfully.');
+    this.#eventSub = eventSub || new TurnEventSubscription(dispatcher, logger, scheduler);
   }
 
   /**
-   * Starts the turn management process. Subscribes to turn end events.
+   * Retrieves the id of the current actor.
    *
-   * @async
-   * @returns {Promise<void>} A promise that resolves when the manager has successfully started and the first turn advance is initiated.
+   * @returns {string|null} Actor id or null.
    */
-  async start() {
-    if (this.#isRunning) {
-      this.#logger.warn(
-        'TurnManager.start() called but manager is already running.'
-      );
-      return;
-    }
-    this.#isRunning = true;
-    this.#roundManager.resetFlags(); // Reset round flags on start
-    logStart(this.#logger, 'Turn Manager started.');
-
-    try {
-      this.#eventSubscription.subscribe((ev) => this.#handleTurnEndedEvent(ev));
-    } catch (error) {
-      safeDispatchError(
-        this.#dispatcher,
-        `Failed to subscribe to ${TURN_ENDED_ID}. Turn advancement will likely fail.`,
-        { error: error.message }
-      );
-      await this.#dispatchSystemError(
-        `Failed to subscribe to ${TURN_ENDED_ID}. Game cannot proceed reliably.`,
-        error
-      );
-      await this.stop();
-      return;
-    }
-    await this.advanceTurn();
+  getCurrentActorId() {
+    return this.#currentActor?.id ?? null;
   }
 
   /**
-   * Stops the turn management process. Unsubscribes from turn end events.
+   * Retrieves the active handler's constructor name.
    *
-   * @async
-   * @returns {Promise<void>} A promise that resolves when the manager has successfully stopped.
+   * @returns {string|null} Handler name.
    */
-  async stop() {
-    if (!this.#isRunning) {
-      this.#logger.debug(
-        'TurnManager.stop() called but manager is already stopped.'
-      );
-      return;
-    }
-    this.#isRunning = false;
-    this.#eventSubscription.unsubscribe();
-
-    if (
-      this.#currentHandler &&
-      typeof this.#currentHandler.destroy === 'function'
-    ) {
-      try {
-        logStart(
-          this.#logger,
-          `Calling destroy() on current handler (${this.#currentHandler.constructor?.name || 'Unknown'}) for actor ${this.#currentActor?.id || 'N/A'}`
-        );
-        await Promise.resolve(this.#currentHandler.destroy());
-      } catch (destroyError) {
-        logError(
-          this.#logger,
-          'Error calling destroy() on current handler during stop',
-          destroyError
-        );
-      }
-    }
-
-    this.#currentActor = null;
-    this.#currentHandler = null;
-
-    try {
-      await this.#turnCycle.clear();
-      this.#logger.debug('Turn order service current round cleared.');
-    } catch (error) {
-      safeDispatchError(
-        this.#dispatcher,
-        'Error clearing turn order service during stop',
-        { error: error.message }
-      );
-    }
-    logEnd(this.#logger, 'Turn Manager stopped.');
+  getActiveHandlerName() {
+    return this.#currentHandler?.constructor?.name ?? null;
   }
 
   /**
-   * Retrieves the entity instance whose turn it is currently.
+   * Returns the last error recorded by the manager.
    *
-   * @returns {Entity | null} The entity currently taking its turn, or `null`.
+   * @returns {Error|null} Last error instance or null.
    */
+  getLastError() {
+    return this.#error;
+  }
+
+  // Deprecated
   getCurrentActor() {
-    const actor = this.#currentActor;
-    console.log('TurnManager.getCurrentActor: currentActor =', actor?.id);
-    return actor;
+    return this.#currentActor;
   }
 
-  /**
-   * Retrieves the turn handler instance that is currently managing the active turn.
-   *
-   * @returns {ITurnHandler | null} The currently active turn handler, or `null`.
-   */
+  // Deprecated
   getActiveTurnHandler() {
     return this.#currentHandler;
   }
 
   /**
-   * Advances the game state to the next entity's turn, or starts a new round.
-   * Resolves the handler, calls its `startTurn` method, and then *waits* for the
-   * `core:turn_ended` event before proceeding.
-   * Handles system-level errors by dispatching SYSTEM_ERROR_OCCURRED_ID.
-   * **Includes logic to stop if a round completes with no successful turns.**
+   * Deprecated direct turn advancement method.
    *
-   * @async
-   * @private
-   * @returns {Promise<void>} A promise that resolves when the next turn has been *initiated*.
+   * @returns {Promise<void>}
    */
   async advanceTurn() {
-    if (!this.#isRunning) {
-      this.#logger.debug(
-        'TurnManager.advanceTurn() called while manager is not running. Returning.'
-      );
+    await this.#tick();
+  }
+
+  /** @returns {Promise<void>} */
+  async start() {
+    if (this.#state !== TMState.Idle && this.#state !== TMState.Stopped) {
+      this.#logger.warn('TurnManager.start() called but already running.');
       return;
     }
+    this.#eventSub.subscribe((ev) => this.#onTurnEnded(ev));
+    this.#state = TMState.AwaitingActor;
+    logStart(this.#logger, 'Turn Manager started');
+    await this.advanceTurn();
+  }
 
-    logStart(this.#logger, 'TurnManager.advanceTurn() initiating...');
-    // Clear previous actor/handler
-    const previousActorIdForLog = this.#currentActor?.id;
-    if (previousActorIdForLog) {
-      this.#logger.debug(
-        `Clearing previous actor ${previousActorIdForLog} and handler before advancing.`
-      );
-    }
+  /** @returns {Promise<void>} */
+  async stop() {
+    if (this.#state === TMState.Stopped || this.#state === TMState.Idle) return;
+    this.#state = TMState.Stopped;
+    this.#eventSub.unsubscribe();
+    const handler = this.#currentHandler;
     this.#currentActor = null;
     this.#currentHandler = null;
-
     try {
-      const nextEntity = await this.#turnCycle.nextActor();
-      console.log('TurnManager.advanceTurn: nextActor =', nextEntity?.id);
-
-      if (!nextEntity) {
-        // TurnCycle.nextActor() returns null only when the queue is empty
-        // (TurnCycle calls isEmpty() first, then getNextEntity() only if not empty)
-        this.#logger.debug(
-          'Turn queue is empty. Preparing for new round or stopping.'
-        );
-
-        // --- NEW CHECK: Stop if previous round had no success ---
-        if (this.#roundManager.inProgress && !this.#roundManager.hadSuccess) {
-          const errorMsg =
-            'No successful turns completed in the previous round. Stopping TurnManager.';
-          this.#logger.error(errorMsg);
-          await this.#dispatchSystemError(
-            'System Error: No progress made in the last round.',
-            errorMsg
-          );
-          await this.stop();
-          return; // Stop processing
-        }
-        // --- END NEW CHECK ---
-
-        // --- Start new round using RoundManager ---
-        this.#logger.debug('Attempting to start a new round.');
-        try {
-          await this.#roundManager.startRound();
-          this.#logger.debug(
-            'New round started, recursively calling advanceTurn() to process the first turn.'
-          );
-          await this.advanceTurn(); // Recursive call to process the first turn of the new round
-          return;
-        } catch (roundError) {
-          // Restore original error handling for test compatibility
-          safeDispatchError(
-            this.#dispatcher,
-            'Critical error during turn advancement logic',
-            { error: roundError.message }
-          );
-          await this.#dispatchSystemError(
-            'System Error: No active actors found to start a round. Stopping game.',
-            roundError.message
-          );
-          await this.stop();
-          return;
-        }
-        // --- End Start new round ---
-      } else {
-        // Queue is not empty, process next turn
-        this.#logger.debug('Queue not empty, processing next entity.');
-
-        this.#currentActor = nextEntity; // Set the new current actor
-        const actorId = this.#currentActor.id;
-        const isActor = this.#currentActor.hasComponent(ACTOR_COMPONENT_ID);
-
-        // Determine entity type using new player_type component
-        let entityType = 'ai'; // default
-        if (this.#currentActor.hasComponent(PLAYER_TYPE_COMPONENT_ID)) {
-          const playerTypeData = this.#currentActor.getComponentData(
-            PLAYER_TYPE_COMPONENT_ID
-          );
-          entityType = playerTypeData?.type === 'human' ? 'player' : 'ai';
-        } else if (this.#currentActor.hasComponent(PLAYER_COMPONENT_ID)) {
-          // Fallback to old player component for backward compatibility
-          entityType = 'player';
-        }
-
-        if (!isActor) {
-          this.#logger.warn(
-            `Entity ${actorId} is not an actor. Skipping turn advancement for this entity.`
-          );
-          this.#currentActor = null; // Clear current actor for non-actor entities
-          return;
-        }
-
-        this.#logger.debug(
-          `>>> Starting turn initiation for Entity: ${actorId} (${entityType}) <<<`
-        );
-        await safeDispatch(
-          this.#dispatcher,
-          'core:turn_started',
-          {
-            entityId: actorId,
-            entityType: entityType,
-            entity: this.#currentActor, // Include full entity for component access
-          },
-          this.#logger
-        );
-
-        await safeDispatch(
-          this.#dispatcher,
-          TURN_PROCESSING_STARTED,
-          {
-            entityId: actorId,
-            actorType: entityType,
-          },
-          this.#logger
-        );
-
-        this.#logger.debug(`Resolving turn handler for entity ${actorId}...`);
-        const handler = await this.#turnHandlerResolver.resolveHandler(
-          this.#currentActor
-        );
-        this.#currentHandler = handler; // Set the new current handler
-
-        if (!handler) {
-          this.#logger.warn(
-            `Could not resolve a turn handler for actor ${actorId}. Skipping turn and advancing.`
-          );
-          // Simulate an unsuccessful turn end to allow round progression check
-          // Since #handleTurnEndedEvent is now called asynchronously via the event bus,
-          // we directly call it here if we want immediate processing for this specific case.
-          // However, to maintain consistency with event-driven flow, it might be better
-          // to dispatch a dummy 'core:turn_ended' event, but that could be overkill.
-          // For now, directly calling #handleTurnEndedEvent (which is not async itself) is okay.
-          this.#handleTurnEndedEvent({
-            // This will schedule advanceTurn via its own logic
-            type: TURN_ENDED_ID,
-            payload: {
-              entityId: actorId,
-              success: false,
-              error: new Error(
-                `No turn handler resolved for actor ${actorId}.`
-              ),
-            },
-          });
-          return;
-        }
-
-        const handlerName = handler.constructor?.name || 'resolved handler';
-        this.#logger.debug(
-          `Calling startTurn on ${handlerName} for entity ${actorId}`
-        );
-
-        console.log(
-          'TurnManager: handler =',
-          handler,
-          'handler.startTurn =',
-          typeof handler?.startTurn
-        );
-        handler.startTurn(this.#currentActor).catch((startTurnError) => {
-          const errorMsg = `Error during handler.startTurn() initiation for entity ${actorId} (${handlerName}): ${startTurnError.message}`;
-          safeDispatchError(
-            this.#dispatcher,
-            `Error initiating turn for ${actorId}`,
-            { error: startTurnError.message, handlerName }
-          );
-          this.#dispatchSystemError(
-            `Error initiating turn for ${actorId}.`,
-            startTurnError
-          ).catch((e) =>
-            logError(
-              this.#logger,
-              'Failed to dispatch system error after startTurn failure',
-              e
-            )
-          );
-
-          if (this.#currentActor?.id === actorId) {
-            this.#logger.warn(
-              `Manually handling turn end after startTurn initiation failure for ${actorId}.`
-            );
-            this.#handleTurnEndedEvent({
-              type: TURN_ENDED_ID,
-              payload: {
-                entityId: actorId,
-                success: false,
-                error: startTurnError,
-              },
-            });
-          } else {
-            this.#logger.warn(
-              `startTurn initiation failed for ${actorId}, but current actor changed before manual advance could occur. No advance triggered by this error handler.`
-            );
-          }
-        });
-        this.#logger.debug(
-          `Turn initiation for ${actorId} started via ${handlerName}. TurnManager now WAITING for '${TURN_ENDED_ID}' event.`
-        );
-      }
-    } catch (error) {
-      const errorMsg = `CRITICAL Error during turn advancement logic (before handler initiation): ${error.message}`;
-      safeDispatchError(
-        this.#dispatcher,
-        'System Error during turn advancement',
-        { error: error.message }
-      );
-      await this.#dispatchSystemError(
-        'System Error during turn advancement. Stopping game.',
-        error
-      );
-      await this.stop();
+      await this.#cycle.clear();
+    } catch (e) {
+      safeDispatchError(this.#dispatcher, 'Error clearing turn order service during stop', { error: e.message });
     }
+    if (handler?.destroy) {
+      try {
+        await handler.destroy();
+      } catch (e) {
+        logError(this.#logger, 'Error destroying handler during stop', e);
+      }
+    }
+    logEnd(this.#logger, 'Turn Manager stopped.');
   }
 
-  /**
-   * Subscribes to the event indicating a turn has ended.
-   *
-   * @private
-   */
-
-  /**
-   * Handles the received TURN_ENDED_ID event.
-   * Checks if it matches the current actor, **updates the round success flag**,
-   * and advances the turn if appropriate.
-   *
-   * @param {{ type?: typeof TURN_ENDED_ID, payload: SystemEventPayloads[typeof TURN_ENDED_ID] }} event - The full event object or a simulated payload.
-   * @private
-   */
-  #handleTurnEndedEvent(event) {
-    // This method itself is not async
-    if (!this.#isRunning) {
-      this.#logger.debug(
-        `Received '${TURN_ENDED_ID}' but manager is stopped. Ignoring.`
-      );
+  async #tick() {
+    if (this.#state !== TMState.AwaitingActor) return;
+    let actor = await this.#cycle.nextActor();
+    if (!actor) {
+      try {
+        await this.#roundMgr.startRound();
+      } catch (e) {
+        await this.#dispatchSystemError('System Error: No active actors found to start a round. Stopping game.', e);
+        await this.stop();
+        return;
+      }
+      actor = await this.#cycle.nextActor();
+      if (!actor) {
+        await this.stop();
+        return;
+      }
+    }
+    this.#currentActor = actor;
+    const actorId = actor.id;
+    const entityType = actor.hasComponent(PLAYER_TYPE_COMPONENT_ID)
+      ? actor.getComponentData(PLAYER_TYPE_COMPONENT_ID)?.type === 'human'
+        ? 'player'
+        : 'ai'
+      : actor.hasComponent(PLAYER_COMPONENT_ID)
+      ? 'player'
+      : 'ai';
+    await safeDispatch(this.#dispatcher, TURN_STARTED_ID, { entityId: actorId, entityType, entity: actor }, this.#logger);
+    await safeDispatch(this.#dispatcher, TURN_PROCESSING_STARTED, { entityId: actorId, actorType: entityType }, this.#logger);
+    let handler;
+    try {
+      handler = await this.#resolver.resolveHandler(actor);
+    } catch (e) {
+      await this.#dispatchSystemError('System Error during turn advancement. Stopping game.', e);
+      await this.stop();
       return;
     }
-
-    const payload = event?.payload;
-    if (!payload) {
-      this.#logger.warn(
-        `Received '${TURN_ENDED_ID}' event but it has no payload. Ignoring. Event:`,
-        event
-      );
+    this.#currentHandler = handler;
+    if (!handler) {
+      this.#onTurnEnded({ type: TURN_ENDED_ID, payload: { entityId: actorId, success: false } });
       return;
     }
-
-    const endedActorId = payload.entityId;
-    const successStatus = payload.success;
-
-    this.#logger.debug(
-      `Received '${TURN_ENDED_ID}' event for entity ${endedActorId}. Success: ${successStatus ?? 'N/A'}. Current actor: ${this.#currentActor?.id || 'None'}`
-    );
-
-    if (!this.#currentActor || this.#currentActor.id !== endedActorId) {
-      this.#logger.warn(
-        `Received '${TURN_ENDED_ID}' for entity ${endedActorId}, but current active actor is ${this.#currentActor?.id || 'None'}. This event will be IGNORED by TurnManager's primary turn cycling logic.`
-      );
+    const name = handler.constructor?.name || 'handler';
+    try {
+      await handler.startTurn(actor);
+    } catch (e) {
+      safeDispatchError(this.#dispatcher, `Error initiating turn for ${actorId}`, { error: e.message, handlerName: name });
+      await this.#dispatchSystemError(`Error initiating turn for ${actorId}.`, e);
+      this.#onTurnEnded({ type: TURN_ENDED_ID, payload: { entityId: actorId, success: false, error: e } });
       return;
     }
+    this.#state = TMState.AwaitingTurnEnd;
+    this.#logger.debug(`Turn initiation for ${actorId} started via ${name}. TurnManager now WAITING for '${TURN_ENDED_ID}' event.`);
+  }
 
-    if (successStatus === true) {
-      this.#logger.debug(
-        `Marking round as having had a successful turn (actor: ${endedActorId}).`
-      );
-      this.#roundManager.endTurn(true);
+  #onTurnEnded(event) {
+    if (this.#state !== TMState.AwaitingTurnEnd) return;
+    const { entityId, success } = event?.payload || {};
+    if (!entityId || entityId !== this.#currentActor?.id) {
+      this.#logger.warn(`Received '${TURN_ENDED_ID}' for ${entityId} but current actor is ${this.#currentActor?.id ?? 'none'}`);
+      return;
     }
-
-    const currentActor = this.#currentActor;
-    const endedIsPlayer = currentActor?.hasComponent(PLAYER_COMPONENT_ID);
-
-    const actorType = endedIsPlayer ? 'player' : 'ai';
-    this.#dispatcher
-      .dispatch(TURN_PROCESSING_ENDED, {
-        entityId: endedActorId,
-        actorType,
-      })
-      .catch((dispatchError) =>
-        safeDispatchError(
-          this.#dispatcher,
-          `Failed to dispatch ${TURN_PROCESSING_ENDED} for ${endedActorId}`,
-          { error: dispatchError.message }
-        )
-      );
-
-    this.#logger.debug(
-      `Turn for current actor ${endedActorId} confirmed ended (Internal Status from Event: Success=${successStatus === undefined ? 'N/A' : successStatus}). Advancing turn...`
-    );
-
-    const handlerToDestroy = this.#currentHandler;
-
+    if (success) this.#roundMgr.endTurn(true);
+    const actor = this.#currentActor;
+    const handler = this.#currentHandler;
     this.#currentActor = null;
     this.#currentHandler = null;
-
-    if (handlerToDestroy) {
-      if (
-        typeof handlerToDestroy.signalNormalApparentTermination === 'function'
-      ) {
-        handlerToDestroy.signalNormalApparentTermination();
-      }
-      if (typeof handlerToDestroy.destroy === 'function') {
-        logStart(
-          this.#logger,
-          `Calling destroy() on handler (${handlerToDestroy.constructor?.name || 'Unknown'}) for completed turn ${endedActorId}`
-        );
-        // destroy() can be async, handle its promise to catch errors
-        Promise.resolve(handlerToDestroy.destroy()).catch((destroyError) =>
-          logError(
-            this.#logger,
-            `Error destroying handler for ${endedActorId} after turn end`,
-            destroyError
-          )
-        );
-      }
+    const actorType = actor.hasComponent(PLAYER_COMPONENT_ID) ? 'player' : 'ai';
+    this.#dispatcher.dispatch(TURN_PROCESSING_ENDED, { entityId, actorType }).catch((e) => safeDispatchError(this.#dispatcher, `Failed to dispatch ${TURN_PROCESSING_ENDED} for ${entityId}`, { error: e.message }));
+    if (handler) {
+      if (handler.signalNormalApparentTermination) handler.signalNormalApparentTermination();
+      if (handler.destroy) handler.destroy().catch((e) => logError(this.#logger, `Error destroying handler for ${entityId}`, e));
     }
-
-    // Advance the turn asynchronously via the subscription's scheduler.
-    this.advanceTurn().catch((advanceTurnError) => {
-      safeDispatchError(
-        this.#dispatcher,
-        'Error during scheduled turn advancement',
-        { error: advanceTurnError.message, entityId: endedActorId }
-      );
-      // This is a critical failure in turn advancement, dispatch system error and stop.
-      this.#dispatchSystemError(
-        'Critical error during scheduled turn advancement.',
-        advanceTurnError
-      ).catch((e) =>
-        logError(
-          this.#logger,
-          'Failed to dispatch system error for advanceTurn failure',
-          e
-        )
-      );
-      this.stop().catch((e) =>
-        this.#logger.error(
-          `Failed to stop manager after advanceTurn failure: ${e.message}`
-        )
-      );
-    });
+    this.#state = TMState.AwaitingActor;
+    this.#scheduler.setTimeout(() => {
+      this.#tick().catch((e) => {
+        safeDispatchError(this.#dispatcher, 'Error during scheduled turn advancement', { error: e.message, entityId });
+        this.#dispatchSystemError('Critical error during scheduled turn advancement.', e).catch(() => {});
+        this.stop().catch(() => {});
+      });
+    }, 0);
   }
 
-  /**
-   * Helper to dispatch system errors. Extracts message from Error objects.
-   *
-   * @param {string} message - User-friendly message.
-   * @param {string | Error} detailsOrError - Technical details string or an Error object.
-   * @returns {Promise<void>}
-   * @private
-   */
-  async #dispatchSystemError(message, detailsOrError) {
-    const detailString =
-      detailsOrError instanceof Error
-        ? detailsOrError.message
-        : String(detailsOrError);
-    const stackString =
-      detailsOrError instanceof Error
-        ? detailsOrError.stack
-        : new Error().stack;
+  async #dispatchSystemError(message, details) {
     await safeDispatch(
       this.#dispatcher,
       SYSTEM_ERROR_OCCURRED_ID,
       {
-        message: message,
+        message,
         details: {
-          raw: detailString,
-          stack: stackString,
+          raw: details instanceof Error ? details.message : String(details),
+          stack: details instanceof Error ? details.stack : new Error().stack,
           timestamp: new Date().toISOString(),
         },
       },
       this.#logger
     );
+    this.#error = details instanceof Error ? details : new Error(String(details));
   }
 }
-
-export default TurnManager;
-
-// --- FILE END ---

--- a/tests/turns/turnManager.fsm.spec.js
+++ b/tests/turns/turnManager.fsm.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import TurnManager from '../../src/turns/turnManager.js';
+import TurnEventSubscription from '../../src/turns/turnEventSubscription.js';
+import { ImmediateScheduler } from '../../src/scheduling/index.js';
+import { TURN_ENDED_ID } from '../../src/constants/eventIds.js';
+import { createEventBus, createMockTurnHandler } from '../common/mockFactories/index.js';
+import { createAiActor } from '../common/turns/testActors.js';
+import { flushPromisesAndTimers } from '../common/jestHelpers.js';
+
+class StubCycle {
+  constructor(list) {
+    this.list = list;
+    this.index = 0;
+  }
+  async nextActor() {
+    return this.list[this.index++] ?? null;
+  }
+  async clear() {
+    this.index = 0;
+  }
+}
+
+class StubRoundManager {
+  constructor(cycle) {
+    this.cycle = cycle;
+    this.startRound = jest.fn(async () => {
+      this.cycle.index = 0;
+    });
+    this.endTurn = jest.fn();
+  }
+}
+
+describe('TurnManager FSM', () => {
+  let bus;
+  let scheduler;
+  let cycle;
+  let roundMgr;
+  let resolver;
+  let tm;
+  let a1;
+  let a2;
+
+  beforeEach(() => {
+    scheduler = new ImmediateScheduler();
+    bus = createEventBus();
+    a1 = createAiActor('a1');
+    a2 = createAiActor('a2');
+    cycle = new StubCycle([a1, a2]);
+    roundMgr = new StubRoundManager(cycle);
+    resolver = { resolveHandler: jest.fn(async () => createMockTurnHandler()) };
+    const logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    tm = new TurnManager({
+      turnOrderService: { clearCurrentRound: jest.fn() },
+      entityManager: { getEntityInstance: jest.fn() },
+      logger,
+      dispatcher: bus,
+      turnHandlerResolver: resolver,
+      roundManager: roundMgr,
+      turnCycle: cycle,
+      eventSub: new TurnEventSubscription(bus, logger, scheduler),
+      scheduler,
+    });
+  });
+
+  it('cycles through actors and starts new round when list exhausted', async () => {
+    await tm.start();
+    expect(tm.getCurrentActorId()).toBe('a1');
+    await bus.dispatch(TURN_ENDED_ID, { entityId: 'a1', success: true });
+    expect(tm.getCurrentActorId()).toBe('a2');
+    await bus.dispatch(TURN_ENDED_ID, { entityId: 'a2', success: true });
+    await flushPromisesAndTimers();
+    expect(roundMgr.startRound).toHaveBeenCalled();
+    expect(tm.getCurrentActorId()).toBe('a1');
+  });
+});


### PR DESCRIPTION
Summary: implemented new finite state machine for TurnManager and added basic FSM tests. Introduced TMState enum.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [ ] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

⚠️ Tests are failing, needs human review. See attached logs for details.

------
https://chatgpt.com/codex/tasks/task_e_685f761ce68c8331bebe7490e85833d1