### PR TITLE
[Agent] add missing JSDoc descriptions

### DIFF
--- a/src/entities/services/errorTranslator.js
+++ b/src/entities/services/errorTranslator.js
@@ -22,6 +22,8 @@ export class ErrorTranslator {
   #logger;
 
   /**
+   * Creates a new ErrorTranslator instance.
+   *
    * @param {object} deps - Dependencies
    * @param {ILogger} deps.logger - Logger instance
    */

--- a/src/errors/invalidActorEntityError.js
+++ b/src/errors/invalidActorEntityError.js
@@ -10,6 +10,8 @@
  */
 export class InvalidActorEntityError extends Error {
   /**
+   * Creates a new InvalidActorEntityError instance.
+   *
    * @param {string} [message] - Optional custom message.
    */
   constructor(message = 'Invalid actor entity') {

--- a/src/errors/invalidArgumentError.js
+++ b/src/errors/invalidArgumentError.js
@@ -10,6 +10,8 @@
  */
 export class InvalidArgumentError extends Error {
   /**
+   * Creates a new InvalidArgumentError instance.
+   *
    * @param {string} message - The error message describing the invalid argument.
    * @param {string} [parameterName] - The name of the parameter that was invalid.
    * @param {any} [receivedValue] - The actual value that was received.


### PR DESCRIPTION
## Summary
- fix JSDoc warnings in error modules and ErrorTranslator constructor

## Testing Done
- `npm run lint` *(fails: remaining issues across repo)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fe310ab5c83318b04fc173675f9e3