### PR TITLE
[Agent] document failure result helper

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -194,6 +194,15 @@ class CommandProcessor extends ICommandProcessor {
     };
   }
 
+  /**
+   * @description Creates a standardized failure {@link CommandResult}.
+   * @param {string} [userError] - User-facing error message.
+   * @param {string} [internalError] - Internal error message for logging.
+   * @param {string} [originalInput] - The command string that was processed.
+   * @param {string} [actionId] - Identifier of the attempted action.
+   * @param {boolean} [turnEnded] - Indicates if the turn should end.
+   * @returns {CommandResult} The failure result object.
+   */
   #createFailureResult(
     userError,
     internalError,


### PR DESCRIPTION
## Summary
- add documentation for `#createFailureResult`

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685fe31f1dd483319134b1fe82149612