### PR TITLE
[Agent] remove thin validation wrappers

### DIFF
--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -12,7 +12,7 @@ import {
 } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 
 /**
  * Provides a stateless view of the world context, deriving information directly

--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -4,7 +4,7 @@ import { BoundDomRendererBase } from './boundDomRendererBase.js';
 import { DomUtils } from '../utils/domUtils.js';
 import createMessageElement from './helpers/createMessageElement.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 import {
   // POSITION_COMPONENT_ID, // No longer directly used for current location logic
   // NAME_COMPONENT_ID, // Handled by EntityDisplayDataProvider

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -3,7 +3,7 @@
 import { IPlaytimeTracker } from '../interfaces/IPlaytimeTracker.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -3,7 +3,7 @@
 
 import { IApiKeyProvider } from './interfaces/IApiKeyProvider.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 import { initLogger } from '../utils/index.js';
 import { CLOUD_API_TYPES } from './constants/llmConstants.js';
 import { isValidEnvironmentContext } from './environmentContext.js';

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -8,7 +8,7 @@ import {
   IEnvironmentVariableReader,
 } from '../../llm-proxy-server/src/utils/IServerUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 import { initLogger } from '../utils/index.js';
 import { isValidEnvironmentContext } from './environmentContext.js';
 

--- a/src/storage/browserStorageProvider.js
+++ b/src/storage/browserStorageProvider.js
@@ -1,7 +1,7 @@
 // src/services/browserStorageProvider.js
 import { IStorageProvider } from '../interfaces/IStorageProvider.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
-import { validateDependency } from '../utils/validationUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
 import { StorageErrorCodes } from './storageErrors.js';
 
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */

--- a/src/utils/dependencyValidators.js
+++ b/src/utils/dependencyValidators.js
@@ -1,5 +1,0 @@
-export {
-  assertPresent,
-  assertFunction,
-  assertMethods,
-} from './dependencyUtils.js';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,4 +18,12 @@ export * from './jsonCleaning.js';
 export * from './jsonRepair.js';
 export * from './evaluationContextUtils.js';
 export * from './eventDispatchUtils.js';
-export * from './dependencyUtils.js';
+export {
+  assertPresent,
+  assertFunction,
+  assertMethods,
+  assertValidId,
+  assertNonBlankString,
+  validateDependency,
+  validateDependencies,
+} from './dependencyUtils.js';

--- a/src/utils/parameterGuards.js
+++ b/src/utils/parameterGuards.js
@@ -1,1 +1,0 @@
-export { assertValidId, assertNonBlankString } from './dependencyUtils.js';

--- a/src/utils/validationUtils.js
+++ b/src/utils/validationUtils.js
@@ -1,1 +1,0 @@
-export { validateDependency, validateDependencies } from './dependencyUtils.js';

--- a/tests/unit/utils/parameterGuards.test.js
+++ b/tests/unit/utils/parameterGuards.test.js
@@ -6,7 +6,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import {
   assertValidId,
   assertNonBlankString,
-} from '../../../src/utils/parameterGuards.js';
+} from '../../../src/utils/dependencyUtils.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 describe('parameterGuards', () => {

--- a/tests/unit/utils/validationUtils.additional.test.js
+++ b/tests/unit/utils/validationUtils.additional.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import * as validationUtils from '../../../src/utils/validationUtils.js';
+import * as validationUtils from '../../../src/utils/dependencyUtils.js';
 import { assertValidActionIndex } from '../../../src/utils/actionIndexUtils.js';
 const { validateDependency, validateDependencies } = validationUtils;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';

--- a/tests/unit/utils/validationUtils.test.js
+++ b/tests/unit/utils/validationUtils.test.js
@@ -8,7 +8,7 @@ import {
   it,
   expect,
 } from '@jest/globals';
-import { validateDependency } from '../../../src/utils/validationUtils.js';
+import { validateDependency } from '../../../src/utils/dependencyUtils.js';
 
 describe('validateDependency', () => {
   let mockLogger;


### PR DESCRIPTION
## Summary
- delete utility wrapper modules
- point imports to dependencyUtils
- re-export validation helpers via utils index
- fix tests to use new paths

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 720 errors, 2666 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685f9b453404833195662a2d6c579e32