### PR TITLE
[Agent] validate logger before resolving dispatcher

### DIFF
--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -97,6 +97,14 @@ export function writeContextVariable(
   const moduleLogger = getModuleLogger('contextVariableUtils', logger);
   const safeDispatcher =
     dispatcher || resolveSafeDispatcher(executionContext, moduleLogger);
+  if (!safeDispatcher) {
+    if (!logger) {
+      throw new Error('writeContextVariable: logger is required.');
+    }
+    moduleLogger.warn(
+      'writeContextVariable: dispatcher unavailable; errors will only be logged.'
+    );
+  }
   const { valid, error, name } = _validateVariableName(variableName);
 
   if (!valid) {

--- a/src/utils/dispatcherUtils.js
+++ b/src/utils/dispatcherUtils.js
@@ -1,6 +1,7 @@
 // src/utils/dispatcherUtils.js
 
 import { SafeEventDispatcher } from '../events/safeEventDispatcher.js';
+import { ensureValidLogger } from './loggerUtils.js';
 
 /**
  * Resolves a usable ISafeEventDispatcher instance.
@@ -24,16 +25,22 @@ export function resolveSafeDispatcher(
   logger,
   dispatcherFactory = (opts) => new SafeEventDispatcher(opts)
 ) {
+  const log = ensureValidLogger(logger, 'resolveSafeDispatcher');
+
   if (executionContext?.validatedEventDispatcher) {
     try {
       return dispatcherFactory({
         validatedEventDispatcher: executionContext.validatedEventDispatcher,
-        logger,
+        logger: log,
       });
-    } catch {
+    } catch (err) {
+      log.warn(
+        `resolveSafeDispatcher: Failed to create dispatcher – ${err.message}`
+      );
       return null;
     }
   }
 
+  log.warn('resolveSafeDispatcher: validatedEventDispatcher not available.');
   return null;
 }

--- a/tests/unit/logic/operationHandlers/setVariableHandler.test.js
+++ b/tests/unit/logic/operationHandlers/setVariableHandler.test.js
@@ -330,7 +330,7 @@ describe('SetVariableHandler', () => {
       expect(mockLoggerInstance.debug).toHaveBeenCalledWith(
         'SET_VARIABLE: Setting context variable "message" in evaluationContext.context to value: "Hello World"'
       );
-      expect(mockLoggerInstance.warn).not.toHaveBeenCalled();
+      expect(mockLoggerInstance.warn).toHaveBeenCalled();
       expect(mockLoggerInstance.error).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/utils/contextVariableUtils.test.js
+++ b/tests/unit/utils/contextVariableUtils.test.js
@@ -64,6 +64,13 @@ describe('writeContextVariable', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
+  test('throws when logger and dispatcher missing', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    expect(() =>
+      writeContextVariable('x', 1, ctx, undefined, undefined)
+    ).toThrow('writeContextVariable: logger is required.');
+  });
+
   test('invalid names do not mutate context', () => {
     const ctx = { evaluationContext: { context: { foo: 1 } } };
     const dispatcher = { dispatch: jest.fn() };
@@ -76,6 +83,13 @@ describe('writeContextVariable', () => {
 });
 
 describe('tryWriteContextVariable', () => {
+  test('throws when logger and dispatcher missing', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    expect(() =>
+      tryWriteContextVariable('x', 1, ctx, undefined, undefined)
+    ).toThrow('writeContextVariable: logger is required.');
+  });
+
   test('returns error object when evaluation context missing', () => {
     const ctx = { evaluationContext: null };
     const dispatcher = { dispatch: jest.fn() };

--- a/tests/unit/utils/dispatcherUtils.test.js
+++ b/tests/unit/utils/dispatcherUtils.test.js
@@ -20,6 +20,19 @@ describe('resolveSafeDispatcher', () => {
     expect(result).toBeInstanceOf(SafeEventDispatcher);
   });
 
+  test('logs warning when dispatcher unavailable', () => {
+    const execCtx = { otherProp: true };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const result = resolveSafeDispatcher(execCtx, logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
   test('returns null when creation fails', () => {
     const execCtx = { validatedEventDispatcher: {} }; // missing required methods
     const logger = {
@@ -30,6 +43,7 @@ describe('resolveSafeDispatcher', () => {
     };
     const result = resolveSafeDispatcher(execCtx, logger);
     expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   test('uses injected dispatcher factory', () => {


### PR DESCRIPTION
## Summary
- validate logger with ensureValidLogger in `resolveSafeDispatcher`
- warn when dispatcher cannot be created or missing
- require logger only when dispatcher unavailable in `writeContextVariable`
- adjust unit tests for new warning behavior
- add tests for missing logger + dispatcher

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 720 errors, 2665 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685f9d760e548331a97cca1d24188b59