### PR TITLE
[Agent] update command processor to return CommandResult

### DIFF
--- a/src/commands/interfaces/ICommandProcessor.js
+++ b/src/commands/interfaces/ICommandProcessor.js
@@ -3,6 +3,10 @@
  * @see src/commands/interfaces/ICommandProcessor.js
  */
 
+/** @typedef {import('../../entities/entity.js').default} Entity */
+/** @typedef {import('../../turns/interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction */
+/** @typedef {import('../../types/commandResult.js').CommandResult} CommandResult */
+
 /**
  * @interface ICommandProcessor
  * @classdesc Defines the contract for processing commands from an actor.
@@ -15,7 +19,7 @@ export class ICommandProcessor {
    * @async
    * @param {Entity} actor - The entity performing the action.
    * @param {ITurnAction} turnAction - The pre-resolved action object.
-   * @returns {Promise<{success: boolean, commandResult: CommandResult | null}>} A promise that resolves to an object indicating the outcome.
+   * @returns {Promise<CommandResult>} A promise that resolves to the command result.
    * @throws {Error} May throw on critical, unrecoverable errors.
    */
   async dispatchAction(actor, turnAction) {

--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -36,7 +36,12 @@ describe('CommandProcessor.dispatchAction', () => {
 
     const result = await processor.dispatchAction(actor, turnAction);
 
-    expect(result).toEqual({ success: true, commandResult: null });
+    expect(result).toEqual({
+      success: true,
+      turnEnded: false,
+      originalInput: 'look north',
+      actionResult: { actionId: 'look' },
+    });
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(safeEventDispatcher.dispatch).toHaveBeenCalledWith(
       ATTEMPT_ACTION_ID,
@@ -61,7 +66,7 @@ describe('CommandProcessor.dispatchAction', () => {
     const result = await processor.dispatchAction(actor, turnAction);
 
     expect(result.success).toBe(false);
-    expect(result.commandResult.error).toBe(
+    expect(result.error).toBe(
       'Internal error: Malformed action prevented execution.'
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
@@ -77,7 +82,7 @@ describe('CommandProcessor.dispatchAction', () => {
     const result = await processor.dispatchAction(actor, null);
 
     expect(result.success).toBe(false);
-    expect(result.commandResult.error).toBe(
+    expect(result.error).toBe(
       'Internal error: Malformed action prevented execution.'
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
@@ -95,7 +100,7 @@ describe('CommandProcessor.dispatchAction', () => {
     const result = await processor.dispatchAction(actor, turnAction);
 
     expect(result.success).toBe(false);
-    expect(result.commandResult).toEqual(
+    expect(result).toEqual(
       expect.objectContaining({
         success: false,
         turnEnded: true,

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -228,7 +228,9 @@ describe('ProcessingCommandState.enterState – error branches', () => {
     // Ensure dispatchAction returns a valid structure even if not strictly used by this error path
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      commandResult: null,
+      turnEnded: false,
+      originalInput: customState.commandString,
+      actionResult: { actionId: 'testAction' },
     });
 
     await customState.enterState(mockHandler, null);
@@ -281,7 +283,9 @@ describe('ProcessingCommandState.enterState – error branches', () => {
 
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      commandResult: null,
+      turnEnded: false,
+      originalInput: defaultCommandString,
+      actionResult: { actionId: 'testAction' },
     });
 
     await stateForNullActionTest.enterState(mockHandler, null); // Call enterState on the local instance
@@ -333,7 +337,9 @@ describe('ProcessingCommandState.enterState – error branches', () => {
 
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      commandResult: null,
+      turnEnded: false,
+      originalInput: badAction.commandString,
+      actionResult: { actionId: badAction.actionDefinitionId },
     });
 
     await stateForInvalidActionTest.enterState(mockHandler, null); // Call enterState on the local instance
@@ -380,7 +386,9 @@ describe('ProcessingCommandState.enterState – error branches', () => {
     };
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      commandResult: null,
+      turnEnded: false,
+      originalInput: 'speakCmd',
+      actionResult: { actionId: turnActionWithSpeech.actionDefinitionId },
     });
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
@@ -448,7 +456,9 @@ describe('ProcessingCommandState.enterState – error branches', () => {
     };
     mockCommandProcessor.dispatchAction.mockResolvedValue({
       success: true,
-      commandResult: null,
+      turnEnded: false,
+      originalInput: 'speakCmd',
+      actionResult: { actionId: turnActionWithSpeech.actionDefinitionId },
     });
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 

--- a/tests/unit/turns/states/processingCommandState.enterState.test.js
+++ b/tests/unit/turns/states/processingCommandState.enterState.test.js
@@ -276,7 +276,11 @@ describe('ProcessingCommandState', () => {
 
       mockCommandProcessor.dispatchAction.mockResolvedValue({
         success: true,
-        commandResult: null,
+        turnEnded: false,
+        originalInput: specificCommandString,
+        actionResult: {
+          actionId: specificActionForThisTest.actionDefinitionId,
+        },
       });
       mockCommandOutcomeInterpreter.interpret.mockReturnValue(
         TurnDirective.END_TURN_SUCCESS

--- a/tests/unit/turns/states/processingCommandState.test.js
+++ b/tests/unit/turns/states/processingCommandState.test.js
@@ -133,38 +133,25 @@ describe('ProcessingCommandState', () => {
     // NEW: Define results from the mocked dispatchAction call
     mockSuccessfulDispatchResult = {
       success: true,
-      commandResult: undefined,
+      turnEnded: false,
+      originalInput: mockTurnAction.commandString,
+      actionResult: { actionId: mockTurnAction.actionDefinitionId },
     };
 
     mockFailedDispatchResult = {
       success: false,
-      commandResult: {
-        error: 'CommandProcFailure',
-        internalError: 'Detailed CommandProcFailure',
-      },
+      turnEnded: true,
+      originalInput: mockTurnAction.commandString,
+      actionResult: { actionId: mockTurnAction.actionDefinitionId },
+      error: 'CommandProcFailure',
+      internalError: 'Detailed CommandProcFailure',
     };
 
     // NEW: Define expected payloads for the outcome interpreter/strategies,
     // which are constructed inside the SUT.
-    expectedInterpreterPayloadSuccess = {
-      success: true,
-      turnEnded: false,
-      originalInput:
-        mockTurnAction.commandString || mockTurnAction.actionDefinitionId,
-      actionResult: { actionId: mockTurnAction.actionDefinitionId },
-      error: undefined,
-      internalError: undefined,
-    };
+    expectedInterpreterPayloadSuccess = { ...mockSuccessfulDispatchResult };
 
-    expectedInterpreterPayloadFailure = {
-      success: false,
-      turnEnded: true,
-      originalInput:
-        mockTurnAction.commandString || mockTurnAction.actionDefinitionId,
-      actionResult: { actionId: mockTurnAction.actionDefinitionId },
-      error: mockFailedDispatchResult.commandResult.error,
-      internalError: mockFailedDispatchResult.commandResult.internalError,
-    };
+    expectedInterpreterPayloadFailure = { ...mockFailedDispatchResult };
 
     mockTurnContext = {
       getLogger: jest.fn().mockReturnValue(mockLogger),
@@ -527,8 +514,6 @@ describe('ProcessingCommandState', () => {
         turnEnded: false,
         originalInput: actionNoCommandString.actionDefinitionId, // Fallback
         actionResult: { actionId: actionNoCommandString.actionDefinitionId },
-        error: undefined,
-        internalError: undefined,
       };
 
       mockCommandOutcomeInterpreter.interpret.mockReturnValue(
@@ -538,7 +523,7 @@ describe('ProcessingCommandState', () => {
         mockEndTurnSuccessStrategy
       );
       mockCommandProcessor.dispatchAction.mockResolvedValue(
-        mockSuccessfulDispatchResult
+        expectedPayloadNoCommandStr
       );
 
       await processingState['_processCommandInternal'](


### PR DESCRIPTION
## Summary
- `ICommandProcessor.dispatchAction` now resolves to a `CommandResult`
- return `CommandResult` objects from `CommandProcessor`
- use the returned `CommandResult` directly in `CommandProcessingWorkflow`
- update tests for the new behaviour

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` *(fails: 3386 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685fa9a6c2d48331939c2b33b4d4937c