### PR TITLE
[Agent] Add coverage for IServerUtils

### DIFF
--- a/llm-proxy-server/tests/utils/IServerUtils.test.js
+++ b/llm-proxy-server/tests/utils/IServerUtils.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  IFileSystemReader,
+  IEnvironmentVariableReader,
+} from '../../src/utils/IServerUtils.js';
+
+describe('IServerUtils interfaces', () => {
+  test('IFileSystemReader.readFile throws not implemented error', async () => {
+    const reader = new IFileSystemReader();
+    await expect(reader.readFile('some.txt', 'utf-8')).rejects.toThrow(
+      'IFileSystemReader.readFile method not implemented.'
+    );
+  });
+
+  test('IEnvironmentVariableReader.getEnv throws not implemented error', () => {
+    const envReader = new IEnvironmentVariableReader();
+    expect(() => envReader.getEnv('VAR')).toThrow(
+      'IEnvironmentVariableReader.getEnv method not implemented.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add missing tests for `IServerUtils` interface implementations

## Testing Done
- `npm run test` in root
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f9af3fde883319d013fca1ea17a88