### PR TITLE
[Agent] refactor operation schemas

### DIFF
--- a/data/schemas/operation-base.schema.json
+++ b/data/schemas/operation-base.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/schemas/operation-base.schema.json",
+  "title": "Base Operation",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string",
+      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
+    },
+    "condition": {
+      "$ref": "./condition-container.schema.json#",
+      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
+    },
+    "parameters": {
+      "$ref": "#/$defs/Parameters"
+    }
+  },
+  "required": ["type", "parameters"],
+  "additionalProperties": false,
+  "$defs": {
+    "Parameters": {
+      "type": "object",
+      "description": "Placeholder definition. Each operation schema must provide its own Parameters definition."
+    }
+  }
+}

--- a/data/schemas/operation.schema.json
+++ b/data/schemas/operation.schema.json
@@ -16,6 +16,9 @@
         }
       ]
     },
+    "OperationBase": {
+      "$ref": "./operation-base.schema.json"
+    },
     "MacroReference": {
       "type": "object",
       "description": "A reference to a macro. The macro's 'actions' will be expanded in place of this reference at load time.",

--- a/data/schemas/operations/addComponent.schema.json
+++ b/data/schemas/operations/addComponent.schema.json
@@ -2,43 +2,33 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/addComponent.schema.json",
   "title": "ADD_COMPONENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "ADD_COMPONENT"
-    },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the ADD_COMPONENT operation. Adds a component to an entity, replacing it if it already exists.",
+  "allOf": [
+    { "$ref": "../operation-base.schema.json" },
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
-        },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "value": {
-          "type": "object",
-          "minProperties": 0
-        }
+        "type": { "const": "ADD_COMPONENT" },
+        "parameters": { "$ref": "#/$defs/Parameters" }
       },
