### PR TITLE
[Agent] refactor dispatch logging

### DIFF
--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -53,6 +53,9 @@ describe('CommandProcessor.dispatchAction', () => {
         originalInput: 'look north',
       })
     );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'CommandProcessor.#dispatchWithErrorHandling: Dispatch successful for ATTEMPT_ACTION_ID dispatch for pre-resolved action look.'
+    );
   });
 
   it('returns failure when actor is missing an id', async () => {
@@ -171,6 +174,11 @@ describe('CommandProcessor.dispatchAction', () => {
       expect.any(Object),
       logger
     );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'CommandProcessor.#dispatchWithErrorHandling: SafeEventDispatcher reported failure for ATTEMPT_ACTION_ID dispatch for pre-resolved action take'
+      )
+    );
   });
 
   it('constructs expected failure result when dispatcher reports failure', async () => {
@@ -226,6 +234,10 @@ describe('CommandProcessor.dispatchAction', () => {
       'Internal error: Failed to initiate action.',
       expect.any(Object),
       logger
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'CommandProcessor.#dispatchWithErrorHandling: CRITICAL - Error during dispatch for ATTEMPT_ACTION_ID dispatch for pre-resolved action jump. Error: boom',
+      expect.any(Error)
     );
   });
 });


### PR DESCRIPTION
## Summary
- log dispatch outcomes in `CommandProcessor`
- add tests verifying log helpers

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' ...)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686025bcc6bc83319e48e8fe4631de89