### PR TITLE
[Agent] Rename internal dep variable in normalizeDeps

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -182,11 +182,15 @@ function finalizeCommand(command, logger, debug) {
  */
 function normalizeDeps(deps, logger) {
   const callerArgs = arguments[2] || [];
-  const depObj = deps && typeof deps === 'object' ? deps : {};
+  const injectedDeps = deps && typeof deps === 'object' ? deps : {};
   let displayNameFn =
-    'displayNameFn' in depObj ? depObj.displayNameFn : getEntityDisplayName;
+    'displayNameFn' in injectedDeps
+      ? injectedDeps.displayNameFn
+      : getEntityDisplayName;
   let formatterMap =
-    'formatterMap' in depObj ? depObj.formatterMap : targetFormatterMap;
+    'formatterMap' in injectedDeps
+      ? injectedDeps.formatterMap
+      : targetFormatterMap;
 
   if (typeof deps === 'function' || callerArgs.length > 5) {
     logger.warn(


### PR DESCRIPTION
## Summary
- rename `depObj` to `injectedDeps` in `normalizeDeps`
- keep `formatActionCommand()` flow unchanged

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fca3a7268833196af2db0d277a905