### PR TITLE
[Agent] update formatActionCommand deps interface

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -324,7 +324,9 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
         targetCtx,
         this.#entityManager,
         formatterOptions,
-        this.#getEntityDisplayNameFn
+        {
+          displayNameFn: this.#getEntityDisplayNameFn,
+        }
       );
 
       if (formatResult.ok) {

--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -191,9 +191,10 @@ function finalizeCommand(command, logger, debug) {
  * @param {boolean} [options.debug] - If true, logs additional debug information.
  * @param {ILogger} options.logger - Logger instance used for diagnostic output.
  * @param {ISafeEventDispatcher} options.safeEventDispatcher - Dispatcher used for error events.
- * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} [displayNameFn] -
+ * @param {object} [deps] - Additional dependencies.
+ * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} [deps.displayNameFn] -
  * Function used to resolve entity display names.
- * @param {TargetFormatterMap} [formatterMap] - Map of target types to formatter functions.
+ * @param {TargetFormatterMap} [deps.formatterMap] - Map of target types to formatter functions.
  * @returns {FormatActionCommandResult} Result object containing the formatted command or an error.
  */
 export function formatActionCommand(
@@ -201,9 +202,23 @@ export function formatActionCommand(
   targetContext,
   entityManager,
   options = {},
-  displayNameFn = getEntityDisplayName,
-  formatterMap = targetFormatterMap
+  deps = {}
 ) {
+  // Backwards compatibility for old positional arguments
+  const depObj = deps && typeof deps === 'object' ? deps : {};
+  let displayNameFn =
+    'displayNameFn' in depObj ? depObj.displayNameFn : getEntityDisplayName;
+  let formatterMap =
+    'formatterMap' in depObj ? depObj.formatterMap : targetFormatterMap;
+
+  if (typeof deps === 'function' || arguments.length > 5) {
+    console.warn(
+      'DEPRECATION: formatActionCommand now expects a single dependency object after options.'
+    );
+    displayNameFn = deps || getEntityDisplayName;
+    formatterMap = arguments[5] || targetFormatterMap;
+  }
+
   const { debug = false, logger, safeEventDispatcher } = options;
 
   // --- 1. Input Validation ---

--- a/src/actions/formatters/targetFormatters.js
+++ b/src/actions/formatters/targetFormatters.js
@@ -116,7 +116,10 @@ export function formatNoneTarget(
  *   entity: myEntityFormatter,
  *   none: formatNoneTarget,
  * };
- * formatActionCommand(def, ctx, manager, { logger }, getEntityDisplayName, customMap);
+ * formatActionCommand(def, ctx, manager, { logger }, {
+ *   displayNameFn: getEntityDisplayName,
+ *   formatterMap: customMap,
+ * });
  * ```
  *
  * @type {TargetFormatterMap}

--- a/src/utils/systemErrorDispatchUtils.js
+++ b/src/utils/systemErrorDispatchUtils.js
@@ -1,0 +1,28 @@
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/systemEventIds.js';
+import { ensureValidLogger } from './loggerUtils.js';
+
+/**
+ * @description Safely dispatches a system error event.
+ * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher
+ * @param {string} message - Human readable error message.
+ * @param {object} [details] - Additional error details.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger for diagnostic output.
+ * @returns {Promise<void>} Resolves when the event has been dispatched.
+ */
+export async function dispatchSystemErrorEvent(
+  dispatcher,
+  message,
+  details = {},
+  logger
+) {
+  const log = ensureValidLogger(logger, 'dispatchSystemErrorEvent');
+  const hasDispatch = dispatcher && typeof dispatcher.dispatch === 'function';
+  if (!hasDispatch) {
+    log.error(
+      "Invalid or missing method 'dispatch' on dependency 'safeEventDispatcher'."
+    );
+    return;
+  }
+
+  await dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });
+}

--- a/tests/integration/actions/actionDiscoveryService.p4-05.test.js
+++ b/tests/integration/actions/actionDiscoveryService.p4-05.test.js
@@ -182,14 +182,14 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
         expect.objectContaining({ entityId: 'goblin1' }),
         mockEntityManager,
         expect.anything(),
-        expect.any(Function)
+        { displayNameFn: expect.any(Function) }
       );
       expect(mockFormatActionCommandFn).toHaveBeenCalledWith(
         actionDef,
         expect.objectContaining({ entityId: 'goblin2' }),
         mockEntityManager,
         expect.anything(),
-        expect.any(Function)
+        { displayNameFn: expect.any(Function) }
       );
     });
 
@@ -221,7 +221,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
         expect.objectContaining({ entityId: actorEntity.id }),
         mockEntityManager,
         expect.anything(),
-        expect.any(Function)
+        { displayNameFn: expect.any(Function) }
       );
     });
 
@@ -253,7 +253,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
         expect.objectContaining({ type: 'none' }),
         mockEntityManager,
         expect.anything(),
-        expect.any(Function)
+        { displayNameFn: expect.any(Function) }
       );
     });
 

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -146,7 +146,7 @@ describeActionDiscoverySuite(
         expectedGoTargetContext,
         expect.any(Object),
         expect.any(Object),
-        expect.any(Function)
+        { displayNameFn: expect.any(Function) }
       );
     });
   }

--- a/tests/unit/actions/actionFormatter.additional.test.js
+++ b/tests/unit/actions/actionFormatter.additional.test.js
@@ -49,7 +49,7 @@ describe('formatActionCommand additional cases', () => {
         logger,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(result).toEqual({ ok: false, error: expect.any(String) });
@@ -73,7 +73,7 @@ describe('formatActionCommand additional cases', () => {
         logger,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(logger.warn).toHaveBeenCalledWith(
@@ -96,7 +96,7 @@ describe('formatActionCommand additional cases', () => {
         logger,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(result.ok).toBe(false);
@@ -122,8 +122,7 @@ describe('formatActionCommand additional cases', () => {
       context,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn,
-      customMap
+      { displayNameFn, formatterMap: customMap }
     );
 
     expect(result).toEqual({ ok: true, value: 'test-value' });

--- a/tests/unit/actions/actionFormatter.branches.test.js
+++ b/tests/unit/actions/actionFormatter.branches.test.js
@@ -30,7 +30,7 @@ describe('formatActionCommand uncovered branches', () => {
       null,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn
+      { displayNameFn }
     );
     expect(result).toEqual({
       ok: false,
@@ -52,7 +52,7 @@ describe('formatActionCommand uncovered branches', () => {
       context,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      null
+      { displayNameFn: null }
     );
     expect(result).toEqual({
       ok: false,
@@ -80,8 +80,7 @@ describe('formatActionCommand uncovered branches', () => {
       context,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn,
-      customMap
+      { displayNameFn, formatterMap: customMap }
     );
     expect(result).toEqual({ ok: true, value: 'custom' });
   });

--- a/tests/unit/actions/actionFormatter.test.js
+++ b/tests/unit/actions/actionFormatter.test.js
@@ -37,7 +37,7 @@ describe('formatActionCommand', () => {
         debug: true,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(result).toEqual({ ok: true, value: 'inspect The Entity' });
@@ -58,7 +58,7 @@ describe('formatActionCommand', () => {
         logger,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(result).toEqual({ ok: true, value: 'inspect e1' });
@@ -76,7 +76,7 @@ describe('formatActionCommand', () => {
       context,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn
+      { displayNameFn }
     );
 
     expect(result).toEqual({ ok: true, value: 'wait' });
@@ -88,7 +88,7 @@ describe('formatActionCommand', () => {
       { type: TARGET_TYPE_NONE },
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn
+      { displayNameFn }
     );
     expect(result).toEqual({
       ok: false,
@@ -110,7 +110,7 @@ describe('formatActionCommand', () => {
       { type: TARGET_TYPE_ENTITY, entityId: 'e1' },
       {},
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn
+      { displayNameFn }
     );
     expect(result).toEqual({
       ok: false,
@@ -129,7 +129,7 @@ describe('formatActionCommand', () => {
         logger,
         safeEventDispatcher: dispatcher,
       },
-      displayNameFn
+      { displayNameFn }
     );
     expect(result).toEqual({ ok: true, value: 'do it' });
     expect(logger.warn).toHaveBeenCalledWith(
@@ -146,8 +146,7 @@ describe('formatActionCommand', () => {
       context,
       entityManager,
       { logger, safeEventDispatcher: dispatcher },
-      displayNameFn,
-      customMap
+      { displayNameFn, formatterMap: customMap }
     );
 
     expect(result).toEqual({ ok: true, value: 'inspect {target}' });
@@ -166,7 +165,7 @@ describe('formatActionCommand', () => {
         context,
         entityManager,
         { safeEventDispatcher: dispatcher },
-        displayNameFn
+        { displayNameFn }
       )
     ).toThrow('formatActionCommand: logger is required.');
   });
@@ -176,7 +175,13 @@ describe('formatActionCommand', () => {
     const context = { type: TARGET_TYPE_NONE };
 
     expect(() =>
-      formatActionCommand(actionDef, context, entityManager, {}, displayNameFn)
+      formatActionCommand(
+        actionDef,
+        context,
+        entityManager,
+        {},
+        { displayNameFn }
+      )
     ).toThrow('formatActionCommand: logger is required.');
   });
 });


### PR DESCRIPTION
## Summary
- make `formatActionCommand` accept a deps object
- add backward compatibility warning
- update target formatter docs
- add missing `systemErrorDispatchUtils`
- adjust integration and unit tests for new signature

## Testing Done
- `npm run format`
- `npm run lint` *(fails: no-unused-private-class-members in unrelated files)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f8a160dd88331a3d877d6a4e4d3b7