### PR TITLE
[Agent] Update dispatchAction return type

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -50,7 +50,7 @@ class CommandProcessor extends ICommandProcessor {
    *
    * @param {Entity} actor - The entity performing the action.
    * @param {ITurnAction} turnAction - The pre-resolved action object.
-   * @returns {Promise<{success: boolean, errorResult: CommandResult | null}>} A promise that resolves to an object indicating the outcome.
+   * @returns {Promise<{success: boolean, commandResult: CommandResult | null}>} A promise that resolves to an object indicating the outcome.
    */
   async dispatchAction(actor, turnAction) {
     const { actionDefinitionId, commandString } = turnAction;
@@ -77,7 +77,7 @@ class CommandProcessor extends ICommandProcessor {
       );
       return {
         success: false,
-        errorResult: this.#createFailureResult(
+        commandResult: this.#createFailureResult(
           userMsg,
           internalMsg,
           commandString,
@@ -100,7 +100,7 @@ class CommandProcessor extends ICommandProcessor {
       this.#logger.debug(
         `CommandProcessor.dispatchAction: Successfully dispatched '${actionDefinitionId}' for actor ${actorId}.`
       );
-      return { success: true, errorResult: null };
+      return { success: true, commandResult: null };
     } else {
       const internalMsg = `CRITICAL: Failed to dispatch pre-resolved ATTEMPT_ACTION_ID for ${actorId}, action "${actionDefinitionId}". Dispatcher reported failure.`;
       const userMsg = 'Internal error: Failed to initiate action.';
@@ -125,7 +125,7 @@ class CommandProcessor extends ICommandProcessor {
         commandString,
         actionDefinitionId
       );
-      return { success: false, errorResult: failureResult };
+      return { success: false, commandResult: failureResult };
     }
   }
 

--- a/src/commands/interfaces/ICommandProcessor.js
+++ b/src/commands/interfaces/ICommandProcessor.js
@@ -15,7 +15,7 @@ export class ICommandProcessor {
    * @async
    * @param {Entity} actor - The entity performing the action.
    * @param {ITurnAction} turnAction - The pre-resolved action object.
-   * @returns {Promise<{success: boolean, errorResult: CommandResult | null}>} A promise that resolves to an object indicating the outcome.
+   * @returns {Promise<{success: boolean, commandResult: CommandResult | null}>} A promise that resolves to an object indicating the outcome.
    * @throws {Error} May throw on critical, unrecoverable errors.
    */
   async dispatchAction(actor, turnAction) {

--- a/src/turns/states/helpers/commandProcessingWorkflow.js
+++ b/src/turns/states/helpers/commandProcessingWorkflow.js
@@ -103,7 +103,7 @@ export class CommandProcessingWorkflow {
       `${this._state.getStateName()}: Invoking commandProcessor.dispatchAction() for actor ${actorId}, actionId: ${turnAction.actionDefinitionId}.`
     );
 
-    const { success, errorResult: dispatchErrorDetails } =
+    const { success, commandResult: dispatchCommandResult } =
       await commandProcessor.dispatchAction(actor, turnAction);
 
     if (!this._state.isProcessing) {
@@ -140,8 +140,8 @@ export class CommandProcessingWorkflow {
       turnEnded: !success,
       originalInput: turnAction.commandString || turnAction.actionDefinitionId,
       actionResult: { actionId: turnAction.actionDefinitionId },
-      error: success ? undefined : dispatchErrorDetails?.error,
-      internalError: success ? undefined : dispatchErrorDetails?.internalError,
+      error: success ? undefined : dispatchCommandResult?.error,
+      internalError: success ? undefined : dispatchCommandResult?.internalError,
     };
 
     logger.debug(

--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -36,7 +36,7 @@ describe('CommandProcessor.dispatchAction', () => {
 
     const result = await processor.dispatchAction(actor, turnAction);
 
-    expect(result).toEqual({ success: true, errorResult: null });
+    expect(result).toEqual({ success: true, commandResult: null });
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
       ATTEMPT_ACTION_ID,
@@ -57,7 +57,7 @@ describe('CommandProcessor.dispatchAction', () => {
     const result = await processor.dispatchAction(actor, turnAction);
 
     expect(result.success).toBe(false);
-    expect(result.errorResult).toEqual(
+    expect(result.commandResult).toEqual(
       expect.objectContaining({
         success: false,
         turnEnded: true,

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -228,7 +228,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
     // Ensure dispatchAction returns a valid structure even if not strictly used by this error path
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      errorResult: null,
+      commandResult: null,
     });
 
     await customState.enterState(mockHandler, null);
@@ -281,7 +281,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
 
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      errorResult: null,
+      commandResult: null,
     });
 
     await stateForNullActionTest.enterState(mockHandler, null); // Call enterState on the local instance
@@ -333,7 +333,7 @@ describe('ProcessingCommandState.enterState – error branches', () => {
 
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      errorResult: null,
+      commandResult: null,
     });
 
     await stateForInvalidActionTest.enterState(mockHandler, null); // Call enterState on the local instance
@@ -378,7 +378,10 @@ describe('ProcessingCommandState.enterState – error branches', () => {
         notes: [],
       }),
     };
-    mockCommandProcessor.dispatchAction.mockResolvedValue({ success: true });
+    mockCommandProcessor.dispatchAction.mockResolvedValue({
+      success: true,
+      commandResult: null,
+    });
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     // Mock the resolver so it returns a no-op strategy, preventing further execution
@@ -443,7 +446,10 @@ describe('ProcessingCommandState.enterState – error branches', () => {
         notes: ['first note', 'second note'],
       }),
     };
-    mockCommandProcessor.dispatchAction.mockResolvedValue({ success: true });
+    mockCommandProcessor.dispatchAction.mockResolvedValue({
+      success: true,
+      commandResult: null,
+    });
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     jest

--- a/tests/unit/turns/states/processingCommandState.enterState.test.js
+++ b/tests/unit/turns/states/processingCommandState.enterState.test.js
@@ -276,7 +276,7 @@ describe('ProcessingCommandState', () => {
 
       mockCommandProcessor.dispatchAction.mockResolvedValue({
         success: true,
-        errorResult: null,
+        commandResult: null,
       });
       mockCommandOutcomeInterpreter.interpret.mockReturnValue(
         TurnDirective.END_TURN_SUCCESS

--- a/tests/unit/turns/states/processingCommandState.test.js
+++ b/tests/unit/turns/states/processingCommandState.test.js
@@ -133,12 +133,12 @@ describe('ProcessingCommandState', () => {
     // NEW: Define results from the mocked dispatchAction call
     mockSuccessfulDispatchResult = {
       success: true,
-      errorResult: undefined,
+      commandResult: undefined,
     };
 
     mockFailedDispatchResult = {
       success: false,
-      errorResult: {
+      commandResult: {
         error: 'CommandProcFailure',
         internalError: 'Detailed CommandProcFailure',
       },
@@ -162,8 +162,8 @@ describe('ProcessingCommandState', () => {
       originalInput:
         mockTurnAction.commandString || mockTurnAction.actionDefinitionId,
       actionResult: { actionId: mockTurnAction.actionDefinitionId },
-      error: mockFailedDispatchResult.errorResult.error,
-      internalError: mockFailedDispatchResult.errorResult.internalError,
+      error: mockFailedDispatchResult.commandResult.error,
+      internalError: mockFailedDispatchResult.commandResult.internalError,
     };
 
     mockTurnContext = {


### PR DESCRIPTION
Summary: Align ICommandProcessor.dispatchAction with new return structure.

Changes Made:
- JSDoc updated to use `{success, commandResult}` object.
- CommandProcessor.dispatchAction returns `commandResult` and callers adjusted.
- Updated processing workflow and related unit tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685f9baa45608331a262ec4c2d61edad