### PR TITLE
[Agent] fix lint warnings in llm-proxy-server

### DIFF
--- a/llm-proxy-server/src/config/llmConfigService.js
+++ b/llm-proxy-server/src/config/llmConfigService.js
@@ -299,7 +299,8 @@ export class LlmConfigService {
    */
   getInitializationErrorDetails() {
     if (!this.#initializationError) return null;
-    const { originalError: _unused, ...safe } = this.#initializationError;
+    const { originalError, ...safe } = this.#initializationError;
+    void originalError; // prevent unused variable lint warning
     return safe;
   }
 

--- a/llm-proxy-server/src/interfaces/ILlmConfigService.js
+++ b/llm-proxy-server/src/interfaces/ILlmConfigService.js
@@ -1,5 +1,10 @@
 // llm-proxy-server/src/interfaces/ILlmConfigService.js
 /**
+ * @typedef {import('../config/llmConfigService.js').LLMConfigurationFileForProxy} LLMConfigurationFileForProxy
+ * @typedef {import('../config/llmConfigService.js').LLMModelConfig} LLMModelConfig
+ * @typedef {import('../config/llmConfigService.js').StandardizedErrorObject} StandardizedErrorObject
+ */
+/**
  * @interface ILlmConfigService
  * @description Defines an interface for working with LLM configuration data.
  */


### PR DESCRIPTION
## Summary
- resolve unused var in `getInitializationErrorDetails`
- import JSDoc types for `ILlmConfigService`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 724 errors, 2679 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`
- `npm run start` *(fails: missing config file)*

------
https://chatgpt.com/codex/tasks/task_e_685fcaa908548331b25156512121d880