### PR TITLE
[Agent] Fix lint issues in selected modules

### DIFF
--- a/src/ai/notesService.js
+++ b/src/ai/notesService.js
@@ -23,9 +23,9 @@ export default class NotesService {
   /**
    * Creates a new NotesService.
    *
-   * @param {object} [options] - Configuration options. Currently unused.
+   * @param {object} [_options] - Configuration options. Currently unused.
    */
-  constructor(options = {}) {
+  constructor(_options = {}) {
     // No options needed yet, but keeping for future-proofing.
   }
 

--- a/src/alerting/throttler.js
+++ b/src/alerting/throttler.js
@@ -15,7 +15,7 @@
  * @typedef {object} ThrottleEntry
  * @property {number} firstTimestamp - The time the first event for this key arrived (ms since epoch).
  * @property {number} suppressedCount - The number of duplicates suppressed.
- * @property {NodeJS.Timeout} timerId - The ID of the setTimeout timer for the summary check.
+ * @property {ReturnType<typeof setTimeout>} timerId - The ID of the setTimeout timer for the summary check.
  * @property {object} originalPayload - The payload of the first event, stored for the summary.
  */
 

--- a/src/context/worldContext.js
+++ b/src/context/worldContext.js
@@ -61,8 +61,6 @@ class WorldContext extends IWorldContext {
     ) {
       const errorMsg =
         'WorldContext requires a valid EntityManager instance with getEntitiesWithComponent and getEntityInstance methods.';
-      // Log directly to console if logger might not be set up
-      console.error(errorMsg);
       throw new Error(errorMsg);
     }
     if (


### PR DESCRIPTION
## Summary
- rename unused constructor param in `notesService`
- clarify throttler timer property type
- remove console usage in `worldContext`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 711 errors, 2654 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686016a3acdc8331813124cd143057af