### PR TITLE
[Agent] add safeExecute utility and refactor wrappers

### DIFF
--- a/src/utils/safeExecutionUtils.js
+++ b/src/utils/safeExecutionUtils.js
@@ -12,8 +12,38 @@
  * @returns {{success: boolean, result?: any, error?: any}} Execution result.
  */
 export function safeCall(fn, logger, context = 'safeCall') {
+  return safeExecute(fn, logger, context);
+}
+
+/**
+ * Safely executes a synchronous or asynchronous function.
+ *
+ * @description
+ * Provides a common wrapper around try/catch logic and normalizes the
+ * return shape for both sync and async callbacks. If the executed function
+ * returns a Promise, the result is also wrapped in a Promise.
+ * @param {() => any | Promise<any>} fn - Function to execute.
+ * @param {import('../interfaces/coreServices.js').ILogger} [logger] - Logger used for debug output.
+ * @param {string} [context] - Context message for logging.
+ * @returns
+ *   | {success: true, result: any}
+ *   | {success: false, error: any}
+ *   | Promise<{success: true, result: any} | {success: false, error: any}>
+ */
+export function safeExecute(fn, logger, context = 'safeExecute') {
   try {
-    return { success: true, result: fn() };
+    const maybePromise = fn();
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      return maybePromise
+        .then((result) => ({ success: true, result }))
+        .catch((error) => {
+          if (logger && typeof logger.debug === 'function') {
+            logger.debug(`${context}: operation failed`, error);
+          }
+          return { success: false, error };
+        });
+    }
+    return { success: true, result: maybePromise };
   } catch (error) {
     if (logger && typeof logger.debug === 'function') {
       logger.debug(`${context}: operation failed`, error);


### PR DESCRIPTION
## Summary
- implement `safeExecute` to handle sync & async functions
- refactor `safeCall`, `wrapPersistenceOperation`, and `wrapSyncPersistenceOperation`
- add tests for `safeExecute`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing repo issues)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685f9b5253cc8331905f82085f07b4f5