### PR TITLE
[Agent] pass logger to safeDispatchError

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -152,7 +152,8 @@ function applyTargetFormatter(command, targetContext, options) {
     safeDispatchError(
       dispatcher,
       `formatActionCommand: Error during placeholder substitution for action ${actionDefinition.id}:`,
-      { error: error.message, stack: error.stack }
+      { error: error.message, stack: error.stack },
+      logger
     );
     return buildFormatError('placeholder substitution failed', error.message);
   }


### PR DESCRIPTION
## Summary
- include logger when dispatching placeholder substitution errors

## Testing
- `npm run lint` *(fails: 716 errors, 2657 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685fdd284b2883319c125ed7881760cd