### PR TITLE
[Feat] use logger for input validation

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -67,13 +67,15 @@ function normalizeFormatResult(result) {
  * @param {ActionTargetContext} targetContext - Target context for formatting.
  * @param {EntityManager} entityManager - Entity manager for lookups.
  * @param {(entity: Entity, fallback: string, logger?: ILogger) => string} displayNameFn - Utility for entity names.
+ * @param {ILogger} logger - Logger used for validation.
  * @returns {string | null} An error message string when invalid, otherwise `null`.
  */
 function checkFormatInputs(
   actionDefinition,
   targetContext,
   entityManager,
-  displayNameFn
+  displayNameFn,
+  logger
 ) {
   if (!actionDefinition || !actionDefinition.template) {
     return 'formatActionCommand: Invalid or missing actionDefinition or template.';
@@ -82,14 +84,14 @@ function checkFormatInputs(
     return 'formatActionCommand: Invalid or missing targetContext.';
   }
   try {
-    validateDependency(entityManager, 'entityManager', console, {
+    validateDependency(entityManager, 'entityManager', logger, {
       requiredMethods: ['getEntityInstance'],
     });
   } catch {
     return 'formatActionCommand: Invalid or missing entityManager.';
   }
   try {
-    validateDependency(displayNameFn, 'displayNameFn', console, {
+    validateDependency(displayNameFn, 'displayNameFn', logger, {
       isFunction: true,
     });
   } catch {
@@ -234,7 +236,8 @@ export function formatActionCommand(
     actionDefinition,
     targetContext,
     entityManager,
-    displayNameFn
+    displayNameFn,
+    logger
   );
   if (validationMessage && !logger) {
     throw new Error('formatActionCommand: logger is required.');


### PR DESCRIPTION
Summary: Updated checkFormatInputs to accept a logger parameter and pass it to validateDependency. formatActionCommand now forwards its logger to checkFormatInputs so validation uses custom logging.

Changes Made:
- Added logger argument in checkFormatInputs
- Passed logger to validateDependency for entity manager and display name checks
- Updated formatActionCommand to supply the logger when calling checkFormatInputs

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685fbeb5936c8331a7310ae64928a3b8