### PR TITLE
[Agent] Cache scope ASTs and inject runtime context builder

### DIFF
--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -26,6 +26,7 @@ import { TargetResolutionService } from '../../actions/targetResolutionService.j
 import { ActionIndex } from '../../actions/actionIndex.js';
 import { ActionValidationContextBuilder } from '../../actions/validation/actionValidationContextBuilder.js';
 import { PrerequisiteEvaluationService } from '../../actions/validation/prerequisiteEvaluationService.js';
+import RuntimeContextBuilder from '../../scopeDsl/runtimeContextBuilder.js';
 import CommandProcessor from '../../commands/commandProcessor.js';
 import { TraceContext as TraceContextImpl } from '../../actions/tracing/traceContext.js';
 
@@ -65,16 +66,25 @@ export function registerCommandAndAction(container) {
     tokens.IEntityManager,
   ]);
 
+  // --- Runtime Context Builder ---
+  registrar.singletonFactory(tokens.RuntimeContextBuilder, (c) => {
+    return new RuntimeContextBuilder({
+      entityManager: c.resolve(tokens.IEntityManager),
+      jsonLogicEvaluationService: c.resolve(tokens.JsonLogicEvaluationService),
+      logger: c.resolve(tokens.ILogger),
+    });
+  });
+
   // --- Target Resolution Service ---
   // Must be registered before ActionDiscoveryService
   registrar.singletonFactory(tokens.ITargetResolutionService, (c) => {
     return new TargetResolutionService({
       scopeRegistry: c.resolve(tokens.IScopeRegistry),
       scopeEngine: c.resolve(tokens.IScopeEngine),
-      entityManager: c.resolve(tokens.IEntityManager),
       logger: c.resolve(tokens.ILogger),
       safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       jsonLogicEvaluationService: c.resolve(tokens.JsonLogicEvaluationService),
+      runtimeContextBuilder: c.resolve(tokens.RuntimeContextBuilder),
     });
   });
 

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -340,6 +340,7 @@ export const tokens = freeze({
   // Core Builders
   ActionContextBuilder: 'ActionContextBuilder',
   TurnContextBuilder: 'TurnContextBuilder',
+  RuntimeContextBuilder: 'RuntimeContextBuilder',
 
   // Initialization & Orchestration
   WorldInitializer: 'WorldInitializer',

--- a/src/scopeDsl/runtimeContextBuilder.js
+++ b/src/scopeDsl/runtimeContextBuilder.js
@@ -1,0 +1,71 @@
+/**
+ * @file RuntimeContextBuilder
+ * @description Builds runtime contexts for Scope-DSL evaluation.
+ */
+
+/** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+/** @typedef {import('../logging/consoleLogger.js').default} ILogger */
+/** @typedef {import('../logic/jsonLogicEvaluationService.js').default} JsonLogicEvaluationService */
+/** @typedef {import('../actions/actionTypes.js').ActionContext} ActionContext */
+/** @typedef {import('../entities/entity.js').default} Entity */
+
+import { validateDependency } from '../utils/dependencyUtils.js';
+
+/**
+ * @typedef {object} RuntimeContextBuilderDeps
+ * @property {IEntityManager} entityManager
+ * @property {JsonLogicEvaluationService} jsonLogicEvaluationService
+ * @property {ILogger} logger
+ */
+
+/**
+ * Utility class that constructs runtime context objects for the Scope-DSL engine.
+ *
+ * @class RuntimeContextBuilder
+ */
+class RuntimeContextBuilder {
+  #entityManager;
+  #jsonLogicEvalService;
+  #logger;
+
+  /**
+   * @param {RuntimeContextBuilderDeps} deps
+   */
+  constructor({ entityManager, jsonLogicEvaluationService, logger }) {
+    validateDependency(entityManager, 'entityManager', logger);
+    validateDependency(
+      jsonLogicEvaluationService,
+      'jsonLogicEvaluationService',
+      logger,
+      {
+        requiredMethods: ['evaluate'],
+      }
+    );
+    validateDependency(logger, 'logger', console, {
+      requiredMethods: ['debug', 'info', 'warn', 'error'],
+    });
+
+    this.#entityManager = entityManager;
+    this.#jsonLogicEvalService = jsonLogicEvaluationService;
+    this.#logger = logger;
+  }
+
+  /**
+   * Builds the runtime context passed to the scope engine.
+   *
+   * @param {Entity} actorEntity - The acting entity.
+   * @param {ActionContext} discoveryContext - Context for scope resolution.
+   * @returns {object} Runtime context for Scope-DSL evaluation.
+   */
+  build(actorEntity, discoveryContext) {
+    return {
+      entityManager: this.#entityManager,
+      jsonLogicEval: this.#jsonLogicEvalService,
+      logger: this.#logger,
+      actor: actorEntity,
+      location: discoveryContext.currentLocation,
+    };
+  }
+}
+
+export default RuntimeContextBuilder;

--- a/src/scopeDsl/scopeRegistry.js
+++ b/src/scopeDsl/scopeRegistry.js
@@ -3,6 +3,8 @@
  * @description Manages scope definitions loaded from mods
  */
 
+import { parseDslExpression } from './parser.js';
+
 class ScopeRegistry {
   constructor() {
     this._scopes = new Map();
@@ -18,7 +20,15 @@ class ScopeRegistry {
     this._scopes.clear();
 
     for (const [scopeName, scopeDef] of Object.entries(scopeDefinitions)) {
-      this._scopes.set(scopeName, scopeDef);
+      let ast = null;
+      if (
+        scopeDef &&
+        typeof scopeDef.expr === 'string' &&
+        scopeDef.expr.trim()
+      ) {
+        ast = parseDslExpression(scopeDef.expr);
+      }
+      this._scopes.set(scopeName, { ...scopeDef, ast });
     }
 
     this._initialized = true;

--- a/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
+++ b/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
@@ -18,6 +18,7 @@ import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
 import ScopeEngine from '../../../src/scopeDsl/engine.js';
+import RuntimeContextBuilder from '../../../src/scopeDsl/runtimeContextBuilder.js';
 import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionParser.js';
 import {
   LEADING_COMPONENT_ID,
@@ -186,10 +187,14 @@ describe('Scope Integration Tests', () => {
     const targetResolutionService = new TargetResolutionService({
       scopeRegistry,
       scopeEngine,
-      entityManager,
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      runtimeContextBuilder: new RuntimeContextBuilder({
+        entityManager,
+        jsonLogicEvaluationService: jsonLogicEval,
+        logger,
+      }),
     });
 
     // FIX: Add the new prerequisiteEvaluationService dependency to the constructor

--- a/tests/integration/scopes/environmentScope.integration.test.js
+++ b/tests/integration/scopes/environmentScope.integration.test.js
@@ -17,6 +17,7 @@ import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
 import ScopeEngine from '../../../src/scopeDsl/engine.js';
+import RuntimeContextBuilder from '../../../src/scopeDsl/runtimeContextBuilder.js';
 import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionParser.js';
 import {
   POSITION_COMPONENT_ID,
@@ -141,10 +142,14 @@ describe('Scope Integration Tests', () => {
     const targetResolutionService = new TargetResolutionService({
       scopeRegistry,
       scopeEngine,
-      entityManager,
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      runtimeContextBuilder: new RuntimeContextBuilder({
+        entityManager,
+        jsonLogicEvaluationService: jsonLogicEval,
+        logger,
+      }),
     });
 
     // FIX: Add the missing dependency to the constructor call

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -18,6 +18,7 @@ import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
 import ScopeEngine from '../../../src/scopeDsl/engine.js';
+import RuntimeContextBuilder from '../../../src/scopeDsl/runtimeContextBuilder.js';
 import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionParser.js';
 import {
   LEADING_COMPONENT_ID,
@@ -149,10 +150,14 @@ describe('Scope Integration Tests', () => {
     const targetResolutionService = new TargetResolutionService({
       scopeRegistry,
       scopeEngine,
-      entityManager,
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      runtimeContextBuilder: new RuntimeContextBuilder({
+        entityManager,
+        jsonLogicEvaluationService: jsonLogicEval,
+        logger,
+      }),
     });
 
     return new ActionDiscoveryService({

--- a/tests/unit/actions/targetResolutionService.branches.test.js
+++ b/tests/unit/actions/targetResolutionService.branches.test.js
@@ -12,15 +12,14 @@ describe('TargetResolutionService - additional branches', () => {
   let service;
   let mockScopeRegistry;
   let mockScopeEngine;
-  let mockEntityManager;
   let mockLogger;
   let mockSafeDispatcher;
   let mockJsonLogic;
+  let mockRuntimeContextBuilder;
 
   beforeEach(() => {
     mockScopeRegistry = { getScope: jest.fn() };
     mockScopeEngine = { resolve: jest.fn() };
-    mockEntityManager = {};
     mockLogger = {
       error: jest.fn(),
       warn: jest.fn(),
@@ -29,14 +28,15 @@ describe('TargetResolutionService - additional branches', () => {
     };
     mockSafeDispatcher = { dispatch: jest.fn() };
     mockJsonLogic = { evaluate: jest.fn() };
+    mockRuntimeContextBuilder = { build: jest.fn(() => ({})) };
 
     service = new TargetResolutionService({
       scopeRegistry: mockScopeRegistry,
       scopeEngine: mockScopeEngine,
-      entityManager: mockEntityManager,
       logger: mockLogger,
       safeEventDispatcher: mockSafeDispatcher,
       jsonLogicEvaluationService: mockJsonLogic,
+      runtimeContextBuilder: mockRuntimeContextBuilder,
     });
   });
 
@@ -62,6 +62,7 @@ describe('TargetResolutionService - additional branches', () => {
     const def = {
       name: 'core:test',
       expr: 'actor',
+      ast: {},
       modId: 'core',
       source: 'file',
     };

--- a/tests/unit/actions/targetResolutionService.scope-loading.test.js
+++ b/tests/unit/actions/targetResolutionService.scope-loading.test.js
@@ -7,10 +7,10 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
   let targetResolutionService;
   let mockScopeRegistry;
   let mockScopeEngine;
-  let mockEntityManager;
   let mockLogger;
   let mockSafeEventDispatcher;
   let mockJsonLogicEvalService;
+  let mockRuntimeContextBuilder;
 
   beforeEach(() => {
     mockScopeRegistry = {
@@ -20,8 +20,6 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
     mockScopeEngine = {
       resolve: jest.fn(),
     };
-
-    mockEntityManager = {};
 
     mockLogger = {
       error: jest.fn(),
@@ -38,14 +36,15 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
     mockJsonLogicEvalService = {
       evaluate: jest.fn(),
     };
+    mockRuntimeContextBuilder = { build: jest.fn(() => ({})) };
 
     targetResolutionService = new TargetResolutionService({
       scopeRegistry: mockScopeRegistry,
       scopeEngine: mockScopeEngine,
-      entityManager: mockEntityManager,
       logger: mockLogger,
       safeEventDispatcher: mockSafeEventDispatcher,
       jsonLogicEvaluationService: mockJsonLogicEvalService,
+      runtimeContextBuilder: mockRuntimeContextBuilder,
     });
   });
 
@@ -55,6 +54,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockScopeDefinition = {
         name: 'core:clear_directions',
         expr: 'location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target',
+        ast: {},
         modId: 'core',
         source: 'file',
       };
@@ -115,6 +115,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockScopeDefinition = {
         name: 'core:clear_directions',
         expr: '',
+        ast: null,
         modId: 'core',
         source: 'file',
       };
@@ -141,6 +142,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockScopeDefinition = {
         name: 'core:clear_directions',
         expr: 'invalid.expression[syntax]',
+        ast: null,
         modId: 'core',
         source: 'file',
       };
@@ -160,12 +162,9 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
         'core:system_error_occurred',
         expect.objectContaining({
-          message: expect.stringContaining(
-            "Error resolving scope 'core:clear_directions'"
-          ),
-          details: expect.objectContaining({
-            error: expect.stringContaining('Unknown source node'),
-          }),
+          message:
+            "Error resolving scope 'core:clear_directions': AST not available",
+          details: { scopeName: 'core:clear_directions' },
         })
       );
     });

--- a/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
@@ -26,6 +26,7 @@ import { ActionDiscoveryService } from '../../../../src/actions/actionDiscoveryS
 import { ActionValidationContextBuilder } from '../../../../src/actions/validation/actionValidationContextBuilder.js';
 import { PrerequisiteEvaluationService } from '../../../../src/actions/validation/prerequisiteEvaluationService.js';
 import CommandProcessor from '../../../../src/commands/commandProcessor.js';
+import RuntimeContextBuilder from '../../../../src/scopeDsl/runtimeContextBuilder.js';
 import { expectSingleton } from '../../../common/containerAssertions.js';
 
 describe('registerCommandAndAction', () => {
@@ -131,6 +132,12 @@ describe('registerCommandAndAction', () => {
       {
         token: tokens.ICommandProcessor,
         Class: CommandProcessor,
+        lifecycle: 'singletonFactory',
+        tags: undefined,
+      },
+      {
+        token: tokens.RuntimeContextBuilder,
+        Class: RuntimeContextBuilder,
         lifecycle: 'singletonFactory',
         tags: undefined,
       },

--- a/tests/unit/scopeDsl/scopeRegistry.test.js
+++ b/tests/unit/scopeDsl/scopeRegistry.test.js
@@ -13,15 +13,15 @@ describe('ScopeRegistry', () => {
     scopeRegistry = new ScopeRegistry();
     mockScopeDefinitions = {
       'core:all_characters': {
-        expr: 'entities() | filter(e -> e.hasComponent("c-character-sheet"))',
+        expr: 'actor',
         description: 'All entities with a character sheet.',
       },
       'core:nearby_items': {
-        expr: 'in_location(actor) | filter(e -> e.hasComponent("c-item"))',
+        expr: 'location',
         description: 'All items in the same location as the actor.',
       },
       'mod:custom_scope': {
-        expr: 'location -> entities(Item)',
+        expr: 'actor',
         description: 'A custom scope from a mod.',
       },
     };
@@ -67,7 +67,7 @@ describe('ScopeRegistry', () => {
     it('should clear any existing scopes on re-initialization', () => {
       // Arrange: Initialize with one set of scopes
       const initialScopes = {
-        'initial:scope': { expr: 'entities()' },
+        'initial:scope': { expr: 'actor' },
       };
       scopeRegistry.initialize(initialScopes);
       expect(scopeRegistry.hasScope('initial:scope')).toBe(true);
@@ -93,7 +93,10 @@ describe('ScopeRegistry', () => {
       const scope = scopeRegistry.getScope('core:all_characters');
 
       // Assert
-      expect(scope).toEqual(mockScopeDefinitions['core:all_characters']);
+      expect(scope).toMatchObject({
+        expr: mockScopeDefinitions['core:all_characters'].expr,
+      });
+      expect(scope.ast).toBeDefined();
     });
 
     it('should return null for a non-existent scope name', () => {
@@ -133,9 +136,10 @@ describe('ScopeRegistry', () => {
       // Assert
       expect(scopes).toBeInstanceOf(Map);
       expect(scopes.size).toBe(3);
-      expect(scopes.get('mod:custom_scope')).toEqual(
-        mockScopeDefinitions['mod:custom_scope']
-      );
+      expect(scopes.get('mod:custom_scope')).toMatchObject({
+        expr: mockScopeDefinitions['mod:custom_scope'].expr,
+      });
+      expect(scopes.get('mod:custom_scope').ast).toBeDefined();
     });
 
     it('should return a copy of the scopes map, not a reference', () => {
@@ -150,12 +154,12 @@ describe('ScopeRegistry', () => {
 
     it('should require namespaced scope names (no fallback)', () => {
       // Assert: Can find by exact namespaced name
-      expect(scopeRegistry.getScope('core:all_characters')).toEqual(
-        mockScopeDefinitions['core:all_characters']
-      );
-      expect(scopeRegistry.getScope('mod:custom_scope')).toEqual(
-        mockScopeDefinitions['mod:custom_scope']
-      );
+      expect(scopeRegistry.getScope('core:all_characters')).toMatchObject({
+        expr: mockScopeDefinitions['core:all_characters'].expr,
+      });
+      expect(scopeRegistry.getScope('mod:custom_scope')).toMatchObject({
+        expr: mockScopeDefinitions['mod:custom_scope'].expr,
+      });
 
       // Assert: Should throw error for non-namespaced names (no fallback)
       expect(() => scopeRegistry.getScope('all_characters')).toThrow(


### PR DESCRIPTION
## Summary
- add `RuntimeContextBuilder` for scope engine runtime contexts
- parse DSL expressions when initializing `ScopeRegistry` and keep the AST
- inject the new builder into `TargetResolutionService`
- update DI wiring for runtime context builder
- adjust integration and unit tests to use the builder and pre-parsed ASTs

## Testing Done
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f7e6411f88331a928f6514b2e514f