### PR TITLE
[Agent] Remove duplicate JSDoc and fix test

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -62,16 +62,6 @@ function normalizeFormatResult(result) {
 }
 
 /**
- * @description Validates inputs for {@link formatActionCommand}.
- * @param {ActionDefinition} actionDefinition - Validated action definition.
- * @param {ActionTargetContext} targetContext - Validated target context.
- * @param {EntityManager} entityManager - Entity manager for lookups.
- * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} displayNameFn - Utility to resolve entity names.
- * @param {ISafeEventDispatcher} dispatcher - Dispatcher used for error events.
- * @param {ILogger} logger - Logger instance used for validation.
- * @returns {FormatActionError | null} An error result if validation fails, otherwise `null`.
- */
-/**
  * @description Checks required inputs for {@link formatActionCommand}.
  * @param {ActionDefinition} actionDefinition - Action definition to check.
  * @param {ActionTargetContext} targetContext - Target context for formatting.

--- a/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
+++ b/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
@@ -235,17 +235,20 @@ describe('Scope Registry Initialization - Focused Test', () => {
       // Simulate initialization
       const scopes = mockDataRegistry.getAll(SCOPES_KEY);
       const scopeMap = {};
+      const expectedScope = addMockAst(properlyFormattedScopes[0]);
       scopes.forEach((scope) => {
         if (scope.id) {
-          scopeMap[scope.id] = addMockAst(scope);
+          // Reuse the same AST instance for deterministic comparison
+          scopeMap[scope.id] =
+            scope === properlyFormattedScopes[0]
+              ? expectedScope
+              : addMockAst(scope);
         }
       });
 
       // Critical assertion: the scope should be accessible by its qualified name
       expect(scopeMap['core:potential_leaders']).toBeDefined();
-      expect(scopeMap['core:potential_leaders']).toEqual(
-        addMockAst(properlyFormattedScopes[0])
-      );
+      expect(scopeMap['core:potential_leaders']).toEqual(expectedScope);
 
       // Anti-regression: it should NOT be accessible by base name only
       expect(scopeMap['potential_leaders']).toBeUndefined();


### PR DESCRIPTION
## Summary
- clean up checkFormatInputs JSDoc
- stabilize scope registry test for deterministic AST comparisons

## Testing Done
- `npm run format`
- `npx eslint src/actions/actionFormatter.js`
- `npx eslint tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fa9632fe88331bc0c201cb3e12bc1