### PR TITLE
[Agent] Clean comments and imports

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -20,12 +20,6 @@ import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.j
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
-import {
-  TRACE_INFO,
-  TRACE_SUCCESS,
-  TRACE_FAILURE,
-  TRACE_STEP,
-} from './tracing/traceContext.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 /**
@@ -245,7 +239,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   }
 
   /**
-   * NEW: Processes a single candidate action through the entire pipeline.
+   * Processes a single candidate action through the entire pipeline.
    *
    * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
    * @param {Entity} actorEntity
@@ -301,7 +295,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   }
 
   /**
-   * NEW: Formats an action for a given list of targets.
+   * Formats an action for a given list of targets.
    *
    * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
    * @param {ActionTargetContext[]} targetContexts


### PR DESCRIPTION
## Summary
- remove unused TRACE_* imports
- strip "NEW:" prefixes from jsdoc comments

## Testing Done
- `npm run lint`
- `npm run test` *(fails: Cannot find module '../utils/systemErrorDispatchUtils.js')*
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f89d166708331b97d9ed6a2f3a4a4