### PR TITLE
[Agent] Extract error details utility

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -6,6 +6,7 @@ import { ICommandProcessor } from './interfaces/ICommandProcessor.js';
 import { initLogger } from '../utils/index.js';
 import { validateDependency, assertValidId } from '../utils/dependencyUtils.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { createErrorDetails } from '../utils/errorDetails.js';
 
 // --- Type Imports ---
 /** @typedef {import('../entities/entity.js').default} Entity */
@@ -165,7 +166,7 @@ class CommandProcessor extends ICommandProcessor {
     safeDispatchError(
       this.#safeEventDispatcher,
       userMsg,
-      this.#createErrorDetails(internalMsg),
+      createErrorDetails(internalMsg),
       this.#logger
     );
     return this.#createFailureResult(
@@ -223,20 +224,6 @@ class CommandProcessor extends ICommandProcessor {
     return result;
   }
 
-  /**
-   * @description Creates standardized error details for safeDispatchError.
-   * @param {string} rawMessage - The raw internal error message.
-   * @param {string} [stackOverride] - Stack trace to attach.
-   * @returns {{raw: string, timestamp: string, stack: string}} Error details object.
-   */
-  #createErrorDetails(rawMessage, stackOverride = new Error().stack) {
-    return {
-      raw: rawMessage,
-      timestamp: new Date().toISOString(),
-      stack: stackOverride,
-    };
-  }
-
   async #dispatchWithErrorHandling(eventName, payload, loggingContextName) {
     this.#logger.debug(
       `CommandProcessor.#dispatchWithErrorHandling: Attempting dispatch: ${loggingContextName} ('${eventName}')`
@@ -277,7 +264,7 @@ class CommandProcessor extends ICommandProcessor {
       safeDispatchError(
         this.#safeEventDispatcher,
         'System error during event dispatch.',
-        this.#createErrorDetails(
+        createErrorDetails(
           `Exception in dispatch for ${eventName}`,
           dispatchError?.stack || new Error().stack
         ),

--- a/src/utils/errorDetails.js
+++ b/src/utils/errorDetails.js
@@ -1,0 +1,25 @@
+// src/utils/errorDetails.js
+
+/**
+ * @file Utility for creating standardized error details objects.
+ */
+
+/**
+ * Creates standardized error detail information for system error dispatching.
+ *
+ * @description Generates an object containing the raw error message,
+ * a timestamp, and a stack trace. A custom stack trace can be supplied
+ * for cases where the standard `Error().stack` is insufficient.
+ * @param {string} message - The raw internal error message.
+ * @param {string} [stackOverride] - Optional stack trace to attach.
+ * @returns {{raw: string, timestamp: string, stack: string}} Structured error details.
+ */
+export function createErrorDetails(message, stackOverride = new Error().stack) {
+  return {
+    raw: message,
+    timestamp: new Date().toISOString(),
+    stack: stackOverride,
+  };
+}
+
+// --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,3 +27,4 @@ export {
   validateDependency,
   validateDependencies,
 } from './dependencyUtils.js';
+export { createErrorDetails } from './errorDetails.js';

--- a/tests/unit/utils/errorDetails.test.js
+++ b/tests/unit/utils/errorDetails.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from '@jest/globals';
+import { createErrorDetails } from '../../../src/utils/errorDetails.js';
+
+describe('createErrorDetails', () => {
+  it('returns error details with provided stack', () => {
+    const details = createErrorDetails('boom', 'my-stack');
+    expect(details).toEqual({
+      raw: 'boom',
+      timestamp: expect.any(String),
+      stack: 'my-stack',
+    });
+    expect(new Date(details.timestamp).toISOString()).toBe(details.timestamp);
+  });
+
+  it('uses default stack when none provided', () => {
+    const details = createErrorDetails('oops');
+    expect(details.raw).toBe('oops');
+    expect(details.stack).toEqual(expect.any(String));
+    expect(new Date(details.timestamp).toISOString()).toBe(details.timestamp);
+  });
+});


### PR DESCRIPTION
## Summary
- move error detail creation into `createErrorDetails`
- use it in `CommandProcessor`
- export utility via utils index
- add unit tests for error details

## Testing Done
- `npm run lint` *(fails: 3361 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686020dedcec8331be8f3e02bd81cf02