### PR TITLE
[Agent] replace deprecated console.warn

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -17,7 +17,6 @@ import {
   dispatchValidationError,
 } from '../utils/safeDispatchErrorUtils.js';
 import { validateDependency } from '../utils/dependencyUtils.js';
-import { resolveSafeDispatcher } from '../utils/dispatcherUtils.js';
 
 import { targetFormatterMap } from './formatters/targetFormatters.js';
 
@@ -190,8 +189,7 @@ function normalizeDeps(deps, logger) {
     'formatterMap' in depObj ? depObj.formatterMap : targetFormatterMap;
 
   if (typeof deps === 'function' || callerArgs.length > 5) {
-    const warnLogger = logger ?? console;
-    warnLogger.warn(
+    logger.warn(
       'DEPRECATION: formatActionCommand now expects a single dependency object after options.'
     );
     displayNameFn = deps || getEntityDisplayName;


### PR DESCRIPTION
Summary: remove unused resolveSafeDispatcher import and switch deprecated-argument warning to use logger

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_685fc3b3ca408331957522adee0defbd