### PR TITLE
[Feat] shared filename parsing utilities

### DIFF
--- a/src/utils/idUtils.js
+++ b/src/utils/idUtils.js
@@ -103,6 +103,77 @@ export function parseAndValidateId(
 }
 
 /**
+ * @description Normalizes a file path, removing directory segments and
+ * returning just the file name.
+ * @param {string} filename - The file path or name to normalize.
+ * @returns {string} The final segment of the path, or an empty string for
+ * invalid input.
+ */
+export function stripDirectories(filename) {
+  if (typeof filename !== 'string') {
+    return '';
+  }
+
+  let name = filename.trim().replace(/\\/g, '/');
+  if (name === '') {
+    return '';
+  }
+
+  if (name.includes('/')) {
+    name = name.substring(name.lastIndexOf('/') + 1);
+  }
+
+  return name;
+}
+
+/**
+ * @description Removes the final extension from a file name.
+ * @param {string} name - A file name with no directory segments.
+ * @returns {string} The file name without its last extension.
+ */
+export function removeFileExtension(name) {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  const trimmed = name.trim();
+  if (trimmed === '') {
+    return '';
+  }
+
+  if (trimmed.includes('.')) {
+    return trimmed.substring(0, trimmed.lastIndexOf('.'));
+  }
+  return trimmed;
+}
+
+/**
+ * @description Removes the first matching suffix from the provided name.
+ * Comparison is case-insensitive.
+ * @param {string} name - The name from which to remove suffixes.
+ * @param {string[]} suffixes - Allowed suffixes to strip.
+ * @returns {string} The name without a matching suffix.
+ */
+export function stripSuffixes(name, suffixes = []) {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  let result = name;
+  for (const suffix of suffixes) {
+    if (
+      typeof suffix === 'string' &&
+      result.toLowerCase().endsWith(suffix.toLowerCase())
+    ) {
+      result = result.substring(0, result.length - suffix.length);
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Extracts a base identifier from a filename by removing directory segments,
  * the final extension, and an optional list of suffixes.
  *
@@ -111,36 +182,15 @@ export function parseAndValidateId(
  * @returns {string} The base identifier or an empty string if it cannot be derived.
  */
 export function extractBaseIdFromFilename(filename, suffixes = []) {
-  if (typeof filename !== 'string') {
+  const fileOnly = stripDirectories(filename);
+  if (fileOnly === '') {
     return '';
   }
 
-  let name = filename.trim();
-  if (name === '') {
+  const withoutExt = removeFileExtension(fileOnly);
+  if (withoutExt === '') {
     return '';
   }
 
-  // Normalize separators and remove directory segments
-  name = name.replace(/\\/g, '/');
-  if (name.includes('/')) {
-    name = name.substring(name.lastIndexOf('/') + 1);
-  }
-
-  // Strip the final extension
-  if (name.includes('.')) {
-    name = name.substring(0, name.lastIndexOf('.'));
-  }
-
-  // Remove any provided suffix
-  for (const suffix of suffixes) {
-    if (
-      typeof suffix === 'string' &&
-      name.toLowerCase().endsWith(suffix.toLowerCase())
-    ) {
-      name = name.substring(0, name.length - suffix.length);
-      break;
-    }
-  }
-
-  return name;
+  return stripSuffixes(withoutExt, suffixes);
 }

--- a/tests/unit/utils/idUtils.test.js
+++ b/tests/unit/utils/idUtils.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   extractBaseIdFromFilename,
+  stripDirectories,
+  removeFileExtension,
+  stripSuffixes,
   extractModId,
 } from '../../../src/utils/idUtils.js';
 
@@ -25,6 +28,42 @@ describe('extractBaseIdFromFilename', () => {
     expect(extractBaseIdFromFilename('   ', ['.rule'])).toBe('');
     // @ts-ignore Testing invalid input type
     expect(extractBaseIdFromFilename(null, ['.rule'])).toBe('');
+  });
+});
+
+describe('stripDirectories', () => {
+  it('returns last path segment regardless of separators', () => {
+    expect(stripDirectories('dir/sub/file.json')).toBe('file.json');
+    expect(stripDirectories('dir\\sub\\another.yml')).toBe('another.yml');
+  });
+
+  it('handles invalid input gracefully', () => {
+    // @ts-ignore
+    expect(stripDirectories(null)).toBe('');
+    expect(stripDirectories('')).toBe('');
+  });
+});
+
+describe('removeFileExtension', () => {
+  it('removes the last extension', () => {
+    expect(removeFileExtension('test.rule.json')).toBe('test.rule');
+    expect(removeFileExtension('demo.yml')).toBe('demo');
+  });
+
+  it('returns input when no extension present', () => {
+    expect(removeFileExtension('file')).toBe('file');
+  });
+});
+
+describe('stripSuffixes', () => {
+  const suffixes = ['.rule', '.json'];
+  it('removes the first matching suffix, case-insensitive', () => {
+    expect(stripSuffixes('test.rule', suffixes)).toBe('test');
+    expect(stripSuffixes('demo.JSON', suffixes)).toBe('demo');
+  });
+
+  it('returns input when no suffix matches', () => {
+    expect(stripSuffixes('sample.txt', suffixes)).toBe('sample.txt');
   });
 });
 


### PR DESCRIPTION
Summary: Adds helper functions for parsing IDs from filenames and refactors utilities to use them.

Changes Made:
- Added `stripDirectories`, `removeFileExtension`, and `stripSuffixes` helpers in `idUtils.js`.
- Updated `extractBaseIdFromFilename` to leverage new helpers.
- Extended unit tests to cover new helpers and verify behaviour.

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)

------
https://chatgpt.com/codex/tasks/task_e_685f7cce2ed08331a4aa5857da8ca38d