### PR TITLE
[Test] Improve auxiliary UI initializers coverage

### DIFF
--- a/tests/unit/bootstrapper/stages/auxiliary/initCurrentTurnActorRenderer.test.js
+++ b/tests/unit/bootstrapper/stages/auxiliary/initCurrentTurnActorRenderer.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { initCurrentTurnActorRenderer } from '../../../../../src/bootstrapper/stages/auxiliary/initCurrentTurnActorRenderer.js';
+import StageError from '../../../../../src/bootstrapper/StageError.js';
+import {
+  stageSuccess,
+  stageFailure,
+} from '../../../../../src/bootstrapper/helpers.js';
+
+jest.mock('../../../../../src/bootstrapper/helpers.js', () => ({
+  __esModule: true,
+  stageSuccess: jest.fn(() => ({ success: true })),
+  stageFailure: jest.fn((phase, message, cause) => ({
+    success: false,
+    error:
+      new (require('../../../../../src/bootstrapper/StageError.js').default)(
+        phase,
+        message,
+        cause
+      ),
+  })),
+}));
+
+/**
+ * Create a basic logger mock.
+ *
+ * @returns {{debug: jest.Mock, warn: jest.Mock, error: jest.Mock}} Logger mock
+ */
+function createLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+const tokens = { CurrentTurnActorRenderer: 'CurrentTurnActorRenderer' };
+
+describe('initCurrentTurnActorRenderer', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns success when renderer resolves', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => ({ stub: true })) };
+    const result = initCurrentTurnActorRenderer({ container, logger, tokens });
+    expect(container.resolve).toHaveBeenCalledWith(
+      tokens.CurrentTurnActorRenderer
+    );
+    expect(stageSuccess).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init: Resolving CurrentTurnActorRenderer...'
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init: Resolved successfully.'
+    );
+  });
+
+  it('returns failure when renderer is missing', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => null) };
+    const result = initCurrentTurnActorRenderer({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init',
+      'CurrentTurnActorRenderer could not be resolved.'
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init: CurrentTurnActorRenderer could not be resolved.'
+    );
+  });
+
+  it('returns failure when container.resolve throws', () => {
+    const logger = createLogger();
+    const error = new Error('boom');
+    const container = {
+      resolve: jest.fn(() => {
+        throw error;
+      }),
+    };
+    const result = initCurrentTurnActorRenderer({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init',
+      error.message,
+      error
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'CurrentTurnActorRenderer Init: Error during resolution.',
+      error
+    );
+  });
+});

--- a/tests/unit/bootstrapper/stages/auxiliary/initLlmSelectionModal.test.js
+++ b/tests/unit/bootstrapper/stages/auxiliary/initLlmSelectionModal.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { initLlmSelectionModal } from '../../../../../src/bootstrapper/stages/auxiliary/initLlmSelectionModal.js';
+import StageError from '../../../../../src/bootstrapper/StageError.js';
+import {
+  stageSuccess,
+  stageFailure,
+} from '../../../../../src/bootstrapper/helpers.js';
+
+jest.mock('../../../../../src/bootstrapper/helpers.js', () => ({
+  __esModule: true,
+  stageSuccess: jest.fn(() => ({ success: true })),
+  stageFailure: jest.fn((phase, message, cause) => ({
+    success: false,
+    error:
+      new (require('../../../../../src/bootstrapper/StageError.js').default)(
+        phase,
+        message,
+        cause
+      ),
+  })),
+}));
+
+/**
+ * Create a basic logger mock.
+ *
+ * @returns {{debug: jest.Mock, warn: jest.Mock, error: jest.Mock}} Logger mock
+ */
+function createLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+const tokens = { LlmSelectionModal: 'LlmSelectionModal' };
+
+describe('initLlmSelectionModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns success when modal resolves', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => ({ stub: true })) };
+    const result = initLlmSelectionModal({ container, logger, tokens });
+    expect(container.resolve).toHaveBeenCalledWith(tokens.LlmSelectionModal);
+    expect(stageSuccess).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'LlmSelectionModal Init: Resolving LlmSelectionModal...'
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'LlmSelectionModal Init: Resolved successfully.'
+    );
+  });
+
+  it('returns failure when modal is missing', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => null) };
+    const result = initLlmSelectionModal({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'LlmSelectionModal Init',
+      'LlmSelectionModal could not be resolved.'
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'LlmSelectionModal Init: LlmSelectionModal could not be resolved.'
+    );
+  });
+
+  it('returns failure when container.resolve throws', () => {
+    const logger = createLogger();
+    const error = new Error('boom');
+    const container = {
+      resolve: jest.fn(() => {
+        throw error;
+      }),
+    };
+    const result = initLlmSelectionModal({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'LlmSelectionModal Init',
+      error.message,
+      error
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'LlmSelectionModal Init: Error during resolution.',
+      error
+    );
+  });
+});

