### PR TITLE
[Agent] remove async from target resolution

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -289,7 +289,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     );
 
     // STEP 2: Resolve targets using the dedicated service
-    const targetContexts = await this.#targetResolutionService.resolveTargets(
+    const targetContexts = this.#targetResolutionService.resolveTargets(
       actionDef.scope,
       actorEntity,
       discoveryContext,

--- a/src/actions/targetResolutionService.js
+++ b/src/actions/targetResolutionService.js
@@ -82,9 +82,9 @@ export class TargetResolutionService extends ITargetResolutionService {
    * @param {Entity} actorEntity - The entity performing the action.
    * @param {ActionContext} discoveryContext - Context for DSL evaluation.
    * @param {TraceContext|null} [trace] - Optional tracing instance.
-   * @returns {Promise<ActionTargetContext[]>} Resolved target contexts.
+   * @returns {ActionTargetContext[]} Resolved target contexts.
    */
-  async resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
+  resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
     const source = 'TargetResolutionService.resolveTargets';
     trace?.info(`Resolving scope '${scopeName}'.`, source);
 

--- a/src/interfaces/ITargetResolutionService.js
+++ b/src/interfaces/ITargetResolutionService.js
@@ -15,9 +15,9 @@ export class ITargetResolutionService {
    * @param {Entity} actorEntity - The entity performing the action.
    * @param {ActionContext} discoveryContext - The dynamic context for the resolution.
    * @param {TraceContext} [trace] - Optional trace context for logging.
-   * @returns {Promise<ActionTargetContext[]>} A list of valid target contexts.
+   * @returns {ActionTargetContext[]} A list of valid target contexts.
    */
-  async resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
+  resolveTargets(scopeName, actorEntity, discoveryContext, trace = null) {
     throw new Error(
       'ITargetResolutionService.resolveTargets method not implemented.'
     );

--- a/tests/integration/actions/actionDiscoveryService.p4-05.test.js
+++ b/tests/integration/actions/actionDiscoveryService.p4-05.test.js
@@ -133,7 +133,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
         scope: 'some_scope',
       };
       mockActionIndex.getCandidateActions.mockReturnValue([actionDef]);
-      mockTargetResolutionService.resolveTargets.mockResolvedValue([
+      mockTargetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'target1' },
       ]);
 
@@ -160,7 +160,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
       };
       mockActionIndex.getCandidateActions.mockReturnValue([actionDef]);
       mockPrereqService.evaluate.mockReturnValue(true);
-      mockTargetResolutionService.resolveTargets.mockResolvedValue([
+      mockTargetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'goblin1' },
         { type: 'entity', entityId: 'goblin2' },
       ]);
@@ -202,7 +202,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
       };
       mockActionIndex.getCandidateActions.mockReturnValue([actionDef]);
       mockPrereqService.evaluate.mockReturnValue(true);
-      mockTargetResolutionService.resolveTargets.mockResolvedValue([
+      mockTargetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: actorEntity.id },
       ]);
 
@@ -234,7 +234,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
       };
       mockActionIndex.getCandidateActions.mockReturnValue([actionDef]);
       mockPrereqService.evaluate.mockReturnValue(true);
