### PR TITLE
[Agent] Document constructor options for CommandProcessor

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -26,6 +26,14 @@ class CommandProcessor extends ICommandProcessor {
   /** @type {ISafeEventDispatcher} */
   #safeEventDispatcher;
 
+  /**
+   * Creates an instance of CommandProcessor.
+   *
+   * @param {object} options - Configuration options for the processor.
+   * @param {ISafeEventDispatcher} options.safeEventDispatcher - Required event dispatcher that must implement `dispatch`.
+   * @param {ILogger} [options.logger] - Optional logger instance.
+   * @throws {Error} If `safeEventDispatcher` is missing or lacks a `dispatch` method.
+   */
   constructor(options) {
     super();
 


### PR DESCRIPTION
## Summary
- add detailed JSDoc for the `CommandProcessor` constructor

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686025b5bdec83319d564fec330db521