--- a/tests/unit/bootstrapper/stages/auxiliary/initSpeechBubbleRenderer.test.js
+++ b/tests/unit/bootstrapper/stages/auxiliary/initSpeechBubbleRenderer.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { initSpeechBubbleRenderer } from '../../../../../src/bootstrapper/stages/auxiliary/initSpeechBubbleRenderer.js';
+import StageError from '../../../../../src/bootstrapper/StageError.js';
+import {
+  stageSuccess,
+  stageFailure,
+} from '../../../../../src/bootstrapper/helpers.js';
+
+jest.mock('../../../../../src/bootstrapper/helpers.js', () => ({
+  __esModule: true,
+  stageSuccess: jest.fn(() => ({ success: true })),
+  stageFailure: jest.fn((phase, message, cause) => ({
+    success: false,
+    error:
+      new (require('../../../../../src/bootstrapper/StageError.js').default)(
+        phase,
+        message,
+        cause
+      ),
+  })),
+}));
+
+/**
+ * Create a basic logger mock.
+ *
+ * @returns {{debug: jest.Mock, warn: jest.Mock, error: jest.Mock}} Logger mock
+ */
+function createLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+const tokens = { SpeechBubbleRenderer: 'SpeechBubbleRenderer' };
+
+describe('initSpeechBubbleRenderer', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns success when renderer resolves', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => ({ stub: true })) };
+    const result = initSpeechBubbleRenderer({ container, logger, tokens });
+    expect(container.resolve).toHaveBeenCalledWith(tokens.SpeechBubbleRenderer);
+    expect(stageSuccess).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init: Resolving SpeechBubbleRenderer...'
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init: Resolved successfully.'
+    );
+  });
+
+  it('returns failure when renderer is missing', () => {
+    const logger = createLogger();
+    const container = { resolve: jest.fn(() => null) };
+    const result = initSpeechBubbleRenderer({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init',
+      'SpeechBubbleRenderer could not be resolved.'
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init: SpeechBubbleRenderer could not be resolved.'
+    );
+  });
+
+  it('returns failure when container.resolve throws', () => {
+    const logger = createLogger();
+    const error = new Error('boom');
+    const container = {
+      resolve: jest.fn(() => {
+        throw error;
+      }),
+    };
+    const result = initSpeechBubbleRenderer({ container, logger, tokens });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(StageError);
+    expect(stageFailure).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init',
+      error.message,
+      error
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'SpeechBubbleRenderer Init: Error during resolution.',
+      error
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added comprehensive unit tests for auxiliary UI initializer modules to improve branch coverage.

Changes Made:
- Added tests for `initCurrentTurnActorRenderer`, `initLlmSelectionModal`, and `initSpeechBubbleRenderer` covering success, missing dependency, and error paths.
- Ensured logger interactions and stage results are validated.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and llm-proxy-server)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_685fd838a37483318ba0799236d04f54