### PR TITLE
[Agent] handle prerequisite eval errors in discovery

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -258,7 +258,25 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     trace?.step(`Processing candidate action: '${actionDef.id}'`, source);
 
     // STEP 1: Check actor prerequisites
-    if (!this.#actorMeetsPrerequisites(actionDef, actorEntity, trace)) {
+    let meetsPrereqs;
+    try {
+      meetsPrereqs = this.#actorMeetsPrerequisites(
+        actionDef,
+        actorEntity,
+        trace
+      );
+    } catch (error) {
+      this.#logger.error(
+        `Error checking prerequisites for action '${actionDef.id}'.`,
+        error
+      );
+      return {
+        actions: [],
+        errors: [this.#createDiscoveryError(actionDef.id, null, error)],
+      };
+    }
+
+    if (!meetsPrereqs) {
       trace?.failure(
         `Action '${actionDef.id}' discarded due to failed actor prerequisites.`,
         source


### PR DESCRIPTION
## Summary
- wrap actor prerequisite check in try/catch
- report prerequisite failures as discovery errors
- test prerequisite exception handling

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685fa4cb1f00833189e685fefaba0953