### PR TITLE
[Agent] centralize prefixed logger setup

### DIFF
--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -7,10 +7,25 @@
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
-export {
-  setupService as initHandlerLogger,
-  validateServiceDeps as validateDeps,
-} from '../serviceInitializerUtils.js';
+import { validateServiceDeps } from '../serviceInitializerUtils.js';
+import { setupPrefixedLogger } from '../loggerUtils.js';
+
+/**
+ * Initialize a handler-specific logger and validate its dependencies.
+ *
+ * @param {string} handlerName - Name used for log prefixing and validation.
+ * @param {ILogger | undefined | null} logger - Logger instance to wrap.
+ * @param {Record<string, import('../serviceInitializerUtils.js').DependencySpec>} [deps]
+ *   - Optional dependency specification map.
+ * @returns {ILogger} Prefixed logger instance.
+ */
+export function initHandlerLogger(handlerName, logger, deps) {
+  const prefixed = setupPrefixedLogger(logger, `${handlerName}: `);
+  validateServiceDeps(handlerName, prefixed, deps);
+  return prefixed;
+}
+
+export { validateServiceDeps as validateDeps };
 
 /**
  * @description Retrieve the logger to use during execution. If the

--- a/src/utils/loggerUtils.js
+++ b/src/utils/loggerUtils.js
@@ -90,6 +90,21 @@ export function getPrefixedLogger(logger, prefix) {
 }
 
 /**
+ * Validates the given logger and returns a prefixed wrapper using the provided
+ * prefix. This is a light-weight helper for service initialization where a
+ * simple prefixed logger is sufficient.
+ *
+ * @param {ILogger | undefined | null} logger - Logger instance to validate.
+ * @param {string} prefix - Prefix to prepend to every log message.
+ * @returns {ILogger} Logger instance that prefixes messages with `prefix`.
+ */
+export function setupPrefixedLogger(logger, prefix) {
+  const name = (prefix || '').replace(/[:\s]+$/, '');
+  const validated = initLogger(name, logger);
+  return createPrefixedLogger(validated, prefix || '');
+}
+
+/**
  * Convenience wrapper for creating a logger prefixed with the module name in square brackets.
  * Falls back to the console when the base logger is missing.
  *

--- a/src/utils/serviceBase.js
+++ b/src/utils/serviceBase.js
@@ -1,7 +1,5 @@
-import {
-  initPrefixedLogger,
-  validateServiceDeps,
-} from './serviceInitializerUtils.js';
+import { validateServiceDeps } from './serviceInitializerUtils.js';
+import { setupPrefixedLogger } from './loggerUtils.js';
 
 /**
  * @class BaseService
@@ -20,7 +18,7 @@ export class BaseService {
    * @returns {import('../interfaces/coreServices.js').ILogger} The initialized logger.
    */
   _init(serviceName, logger, deps) {
-    const prefixed = initPrefixedLogger(serviceName, logger);
+    const prefixed = setupPrefixedLogger(logger, `${serviceName}: `);
     this._validateDeps(serviceName, prefixed, deps);
     return prefixed;
   }

--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -7,25 +7,8 @@
  * @property {boolean} [isFunction] - Whether the dependency should be a function.
  */
 
-import {
-  createPrefixedLogger,
-  initLogger as baseInitLogger,
-} from './loggerUtils.js';
+import { setupPrefixedLogger } from './loggerUtils.js';
 import { validateDependencies } from './dependencyUtils.js';
-
-/**
- * Validate the provided logger and return a prefixed logger instance.
- *
- * @description Validates the provided logger and returns a prefixed logger
- *   instance.
- * @param {string} serviceName - Name used for log prefix and error messages.
- * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to validate.
- * @returns {import('../interfaces/coreServices.js').ILogger} Prefixed logger.
- */
-export function initPrefixedLogger(serviceName, logger) {
-  const validated = baseInitLogger(serviceName, logger);
-  return createPrefixedLogger(validated, `${serviceName}: `);
-}
 
 /**
  * Validates a set of service dependencies using `validateDependency`.
@@ -57,7 +40,7 @@ export function validateServiceDeps(serviceName, logger, deps) {
  * Initialize a service logger and validate dependencies.
  *
  * @description Convenience helper that initializes a service logger via
- *   {@link initPrefixedLogger} and validates its dependencies in one step.
+ *   {@link setupPrefixedLogger} and validates its dependencies in one step.
  * @param {string} serviceName - The service name used for logger prefixing and
  *   validation messages.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger to
@@ -68,7 +51,7 @@ export function validateServiceDeps(serviceName, logger, deps) {
  *   prefixed logger instance.
  */
 export function setupService(serviceName, logger, deps) {
-  const prefixedLogger = initPrefixedLogger(serviceName, logger);
+  const prefixedLogger = setupPrefixedLogger(logger, `${serviceName}: `);
   validateServiceDeps(serviceName, prefixedLogger, deps);
   return prefixedLogger;
 }

