### PR TITLE
[Agent] use helper for error dispatch

### DIFF
--- a/src/turns/turnManager.js
+++ b/src/turns/turnManager.js
@@ -32,6 +32,7 @@ import { RealScheduler } from '../scheduling/index.js';
 import { safeDispatch } from '../utils/eventHelpers.js';
 import { logStart, logEnd, logError } from '../utils/logHelpers.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { dispatchSystemErrorEvent } from '../utils/systemErrorDispatchUtils.js';
 
 /**
  * @class TurnManager
@@ -651,16 +652,14 @@ class TurnManager extends ITurnManager {
       detailsOrError instanceof Error
         ? detailsOrError.stack
         : new Error().stack;
-    await safeDispatch(
+
+    await dispatchSystemErrorEvent(
       this.#dispatcher,
-      SYSTEM_ERROR_OCCURRED_ID,
+      message,
       {
-        message: message,
-        details: {
-          raw: detailString,
-          stack: stackString,
-          timestamp: new Date().toISOString(),
-        },
+        raw: detailString,
+        stack: stackString,
+        timestamp: new Date().toISOString(),
       },
       this.#logger
     );


### PR DESCRIPTION
Summary: Simplified TurnManager's system error dispatch by calling `dispatchSystemErrorEvent`. This ensures consistent payload construction and aligns with other modules.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: existing issues)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685f7cfbe3a08331bca53736118c7625