### PR TITLE
[Test] increase GenericStrategyFactory coverage

### DIFF
--- a/tests/unit/turns/factories/genericStrategyFactory.test.js
+++ b/tests/unit/turns/factories/genericStrategyFactory.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { GenericStrategyFactory } from '../../../../src/turns/factories/genericStrategyFactory.js';
+import { GenericTurnStrategy } from '../../../../src/turns/strategies/genericTurnStrategy.js';
+
+const createDeps = () => ({
+  choicePipeline: {},
+  decisionProvider: { constructor: { name: 'TestProvider' } },
+  turnActionFactory: {},
+  logger: { debug: jest.fn() },
+  fallbackFactory: { name: 'fallback' },
+});
+
+describe('GenericStrategyFactory', () => {
+  it('throws when choicePipeline is missing', () => {
+    const deps = createDeps();
+    delete deps.choicePipeline;
+    expect(() => new GenericStrategyFactory(deps)).toThrow(
+      'GenericStrategyFactory: choicePipeline is required'
+    );
+  });
+
+  it('throws when decisionProvider is missing', () => {
+    const deps = createDeps();
+    delete deps.decisionProvider;
+    expect(() => new GenericStrategyFactory(deps)).toThrow(
+      'GenericStrategyFactory: decisionProvider is required'
+    );
+  });
+
+  it('throws when turnActionFactory is missing', () => {
+    const deps = createDeps();
+    delete deps.turnActionFactory;
+    expect(() => new GenericStrategyFactory(deps)).toThrow(
+      'GenericStrategyFactory: turnActionFactory is required'
+    );
+  });
+
+  it('throws when logger is missing', () => {
+    const deps = createDeps();
+    delete deps.logger;
+    expect(() => new GenericStrategyFactory(deps)).toThrow(
+      'GenericStrategyFactory: logger is required'
+    );
+  });
+
+  it('creates GenericTurnStrategy and logs creation', () => {
+    const deps = createDeps();
+    const factory = new GenericStrategyFactory(deps);
+    const strategy = factory.create('actor1');
+    expect(strategy).toBeInstanceOf(GenericTurnStrategy);
+    expect(strategy.choicePipeline).toBe(deps.choicePipeline);
+    expect(strategy.decisionProvider).toBe(deps.decisionProvider);
+    expect(strategy.turnActionFactory).toBe(deps.turnActionFactory);
+    expect(strategy.logger).toBe(deps.logger);
+    expect(strategy.fallbackFactory).toBe(deps.fallbackFactory);
+    expect(deps.logger.debug).toHaveBeenCalledWith(
+      'GenericStrategyFactory: Creating new GenericTurnStrategy for actor actor1 using TestProvider.'
+    );
+  });
+});


### PR DESCRIPTION
Summary: Adds a new unit test for GenericStrategyFactory covering construction validation and normal creation flows.

Changes Made:
- Created `genericStrategyFactory.test.js` verifying error branches and successful creation.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685fc9e432288331baf7dc312b24a7e2