### PR TITLE
[Agent] refactor dispatchAction alias variable

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -76,9 +76,9 @@ class CommandProcessor extends ICommandProcessor {
     }
 
     const actorId = actor.id;
-    const { actionDefinitionId, commandString } = turnAction;
+    const { actionDefinitionId: actionId, commandString } = turnAction;
     this.#logger.debug(
-      `CommandProcessor.dispatchAction: Dispatching pre-resolved action '${actionDefinitionId}' for actor ${actorId}.`,
+      `CommandProcessor.dispatchAction: Dispatching pre-resolved action '${actionId}' for actor ${actorId}.`,
       { turnAction }
     );
 
@@ -89,29 +89,29 @@ class CommandProcessor extends ICommandProcessor {
     const dispatchSuccess = await this.#dispatchWithErrorHandling(
       ATTEMPT_ACTION_ID,
       payload,
-      `ATTEMPT_ACTION_ID dispatch for pre-resolved action ${actionDefinitionId}`
+      `ATTEMPT_ACTION_ID dispatch for pre-resolved action ${actionId}`
     );
 
     if (dispatchSuccess) {
       this.#logger.debug(
-        `CommandProcessor.dispatchAction: Successfully dispatched '${actionDefinitionId}' for actor ${actorId}.`
+        `CommandProcessor.dispatchAction: Successfully dispatched '${actionId}' for actor ${actorId}.`
       );
       return {
         success: true,
         turnEnded: false,
-        originalInput: commandString || actionDefinitionId,
-        actionResult: { actionId: actionDefinitionId },
+        originalInput: commandString || actionId,
+        actionResult: { actionId },
       };
     }
 
-    const internalMsg = `CRITICAL: Failed to dispatch pre-resolved ATTEMPT_ACTION_ID for ${actorId}, action "${actionDefinitionId}". Dispatcher reported failure.`;
+    const internalMsg = `CRITICAL: Failed to dispatch pre-resolved ATTEMPT_ACTION_ID for ${actorId}, action "${actionId}". Dispatcher reported failure.`;
     const userMsg = 'Internal error: Failed to initiate action.';
     this.#logger.error(internalMsg, { payload });
     return this.#handleDispatchFailure({
       userMsg,
       internalMsg,
       commandString,
-      actionId: actionDefinitionId,
+      actionId,
     });
   }
 


### PR DESCRIPTION
## Summary
- alias `actionDefinitionId` as `actionId` in `dispatchAction`
- update method references accordingly

## Testing Done
- `npm run format`
- `npx eslint src/commands/commandProcessor.js`
- `npm test`
- `cd llm-proxy-server && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68602a39c6c08331adfbccdeda88d235