### PR TITLE
[Test] Add coverage for WindowUserPrompt

### DIFF
--- a/tests/unit/domUI/windowUserPrompt.test.js
+++ b/tests/unit/domUI/windowUserPrompt.test.js
@@ -1,0 +1,49 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
+import WindowUserPrompt, {
+  WindowUserPrompt as NamedExport,
+} from '../../../src/domUI/windowUserPrompt.js';
+
+describe('WindowUserPrompt', () => {
+  let originalWindow;
+
+  beforeEach(() => {
+    originalWindow = global.window;
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    jest.restoreAllMocks();
+  });
+
+  it('exports the class as default and named', () => {
+    expect(NamedExport).toBe(WindowUserPrompt);
+  });
+
+  it('calls window.confirm when window is available', () => {
+    const confirmMock = jest.fn(() => true);
+    global.window.confirm = confirmMock;
+    const prompt = new WindowUserPrompt();
+    const result = prompt.confirm('proceed?');
+    expect(confirmMock).toHaveBeenCalledWith('proceed?');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when window is undefined', () => {
+    // Simulate non-browser environment by redefining global window
+    Object.defineProperty(global, 'window', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const prompt = new WindowUserPrompt();
+    const result = prompt.confirm('ignored');
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary: Added a new Jest test covering `WindowUserPrompt` to ensure both browser and non-browser branches execute correctly.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68602cd9c50083318ab1e220ce546506