### PR TITLE
[Agent] remove unused constants and update comments

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -20,12 +20,6 @@ import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.j
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
 import { getEntityDisplayName } from '../utils/entityUtils.js';
-import {
-  TRACE_INFO,
-  TRACE_SUCCESS,
-  TRACE_FAILURE,
-  TRACE_STEP,
-} from './tracing/traceContext.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 /**
@@ -245,7 +239,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   }
 
   /**
-   * NEW: Processes a single candidate action through the entire pipeline.
+   * Processes a single candidate action through the entire pipeline.
    *
    * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
    * @param {Entity} actorEntity
@@ -301,7 +295,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   }
 
   /**
-   * NEW: Formats an action for a given list of targets.
+   * Formats an action for a given list of targets.
    *
    * @param {import('../data/gameDataRepository.js').ActionDefinition} actionDef
    * @param {ActionTargetContext[]} targetContexts


### PR DESCRIPTION
## Summary
- remove unused trace constants import in ActionDiscoveryService
- update comments for `#processCandidateAction` and `#formatActionsForTargets`

## Testing Done
- `npm run lint` *(fails: 720 errors, 2662 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f9b98b41883318f81ec3323eb029e