-      "required": ["entity_ref", "component_type", "value"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the ADD_COMPONENT operation. Adds a component to an entity, replacing it if it already exists.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "value": {
+              "type": "object",
+              "minProperties": 0
+            }
+          },
+          "required": ["entity_ref", "component_type", "value"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/addPerceptionLogEntry.schema.json
+++ b/data/schemas/operations/addPerceptionLogEntry.schema.json
@@ -2,43 +2,39 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/addPerceptionLogEntry.schema.json",
   "title": "ADD_PERCEPTION_LOG_ENTRY Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "ADD_PERCEPTION_LOG_ENTRY"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
+    {
       "properties": {
-        "location_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "ADD_PERCEPTION_LOG_ENTRY"
         },
-        "entry": {
-          "type": "object",
-          "minProperties": 1
-        },
-        "originating_actor_id": {
-          "type": "string"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["location_id", "entry"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "properties": {
+            "location_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "entry": {
+              "type": "object",
+              "minProperties": 1
+            },
+            "originating_actor_id": {
+              "type": "string"
+            }
+          },
+          "required": ["location_id", "entry"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/autoMoveFollowers.schema.json
+++ b/data/schemas/operations/autoMoveFollowers.schema.json
@@ -2,31 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/autoMoveFollowers.schema.json",
   "title": "AUTO_MOVE_FOLLOWERS Operation",
-  "type": "object",
-  "properties": {
-    "type": { "const": "AUTO_MOVE_FOLLOWERS" },
-    "comment": {
-      "type": "string",
-      "description": "Optional note for modders; ignored at runtime."
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": { "$ref": "#/$defs/Parameters" }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Moves followers of a leader to a destination location.",
+    {
       "properties": {
-        "leader_id": { "type": "string", "minLength": 1 },
-        "destination_id": { "type": "string", "minLength": 1 }
+        "type": {
+          "const": "AUTO_MOVE_FOLLOWERS"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
+        }
       },
-      "required": ["leader_id", "destination_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Moves followers of a leader to a destination location.",
+          "properties": {
+            "leader_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "destination_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["leader_id", "destination_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/breakFollowRelation.schema.json
+++ b/data/schemas/operations/breakFollowRelation.schema.json
@@ -2,37 +2,33 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/breakFollowRelation.schema.json",
   "title": "BREAK_FOLLOW_RELATION Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "BREAK_FOLLOW_RELATION"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the BREAK_FOLLOW_RELATION operation.",
+    {
       "properties": {
-        "follower_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "BREAK_FOLLOW_RELATION"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["follower_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the BREAK_FOLLOW_RELATION operation.",
+          "properties": {
+            "follower_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["follower_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/checkFollowCycle.schema.json
+++ b/data/schemas/operations/checkFollowCycle.schema.json
@@ -2,46 +2,42 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/checkFollowCycle.schema.json",
   "title": "CHECK_FOLLOW_CYCLE Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "CHECK_FOLLOW_CYCLE"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the CHECK_FOLLOW_CYCLE operation. Checks if following would create a cycle.",
+    {
       "properties": {
-        "follower_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "CHECK_FOLLOW_CYCLE"
         },
-        "leader_id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^\\S(.*\\S)?$"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["follower_id", "leader_id", "result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the CHECK_FOLLOW_CYCLE operation. Checks if following would create a cycle.",
+          "properties": {
+            "follower_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "leader_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^\\S(.*\\S)?$"
+            }
+          },
+          "required": ["follower_id", "leader_id", "result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/dispatchEvent.schema.json
+++ b/data/schemas/operations/dispatchEvent.schema.json
@@ -2,40 +2,36 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/dispatchEvent.schema.json",
   "title": "DISPATCH_EVENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "DISPATCH_EVENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the DISPATCH_EVENT operation. Sends an event through the dispatcher.",
+    {
       "properties": {
-        "eventType": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
+        "type": {
+          "const": "DISPATCH_EVENT"
         },
-        "payload": {
-          "type": "object",
-          "default": {}
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["eventType"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the DISPATCH_EVENT operation. Sends an event through the dispatcher.",
+          "properties": {
+            "eventType": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "payload": {
+              "type": "object",
+              "default": {}
+            }
+          },
+          "required": ["eventType"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/dispatchPerceptibleEvent.schema.json
+++ b/data/schemas/operations/dispatchPerceptibleEvent.schema.json
@@ -2,82 +2,78 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/dispatchPerceptibleEvent.schema.json",
   "title": "DISPATCH_PERCEPTIBLE_EVENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "DISPATCH_PERCEPTIBLE_EVENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the DISPATCH_PERCEPTIBLE_EVENT operation. Builds and dispatches core:perceptible_event.",
+    {
       "properties": {
-        "location_id": {
-          "type": "string"
+        "type": {
+          "const": "DISPATCH_PERCEPTIBLE_EVENT"
         },
-        "description_text": {
-          "type": "string",
-          "minLength": 1
-        },
-        "perception_type": {
-          "type": "string",
-          "enum": [
-            "character_enter",
-            "character_exit",
-            "item_pickup",
-            "item_drop",
-            "item_use",
-            "speech_local",
-            "action_self_general",
-            "action_target_general",
-            "combat_attack",
-            "combat_effect",
-            "state_change_observable"
-          ]
-        },
-        "actor_id": {
-          "type": "string"
-        },
-        "target_id": {
-          "type": ["string", "null"]
-        },
-        "involved_entities": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        },
-        "contextual_data": {
-          "type": "object",
-          "default": {}
-        },
-        "log_entry": {
-          "type": "boolean",
-          "default": false
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": [
-        "location_id",
-        "description_text",
-        "perception_type",
-        "actor_id"
-      ],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the DISPATCH_PERCEPTIBLE_EVENT operation. Builds and dispatches core:perceptible_event.",
+          "properties": {
+            "location_id": {
+              "type": "string"
+            },
+            "description_text": {
+              "type": "string",
+              "minLength": 1
+            },
+            "perception_type": {
+              "type": "string",
+              "enum": [
+                "character_enter",
+                "character_exit",
+                "item_pickup",
+                "item_drop",
+                "item_use",
+                "speech_local",
+                "action_self_general",
+                "action_target_general",
+                "combat_attack",
+                "combat_effect",
+                "state_change_observable"
+              ]
+            },
+            "actor_id": {
+              "type": "string"
+            },
+            "target_id": {
+              "type": ["string", "null"]
+            },
+            "involved_entities": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "contextual_data": {
+              "type": "object",
+              "default": {}
+            },
+            "log_entry": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "location_id",
+            "description_text",
+            "perception_type",
+            "actor_id"
+          ],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/dispatchSpeech.schema.json
+++ b/data/schemas/operations/dispatchSpeech.schema.json
@@ -2,52 +2,48 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/dispatchSpeech.schema.json",
   "title": "DISPATCH_SPEECH Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "DISPATCH_SPEECH"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the DISPATCH_SPEECH operation. Emits core:display_speech.",
+    {
       "properties": {
-        "entity_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "DISPATCH_SPEECH"
         },
-        "speech_content": {
-          "type": "string",
-          "minLength": 1
-        },
-        "thoughts": {
-          "type": "string",
-          "minLength": 1
-        },
-        "notes": {
-          "type": "string",
-          "minLength": 1
-        },
-        "allow_html": {
-          "type": "boolean"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_id", "speech_content"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the DISPATCH_SPEECH operation. Emits core:display_speech.",
+          "properties": {
+            "entity_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "speech_content": {
+              "type": "string",
+              "minLength": 1
+            },
+            "thoughts": {
+              "type": "string",
+              "minLength": 1
+            },
+            "notes": {
+              "type": "string",
+              "minLength": 1
+            },
+            "allow_html": {
+              "type": "boolean"
+            }
+          },
+          "required": ["entity_id", "speech_content"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/endTurn.schema.json
+++ b/data/schemas/operations/endTurn.schema.json
@@ -2,43 +2,39 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/endTurn.schema.json",
   "title": "END_TURN Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "END_TURN"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the END_TURN operation, dispatching core:turn_ended.",
+    {
       "properties": {
-        "entityId": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "END_TURN"
         },
-        "success": {
-          "type": "boolean"
-        },
-        "error": {
-          "type": "object"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entityId", "success"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the END_TURN operation, dispatching core:turn_ended.",
+          "properties": {
+            "entityId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "success": {
+              "type": "boolean"
+            },
+            "error": {
+              "type": "object"
+            }
+          },
+          "required": ["entityId", "success"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/establishFollowRelation.schema.json
+++ b/data/schemas/operations/establishFollowRelation.schema.json
@@ -2,41 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/establishFollowRelation.schema.json",
   "title": "ESTABLISH_FOLLOW_RELATION Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "ESTABLISH_FOLLOW_RELATION"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the ESTABLISH_FOLLOW_RELATION operation.",
+    {
       "properties": {
-        "follower_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "ESTABLISH_FOLLOW_RELATION"
         },
-        "leader_id": {
-          "type": "string",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["follower_id", "leader_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the ESTABLISH_FOLLOW_RELATION operation.",
+          "properties": {
+            "follower_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "leader_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["follower_id", "leader_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/forEach.schema.json
+++ b/data/schemas/operations/forEach.schema.json
@@ -2,46 +2,42 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/forEach.schema.json",
   "title": "FOR_EACH Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "FOR_EACH"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the FOR_EACH loop operation.",
+    {
       "properties": {
-        "collection": {
-          "type": "string"
+        "type": {
+          "const": "FOR_EACH"
         },
-        "item_variable": {
-          "type": "string"
-        },
-        "actions": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "../operation.schema.json#/$defs/Action"
-          }
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["collection", "item_variable", "actions"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the FOR_EACH loop operation.",
+          "properties": {
+            "collection": {
+              "type": "string"
+            },
+            "item_variable": {
+              "type": "string"
+            },
+            "actions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "../operation.schema.json#/$defs/Action"
+              }
+            }
+          },
+          "required": ["collection", "item_variable", "actions"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/getName.schema.json
+++ b/data/schemas/operations/getName.schema.json
@@ -2,42 +2,38 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/getName.schema.json",
   "title": "GET_NAME Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "GET_NAME"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "GET_NAME"
         },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1
-        },
-        "default_value": {
-          "type": "string"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default_value": {
+              "type": "string"
+            }
+          },
+          "required": ["entity_ref", "result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/getTimestamp.schema.json
+++ b/data/schemas/operations/getTimestamp.schema.json
@@ -2,36 +2,32 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/getTimestamp.schema.json",
   "title": "GET_TIMESTAMP Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "GET_TIMESTAMP"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
+    {
       "properties": {
-        "result_variable": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "GET_TIMESTAMP"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "properties": {
+            "result_variable": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/hasComponent.schema.json
+++ b/data/schemas/operations/hasComponent.schema.json
@@ -2,44 +2,40 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/hasComponent.schema.json",
   "title": "HAS_COMPONENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "HAS_COMPONENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the HAS_COMPONENT operation. Checks if an entity has a component.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "HAS_COMPONENT"
         },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "result_variable": {
-          "type": "string",
-          "description": "Required. The context variable to store the boolean result (true/false) in.",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "component_type", "result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the HAS_COMPONENT operation. Checks if an entity has a component.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "result_variable": {
+              "type": "string",
+              "description": "Required. The context variable to store the boolean result (true/false) in.",
+              "minLength": 1
+            }
+          },
+          "required": ["entity_ref", "component_type", "result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/if.schema.json
+++ b/data/schemas/operations/if.schema.json
@@ -2,50 +2,46 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/if.schema.json",
   "title": "IF Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "IF"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the IF operation, enabling conditional execution.",
+    {
       "properties": {
-        "condition": {
-          "$ref": "../json-logic.schema.json#"
+        "type": {
+          "const": "IF"
         },
-        "then_actions": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "../operation.schema.json#/$defs/Action"
-          }
-        },
-        "else_actions": {
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "../operation.schema.json#/$defs/Action"
-          }
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["condition", "then_actions"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the IF operation, enabling conditional execution.",
+          "properties": {
+            "condition": {
+              "$ref": "../json-logic.schema.json#"
+            },
+            "then_actions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "../operation.schema.json#/$defs/Action"
+              }
+            },
+            "else_actions": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "$ref": "../operation.schema.json#/$defs/Action"
+              }
+            }
+          },
+          "required": ["condition", "then_actions"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/ifCoLocated.schema.json
+++ b/data/schemas/operations/ifCoLocated.schema.json
@@ -2,53 +2,49 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/ifCoLocated.schema.json",
   "title": "IF_CO_LOCATED Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "IF_CO_LOCATED"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the IF_CO_LOCATED operation. Executes different actions based on shared location.",
+    {
       "properties": {
-        "entity_ref_a": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "IF_CO_LOCATED"
         },
-        "entity_ref_b": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
-        },
-        "then_actions": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "../operation.schema.json#/$defs/Action"
-          }
-        },
-        "else_actions": {
-          "type": "array",
-          "items": {
-            "$ref": "../operation.schema.json#/$defs/Action"
-          },
-          "default": []
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref_a", "entity_ref_b", "then_actions"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the IF_CO_LOCATED operation. Executes different actions based on shared location.",
+          "properties": {
+            "entity_ref_a": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "entity_ref_b": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "then_actions": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "../operation.schema.json#/$defs/Action"
+              }
+            },
+            "else_actions": {
+              "type": "array",
+              "items": {
+                "$ref": "../operation.schema.json#/$defs/Action"
+              },
+              "default": []
+            }
+          },
+          "required": ["entity_ref_a", "entity_ref_b", "then_actions"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/log.schema.json
+++ b/data/schemas/operations/log.schema.json
@@ -2,42 +2,38 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/log.schema.json",
   "title": "LOG Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "LOG"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the LOG operation, used for debugging.",
+    {
       "properties": {
-        "message": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "LOG"
         },
-        "level": {
-          "type": "string",
-          "enum": ["debug", "info", "warn", "error"],
-          "default": "info"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["message"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the LOG operation, used for debugging.",
+          "properties": {
+            "message": {
+              "type": "string",
+              "minLength": 1
+            },
+            "level": {
+              "type": "string",
+              "enum": ["debug", "info", "warn", "error"],
+              "default": "info"
+            }
+          },
+          "required": ["message"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/math.schema.json
+++ b/data/schemas/operations/math.schema.json
@@ -2,80 +2,35 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/math.schema.json",
   "title": "MATH Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "MATH"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the MATH operation. Performs a calculation and stores the result.",
+    {
       "properties": {
-        "result_variable": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "MATH"
         },
-        "expression": {
-          "$ref": "#/$defs/MathExpression"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["result_variable", "expression"]
-    },
-    "MathExpression": {
-      "type": "object",
-      "description": "A recursive mathematical expression.",
-      "properties": {
-        "operator": {
-          "type": "string",
-          "enum": ["add", "subtract", "multiply", "divide", "modulo"]
-        },
-        "operands": {
-          "type": "array",
-          "description": "An array of two operands for the operation.",
-          "items": {
-            "$ref": "#/$defs/MathOperand"
-          },
-          "minItems": 2,
-          "maxItems": 2
-        }
-      },
-      "required": ["operator", "operands"]
-    },
-    "MathOperand": {
-      "description": "An operand for a math expression. Can be a number, a variable reference, or a nested expression.",
-      "oneOf": [
-        {
-          "type": "number"
-        },
-        {
+      "$defs": {
+        "Parameters": {
           "type": "object",
+          "description": "Parameters for the MATH operation. Performs a calculation and stores the result.",
           "properties": {
-            "var": {
-              "type": "string"
+            "result_variable": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expression": {
+              "$ref": "#/$defs/MathExpression"
             }
           },
-          "required": ["var"],
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/$defs/MathExpression"
+          "required": ["result_variable", "expression"]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/mergeClosenessCircle.schema.json
+++ b/data/schemas/operations/mergeClosenessCircle.schema.json
@@ -2,36 +2,42 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/mergeClosenessCircle.schema.json",
   "title": "MERGE_CLOSENESS_CIRCLE Operation",
-  "type": "object",
-  "properties": {
-    "type": { "const": "MERGE_CLOSENESS_CIRCLE" },
-    "comment": {
-      "type": "string",
-      "description": "Optional developer note; ignored at runtime."
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": { "$ref": "#/$defs/Parameters" }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for merging two closeness circles and locking movement.",
+    {
       "properties": {
-        "actor_id": { "type": "string", "minLength": 1 },
-        "target_id": { "type": "string", "minLength": 1 },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Optional context variable to store affected entity IDs."
+        "type": {
+          "const": "MERGE_CLOSENESS_CIRCLE"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["actor_id", "target_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for merging two closeness circles and locking movement.",
+          "properties": {
+            "actor_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional context variable to store affected entity IDs."
+            }
+          },
+          "required": ["actor_id", "target_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/modifyArrayField.schema.json
+++ b/data/schemas/operations/modifyArrayField.schema.json
@@ -2,95 +2,91 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/modifyArrayField.schema.json",
   "title": "MODIFY_ARRAY_FIELD Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "MODIFY_ARRAY_FIELD"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for MODIFY_ARRAY_FIELD. Atomically modifies an array within a component.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "MODIFY_ARRAY_FIELD"
         },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "field": {
-          "type": "string",
-          "description": "Required. Dot-separated path to the array field within the component.",
-          "minLength": 1
-        },
-        "mode": {
-          "type": "string",
-          "description": "The operation to perform: 'push' adds a value, 'push_unique' adds a value if it's not already present, 'remove_by_value' removes the first matching value, 'pop' removes the last value.",
-          "enum": ["push", "push_unique", "remove_by_value", "pop"]
-        },
-        "value": {
-          "description": "The value to add or remove. Required for 'push', 'push_unique' and 'remove_by_value'."
-        },
-        "result_variable": {
-          "type": "string",
-          "description": "Optional. For 'pop', stores the removed item. For others, can store the modified array.",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "component_type", "field", "mode"],
-      "additionalProperties": false,
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "push"
-              }
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for MODIFY_ARRAY_FIELD. Atomically modifies an array within a component.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "field": {
+              "type": "string",
+              "description": "Required. Dot-separated path to the array field within the component.",
+              "minLength": 1
+            },
+            "mode": {
+              "type": "string",
+              "description": "The operation to perform: 'push' adds a value, 'push_unique' adds a value if it's not already present, 'remove_by_value' removes the first matching value, 'pop' removes the last value.",
+              "enum": ["push", "push_unique", "remove_by_value", "pop"]
+            },
+            "value": {
+              "description": "The value to add or remove. Required for 'push', 'push_unique' and 'remove_by_value'."
+            },
+            "result_variable": {
+              "type": "string",
+              "description": "Optional. For 'pop', stores the removed item. For others, can store the modified array.",
+              "minLength": 1
             }
           },
-          "then": {
-            "required": ["value"]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "push_unique"
+          "required": ["entity_ref", "component_type", "field", "mode"],
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "push"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "push_unique"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "remove_by_value"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
               }
             }
-          },
-          "then": {
-            "required": ["value"]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "remove_by_value"
-              }
-            }
-          },
-          "then": {
-            "required": ["value"]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/modifyComponent.schema.json
+++ b/data/schemas/operations/modifyComponent.schema.json
@@ -2,49 +2,51 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/modifyComponent.schema.json",
   "title": "MODIFY_COMPONENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "MODIFY_COMPONENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the MODIFY_COMPONENT operation. Modifies a specific field within an existing component (mode \"set\" only—use a MATH + SET_VARIABLE combo for arithmetic).",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "MODIFY_COMPONENT"
         },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "field": {
-          "type": "string",
-          "minLength": 1
-        },
-        "mode": {
-          "type": "string",
-          "enum": ["set"],
-          "default": "set"
-        },
-        "value": {}
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
+        }
       },
-      "required": ["entity_ref", "component_type", "field", "mode", "value"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the MODIFY_COMPONENT operation. Modifies a specific field within an existing component (mode \"set\" only—use a MATH + SET_VARIABLE combo for arithmetic).",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "field": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mode": {
+              "type": "string",
+              "enum": ["set"],
+              "default": "set"
+            },
+            "value": {}
+          },
+          "required": [
+            "entity_ref",
+            "component_type",
+            "field",
+            "mode",
+            "value"
+          ],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/modifyContextArray.schema.json
+++ b/data/schemas/operations/modifyContextArray.schema.json
@@ -2,89 +2,85 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/modifyContextArray.schema.json",
   "title": "MODIFY_CONTEXT_ARRAY Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "MODIFY_CONTEXT_ARRAY"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for MODIFY_CONTEXT_ARRAY. Modifies an array stored in a context variable.",
+    {
       "properties": {
-        "variable_path": {
-          "type": "string",
-          "description": "Required. Dot-separated path to the array within the context.",
-          "minLength": 1
+        "type": {
+          "const": "MODIFY_CONTEXT_ARRAY"
         },
-        "mode": {
-          "type": "string",
-          "description": "The operation to perform: 'push', 'push_unique', 'remove_by_value', 'pop'.",
-          "enum": ["push", "push_unique", "remove_by_value", "pop"]
-        },
-        "value": {
-          "description": "The value to add or remove. Required for 'push', 'push_unique' and 'remove_by_value'."
-        },
-        "result_variable": {
-          "type": "string",
-          "description": "Optional. For 'pop', stores the removed item. For others, can store the modified array.",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["variable_path", "mode"],
-      "additionalProperties": false,
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "push"
-              }
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for MODIFY_CONTEXT_ARRAY. Modifies an array stored in a context variable.",
+          "properties": {
+            "variable_path": {
+              "type": "string",
+              "description": "Required. Dot-separated path to the array within the context.",
+              "minLength": 1
+            },
+            "mode": {
+              "type": "string",
+              "description": "The operation to perform: 'push', 'push_unique', 'remove_by_value', 'pop'.",
+              "enum": ["push", "push_unique", "remove_by_value", "pop"]
+            },
+            "value": {
+              "description": "The value to add or remove. Required for 'push', 'push_unique' and 'remove_by_value'."
+            },
+            "result_variable": {
+              "type": "string",
+              "description": "Optional. For 'pop', stores the removed item. For others, can store the modified array.",
+              "minLength": 1
             }
           },
-          "then": {
-            "required": ["value"]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "push_unique"
+          "required": ["variable_path", "mode"],
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "push"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "push_unique"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "remove_by_value"
+                  }
+                }
+              },
+              "then": {
+                "required": ["value"]
               }
             }
-          },
-          "then": {
-            "required": ["value"]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "mode": {
-                "const": "remove_by_value"
-              }
-            }
-          },
-          "then": {
-            "required": ["value"]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/queryComponent.schema.json
+++ b/data/schemas/operations/queryComponent.schema.json
@@ -2,45 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/queryComponent.schema.json",
   "title": "QUERY_COMPONENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "QUERY_COMPONENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the QUERY_COMPONENT operation.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "QUERY_COMPONENT"
         },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^\\S(.*\\S)?$"
-        },
-        "missing_value": {}
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
+        }
       },
-      "required": ["entity_ref", "component_type", "result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the QUERY_COMPONENT operation.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^\\S(.*\\S)?$"
+            },
+            "missing_value": {}
+          },
+          "required": ["entity_ref", "component_type", "result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/queryComponents.schema.json
+++ b/data/schemas/operations/queryComponents.schema.json
@@ -2,52 +2,39 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/queryComponents.schema.json",
   "title": "QUERY_COMPONENTS Operation",
-  "type": "object",
-  "properties": {
-    "type": { "const": "QUERY_COMPONENTS" },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note; ignored at runtime."
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": { "$ref": "#/$defs/Parameters" }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the QUERY_COMPONENTS operation.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "QUERY_COMPONENTS"
         },
-        "pairs": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/Pair" }
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "pairs"],
-      "additionalProperties": false
-    },
-    "Pair": {
-      "type": "object",
-      "properties": {
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
-        },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^\\S(.*\\S)?$"
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the QUERY_COMPONENTS operation.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "pairs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/Pair"
+              }
+            }
+          },
+          "required": ["entity_ref", "pairs"],
+          "additionalProperties": false
         }
-      },
-      "required": ["component_type", "result_variable"],
-      "additionalProperties": false
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/queryEntities.schema.json
+++ b/data/schemas/operations/queryEntities.schema.json
@@ -2,77 +2,73 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/queryEntities.schema.json",
   "title": "QUERY_ENTITIES Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "QUERY_ENTITIES"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the QUERY_ENTITIES operation. Finds entities matching a set of filters.",
+    {
       "properties": {
-        "result_variable": {
-          "type": "string",
-          "description": "Required. The context variable to store the resulting array of entity IDs in.",
-          "minLength": 1
+        "type": {
+          "const": "QUERY_ENTITIES"
         },
-        "limit": {
-          "type": "integer",
-          "description": "Optional. The maximum number of entity IDs to return.",
-          "minimum": 1
-        },
-        "filters": {
-          "type": "array",
-          "description": "Required. An array of filter conditions. An entity must pass all filters to be included.",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "minProperties": 1,
-            "maxProperties": 1,
-            "properties": {
-              "by_location": {
-                "type": "string",
-                "description": "Filter for entities in a specific location ID.",
-                "minLength": 1
-              },
-              "with_component": {
-                "$ref": "../common.schema.json#/definitions/namespacedId",
-                "description": "Filter for entities that have a specific component type."
-              },
-              "with_component_data": {
-                "type": "object",
-                "description": "Advanced filter for entities based on data within one of their components.",
-                "properties": {
-                  "component_type": {
-                    "$ref": "../common.schema.json#/definitions/namespacedId"
-                  },
-                  "condition": {
-                    "$ref": "../json-logic.schema.json#"
-                  }
-                },
-                "required": ["component_type", "condition"]
-              }
-            }
-          }
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["result_variable", "filters"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the QUERY_ENTITIES operation. Finds entities matching a set of filters.",
+          "properties": {
+            "result_variable": {
+              "type": "string",
+              "description": "Required. The context variable to store the resulting array of entity IDs in.",
+              "minLength": 1
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Optional. The maximum number of entity IDs to return.",
+              "minimum": 1
+            },
+            "filters": {
+              "type": "array",
+              "description": "Required. An array of filter conditions. An entity must pass all filters to be included.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 1,
+                "properties": {
+                  "by_location": {
+                    "type": "string",
+                    "description": "Filter for entities in a specific location ID.",
+                    "minLength": 1
+                  },
+                  "with_component": {
+                    "$ref": "../common.schema.json#/definitions/namespacedId",
+                    "description": "Filter for entities that have a specific component type."
+                  },
+                  "with_component_data": {
+                    "type": "object",
+                    "description": "Advanced filter for entities based on data within one of their components.",
+                    "properties": {
+                      "component_type": {
+                        "$ref": "../common.schema.json#/definitions/namespacedId"
+                      },
+                      "condition": {
+                        "$ref": "../json-logic.schema.json#"
+                      }
+                    },
+                    "required": ["component_type", "condition"]
+                  }
+                }
+              }
+            }
+          },
+          "required": ["result_variable", "filters"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/rebuildLeaderListCache.schema.json
+++ b/data/schemas/operations/rebuildLeaderListCache.schema.json
@@ -2,41 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/rebuildLeaderListCache.schema.json",
   "title": "REBUILD_LEADER_LIST_CACHE Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "REBUILD_LEADER_LIST_CACHE"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Rebuilds the core:leading cache for specified leader IDs.",
+    {
       "properties": {
-        "leaderIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "description": "Array of leader entity IDs."
+        "type": {
+          "const": "REBUILD_LEADER_LIST_CACHE"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["leaderIds"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Rebuilds the core:leading cache for specified leader IDs.",
+          "properties": {
+            "leaderIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "description": "Array of leader entity IDs."
+            }
+          },
+          "required": ["leaderIds"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/removeComponent.schema.json
+++ b/data/schemas/operations/removeComponent.schema.json
@@ -2,39 +2,35 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/removeComponent.schema.json",
   "title": "REMOVE_COMPONENT Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "REMOVE_COMPONENT"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the REMOVE_COMPONENT operation. Removes a component from an entity.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference"
+        "type": {
+          "const": "REMOVE_COMPONENT"
         },
-        "component_type": {
-          "$ref": "../common.schema.json#/definitions/namespacedId"
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "component_type"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the REMOVE_COMPONENT operation. Removes a component from an entity.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference"
+            },
+            "component_type": {
+              "$ref": "../common.schema.json#/definitions/namespacedId"
+            }
+          },
+          "required": ["entity_ref", "component_type"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/removeFromClosenessCircle.schema.json
+++ b/data/schemas/operations/removeFromClosenessCircle.schema.json
@@ -2,37 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/removeFromClosenessCircle.schema.json",
   "title": "REMOVE_FROM_CLOSENESS_CIRCLE Operation",
-  "type": "object",
-  "properties": {
-    "type": { "const": "REMOVE_FROM_CLOSENESS_CIRCLE" },
-    "comment": {
-      "type": "string",
-      "description": "Optional developer note; ignored at runtime."
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": { "$ref": "#/$defs/Parameters" }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the REMOVE_FROM_CLOSENESS_CIRCLE operation.",
+    {
       "properties": {
-        "actor_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "REMOVE_FROM_CLOSENESS_CIRCLE"
         },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["actor_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the REMOVE_FROM_CLOSENESS_CIRCLE operation.",
+          "properties": {
+            "actor_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["actor_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/resolveDirection.schema.json
+++ b/data/schemas/operations/resolveDirection.schema.json
@@ -2,44 +2,40 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/resolveDirection.schema.json",
   "title": "RESOLVE_DIRECTION Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "RESOLVE_DIRECTION"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
+    {
       "properties": {
-        "current_location_id": {
-          "type": "string",
-          "minLength": 1
+        "type": {
+          "const": "RESOLVE_DIRECTION"
         },
-        "direction": {
-          "type": "string",
-          "minLength": 1
-        },
-        "result_variable": {
-          "type": "string",
-          "minLength": 1
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["current_location_id", "direction", "result_variable"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "properties": {
+            "current_location_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "direction": {
+              "type": "string",
+              "minLength": 1
+            },
+            "result_variable": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["current_location_id", "direction", "result_variable"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/setVariable.schema.json
+++ b/data/schemas/operations/setVariable.schema.json
@@ -2,39 +2,35 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/setVariable.schema.json",
   "title": "SET_VARIABLE Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "SET_VARIABLE"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the SET_VARIABLE operation. Sets or updates a variable within the current rule execution context.",
+    {
       "properties": {
-        "variable_name": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^\\S(.*\\S)?$"
+        "type": {
+          "const": "SET_VARIABLE"
         },
-        "value": {}
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
+        }
       },
-      "required": ["variable_name", "value"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the SET_VARIABLE operation. Sets or updates a variable within the current rule execution context.",
+          "properties": {
+            "variable_name": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^\\S(.*\\S)?$"
+            },
+            "value": {}
+          },
+          "required": ["variable_name", "value"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/data/schemas/operations/systemMoveEntity.schema.json
+++ b/data/schemas/operations/systemMoveEntity.schema.json
@@ -2,41 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/schemas/operations/systemMoveEntity.schema.json",
   "title": "SYSTEM_MOVE_ENTITY Operation",
-  "type": "object",
-  "properties": {
-    "type": {
-      "const": "SYSTEM_MOVE_ENTITY"
+  "allOf": [
+    {
+      "$ref": "../operation-base.schema.json"
     },
-    "comment": {
-      "type": "string",
-      "description": "Optional. A human-readable description or note for developers or modders; ignored by the interpreter at runtime."
-    },
-    "condition": {
-      "$ref": "../condition-container.schema.json#",
-      "description": "Optional. If present, this operation only executes if the condition evaluates to true. Can be an inline JSON-Logic rule or a 'condition_ref'."
-    },
-    "parameters": {
-      "$ref": "#/$defs/Parameters"
-    }
-  },
-  "required": ["type", "parameters"],
-  "additionalProperties": false,
-  "$defs": {
-    "Parameters": {
-      "type": "object",
-      "description": "Parameters for the SYSTEM_MOVE_ENTITY operation, which directly moves an entity to a new location without consuming a turn.",
+    {
       "properties": {
-        "entity_ref": {
-          "$ref": "../common.schema.json#/definitions/entityReference",
-          "description": "Required. The entity to move."
+        "type": {
+          "const": "SYSTEM_MOVE_ENTITY"
         },
-        "target_location_id": {
-          "type": "string",
-          "description": "Required. The namespaced ID of the location to move the entity to. Can be a placeholder string like '{event.payload.currentLocationId}'."
+        "parameters": {
+          "$ref": "#/$defs/Parameters"
         }
       },
-      "required": ["entity_ref", "target_location_id"],
-      "additionalProperties": false
+      "$defs": {
+        "Parameters": {
+          "type": "object",
+          "description": "Parameters for the SYSTEM_MOVE_ENTITY operation, which directly moves an entity to a new location without consuming a turn.",
+          "properties": {
+            "entity_ref": {
+              "$ref": "../common.schema.json#/definitions/entityReference",
+              "description": "Required. The entity to move."
+            },
+            "target_location_id": {
+              "type": "string",
+              "description": "Required. The namespaced ID of the location to move the entity to. Can be a placeholder string like '{event.payload.currentLocationId}'."
+            }
+          },
+          "required": ["entity_ref", "target_location_id"],
+          "additionalProperties": false
+        }
+      }
     }
-  }
+  ]
 }

--- a/src/configuration/staticConfiguration.js
+++ b/src/configuration/staticConfiguration.js
@@ -109,6 +109,7 @@ class StaticConfiguration {
       'goal.schema.json',
       'mod-manifest.schema.json',
       'operation.schema.json',
+      'operation-base.schema.json',
       'rule.schema.json',
       'llm-configs.schema.json',
       'prompt-text.schema.json',

--- a/tests/nodes/step.test.js
+++ b/tests/nodes/step.test.js
@@ -78,8 +78,16 @@ describe('StepResolver', () => {
 
       expect(result.size).toBe(2);
       const resultArray = [...result];
-      expect(resultArray).toContainEqual({ location: 'location1', x: 10, y: 20 });
-      expect(resultArray).toContainEqual({ location: 'location2', x: 30, y: 40 });
+      expect(resultArray).toContainEqual({
+        location: 'location1',
+        x: 10,
+        y: 20,
+      });
+      expect(resultArray).toContainEqual({
+        location: 'location2',
+        x: 30,
+        y: 40,
+      });
     });
 
     it('should extract field values from objects', () => {

--- a/tests/unit/context/worldContext.test.js
+++ b/tests/unit/context/worldContext.test.js
@@ -144,8 +144,8 @@ describe('WorldContext (Stateless)', () => {
       expect(
         () => new WorldContext(mockEntityManager, {}, mockDispatcher)
       ).toThrow('WorldContext requires a valid ILogger instance');
-      expect(() =>
-        new WorldContext(mockEntityManager, mockLogger, null)
+      expect(
+        () => new WorldContext(mockEntityManager, mockLogger, null)
       ).toThrow('Missing required dependency: safeEventDispatcher.');
     });
 

--- a/tests/unit/helpers/loadOperationSchemas.js
+++ b/tests/unit/helpers/loadOperationSchemas.js
@@ -8,14 +8,14 @@ const path = require('path');
  * @param {import('ajv').default} ajv - AJV instance
  */
 function loadOperationSchemas(ajv) {
-  const dir = path.join(
-    __dirname,
-    '..',
-    '..',
-    '..',
-    'data',
-    'schemas',
-    'operations'
+  const baseDir = path.join(__dirname, '..', '..', '..', 'data', 'schemas');
+  const dir = path.join(baseDir, 'operations');
+
+  // Load the shared base schema first so operation schemas can reference it
+  const baseSchema = require(path.join(baseDir, 'operation-base.schema.json'));
+  ajv.addSchema(
+    baseSchema,
+    'http://example.com/schemas/operation-base.schema.json'
   );
   for (const file of fs.readdirSync(dir)) {
     const schema = require(path.join(dir, file));

--- a/tests/unit/utils/errorUtils.basic.test.js
+++ b/tests/unit/utils/errorUtils.basic.test.js
@@ -7,7 +7,9 @@ import {
 } from '../../../src/utils/startupErrorHandler.js';
 
 jest.mock('../../../src/utils/startupErrorHandler.js', () => {
-  const actual = jest.requireActual('../../../src/utils/startupErrorHandler.js');
+  const actual = jest.requireActual(
+    '../../../src/utils/startupErrorHandler.js'
+  );
   return {
     ...actual,
     StartupErrorHandler: jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- add a reusable `operation-base` schema
- refactor all operation schemas to inherit from the base schema
- include the base schema in `staticConfiguration`
- load the base schema in unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f7ce009c88331b199436901abb082