### PR TITLE
[Agent] fix lint issues across modules

### DIFF
--- a/src/domUI/inputStateController.js
+++ b/src/domUI/inputStateController.js
@@ -6,6 +6,15 @@ import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
  * @typedef {import('../interfaces/ILogger').ILogger} ILogger
  * @typedef {import('../interfaces/IDocumentContext.js').IDocumentContext} IDocumentContext
  * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ * @typedef {object} DisableInputEvent
+ * @property {string} type - Event identifier
+ * @property {{message?: string}} payload - Optional payload
+ */
+
+/**
+ * @typedef {object} EnableInputEvent
+ * @property {string} type - Event identifier
+ * @property {{placeholder?: string}} payload - Optional payload
  */
 
 /**
@@ -92,8 +101,6 @@ export class InputStateController extends RendererBase {
    * @private
    */
   #subscribeToEvents() {
-    const ved = this.validatedEventDispatcher; // Alias for brevity
-
     // Subscribe to events using helper
     this._subscribe('core:disable_input', this.#handleDisableInput.bind(this));
 

--- a/src/domUI/titleRenderer.js
+++ b/src/domUI/titleRenderer.js
@@ -72,8 +72,6 @@ export class TitleRenderer extends RendererBase {
    * @private
    */
   #subscribeToEvents() {
-    const ved = this.validatedEventDispatcher; // Alias for brevity
-
     // Direct title setting
     this._subscribe('core:set_title', this.#handleSetTitle.bind(this));
 

--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -62,17 +62,22 @@ class PlaytimeTracker extends IPlaytimeTracker {
     super();
 
     if (!logger || typeof logger.info !== 'function') {
+      // eslint-disable-next-line no-console
       console.error(
         'PlaytimeTracker: Logger dependency is missing or invalid. Falling back to console.error.'
       );
       // Fallback logger for environments where a full logger isn't available or during initial setup
       this.#logger = {
+         
         info: (message) =>
           console.info(`PlaytimeTracker (fallback): ${message}`),
+         
         warn: (message) =>
           console.warn(`PlaytimeTracker (fallback): ${message}`),
+         
         error: (message) =>
           console.error(`PlaytimeTracker (fallback): ${message}`),
+         
         debug: (message) =>
           console.debug(`PlaytimeTracker (fallback): ${message}`),
       };
@@ -203,7 +208,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
    * FOR TESTING PURPOSES ONLY.
    * Gets the current accumulated playtime in seconds.
    *
-   * @returns {number}
+   * @returns {number} The accumulated playtime in seconds.
    * @private
    */
   _getAccumulatedPlaytimeSeconds() {
@@ -214,7 +219,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
    * FOR TESTING PURPOSES ONLY.
    * Gets the current session start time.
    *
-   * @returns {number}
+   * @returns {number} The session start timestamp.
    * @private
    */
   _getSessionStartTime() {

--- a/tests/integration/scopeEngineSingletonLocationContext.test.js
+++ b/tests/integration/scopeEngineSingletonLocationContext.test.js
@@ -98,7 +98,7 @@ describe('Singleton Scope Engine Location Context', () => {
 
     // Set up registry with actions and conditions
     registry = new InMemoryDataRegistry({ logger });
-    
+
     // Register actions
     registry.store('actions', 'core:follow', {
       id: 'core:follow',
@@ -155,7 +155,7 @@ describe('Singleton Scope Engine Location Context', () => {
 
     // Set up services
     const gameDataRepository = new GameDataRepository(registry, logger);
-    
+
     const jsonLogicEval = new JsonLogicEvaluationService({
       logger,
       gameDataRepository,
@@ -222,7 +222,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(goActions[0].params.targetId).toBe('town');
 
     // Move hero to town
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     // Get actions with new location
     actions = await actionDiscoveryService.getValidActions(heroActor, {
@@ -250,7 +252,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(followActions[0].command).toBe('follow Ninja');
 
     // Move hero to town (ninja stays in guild)
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     actions = await actionDiscoveryService.getValidActions(heroActor, {
       currentLocation: townLocation,
@@ -260,7 +264,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(followActions).toHaveLength(0); // No one to follow in town
 
     // Move ninja to town as well
-    entityManager.addComponent('ninja', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('ninja', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     actions = await actionDiscoveryService.getValidActions(heroActor, {
       currentLocation: townLocation,
@@ -275,9 +281,14 @@ describe('Singleton Scope Engine Location Context', () => {
     const heroActor = entityManager.getEntityInstance('hero');
     const guildLocation = entityManager.getEntityInstance('guild');
     const townLocation = entityManager.getEntityInstance('town');
-    
+
     // Test multiple moves to ensure singleton doesn't cache location
-    const locations = [guildLocation, townLocation, guildLocation, townLocation];
+    const locations = [
+      guildLocation,
+      townLocation,
+      guildLocation,
+      townLocation,
+    ];
     const expectedExits = ['town', 'guild', 'town', 'guild'];
 
     for (let i = 0; i < locations.length; i++) {
@@ -312,7 +323,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(ninjaGo[0].params.targetId).toBe('town');
 
     // Move hero to town
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     // Check hero's actions (should see guild exit, not town)
     let heroActions = await actionDiscoveryService.getValidActions(heroActor, {

--- a/tests/nodes/stepResolver.components.test.js
+++ b/tests/nodes/stepResolver.components.test.js
@@ -1,6 +1,9 @@
 import { jest } from '@jest/globals';
 import createStepResolver from '../../src/scopeDsl/nodes/stepResolver.js';
-import { createMockEntity, createTestEntity } from '../common/mockFactories/entities.js';
+import {
+  createMockEntity,
+  createTestEntity,
+} from '../common/mockFactories/entities.js';
 
 describe('StepResolver - components edge access', () => {
   let resolver;
@@ -107,7 +110,7 @@ describe('StepResolver - components edge access', () => {
       const components = [...result][0];
       // Should return empty components object, not the entity's components
       expect(components).toEqual({});
-      
+
       // Should log a warning
       expect(trace.addLog).toHaveBeenCalledWith(
         'warn',
@@ -129,15 +132,17 @@ describe('StepResolver - components edge access', () => {
 
       dispatcher.resolve.mockReturnValue(new Set(['entity1']));
       entitiesGateway.getEntityInstance.mockReturnValue(entityWithoutMethod);
-      
+
       // Mock the gateway's getComponentData
-      entitiesGateway.getComponentData.mockImplementation((entityId, componentId) => {
-        const data = {
-          'core:name': { first: 'Gateway', last: 'Data' },
-          'core:actor': { type: 'player' },
-        };
-        return data[componentId];
-      });
+      entitiesGateway.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          const data = {
+            'core:name': { first: 'Gateway', last: 'Data' },
+            'core:actor': { type: 'player' },
+          };
+          return data[componentId];
+        }
+      );
 
       const result = resolver.resolve(node, ctx);
 
@@ -147,8 +152,14 @@ describe('StepResolver - components edge access', () => {
         'core:name': { first: 'Gateway', last: 'Data' },
         'core:actor': { type: 'player' },
       });
-      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith('entity1', 'core:name');
-      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith('entity1', 'core:actor');
+      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith(
+        'entity1',
+        'core:name'
+      );
+      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith(
+        'entity1',
+        'core:actor'
+      );
     });
 
     it('should handle entity not found in gateway', () => {
@@ -181,10 +192,10 @@ describe('StepResolver - components edge access', () => {
 
       expect(result.size).toBe(2);
       const componentsArray = [...result];
-      
+
       // First entity should have core:actor component
       expect(componentsArray[0]).toHaveProperty('core:actor');
-      
+
       // Second entity should have core:position component
       expect(componentsArray[1]).toEqual({
         'core:position': { location: 'loc1' },


### PR DESCRIPTION
## Summary
- clean up InputStateController event typedefs and subscription logic
- remove unused variable from TitleRenderer
- silence console warnings and improve JSDoc in PlaytimeTracker
- format updated tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686025a3d648833192f9cdad98e94aa4