### PR TITLE
[Fix] dispatcher warning when resolution fails

### DIFF
--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -1,6 +1,7 @@
 // src/utils/dispatcherUtils.js
 
 import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
+import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * Resolves a usable ISafeEventDispatcher instance.
@@ -24,16 +25,21 @@ export function resolveSafeDispatcher(
   logger,
   dispatcherFactory = (opts) => new SafeEventDispatcher(opts)
 ) {
-  if (executionContext?.validatedEventDispatcher) {
-    try {
-      return dispatcherFactory({
-        validatedEventDispatcher: executionContext.validatedEventDispatcher,
-        logger,
-      });
-    } catch {
-      return null;
-    }
+  const log = ensureValidLogger(logger, 'resolveSafeDispatcher');
+  if (!executionContext?.validatedEventDispatcher) {
+    log.warn('resolveSafeDispatcher: validatedEventDispatcher not available.');
+    return null;
   }
 
-  return null;
+  try {
+    return dispatcherFactory({
+      validatedEventDispatcher: executionContext.validatedEventDispatcher,
+      logger: log,
+    });
+  } catch (err) {
+    log.warn(
+      `resolveSafeDispatcher: Failed to create SafeEventDispatcher – ${err.message}`
+    );
+    return null;
+  }
 }

--- a/tests/unit/actions/actionFormatter.branches.test.js
+++ b/tests/unit/actions/actionFormatter.branches.test.js
@@ -100,4 +100,13 @@ describe('formatActionCommand uncovered branches', () => {
       formatActionCommand(actionDef, context, entityManager, { logger })
     ).toThrow('Missing required dependency: safeEventDispatcher.');
   });
+
+  it('throws explicit error when both logger and dispatcher are missing', () => {
+    const actionDef = { id: 'core:wait', template: 'wait' };
+    const context = { type: TARGET_TYPE_NONE };
+
+    expect(() =>
+      formatActionCommand(actionDef, context, entityManager)
+    ).toThrow('formatActionCommand: logger is required.');
+  });
 });

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -330,7 +330,9 @@ describe('SetVariableHandler', () => {
       expect(mockLoggerInstance.debug).toHaveBeenCalledWith(
         'SET_VARIABLE: Setting context variable "message" in evaluationContext.context to value: "Hello World"'
       );
-      expect(mockLoggerInstance.warn).not.toHaveBeenCalled();
+      expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
+        '[contextVariableUtils] resolveSafeDispatcher: validatedEventDispatcher not available.'
+      );
       expect(mockLoggerInstance.error).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/utils/dispatcherUtils.test.js
+++ b/tests/unit/utils/dispatcherUtils.test.js
@@ -30,6 +30,7 @@ describe('resolveSafeDispatcher', () => {
     };
     const result = resolveSafeDispatcher(execCtx, logger);
     expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   test('uses injected dispatcher factory', () => {


### PR DESCRIPTION
Summary: Added logger validation to dispatcher resolution and warning logging. Updated tests and added coverage for missing logger and dispatcher scenario.

Changes Made:
- validate logger in `resolveSafeDispatcher` and log warnings if dispatcher cannot be created
- updated unit tests for dispatcher utils and setVariableHandler
- added branch test for actionFormatter when dependencies are missing

Testing Done:
- [ ] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [ ] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685f7d078dec8331b0dd44cac4a05611