--- a/tests/unit/utils/loggerUtils.test.js
+++ b/tests/unit/utils/loggerUtils.test.js
@@ -11,6 +11,7 @@ import {
   createPrefixedLogger,
   getPrefixedLogger,
   getModuleLogger,
+  setupPrefixedLogger,
   initLogger,
   logPreview,
 } from '../../../src/utils/loggerUtils.js';
@@ -77,6 +78,12 @@ describe('loggerUtils', () => {
     const logger = getPrefixedLogger(null, 'GP: ');
     logger.debug('a');
     expect(consoleSpies.debug).toHaveBeenCalledWith('GP: : ', 'GP: a');
+  });
+
+  it('setupPrefixedLogger wraps and prefixes messages', () => {
+    const log = setupPrefixedLogger(valid, 'SP: ');
+    log.info('msg');
+    expect(valid.info).toHaveBeenCalledWith('SP: msg');
   });
 
   it('initLogger validates when not optional and returns logger', () => {

--- a/tests/unit/utils/serviceInitializerUtils.test.js
+++ b/tests/unit/utils/serviceInitializerUtils.test.js
@@ -8,15 +8,10 @@ import {
 } from '@jest/globals';
 
 import {
-  initPrefixedLogger,
   validateServiceDeps,
   setupService,
 } from '../../../src/utils/serviceInitializerUtils.js';
-import {
-  createPrefixedLogger,
-  initLogger as baseInitLogger,
-  ensureValidLogger,
-} from '../../../src/utils/loggerUtils.js';
+import { setupPrefixedLogger } from '../../../src/utils/loggerUtils.js';
 import { validateDependencies } from '../../../src/utils/dependencyUtils.js';
 
 jest.mock('../../../src/utils/dependencyUtils.js', () => ({
@@ -24,9 +19,7 @@ jest.mock('../../../src/utils/dependencyUtils.js', () => ({
 }));
 
 jest.mock('../../../src/utils/loggerUtils.js', () => ({
-  createPrefixedLogger: jest.fn(),
-  ensureValidLogger: jest.fn(),
-  initLogger: jest.fn(),
+  setupPrefixedLogger: jest.fn(),
 }));
 
 describe('serviceInitializer utilities', () => {
@@ -39,35 +32,14 @@ describe('serviceInitializer utilities', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    createPrefixedLogger.mockImplementation((logger, prefix) => ({
+    setupPrefixedLogger.mockImplementation((logger, prefix) => ({
       prefix,
       logger,
     }));
-    ensureValidLogger.mockImplementation((l) => l);
-    baseInitLogger.mockImplementation((service, l) => l);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
-  });
-
-  describe('initPrefixedLogger', () => {
-    it('validates and returns a prefixed logger', () => {
-      const logger = initPrefixedLogger('MyService', baseLogger);
-      expect(baseInitLogger).toHaveBeenCalledWith('MyService', baseLogger);
-      expect(createPrefixedLogger).toHaveBeenCalledWith(
-        baseLogger,
-        'MyService: '
-      );
-      expect(logger).toEqual({ prefix: 'MyService: ', logger: baseLogger });
-    });
-
-    it('throws when validation fails', () => {
-      baseInitLogger.mockImplementation(() => {
-        throw new Error('bad');
-      });
-      expect(() => initPrefixedLogger('FailService', null)).toThrow('bad');
-    });
   });
 
   describe('validateServiceDeps', () => {
@@ -129,7 +101,7 @@ describe('serviceInitializer utilities', () => {
         depA: { value: {}, requiredMethods: ['a'] },
       };
       const logger = setupService('Svc', baseLogger, deps);
-      expect(baseInitLogger).toHaveBeenCalledWith('Svc', baseLogger);
+      expect(setupPrefixedLogger).toHaveBeenCalledWith(baseLogger, 'Svc: ');
       expect(validateDependencies).toHaveBeenCalledWith(
         [
           {


### PR DESCRIPTION
Summary:
- add `setupPrefixedLogger` helper
- update service initialization utilities and base classes to use it
- adjust handler logger initialization
- refactor tests for new helper API

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 3386 problems)*
- `npm run test`
- `cd llm-proxy-server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f9b5a6f048331ae0e1f8aff759e08