### PR TITLE
Refactor error handling in ScopeEngine to throw specific error classe…

### DIFF
--- a/src/errors/unknownSourceError.js
+++ b/src/errors/unknownSourceError.js
@@ -1,0 +1,11 @@
+export class UnknownSourceError extends Error {
+  constructor(sourceKind) {
+    super(`Unknown source kind: ${sourceKind}`);
+    this.name = 'UnknownSourceError';
+    this.sourceKind = sourceKind;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnknownSourceError);
+    }
+  }
+}

--- a/src/scopeDsl/core/createScopeEngine.js
+++ b/src/scopeDsl/core/createScopeEngine.js
@@ -14,7 +14,7 @@ export default function createScopeEngine(resolversOrConfig, maxDepth = 4) {
   // 1. Ticket API: createScopeEngine(resolvers, maxDepth)
   // 2. Test API: createScopeEngine({ resolvers, logger, maxDepth })
   let resolvers, logger;
-  
+
   if (Array.isArray(resolversOrConfig)) {
     // Ticket API: createScopeEngine(resolvers, maxDepth)
     resolvers = resolversOrConfig;
@@ -23,11 +23,11 @@ export default function createScopeEngine(resolversOrConfig, maxDepth = 4) {
     // Test API: createScopeEngine({ resolvers, logger, maxDepth })
     const config = resolversOrConfig || {};
     ({ resolvers, logger, maxDepth = 4 } = config);
-    
+
     if (!logger) {
       throw new Error('Logger is required for createScopeEngine');
     }
-    
+
     if (!resolvers || !Array.isArray(resolvers) || resolvers.length === 0) {
       throw new Error('Resolvers array is required and must not be empty');
     }
@@ -56,9 +56,9 @@ export default function createScopeEngine(resolversOrConfig, maxDepth = 4) {
     depth.ensure(level);
     cycle.enter(nodeKey(node));
     try {
-      return dispatch.resolve(node, { 
-        ...ctx, 
-        walk: (n) => walk(n, ctx, level + 1)
+      return dispatch.resolve(node, {
+        ...ctx,
+        walk: (n) => walk(n, ctx, level + 1),
       });
     } finally {
       cycle.leave();
@@ -69,15 +69,19 @@ export default function createScopeEngine(resolversOrConfig, maxDepth = 4) {
     resolve(ast, actor, ports, trace = null) {
       const source = 'ScopeEngine';
       trace?.addLog('step', 'Starting scope resolution.', source, { ast });
-      
-      const result = walk(ast, { 
-        actorEntity: actor, 
-        runtimeCtx: ports,
-        depth: 0,
-        trace,
-        ...ports 
-      }, 0);
-      
+
+      const result = walk(
+        ast,
+        {
+          actorEntity: actor,
+          runtimeCtx: ports,
+          depth: 0,
+          trace,
+          ...ports,
+        },
+        0
+      );
+
       const finalTargets = Array.from(result);
       trace?.addLog(
         'success',
@@ -85,7 +89,7 @@ export default function createScopeEngine(resolversOrConfig, maxDepth = 4) {
         source,
         { targets: finalTargets }
       );
-      
+
       return result;
     },
     setMaxDepth(n) {

--- a/src/scopeDsl/engine.js
+++ b/src/scopeDsl/engine.js
@@ -7,6 +7,8 @@
 
 import ScopeDepthError from '../errors/scopeDepthError.js';
 import ScopeCycleError from '../errors/scopeCycleError.js';
+import { UnknownAstNodeError } from '../errors/unknownAstNodeError.js';
+import { UnknownSourceError } from '../errors/unknownSourceError.js';
 import { IScopeEngine } from '../interfaces/IScopeEngine.js';
 
 /**
@@ -149,8 +151,7 @@ class ScopeEngine extends IScopeEngine {
           trace
         );
       default:
-        runtimeCtx.logger.error(`Unknown AST node type: ${node.type}`);
-        return new Set();
+        throw new UnknownAstNodeError(node.type);
     }
   }
 
@@ -181,11 +182,7 @@ class ScopeEngine extends IScopeEngine {
       case 'entities':
         const componentId = node.param;
         if (!componentId) {
-          runtimeCtx.logger.error(
-            'entities() source node missing component ID'
-          );
-          result = new Set();
-          break;
+          throw new Error('entities() source node missing component ID');
         }
 
         if (componentId.startsWith('!')) {
@@ -228,8 +225,7 @@ class ScopeEngine extends IScopeEngine {
         break;
 
       default:
-        runtimeCtx.logger.error(`Unknown source kind: ${node.kind}`);
-        result = new Set();
+        throw new UnknownSourceError(node.kind);
     }
 
     const source = 'ScopeEngine.resolveSource';

--- a/tests/core/createScopeEngine.test.js
+++ b/tests/core/createScopeEngine.test.js
@@ -77,7 +77,7 @@ describe('createScopeEngine', () => {
 
     it('should accept custom max depth', () => {
       const engine = createScopeEngine(mockResolvers, 6);
-      
+
       // Test that deep nesting up to 6 works
       const deepAST = createDeepAST(6);
       expect(() => {

--- a/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
+++ b/tests/unit/initializers/services/scopeRegistryInitialization.focused.test.js
@@ -247,12 +247,11 @@ describe('Scope Registry Initialization - Focused Test', () => {
         }
       });
 
-      
       expect(scopeMap['core:potential_leaders']).toEqual(
         addMockAst(properlyFormattedScopes[0])
       );
       dateSpy.mockRestore();
-      
+
       // Check all properties except the volatile timestamp
       const result = scopeMap['core:potential_leaders'];
       const expected = addMockAst(properlyFormattedScopes[0]);

--- a/tests/unit/scopeDsl/engine.additional.test.js
+++ b/tests/unit/scopeDsl/engine.additional.test.js
@@ -98,46 +98,34 @@ describe('ScopeEngine - Additional Coverage Tests', () => {
   describe('Error scenarios and edge cases', () => {
     test('should handle unknown AST node type', () => {
       const unknownAst = { type: 'UnknownNodeType', value: 'test' };
-      const result = engine.resolve(unknownAst, actorEntity, mockRuntimeCtx);
 
-      expect(result).toEqual(new Set());
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Unknown AST node type: UnknownNodeType'
-      );
+      expect(() => {
+        engine.resolve(unknownAst, actorEntity, mockRuntimeCtx);
+      }).toThrow('Unknown AST node type: UnknownNodeType');
     });
 
     test('should handle unknown source kind', () => {
       const unknownSourceAst = { type: 'Source', kind: 'unknownSource' };
-      const result = engine.resolve(
-        unknownSourceAst,
-        actorEntity,
-        mockRuntimeCtx
-      );
 
-      expect(result).toEqual(new Set());
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Unknown source kind: unknownSource'
-      );
+      expect(() => {
+        engine.resolve(unknownSourceAst, actorEntity, mockRuntimeCtx);
+      }).toThrow('Unknown source kind: unknownSource');
     });
 
     test('should handle entities source without component ID', () => {
       const ast = { type: 'Source', kind: 'entities', param: null };
-      const result = engine.resolve(ast, actorEntity, mockRuntimeCtx);
 
-      expect(result).toEqual(new Set());
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'entities() source node missing component ID'
-      );
+      expect(() => {
+        engine.resolve(ast, actorEntity, mockRuntimeCtx);
+      }).toThrow('entities() source node missing component ID');
     });
 
     test('should handle entities source with empty component ID', () => {
       const ast = { type: 'Source', kind: 'entities', param: '' };
-      const result = engine.resolve(ast, actorEntity, mockRuntimeCtx);
 
-      expect(result).toEqual(new Set());
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'entities() source node missing component ID'
-      );
+      expect(() => {
+        engine.resolve(ast, actorEntity, mockRuntimeCtx);
+      }).toThrow('entities() source node missing component ID');
     });
 
     test('should handle location source without location in runtime context', () => {

--- a/tests/unit/scopeDsl/engine.comprehensive.test.js
+++ b/tests/unit/scopeDsl/engine.comprehensive.test.js
@@ -230,12 +230,9 @@ describe('ScopeEngine - Comprehensive Coverage Tests', () => {
         someProperty: 'someValue',
       };
 
-      const result = engine.resolve(unknownAst, actorEntity, mockRuntimeCtx);
-
-      expect(result).toEqual(new Set());
-      expect(mockRuntimeCtx.logger.error).toHaveBeenCalledWith(
-        'Unknown AST node type: UnknownType'
-      );
+      expect(() => {
+        engine.resolve(unknownAst, actorEntity, mockRuntimeCtx);
+      }).toThrow('Unknown AST node type: UnknownType');
     });
 
     test('should handle field extraction with various input types', () => {

--- a/tests/unit/utils/contextVariableUtils.branches.test.js
+++ b/tests/unit/utils/contextVariableUtils.branches.test.js
@@ -1,7 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import {
-  writeContextVariable,
-} from '../../../src/utils/contextVariableUtils.js';
+import { writeContextVariable } from '../../../src/utils/contextVariableUtils.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import * as safeDispatchModule from '../../../src/utils/safeDispatchErrorUtils.js';
 
@@ -29,7 +27,10 @@ describe('writeContextVariable additional branches', () => {
       },
     });
     const dispatcher = { dispatch: jest.fn() };
-    const ctx = { evaluationContext: { context }, validatedEventDispatcher: dispatcher };
+    const ctx = {
+      evaluationContext: { context },
+      validatedEventDispatcher: dispatcher,
+    };
 
     const result = writeContextVariable('foo', 2, ctx, dispatcher, undefined);
     expect(result.success).toBe(false);
@@ -51,7 +52,9 @@ describe('writeContextVariable additional branches', () => {
     });
     const ctx = { evaluationContext: { context } };
 
-    const result = writeContextVariable('bar', 3, ctx, undefined, { error: jest.fn() });
+    const result = writeContextVariable('bar', 3, ctx, undefined, {
+      error: jest.fn(),
+    });
     expect(result.success).toBe(false);
     expect(safeDispatchModule.safeDispatchError).not.toHaveBeenCalled();
   });

--- a/ticket.txt
+++ b/ticket.txt
@@ -1,35 +1,12 @@
-T-14 CreateScopeEngine Factory
-Connect everything.
-
+T-16 Error Classes & Removal of Silent Fails
 Files
 
-scopeDsl/core/createScopeEngine.js
+errors/unknownSourceError.js
 
-tests/core/createScopeEngine.test.js
+errors/unknownAstNodeError.js
 
-Factory signature
+Refactor resolvers to throw instead of logger.error + return new Set().
 
-import createDepthGuard from './depthGuard.js';
-import createCycleDetector from './cycleDetector.js';
-import createDispatcher from '../nodes/dispatcher.js';
-
-export default function createScopeEngine(resolvers, maxDepth=4){
-const depth = createDepthGuard(maxDepth);
-const cycle = createCycleDetector();
-const dispatch = createDispatcher(resolvers);
-
-function walk(node, ctx, level){
-depth.ensure(level);
-cycle.enter(nodeKey(node)); // implement same key generator
-try { return dispatch.resolve(node, { ...ctx, walk: n => walk(n, ctx, level+1) }); }
-finally { cycle.leave(); }
-}
-
-return {
-resolve(ast, actor, ports){ return walk(ast, { actorEntity:actor, ...ports }, 0); },
-setMaxDepth(n){ depth.maxDepth = n; }
-};
-}
 Tests
 
-Smoke test with real resolvers reproduces old behaviour.
+Assert thrown error classes when input invalid.


### PR DESCRIPTION
…s instead of logging errors. Update tests to assert thrown errors for invalid inputs. Clean up whitespace in various files.