### PR TITLE
[Feat] commandProcessor ID validation

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -4,7 +4,7 @@
 import { ATTEMPT_ACTION_ID } from '../constants/eventIds.js';
 import { ICommandProcessor } from './interfaces/ICommandProcessor.js';
 import { initLogger } from '../utils/index.js';
-import { validateDependency } from '../utils/dependencyUtils.js';
+import { validateDependency, assertValidId } from '../utils/dependencyUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 
 // --- Type Imports ---
@@ -124,10 +124,17 @@ class CommandProcessor extends ICommandProcessor {
       };
     }
 
-    if (!turnAction.actionDefinitionId) {
+    try {
+      assertValidId(actorId, 'CommandProcessor.dispatchAction', this.#logger);
+      assertValidId(
+        turnAction.actionDefinitionId,
+        'CommandProcessor.dispatchAction',
+        this.#logger
+      );
+    } catch (err) {
       return {
         userMsg: 'Internal error: Malformed action prevented execution.',
-        internalMsg: `dispatchAction failed: ITurnAction for actor ${actorId} is missing actionDefinitionId.`,
+        internalMsg: `dispatchAction failed: ${err.message}`,
       };
     }
 


### PR DESCRIPTION
Summary: Added stricter ID validation in CommandProcessor to ensure actor and action identifiers are non-blank. Updated helper uses `assertValidId` and preserves existing user-facing error messages.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685fc76322d88331a3569063c8654872