### PR TITLE
[Agent] unify evaluation context retrieval

### DIFF
--- a/src/utils/evaluationContextUtils.js
+++ b/src/utils/evaluationContextUtils.js
@@ -13,6 +13,19 @@ import { ensureValidLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 
 /**
+ * Retrieve the execution context's evaluation context object when present.
+ *
+ * @description Helper used by other utilities to access
+ * `executionContext.evaluationContext.context` in a consistent way.
+ * @param {ExecutionContext} executionContext - Current execution context.
+ * @returns {object|null} The context object or `null` when unavailable.
+ */
+export function getEvaluationContext(executionContext) {
+  const context = executionContext?.evaluationContext?.context;
+  return context && typeof context === 'object' ? context : null;
+}
+
+/**
  * Ensures that `executionContext.evaluationContext.context` exists and is an object.
  *
  * Logs an error and dispatches a `core:system_error_occurred` event when the
@@ -26,8 +39,8 @@ import { safeDispatchError } from './safeDispatchErrorUtils.js';
 export function ensureEvaluationContext(executionContext, dispatcher, logger) {
   const log = ensureValidLogger(logger, 'ensureEvaluationContext');
 
-  const context = executionContext?.evaluationContext?.context;
-  if (context && typeof context === 'object') {
+  const context = getEvaluationContext(executionContext);
+  if (context) {
     return context;
   }
 

--- a/tests/unit/utils/evaluationContextUtils.test.js
+++ b/tests/unit/utils/evaluationContextUtils.test.js
@@ -1,5 +1,8 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import { ensureEvaluationContext } from '../../../src/utils/evaluationContextUtils.js';
+import {
+  ensureEvaluationContext,
+  getEvaluationContext,
+} from '../../../src/utils/evaluationContextUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
 
@@ -40,5 +43,23 @@ describe('ensureEvaluationContext', () => {
         ),
       })
     );
+  });
+});
+
+describe('getEvaluationContext', () => {
+  test('returns context when present', () => {
+    const ctx = { evaluationContext: { context: { a: 1 } } };
+
+    const result = getEvaluationContext(ctx);
+
+    expect(result).toBe(ctx.evaluationContext.context);
+  });
+
+  test('returns null when context missing', () => {
+    const ctx = { evaluationContext: {} };
+
+    const result = getEvaluationContext(ctx);
+
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Summary: moved context existence logic into evaluationContextUtils via new `getEvaluationContext` helper and updated context variable utilities to rely on it and `ensureEvaluationContext`. Added unit tests for the new helper.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685f7cc4b5008331bc04780db618a4b4