### PR TITLE
[Agent] increase startup error handler coverage

### DIFF
--- a/tests/integration/scopeEngineSingletonLocationContext.test.js
+++ b/tests/integration/scopeEngineSingletonLocationContext.test.js
@@ -98,7 +98,7 @@ describe('Singleton Scope Engine Location Context', () => {
 
     // Set up registry with actions and conditions
     registry = new InMemoryDataRegistry({ logger });
-    
+
     // Register actions
     registry.store('actions', 'core:follow', {
       id: 'core:follow',
@@ -155,7 +155,7 @@ describe('Singleton Scope Engine Location Context', () => {
 
     // Set up services
     const gameDataRepository = new GameDataRepository(registry, logger);
-    
+
     const jsonLogicEval = new JsonLogicEvaluationService({
       logger,
       gameDataRepository,
@@ -222,7 +222,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(goActions[0].params.targetId).toBe('town');
 
     // Move hero to town
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     // Get actions with new location
     actions = await actionDiscoveryService.getValidActions(heroActor, {
@@ -250,7 +252,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(followActions[0].command).toBe('follow Ninja');
 
     // Move hero to town (ninja stays in guild)
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     actions = await actionDiscoveryService.getValidActions(heroActor, {
       currentLocation: townLocation,
@@ -260,7 +264,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(followActions).toHaveLength(0); // No one to follow in town
 
     // Move ninja to town as well
-    entityManager.addComponent('ninja', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('ninja', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     actions = await actionDiscoveryService.getValidActions(heroActor, {
       currentLocation: townLocation,
@@ -275,9 +281,14 @@ describe('Singleton Scope Engine Location Context', () => {
     const heroActor = entityManager.getEntityInstance('hero');
     const guildLocation = entityManager.getEntityInstance('guild');
     const townLocation = entityManager.getEntityInstance('town');
-    
+
     // Test multiple moves to ensure singleton doesn't cache location
-    const locations = [guildLocation, townLocation, guildLocation, townLocation];
+    const locations = [
+      guildLocation,
+      townLocation,
+      guildLocation,
+      townLocation,
+    ];
     const expectedExits = ['town', 'guild', 'town', 'guild'];
 
     for (let i = 0; i < locations.length; i++) {
@@ -312,7 +323,9 @@ describe('Singleton Scope Engine Location Context', () => {
     expect(ninjaGo[0].params.targetId).toBe('town');
 
     // Move hero to town
-    entityManager.addComponent('hero', POSITION_COMPONENT_ID, { locationId: 'town' });
+    entityManager.addComponent('hero', POSITION_COMPONENT_ID, {
+      locationId: 'town',
+    });
 
     // Check hero's actions (should see guild exit, not town)
     let heroActions = await actionDiscoveryService.getValidActions(heroActor, {

--- a/tests/nodes/stepResolver.components.test.js
+++ b/tests/nodes/stepResolver.components.test.js
@@ -1,6 +1,9 @@
 import { jest } from '@jest/globals';
 import createStepResolver from '../../src/scopeDsl/nodes/stepResolver.js';
-import { createMockEntity, createTestEntity } from '../common/mockFactories/entities.js';
+import {
+  createMockEntity,
+  createTestEntity,
+} from '../common/mockFactories/entities.js';
 
 describe('StepResolver - components edge access', () => {
   let resolver;
@@ -107,7 +110,7 @@ describe('StepResolver - components edge access', () => {
       const components = [...result][0];
       // Should return empty components object, not the entity's components
       expect(components).toEqual({});
-      
+
       // Should log a warning
       expect(trace.addLog).toHaveBeenCalledWith(
         'warn',
@@ -129,15 +132,17 @@ describe('StepResolver - components edge access', () => {
 
       dispatcher.resolve.mockReturnValue(new Set(['entity1']));
       entitiesGateway.getEntityInstance.mockReturnValue(entityWithoutMethod);
-      
+
       // Mock the gateway's getComponentData
-      entitiesGateway.getComponentData.mockImplementation((entityId, componentId) => {
-        const data = {
-          'core:name': { first: 'Gateway', last: 'Data' },
-          'core:actor': { type: 'player' },
-        };
-        return data[componentId];
-      });
+      entitiesGateway.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          const data = {
+            'core:name': { first: 'Gateway', last: 'Data' },
+            'core:actor': { type: 'player' },
+          };
+          return data[componentId];
+        }
+      );
 
       const result = resolver.resolve(node, ctx);
 
@@ -147,8 +152,14 @@ describe('StepResolver - components edge access', () => {
         'core:name': { first: 'Gateway', last: 'Data' },
         'core:actor': { type: 'player' },
       });
-      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith('entity1', 'core:name');
-      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith('entity1', 'core:actor');
+      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith(
+        'entity1',
+        'core:name'
+      );
+      expect(entitiesGateway.getComponentData).toHaveBeenCalledWith(
+        'entity1',
+        'core:actor'
+      );
     });
 
     it('should handle entity not found in gateway', () => {
@@ -181,10 +192,10 @@ describe('StepResolver - components edge access', () => {
 
       expect(result.size).toBe(2);
       const componentsArray = [...result];
-      
+
       // First entity should have core:actor component
       expect(componentsArray[0]).toHaveProperty('core:actor');
-      
+
       // Second entity should have core:position component
       expect(componentsArray[1]).toEqual({
         'core:position': { location: 'loc1' },

--- a/tests/unit/bootstrapper/startupErrorHandler.primitiveErrors.test.js
+++ b/tests/unit/bootstrapper/startupErrorHandler.primitiveErrors.test.js
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { StartupErrorHandler } from '../../../src/utils/startupErrorHandler.js';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+/**
+ *
+ * @param html
+ */
+function setDom(html) {
+  document.body.innerHTML = html;
+}
+
+describe('StartupErrorHandler primitive error branches', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('handles non-Error from showErrorInElement', () => {
+    setDom('<div id="errorDiv"></div>');
+    const ui = {
+      outputDiv: null,
+      errorDiv: document.querySelector('#errorDiv'),
+    };
+    const domAdapter = {
+      createElement: document.createElement.bind(document),
+      insertAfter: jest.fn(),
+      setTextContent: jest.fn(),
+      setStyle: jest.fn(),
+      alert: jest.fn(),
+    };
+    const dispatcher = { dispatch: jest.fn() };
+    const handler = new StartupErrorHandler(null, domAdapter, dispatcher);
+    jest.spyOn(handler, 'showErrorInElement').mockImplementation(() => {
+      throw 'boom';
+    });
+    const result = handler.displayErrorMessage({
+      errorDiv: ui.errorDiv,
+      outputDiv: ui.outputDiv,
+      userMessage: 'oops',
+    });
+    expect(result).toEqual({ displayed: false });
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'displayFatalStartupError: Failed to set textContent on errorDiv.',
+      { error: 'boom' }
+    );
+    expect(domAdapter.alert).toHaveBeenCalledWith('oops');
+  });
+
+  it('handles non-Error from createTemporaryErrorElement', () => {
+    setDom('<div id="outputDiv"></div>');
+    const ui = { outputDiv: document.querySelector('#outputDiv') };
+    const domAdapter = {
+      createElement: () => {
+        throw 'fail';
+      },
+      insertAfter: jest.fn(),
+      setTextContent: jest.fn(),
+      setStyle: jest.fn(),
+      alert: jest.fn(),
+    };
+    const dispatcher = { dispatch: jest.fn() };
+    const handler = new StartupErrorHandler(null, domAdapter, dispatcher);
+    const result = handler.displayErrorMessage({
+      errorDiv: null,
+      outputDiv: ui.outputDiv,
+      userMessage: 'bad',
+    });
+    expect(result).toEqual({ displayed: false });
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'displayFatalStartupError: Failed to create or append temporary error element.',
+      { error: 'fail' }
+    );
+    expect(domAdapter.alert).toHaveBeenCalledWith('bad');
+  });
+
+  it('handles updateElements failures with primitive errors', () => {
+    setDom('<input id="inp" /><h1 id="title"></h1>');
+    const ui = {
+      inputElement: document.querySelector('#inp'),
+      titleElement: document.querySelector('#title'),
+    };
+    const domAdapter = {
+      setTextContent: () => {
+        throw 'tfail';
+      },
+      setStyle: jest.fn(),
+      alert: jest.fn(),
+    };
+    const dispatcher = { dispatch: jest.fn() };
+    const handler = new StartupErrorHandler(null, domAdapter, dispatcher);
+    jest.spyOn(handler, 'disableInput').mockImplementation(() => {
+      throw 'dfail';
+    });
+    handler.updateElements({
+      titleElement: ui.titleElement,
+      inputElement: ui.inputElement,
+      pageTitle: 'x',
+      inputPlaceholder: 'y',
+    });
+    expect(safeDispatchError).toHaveBeenNthCalledWith(
+      1,
+      dispatcher,
+      'displayFatalStartupError: Failed to set textContent on titleElement.',
+      expect.objectContaining({ raw: 'tfail' })
+    );
+    expect(safeDispatchError).toHaveBeenNthCalledWith(
+      2,
+      dispatcher,
+      'displayFatalStartupError: Failed to disable or set placeholder on inputElement.',
+      expect.objectContaining({ raw: 'dfail' })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added new test suite to cover primitive error branches in `StartupErrorHandler`. Updated formatting in a couple of existing tests after running project formatter.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686028b1c6588331b81ca81a905525d0