### PR TITLE
[Agent] Refactor follower and leader ID schemas

### DIFF
--- a/data/schemas/operations/autoMoveFollowers.schema.json
+++ b/data/schemas/operations/autoMoveFollowers.schema.json
@@ -22,7 +22,10 @@
       "type": "object",
       "description": "Moves followers of a leader to a destination location.",
       "properties": {
-        "leader_id": { "type": "string", "minLength": 1 },
+        "leader_id": {
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the leader entity."
+        },
         "destination_id": { "type": "string", "minLength": 1 }
       },
       "required": ["leader_id", "destination_id"],

--- a/data/schemas/operations/breakFollowRelation.schema.json
+++ b/data/schemas/operations/breakFollowRelation.schema.json
@@ -27,8 +27,8 @@
       "description": "Parameters for the BREAK_FOLLOW_RELATION operation.",
       "properties": {
         "follower_id": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the follower entity."
         }
       },
       "required": ["follower_id"],

--- a/data/schemas/operations/checkFollowCycle.schema.json
+++ b/data/schemas/operations/checkFollowCycle.schema.json
@@ -27,12 +27,12 @@
       "description": "Parameters for the CHECK_FOLLOW_CYCLE operation. Checks if following would create a cycle.",
       "properties": {
         "follower_id": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the follower entity."
         },
         "leader_id": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the leader entity."
         },
         "result_variable": {
           "type": "string",

--- a/data/schemas/operations/establishFollowRelation.schema.json
+++ b/data/schemas/operations/establishFollowRelation.schema.json
@@ -27,12 +27,12 @@
       "description": "Parameters for the ESTABLISH_FOLLOW_RELATION operation.",
       "properties": {
         "follower_id": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the follower entity."
         },
         "leader_id": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../common.schema.json#/definitions/entityReference",
+          "description": "Reference to the leader entity."
         }
       },
       "required": ["follower_id", "leader_id"],

--- a/src/utils/systemErrorDispatchUtils.js
+++ b/src/utils/systemErrorDispatchUtils.js
@@ -1,0 +1,38 @@
+import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/systemEventIds.js';
+import { ensureValidLogger } from './loggerUtils.js';
+
+/**
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+/**
+ * Dispatches the core system error event in a safe way.
+ * Any dispatch failure is logged but does not throw.
+ *
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
+ * @param {string} message - Human-readable error message.
+ * @param {object} [details] - Additional error context.
+ * @param {ILogger} [logger] - Optional logger for diagnostics.
+ * @returns {Promise<void>} Promise resolved once dispatch completes.
+ */
+export async function dispatchSystemErrorEvent(
+  dispatcher,
+  message,
+  details = {},
+  logger
+) {
+  const log = ensureValidLogger(logger, 'dispatchSystemErrorEvent');
+  if (!dispatcher || typeof dispatcher.dispatch !== 'function') {
+    log.error('dispatchSystemErrorEvent: invalid dispatcher provided.', {
+      message,
+      details,
+    });
+    return;
+  }
+  try {
+    await dispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, { message, details });
+  } catch (err) {
+    log.error('dispatchSystemErrorEvent: failed to dispatch', err);
+  }
+}


### PR DESCRIPTION
## Summary
- update follow operation schemas to use `entityReference`
- add missing `dispatchSystemErrorEvent` helper

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f89998fb4833188944d168a6c2883