### PR TITLE
[Agent] add createDiscoveryError utility

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -207,11 +207,13 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
           errors.push(...result.errors);
         }
       } catch (err) {
-        errors.push({
-          actionId: actionDef.id,
-          targetId: this.#extractTargetId(err),
-          error: err,
-        });
+        errors.push(
+          this.#createDiscoveryError(
+            actionDef.id,
+            this.#extractTargetId(err),
+            err
+          )
+        );
         this.#logger.error(
           `Error processing candidate action '${actionDef.id}': ${err.message}`,
           err
@@ -334,17 +336,32 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
           params: { targetId: targetCtx.entityId },
         });
       } else {
-        errors.push({
-          actionId: actionDef.id,
-          targetId: targetCtx.entityId,
-          error: formatResult.error,
-          details: formatResult.details,
-        });
+        errors.push(
+          this.#createDiscoveryError(
+            actionDef.id,
+            targetCtx.entityId,
+            formatResult.error,
+            formatResult.details
+          )
+        );
         this.#logger.warn(
           `Failed to format command for action '${actionDef.id}' with target '${targetCtx.entityId}'.`
         );
       }
     }
     return { actions: validActions, errors };
+  }
+
+  /**
+   * @description Creates a standardized error object for action discovery.
+   * @param {string} actionId - ID of the action that failed.
+   * @param {string|null} targetId - ID of the target entity, if available.
+   * @param {Error} error - The encountered error instance.
+   * @param {any|null} [details] - Optional additional error details.
+   * @returns {{ actionId: string, targetId: string|null, error: Error, details: any|null }}
+   * @private
+   */
+  #createDiscoveryError(actionId, targetId, error, details = null) {
+    return { actionId, targetId, error, details };
   }
 }

--- a/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
+++ b/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
@@ -31,6 +31,7 @@ describeActionDiscoverySuite(
       expect(result.errors[0]).toMatchObject({
         actionId: 'bad',
         targetId: 'target-123',
+        details: null,
       });
     });
 
@@ -50,6 +51,7 @@ describeActionDiscoverySuite(
       expect(result.errors[0]).toMatchObject({
         actionId: 'bad',
         targetId: 'target-456',
+        details: null,
       });
     });
   }

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -124,6 +124,7 @@ describeActionDiscoverySuite(
       expect(result.errors[0]).toMatchObject({
         actionId: 'bad',
         targetId: null,
+        details: null,
       });
       expect(result.errors[0].error).toBeInstanceOf(Error);
     });


### PR DESCRIPTION
Summary:
- add private `#createDiscoveryError` helper for standard action-discovery errors
- use helper in `getValidActions` and `#formatActionsForTargets`
- update tests to check default `details` field

Testing Done:
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f7cefc99c83318a096ca9dc77eb18