### PR TITLE
[Agent] update CommandProcessor options usage

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -28,15 +28,20 @@ class CommandProcessor extends ICommandProcessor {
   constructor(options) {
     super();
 
-    const { logger, safeEventDispatcher: dispatcher } = options || {};
+    const { logger, safeEventDispatcher } = options || {};
 
     this.#logger = initLogger('CommandProcessor', logger);
 
-    validateDependency(dispatcher, 'safeEventDispatcher', this.#logger, {
-      requiredMethods: ['dispatch'],
-    });
+    validateDependency(
+      safeEventDispatcher,
+      'safeEventDispatcher',
+      this.#logger,
+      {
+        requiredMethods: ['dispatch'],
+      }
+    );
 
-    this.#safeEventDispatcher = dispatcher;
+    this.#safeEventDispatcher = safeEventDispatcher;
 
     this.#logger.debug(
       'CommandProcessor: Instance created and dependencies validated.'


### PR DESCRIPTION
Summary:
- update CommandProcessor constructor to pull safeEventDispatcher directly
- keep initialization and validation with the new variable

Testing Done:
- `npm run test` *(all suites)*
- `npx jest tests/unit/commands/commandProcessor.test.js --runInBand`
- `cd llm-proxy-server && npm run test`
- `npx jest tests/apiKeyService.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685fdd16b37c8331a5f0ac4012907692