### PR TITLE
[Agent] Add missing branch tests and stabilize scope registry test

### DIFF
--- a/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
+++ b/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
@@ -233,6 +233,7 @@ describe('Scope Registry Initialization - Focused Test', () => {
       mockDataRegistry.getAll.mockReturnValue(properlyFormattedScopes);
 
       // Simulate initialization
+      const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(42);
       const scopes = mockDataRegistry.getAll(SCOPES_KEY);
       const scopeMap = {};
       scopes.forEach((scope) => {
@@ -246,6 +247,7 @@ describe('Scope Registry Initialization - Focused Test', () => {
       expect(scopeMap['core:potential_leaders']).toEqual(
         addMockAst(properlyFormattedScopes[0])
       );
+      dateSpy.mockRestore();
 
       // Anti-regression: it should NOT be accessible by base name only
       expect(scopeMap['potential_leaders']).toBeUndefined();

--- a/tests/unit/utils/contextVariableUtils.branches.test.js
+++ b/tests/unit/utils/contextVariableUtils.branches.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  writeContextVariable,
+} from '../../../src/utils/contextVariableUtils.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+import * as safeDispatchModule from '../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js');
+
+describe('writeContextVariable additional branches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles invalid names with no dispatcher', () => {
+    const ctx = { evaluationContext: { context: {} } };
+    const result = writeContextVariable('', 1, ctx, undefined, undefined);
+    expect(result.success).toBe(false);
+    // safeDispatchError should not be called when no dispatcher is available
+    expect(safeDispatchModule.safeDispatchError).not.toHaveBeenCalled();
+    expect(ctx.evaluationContext.context).toEqual({});
+  });
+
+  it('dispatches and returns failure when setContextValue throws', () => {
+    const context = {};
+    Object.defineProperty(context, 'foo', {
+      set() {
+        throw new Error('fail');
+      },
+    });
+    const dispatcher = { dispatch: jest.fn() };
+    const ctx = { evaluationContext: { context }, validatedEventDispatcher: dispatcher };
+
+    const result = writeContextVariable('foo', 2, ctx, dispatcher, undefined);
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    expect(safeDispatchModule.safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      expect.stringContaining('Failed to write variable'),
+      expect.any(Object),
+      expect.any(Object)
+    );
+  });
+
+  it('returns failure without dispatch when setContextValue throws and no dispatcher', () => {
+    const context = {};
+    Object.defineProperty(context, 'bar', {
+      set() {
+        throw new Error('fail');
+      },
+    });
+    const ctx = { evaluationContext: { context } };
+
+    const result = writeContextVariable('bar', 3, ctx, undefined, { error: jest.fn() });
+    expect(result.success).toBe(false);
+    expect(safeDispatchModule.safeDispatchError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- stabilize scopeRegistryInitialization test by mocking Date.now
- add branch coverage tests for contextVariableUtils

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fa895d024833199ccb3bb35d30bd7