### PR TITLE
[Fix] resolve lint issues in modules

### DIFF
--- a/src/actions/actionIndex.js
+++ b/src/actions/actionIndex.js
@@ -5,11 +5,6 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('./tracing/traceContext.js').TraceContext} TraceContext */
-import {
-  TRACE_DATA,
-  TRACE_INFO,
-  TRACE_SUCCESS,
-} from './tracing/traceContext.js';
 
 export class ActionIndex {
   /** @type {ILogger} */

--- a/src/adapters/fnLoadOrderResolverAdapter.js
+++ b/src/adapters/fnLoadOrderResolverAdapter.js
@@ -5,9 +5,16 @@
 
 /** @typedef {import('../../data/schemas/mod-manifest.schema.json').ModManifest} ModManifest */
 
+/**
+ * Adapter class that exposes a `resolve` method using a provided function.
+ *
+ * @class
+ */
 export default class FnLoadOrderResolverAdapter {
   /**
-   * @param {(ids: string[], manifests: Map<string, ModManifest>) => string[]} fn
+   * Create a resolver adapter around a load-order function.
+   *
+   * @param {(ids: string[], manifests: Map<string, ModManifest>) => string[]} fn Function implementing load order resolution.
    */
   constructor(fn) {
     if (typeof fn !== 'function') {
@@ -21,9 +28,11 @@ export default class FnLoadOrderResolverAdapter {
   }
 
   /**
-   * @param {string[]} ids
-   * @param {Map<string, ModManifest>} manifests
-   * @returns {string[]}
+   * Resolves the load order using the wrapped function.
+   *
+   * @param {string[]} ids The mod IDs to order.
+   * @param {Map<string, ModManifest>} manifests Map of mod manifests keyed by ID.
+   * @returns {string[]} Ordered list of mod IDs.
    */
   resolve(ids, manifests) {
     return this.fn(ids, manifests);

--- a/tests/unit/utils/loggerInitUsage.test.js
+++ b/tests/unit/utils/loggerInitUsage.test.js
@@ -8,12 +8,13 @@ const mockLogger = {
 };
 
 /**
+ * Helper to instantiate a module and assert logger initialization behavior.
  *
- * @param modulePath
- * @param ctorArgs
- * @param expectedName
- * @param expectOptional
- * @param useHelper
+ * @param {string} modulePath Path to the module to require.
+ * @param {object} ctorArgs Arguments passed to the module constructor.
+ * @param {string} expectedName Expected name used when initializing the logger.
+ * @param {boolean} [expectOptional] Whether optional dependencies are expected.
+ * @param {boolean} [useHelper] Whether the helper should check the setupService helper.
  */
 function setup(
   modulePath,
@@ -74,6 +75,7 @@ function setup(
 
 describe('initLogger usage in constructors', () => {
   it('OperationInterpreter uses initLogger', () => {
+    expect.hasAssertions();
     setup(
       '../../../src/logic/operationInterpreter.js',
       { logger: mockLogger, operationRegistry: { getHandler: jest.fn() } },
@@ -82,6 +84,7 @@ describe('initLogger usage in constructors', () => {
   });
 
   it('OperationRegistry uses setupService', () => {
+    expect.hasAssertions();
     setup(
       '../../../src/logic/operationRegistry.js',
       { logger: mockLogger },
@@ -90,6 +93,7 @@ describe('initLogger usage in constructors', () => {
   });
 
   it('JsonLogicEvaluationService uses initLogger', () => {
+    expect.hasAssertions();
     setup(
       '../../../src/logic/jsonLogicEvaluationService.js',
       { logger: mockLogger },
@@ -98,6 +102,7 @@ describe('initLogger usage in constructors', () => {
   });
 
   it('createJsonLogicContext uses initLogger', () => {
+    expect.hasAssertions();
     jest.resetModules();
     const setupPrefixedLogger = jest.fn(() => mockLogger);
     const validateServiceDeps = jest.fn();
@@ -143,6 +148,7 @@ describe('initLogger usage in constructors', () => {
   });
 
   it('AddComponentHandler uses initHandlerLogger', () => {
+    expect.hasAssertions();
     jest.resetModules();
     const initHandlerLogger = jest.fn(() => mockLogger);
     jest.doMock('../../../src/utils/handlerUtils/serviceUtils.js', () => {


### PR DESCRIPTION
Summary: Fixed lint issues in three modules by removing unused imports, improving JSDoc descriptions, and ensuring tests contain explicit assertions.

Changes Made:
- Removed unused trace constants from `actionIndex.js`.
- Documented `FnLoadOrderResolverAdapter` class and methods with proper descriptions.
- Updated `loggerInitUsage.test.js` with full JSDoc and added `expect.hasAssertions()` calls.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` and proxy lint)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6860293683348331af443f1c26b1fbba