### PR TITLE
[Agent] Fix lint issues in three modules

### DIFF
--- a/src/entities/entityManager.js
+++ b/src/entities/entityManager.js
@@ -19,10 +19,8 @@
 import { createDefaultDeps } from './utils/createDefaultDeps.js';
 import Entity from './entity.js';
 import EntityInstanceData from './entityInstanceData.js';
-import EntityFactory from './factories/entityFactory.js';
 import EntityRepositoryAdapter from './services/entityRepositoryAdapter.js';
 import ComponentMutationService from './services/componentMutationService.js';
-import ErrorTranslator from './services/errorTranslator.js';
 import DefinitionCache from './services/definitionCache.js';
 import EntityLifecycleManager from './services/entityLifecycleManager.js';
 import { createDefaultServices } from './utils/createDefaultServices.js';
@@ -108,14 +106,8 @@ class EntityManager extends IEntityManager {
   /** @type {ComponentMutationService} @private */
   #componentMutationService;
 
-  /** @type {ErrorTranslator} @private */
-  #errorTranslator;
-
   /** @type {DefinitionCache} @private */
   #definitionCache;
-
-  /** @type {EntityFactory} @private */
-  #factory;
 
   /** @type {EntityLifecycleManager} @private */
   #lifecycleManager;
@@ -156,8 +148,6 @@ class EntityManager extends IEntityManager {
    * @param {Function}             [deps.defaultPolicyFactory] - Factory for the default component policy.
    * @param {EntityRepositoryAdapter} [deps.entityRepository] - EntityRepositoryAdapter instance.
    * @param {ComponentMutationService} [deps.componentMutationService] - ComponentMutationService instance.
-   * @param {ErrorTranslator} [deps.errorTranslator] - ErrorTranslator instance.
-   * @param {EntityFactory} [deps.entityFactory] - EntityFactory instance.
    * @param deps.entityLifecycleManager
    * @param {DefinitionCache} [deps.definitionCache] - DefinitionCache instance.
    * @throws {Error} If any dependency is missing or malformed.
@@ -175,8 +165,6 @@ class EntityManager extends IEntityManager {
     defaultPolicyFactory,
     entityRepository,
     componentMutationService,
-    errorTranslator,
-    entityFactory,
     definitionCache,
     entityLifecycleManager,
   } = {}) {
@@ -251,11 +239,6 @@ class EntityManager extends IEntityManager {
       componentMutationService,
       serviceDefaults.componentMutationService
     );
-    this.#errorTranslator = resolveDep(
-      errorTranslator,
-      serviceDefaults.errorTranslator
-    );
-    this.#factory = resolveDep(entityFactory, serviceDefaults.entityFactory);
     this.#definitionCache = resolveDep(
       definitionCache,
       serviceDefaults.definitionCache

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -128,8 +128,9 @@ class JsonLogicEvaluationService extends BaseService {
 
         // Only do detailed logging if we're not in a test environment
         const isTestEnv =
-          (typeof global !== 'undefined' && global.jest) ||
-          process.env.NODE_ENV === 'test';
+          (typeof globalThis !== 'undefined' && globalThis.jest) ||
+          (typeof globalThis.process !== 'undefined' &&
+            globalThis.process.env.NODE_ENV === 'test');
         if (
           (op === 'and' || op === 'or') &&
           Array.isArray(args) &&

--- a/src/turns/prompting/promptSession.js
+++ b/src/turns/prompting/promptSession.js
@@ -101,8 +101,8 @@ export class PromptSession {
 
     // macrotask – gives callers a full tick to attach handlers
     const defer =
-      typeof setImmediate === 'function'
-        ? setImmediate // Node
+      typeof globalThis.setImmediate === 'function'
+        ? globalThis.setImmediate // Node
         : (fn) => setTimeout(fn); // browser / JSDOM fallback
 
     defer(() => {


### PR DESCRIPTION
## Summary
- remove unused imports and fields from `entityManager`
- fix test environment detection in `jsonLogicEvaluationService`
- use `globalThis.setImmediate` fallback in `promptSession`

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fedbc4f788331a97bae2b8b5b305f