### PR TITLE
[Fix] Remove await from safeDispatchError calls

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -157,7 +157,7 @@ class CommandProcessor extends ICommandProcessor {
     actionId,
   }) {
     this.#logger.error(internalMsg);
-    await safeDispatchError(
+    safeDispatchError(
       this.#safeEventDispatcher,
       userMsg,
       this.#createErrorDetails(internalMsg),
@@ -260,7 +260,7 @@ class CommandProcessor extends ICommandProcessor {
         dispatchError
       );
       // If dispatch itself throws, it's a more fundamental issue.
-      await safeDispatchError(
+      safeDispatchError(
         this.#safeEventDispatcher,
         'System error during event dispatch.',
         this.#createErrorDetails(


### PR DESCRIPTION
Summary: Removed unnecessary await keywords before safeDispatchError invocations.

Changes Made:
- Updated commandProcessor.js to call safeDispatchError without awaiting.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_685fd5b1acfc8331b91e934e7e9ff830