### PR TITLE
[Agent] Extract checksum logic into service

### DIFF
--- a/src/dependencyInjection/registrations/persistenceRegistrations.js
+++ b/src/dependencyInjection/registrations/persistenceRegistrations.js
@@ -33,6 +33,7 @@ import ActiveModsManifestBuilder from '../../persistence/activeModsManifestBuild
 // import ReferenceResolver from '../../initializers/services/referenceResolver.js'; // Removed - service is deprecated
 import createSaveLoadService from '../../persistence/createSaveLoadService.js';
 import GameStateSerializer from '../../persistence/gameStateSerializer.js';
+import ChecksumService from '../../persistence/checksumService.js';
 import SaveFileRepository from '../../persistence/saveFileRepository.js';
 import SaveFileParser from '../../persistence/saveFileParser.js';
 import { BrowserStorageProvider } from '../../storage/browserStorageProvider.js';
@@ -59,8 +60,10 @@ export function registerPersistence(container) {
   registrar.singletonFactory(tokens.ISaveFileRepository, (c) => {
     const logger = c.resolve(tokens.ILogger);
     const storageProvider = c.resolve(tokens.IStorageProvider);
+    const checksumService = new ChecksumService({ logger });
     const serializer = new GameStateSerializer({
       logger,
+      checksumService,
     });
     const parser = new SaveFileParser({
       logger,

--- a/src/persistence/checksumService.js
+++ b/src/persistence/checksumService.js
@@ -1,0 +1,82 @@
+// src/persistence/checksumService.js
+
+import { BaseService } from '../utils/serviceBase.js';
+import {
+  PersistenceError,
+  PersistenceErrorCodes,
+} from './persistenceErrors.js';
+
+/**
+ * @class ChecksumService
+ * @augments BaseService
+ * @description Generates SHA-256 checksums using the Web Crypto API.
+ */
+class ChecksumService extends BaseService {
+  /** @type {import('../interfaces/coreServices.js').ILogger} */
+  #logger;
+
+  /** @type {Crypto} */
+  #crypto;
+
+  /**
+   * Create a new ChecksumService.
+   *
+   * @param {object} dependencies - Constructor dependencies.
+   * @param {import('../interfaces/coreServices.js').ILogger} dependencies.logger - Logger instance.
+   * @param {Crypto} [dependencies.crypto] - Web Crypto implementation.
+   */
+  constructor({ logger, crypto = globalThis.crypto }) {
+    super();
+    this.#logger = this._init('ChecksumService', logger);
+    this.#crypto = crypto;
+  }
+
+  /**
+   * Convert an ArrayBuffer to a hexadecimal string.
+   *
+   * @param {ArrayBuffer} buffer - Buffer to convert.
+   * @returns {string} Hex string.
+   * @private
+   */
+  #arrayBufferToHex(buffer) {
+    return Array.from(new Uint8Array(buffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  /**
+   * Generate a checksum for the provided data.
+   *
+   * @param {any} data - Data to hash.
+   * @returns {Promise<string>} Hexadecimal checksum.
+   */
+  async generateChecksum(data) {
+    let dataToHash;
+    if (data instanceof Uint8Array) {
+      dataToHash = data;
+    } else {
+      const stringToHash =
+        typeof data === 'string' ? data : JSON.stringify(data);
+      dataToHash = new TextEncoder().encode(stringToHash);
+    }
+
+    try {
+      const hashBuffer = await this.#crypto.subtle.digest(
+        'SHA-256',
+        dataToHash
+      );
+      return this.#arrayBufferToHex(hashBuffer);
+    } catch (error) {
+      this.#logger.error(
+        'Error generating checksum using Web Crypto API:',
+        error
+      );
+      throw new PersistenceError(
+        PersistenceErrorCodes.CHECKSUM_GENERATION_FAILED,
+        `Checksum generation failed: ${error.message}`
+      );
+    }
+  }
+}
+
+export default ChecksumService;

--- a/src/persistence/createSaveLoadService.js
+++ b/src/persistence/createSaveLoadService.js
@@ -1,6 +1,7 @@
 // src/persistence/createSaveLoadService.js
 
 import GameStateSerializer from './gameStateSerializer.js';
+import ChecksumService from './checksumService.js';
 import SaveFileParser from './saveFileParser.js';
 import SaveValidationService from './saveValidationService.js';
 import SaveFileRepository from './saveFileRepository.js';
@@ -20,7 +21,8 @@ export function createSaveLoadService({
   storageProvider,
   crypto = globalThis.crypto,
 }) {
-  const serializer = new GameStateSerializer({ logger, crypto });
+  const checksumService = new ChecksumService({ logger, crypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({
     logger,
     storageProvider,

--- a/tests/integration/saveLoadRoundTrip.integration.test.js
+++ b/tests/integration/saveLoadRoundTrip.integration.test.js
@@ -12,6 +12,7 @@ import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../src/persistence/checksumService.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import ManualSaveCoordinator from '../../src/persistence/manualSaveCoordinator.js';
@@ -68,7 +69,8 @@ describe('Persistence round-trip', () => {
     logger = makeLogger();
     storageProvider = createMemoryStorageProvider();
     const saveValidationService = createMockSaveValidationService();
-    const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+    const serializer = new GameStateSerializer({ logger, checksumService });
     const parser = new SaveFileParser({ logger, storageProvider, serializer });
     const saveFileRepository = new SaveFileRepository({
       logger,

--- a/tests/integration/stateFidelityAfterLoad.integration.test.js
+++ b/tests/integration/stateFidelityAfterLoad.integration.test.js
@@ -10,6 +10,7 @@ import SaveLoadService from '../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../src/persistence/checksumService.js';
 import GamePersistenceService from '../../src/persistence/gamePersistenceService.js';
 import GameStateCaptureService from '../../src/persistence/gameStateCaptureService.js';
 import ManualSaveCoordinator from '../../src/persistence/manualSaveCoordinator.js';
@@ -66,7 +67,8 @@ describe('Integration: state fidelity after save/load', () => {
     logger = makeLogger();
     storageProvider = createMemoryStorageProvider();
     const saveValidationService = createMockSaveValidationService();
-    const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+    const serializer = new GameStateSerializer({ logger, checksumService });
     const parser = new SaveFileParser({ logger, storageProvider, serializer });
     const saveFileRepository = new SaveFileRepository({
       logger,

--- a/tests/unit/persistence/gameStateSerializer.test.js
+++ b/tests/unit/persistence/gameStateSerializer.test.js
@@ -3,6 +3,7 @@
 /* eslint-enable jsdoc/check-tag-names */
 import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import { webcrypto } from 'crypto';
 import pako from 'pako';
@@ -27,7 +28,8 @@ describe('GameStateSerializer persistence tests', () => {
 
   beforeEach(() => {
     logger = createMockLogger();
-    serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+    serializer = new GameStateSerializer({ logger, checksumService });
   });
 
   it('round trips via compressPreparedState/decompress/deserialize', async () => {

--- a/tests/unit/services/gameStateSerializer.test.js
+++ b/tests/unit/services/gameStateSerializer.test.js
@@ -3,6 +3,7 @@
 /* eslint-enable jsdoc/check-tag-names */
 import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import * as msgpack from '@msgpack/msgpack';
 import pako from 'pako';
@@ -32,7 +33,8 @@ describe('GameStateSerializer', () => {
 
   beforeEach(() => {
     logger = createMockLogger();
-    serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+    serializer = new GameStateSerializer({ logger, checksumService });
   });
 
   it('decompress/deserialize round-trip succeeds', () => {

--- a/tests/unit/services/saveLoadService.additional.test.js
+++ b/tests/unit/services/saveLoadService.additional.test.js
@@ -6,6 +6,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { encode, decode } from '@msgpack/msgpack';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
@@ -44,7 +45,8 @@ function makeDeps() {
     fileExists: jest.fn(),
     ensureDirectoryExists: jest.fn(),
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveLoadService.constructor.test.js
+++ b/tests/unit/services/saveLoadService.constructor.test.js
@@ -3,6 +3,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
 
@@ -23,7 +24,8 @@ function makeDeps() {
     deleteFile: jest.fn(),
     fileExists: jest.fn(),
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveLoadService.edgeCases.test.js
+++ b/tests/unit/services/saveLoadService.edgeCases.test.js
@@ -16,6 +16,7 @@ import pako from 'pako';
 import { webcrypto } from 'crypto';
 import SaveValidationService from '../../../src/persistence/saveValidationService.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 
 beforeAll(() => {
   if (typeof window !== 'undefined') {
@@ -48,7 +49,8 @@ function makeDeps() {
     fileExists: jest.fn(),
     ensureDirectoryExists: jest.fn(),
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveLoadService.errorPaths.test.js
+++ b/tests/unit/services/saveLoadService.errorPaths.test.js
@@ -10,6 +10,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import pako from 'pako';
 import { webcrypto } from 'crypto';
@@ -60,7 +61,8 @@ function makeDeps() {
     fileExists: jest.fn(),
     ensureDirectoryExists: jest.fn(),
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
+++ b/tests/unit/services/saveLoadService.noEnsureDirectoryExists.test.js
@@ -3,6 +3,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { webcrypto } from 'crypto';
 import { createMockSaveValidationService } from '../testUtils.js';
 
@@ -37,7 +38,8 @@ function makeDeps() {
     fileExists: jest.fn(),
     // intentionally no ensureDirectoryExists
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveLoadService.privateHelpers.test.js
+++ b/tests/unit/services/saveLoadService.privateHelpers.test.js
@@ -10,6 +10,7 @@ import SaveLoadService from '../../../src/persistence/saveLoadService.js';
 import SaveFileRepository from '../../../src/persistence/saveFileRepository.js';
 import SaveFileParser from '../../../src/persistence/saveFileParser.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { StorageErrorCodes } from '../../../src/storage/storageErrors.js';
 import {
   MSG_FILE_READ_ERROR,
@@ -59,7 +60,8 @@ function makeDeps() {
     fileExists: jest.fn(),
     ensureDirectoryExists: jest.fn(),
   };
-  const serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+  const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+  const serializer = new GameStateSerializer({ logger, checksumService });
   const parser = new SaveFileParser({ logger, storageProvider, serializer });
   const saveFileRepository = new SaveFileRepository({
     logger,

--- a/tests/unit/services/saveValidationService.test.js
+++ b/tests/unit/services/saveValidationService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
 import SaveValidationService from '../../../src/persistence/saveValidationService.js';
 import GameStateSerializer from '../../../src/persistence/gameStateSerializer.js';
+import ChecksumService from '../../../src/persistence/checksumService.js';
 import { PersistenceErrorCodes } from '../../../src/persistence/persistenceErrors.js';
 import { webcrypto } from 'crypto';
 import { createMockLogger } from '../testUtils.js';
@@ -25,7 +26,8 @@ describe('SaveValidationService', () => {
 
   beforeEach(() => {
     logger = createMockLogger();
-    serializer = new GameStateSerializer({ logger, crypto: webcrypto });
+    const checksumService = new ChecksumService({ logger, crypto: webcrypto });
+    serializer = new GameStateSerializer({ logger, checksumService });
     service = new SaveValidationService({
       logger,
       gameStateSerializer: serializer,


### PR DESCRIPTION
## Summary
- add `ChecksumService` for SHA-256 generation
- depend on `ChecksumService` in `GameStateSerializer`
- wire new service through DI and factory helpers
- update unit and integration tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 720 errors, 2658 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f7cba33b0833192b6e73ac6693b5e