### PR TITLE
[Agent] Fix lint issues in two modules

### DIFF
--- a/src/domUI/processingIndicatorController.js
+++ b/src/domUI/processingIndicatorController.js
@@ -32,14 +32,6 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
   #indicatorElement = null;
 
   /**
-   * The speech input element, if handling player input indication.
-   *
-   * @private
-   * @type {HTMLInputElement | null}
-   */
-  #speechInputElement = null;
-
-  /**
    * The DomElementFactory instance.
    *
    * @private
@@ -106,7 +98,6 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
     this.#initializeIndicatorElement();
 
     if (this.elements.speechInputForPlayerIndicator) {
-      this.#speechInputElement = this.elements.speechInputForPlayerIndicator;
       this.logger.debug(
         `${this._logPrefix} Speech input element for player indicator cached.`
       );
@@ -252,7 +243,7 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
    * Determines the player type from turn started event payload.
    *
    * @param {any} payload - The turn started event payload
-   * @returns {IndicatorType}
+   * @returns {IndicatorType} Resolved player type
    * @private
    */
   #determinePlayerType(payload) {
@@ -359,7 +350,6 @@ export class ProcessingIndicatorController extends BoundDomRendererBase {
       );
     }
     this.#indicatorElement = null;
-    this.#speechInputElement = null; // Clear reference
 
     this.logger.debug(
       `${this._logPrefix} ProcessingIndicatorController disposed.`

--- a/src/initializers/worldInitializer.js
+++ b/src/initializers/worldInitializer.js
@@ -49,13 +49,11 @@ class WorldInitializer {
   #validatedEventDispatcher;
   /** @type {ILogger} */
   #logger;
-  /** @type {IScopeRegistry} */
-  #scopeRegistry;
 
   /**
    * Exposes the provided world context for potential external use.
    *
-   * @returns {IWorldContext}
+   * @returns {IWorldContext} The current world context
    */
   getWorldContext() {
     return this.#worldContext;
@@ -64,13 +62,13 @@ class WorldInitializer {
   /**
    * Creates an instance of WorldInitializer.
    *
-   * @param {object} dependencies
-   * @param {IEntityManager} dependencies.entityManager
-   * @param {IWorldContext} dependencies.worldContext
-   * @param {IGameDataRepository} dependencies.gameDataRepository
-   * @param {ValidatedEventDispatcher} dependencies.validatedEventDispatcher
-   * @param {ILogger} dependencies.logger
-   * @param {IScopeRegistry} dependencies.scopeRegistry
+   * @param {object} dependencies - Injected dependencies
+   * @param {IEntityManager} dependencies.entityManager - Entity management service
+   * @param {IWorldContext} dependencies.worldContext - World context reference
+   * @param {IGameDataRepository} dependencies.gameDataRepository - Repository for game data
+   * @param {ValidatedEventDispatcher} dependencies.validatedEventDispatcher - Event dispatcher
+   * @param {ILogger} dependencies.logger - Logger instance
+   * @param {IScopeRegistry} dependencies.scopeRegistry - Registry used for scope initialization
    * @throws {Error} If any required dependency is missing or invalid.
    */
   constructor({
@@ -122,7 +120,6 @@ class WorldInitializer {
     this.#repository = gameDataRepository;
     this.#validatedEventDispatcher = validatedEventDispatcher;
     this.#logger = logger;
-    this.#scopeRegistry = scopeRegistry;
 
     this.#logger.debug(
       'WorldInitializer: Instance created. Spatial index management is now handled by SpatialIndexSynchronizer through event listening.'


### PR DESCRIPTION
## Summary
- clean up unused variable in ProcessingIndicatorController and document return type
- remove unused field from WorldInitializer and add missing JSDoc descriptions

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fcabd157083319fd4f8d75a489a9f