### PR TITLE
[Agent] centralize action formatting typedefs

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -20,26 +20,10 @@ import { validateDependency } from '../utils/dependencyUtils.js';
 
 import { targetFormatterMap } from './formatters/targetFormatters.js';
 
-/**
- * @typedef {object} FormatActionOk
- * @property {true} ok - Indicates success.
- * @property {string} value - The formatted command string.
- */
-
-/**
- * @typedef {object} FormatActionError
- * @property {false} ok - Indicates failure.
- * @property {string} error - The reason formatting failed.
- * @property {string} [details] - Additional error details.
- */
-
-/**
- * @typedef {FormatActionOk | FormatActionError} FormatActionCommandResult
- */
-
-/**
- * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => FormatActionCommandResult>} TargetFormatterMap
- */
+/** @typedef {import('./formatters/formatActionTypedefs.js').FormatActionOk} FormatActionOk */
+/** @typedef {import('./formatters/formatActionTypedefs.js').FormatActionError} FormatActionError */
+/** @typedef {import('./formatters/formatActionTypedefs.js').FormatActionCommandResult} FormatActionCommandResult */
+/** @typedef {import('./formatters/formatActionTypedefs.js').TargetFormatterMap} TargetFormatterMap */
 
 /**
  * @description Builds a standardized formatting error result.

--- a/src/actions/formatters/formatActionTypedefs.js
+++ b/src/actions/formatters/formatActionTypedefs.js
@@ -1,0 +1,37 @@
+// src/actions/formatters/formatActionTypedefs.js
+/**
+ * @file Shared typedefs for action formatting utilities.
+ */
+
+/** @typedef {import('../../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
+
+/**
+ * Result object returned when formatting succeeds.
+ *
+ * @typedef {object} FormatActionOk
+ * @property {true} ok - Indicates success.
+ * @property {string} value - The formatted command string.
+ */
+
+/**
+ * Result object returned when formatting fails.
+ *
+ * @typedef {object} FormatActionError
+ * @property {false} ok - Indicates failure.
+ * @property {string} error - The reason formatting failed.
+ * @property {string} [details] - Additional error details.
+ */
+
+/**
+ * Union of possible formatAction results.
+ *
+ * @typedef {FormatActionOk | FormatActionError} FormatActionCommandResult
+ */
+
+/**
+ * Mapping of target types to formatter functions.
+ *
+ * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => FormatActionCommandResult>} TargetFormatterMap
+ */
+
+export const __formatActionTypedefs = true;

--- a/src/actions/formatters/targetFormatters.js
+++ b/src/actions/formatters/targetFormatters.js
@@ -13,26 +13,10 @@ import {
   NONE as TARGET_TYPE_NONE,
 } from '../../constants/actionTargetTypes.js';
 
-/**
- * @typedef {object} FormatActionOk
- * @property {true} ok - Indicates success.
- * @property {string} value - The formatted command string.
- */
-
-/**
- * @typedef {object} FormatActionError
- * @property {false} ok - Indicates failure.
- * @property {string} error - The reason formatting failed.
- * @property {string} [details] - Additional error details.
- */
-
-/**
- * @typedef {FormatActionOk | FormatActionError} FormatActionCommandResult
- */
-
-/**
- * @typedef {Object.<string, (command: string, context: ActionTargetContext, deps: object) => FormatActionCommandResult>} TargetFormatterMap
- */
+/** @typedef {import('./formatActionTypedefs.js').FormatActionOk} FormatActionOk */
+/** @typedef {import('./formatActionTypedefs.js').FormatActionError} FormatActionError */
+/** @typedef {import('./formatActionTypedefs.js').FormatActionCommandResult} FormatActionCommandResult */
+/** @typedef {import('./formatActionTypedefs.js').TargetFormatterMap} TargetFormatterMap */
 
 /**
  * @description Replaces the `{target}` placeholder using entity information.


### PR DESCRIPTION
## Summary
- centralize action formatting typedefs in one module
- reference shared typedefs in actionFormatter and targetFormatters

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68602e28f46883318d370c487b5479b3