-      mockTargetResolutionService.resolveTargets.mockResolvedValue([
+      mockTargetResolutionService.resolveTargets.mockReturnValue([
         { type: 'none', entityId: null },
       ]);
 
@@ -266,7 +266,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
       };
       mockActionIndex.getCandidateActions.mockReturnValue([actionDef]);
       mockPrereqService.evaluate.mockReturnValue(true);
-      mockTargetResolutionService.resolveTargets.mockResolvedValue([]);
+      mockTargetResolutionService.resolveTargets.mockReturnValue([]);
 
       const { actions } = await service.getValidActions(actorEntity, {});
 

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -18,7 +18,7 @@ describeActionDiscoverySuite(
         dummyActionDef,
       ]);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'rat123' },
       ]);
       bed.mocks.formatActionCommandFn.mockReturnValue({

--- a/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
+++ b/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
@@ -51,7 +51,7 @@ describeActionDiscoverySuite(
       const def = { id: 'bad', commandVerb: 'bad', scope: 'target' };
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 't1' },
       ]);
       bed.mocks.formatActionCommandFn.mockReturnValue({

--- a/tests/unit/actions/actionDiscoveryService.baseContextDefault.test.js
+++ b/tests/unit/actions/actionDiscoveryService.baseContextDefault.test.js
@@ -12,7 +12,7 @@ describeActionDiscoverySuite(
       const bed = getBed();
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([]);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([]);
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([]);
       bed.mocks.getActorLocationFn.mockReturnValue({
         id: 'room1',
         getComponentData: jest.fn(),

--- a/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
+++ b/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
@@ -8,7 +8,7 @@ describeActionDiscoverySuite(
   (getBed) => {
     beforeEach(() => {
       const bed = getBed();
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'none', entityId: null },
       ]);
       bed.mocks.getActorLocationFn.mockReturnValue('room1');

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -27,7 +27,7 @@ describeActionDiscoverySuite(
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue(actionDefs);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
       bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
-        async (scope) => {
+        (scope) => {
           if (scope === 'directions') {
             return [
               { type: 'entity', entityId: 'loc-2' },

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -14,7 +14,7 @@ describeActionDiscoverySuite(
         ok: true,
         value: 'doit',
       });
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([]);
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([]);
       bed.mocks.getActorLocationFn.mockReturnValue({
         id: 'room1',
         getComponentData: jest.fn(),
@@ -31,7 +31,7 @@ describeActionDiscoverySuite(
         okDef,
       ]);
       bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
-        async (scope) => {
+        (scope) => {
           if (scope === 'badScope') return [];
           if (scope === 'none') return [{ type: 'none', entityId: null }];
           return [];
@@ -61,7 +61,7 @@ describeActionDiscoverySuite(
       const def = { id: 'attack', commandVerb: 'attack', scope: 'monster' };
 
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'monster1' },
       ]);
       bed.mocks.formatActionCommandFn.mockReturnValue({
@@ -108,7 +108,7 @@ describeActionDiscoverySuite(
         badDef,
         okDef,
       ]);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'none', entityId: null },
       ]);
       bed.mocks.formatActionCommandFn.mockImplementation((def) => {
@@ -143,7 +143,7 @@ describeActionDiscoverySuite(
         badDef,
         okDef,
       ]);
-      bed.mocks.targetResolutionService.resolveTargets.mockResolvedValue([
+      bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'none', entityId: null },
       ]);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockImplementation(

--- a/tests/unit/actions/actionDiscoveryService.tracing.test.js
+++ b/tests/unit/actions/actionDiscoveryService.tracing.test.js
@@ -79,7 +79,7 @@ describeActionDiscoverySuite(
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([]);
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
       bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
-        async (scopeName) => {
+        (scopeName) => {
           if (scopeName === 'someScope') {
             return [
               { type: 'entity', entityId: 'target1' },

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -59,7 +59,7 @@ describeActionDiscoverySuite(
       });
 
       bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
-        async (scopeName) => {
+        (scopeName) => {
           if (scopeName === 'core:clear_directions') {
             return [{ type: 'entity', entityId: TOWN_INSTANCE_ID }];
           }

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -33,7 +33,7 @@ describeActionDiscoverySuite(
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
 
       bed.mocks.targetResolutionService.resolveTargets.mockImplementation(
-        async (scopeName) => {
+        (scopeName) => {
           if (scopeName === 'none') return [{ type: 'none', entityId: null }];
           if (scopeName === 'self')
             return [{ type: 'entity', entityId: mockActorEntity.id }];

--- a/tests/unit/actions/targetResolutionService.branches.test.js
+++ b/tests/unit/actions/targetResolutionService.branches.test.js
@@ -41,25 +41,25 @@ describe('TargetResolutionService - additional branches', () => {
     });
   });
 
-  it('returns a no target context when scope is none', async () => {
+  it('returns a no target context when scope is none', () => {
     const actor = { id: 'hero' };
-    const result = await service.resolveTargets(TARGET_DOMAIN_NONE, actor, {});
+    const result = service.resolveTargets(TARGET_DOMAIN_NONE, actor, {});
     expect(result).toEqual([ActionTargetContext.noTarget()]);
     expect(mockScopeRegistry.getScope).not.toHaveBeenCalled();
     expect(mockScopeEngine.resolve).not.toHaveBeenCalled();
     expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 
-  it('returns the actor as target when scope is self', async () => {
+  it('returns the actor as target when scope is self', () => {
     const actor = { id: 'hero' };
-    const result = await service.resolveTargets(TARGET_DOMAIN_SELF, actor, {});
+    const result = service.resolveTargets(TARGET_DOMAIN_SELF, actor, {});
     expect(result).toEqual([ActionTargetContext.forEntity('hero')]);
     expect(mockScopeRegistry.getScope).not.toHaveBeenCalled();
     expect(mockScopeEngine.resolve).not.toHaveBeenCalled();
     expect(mockSafeDispatcher.dispatch).not.toHaveBeenCalled();
   });
 
-  it('handles undefined scope resolution result gracefully', async () => {
+  it('handles undefined scope resolution result gracefully', () => {
     const expr = 'actor';
     const def = {
       name: 'core:test',
@@ -72,7 +72,7 @@ describe('TargetResolutionService - additional branches', () => {
     mockScopeEngine.resolve.mockReturnValue(undefined);
 
     const actor = { id: 'hero' };
-    const result = await service.resolveTargets('core:test', actor, {});
+    const result = service.resolveTargets('core:test', actor, {});
 
     expect(result).toEqual([]);
     expect(mockScopeEngine.resolve).toHaveBeenCalled();

--- a/tests/unit/actions/targetResolutionService.scope-loading.test.js
+++ b/tests/unit/actions/targetResolutionService.scope-loading.test.js
@@ -51,7 +51,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
   });
 
   describe('core:clear_directions scope resolution', () => {
-    it('should find the core:clear_directions scope when properly loaded', async () => {
+    it('should find the core:clear_directions scope when properly loaded', () => {
       // Mock a properly loaded scope
       const expr =
         'location.core:exits[{ "condition_ref": "core:exit-is-unblocked" }].target';
@@ -71,7 +71,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockActor = { id: 'hero', type: 'character' };
       const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
 
-      const result = await targetResolutionService.resolveTargets(
+      const result = targetResolutionService.resolveTargets(
         'core:clear_directions',
         mockActor,
         mockDiscoveryContext
@@ -84,14 +84,14 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       expectNoDispatch(mockSafeEventDispatcher.dispatch);
     });
 
-    it('should handle missing scope gracefully and dispatch error event', async () => {
+    it('should handle missing scope gracefully and dispatch error event', () => {
       // Mock missing scope (returns null)
       mockScopeRegistry.getScope.mockReturnValue(null);
 
       const mockActor = { id: 'hero', type: 'character' };
       const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
 
-      const result = await targetResolutionService.resolveTargets(
+      const result = targetResolutionService.resolveTargets(
         'core:clear_directions',
         mockActor,
         mockDiscoveryContext
@@ -114,7 +114,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       );
     });
 
-    it('should handle scope with empty expression gracefully', async () => {
+    it('should handle scope with empty expression gracefully', () => {
       // Mock scope with empty expression
       const mockScopeDefinition = {
         name: 'core:clear_directions',
@@ -128,7 +128,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockActor = { id: 'hero', type: 'character' };
       const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
 
-      const result = await targetResolutionService.resolveTargets(
+      const result = targetResolutionService.resolveTargets(
         'core:clear_directions',
         mockActor,
         mockDiscoveryContext
@@ -140,7 +140,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       );
     });
 
-    it('should handle scope with missing AST gracefully', async () => {
+    it('should handle scope with missing AST gracefully', () => {
       // Mock scope without AST (which is now required)
       const mockScopeDefinition = {
         name: 'core:clear_directions',
@@ -155,7 +155,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       const mockActor = { id: 'hero', type: 'character' };
       const mockDiscoveryContext = { currentLocation: { id: 'room1' } };
 
-      const result = await targetResolutionService.resolveTargets(
+      const result = targetResolutionService.resolveTargets(
         'core:clear_directions',
         mockActor,
         mockDiscoveryContext


### PR DESCRIPTION
Summary: Removes unnecessary Promise usage from target resolution by converting `resolveTargets` to a synchronous method.

Changes Made:
- Updated `ITargetResolutionService` interface to return arrays synchronously.
- Adjusted `TargetResolutionService.resolveTargets` implementation accordingly.
- Dropped `await` where the service is used in `ActionDiscoveryService`.
- Updated related unit and integration tests to use synchronous mocks and calls.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_685fbeed86388331ae7c4789a01c9b03