### PR TITLE
[Fix] streamline logger validation in actionFormatter

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -223,6 +223,10 @@ export function formatActionCommand(
   deps = {}
 ) {
   const { debug = false, logger, safeEventDispatcher } = options;
+  if (!logger) {
+    throw new Error('formatActionCommand: logger is required.');
+  }
+
   const { displayNameFn, formatterMap } = normalizeDeps(
     deps,
     logger,
@@ -237,13 +241,6 @@ export function formatActionCommand(
     displayNameFn,
     logger
   );
-  if (validationMessage && !logger) {
-    throw new Error('formatActionCommand: logger is required.');
-  }
-
-  if (!logger) {
-    throw new Error('formatActionCommand: logger is required.');
-  }
 
   validateDependency(safeEventDispatcher, 'safeEventDispatcher', logger, {
     requiredMethods: ['dispatch'],


### PR DESCRIPTION
Summary: Ensures `formatActionCommand()` validates the logger only once before dependency normalization.

Changes Made:
- Added upfront `logger` check in `formatActionCommand`.
- Moved `normalizeDeps` call after validation.
- Removed redundant logger check block.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npx jest --coverage --runInBand`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_685fc784b3f083318cbbb87fe14a10e2