### PR TITLE
[Agent] Fix lint issues in auxiliary init modules

### DIFF
--- a/src/bootstrapper/stages/auxiliary/initEngineUIManager.js
+++ b/src/bootstrapper/stages/auxiliary/initEngineUIManager.js
@@ -2,12 +2,13 @@
 
 import { resolveAndInitialize } from '../../helpers.js';
 import './typedefs.js';
+/** @typedef {import('./typedefs.js').AuxHelperDeps} AuxHelperDeps */
 
 /**
  * Resolves and initializes the EngineUIManager service.
  *
- * @param {AuxHelperDeps} deps
- * @returns {{success: boolean, error?: Error}}
+ * @param {AuxHelperDeps} deps - Contains DI container, logger, and token map.
+ * @returns {{success: boolean, error?: Error}} Result of initialization.
  */
 export function initEngineUIManager({ container, logger, tokens }) {
   return resolveAndInitialize(

--- a/src/bootstrapper/stages/auxiliary/initLlmSelectionModal.js
+++ b/src/bootstrapper/stages/auxiliary/initLlmSelectionModal.js
@@ -2,12 +2,13 @@
 
 import { stageSuccess, stageFailure } from '../../helpers.js';
 import './typedefs.js';
+/** @typedef {import('./typedefs.js').AuxHelperDeps} AuxHelperDeps */
 
 /**
  * Resolves LlmSelectionModal service.
  *
- * @param {AuxHelperDeps} deps
- * @returns {{success: boolean, error?: Error}}
+ * @param {AuxHelperDeps} deps - Contains DI container, logger, and token map.
+ * @returns {{success: boolean, error?: Error}} Result of initialization.
  */
 export function initLlmSelectionModal({ container, logger, tokens }) {
   const stage = 'LlmSelectionModal Init';

--- a/src/configuration/loggerConfigLoader.js
+++ b/src/configuration/loggerConfigLoader.js
@@ -110,18 +110,16 @@ export class LoggerConfigLoader {
       : this.#defaultConfigPath;
 
     // Use a safe way to log, as this.#logger could be console or a full ILogger
-    const logInfo = (msg, ...args) =>
-      this.#logger.info
-        ? this.#logger.info(msg, ...args)
-        : console.info(msg, ...args);
     const logError = (msg, ...args) =>
       this.#logger.error
         ? this.#logger.error(msg, ...args)
-        : console.error(msg, ...args);
+        : // eslint-disable-next-line no-console
+          console.error(msg, ...args);
     const logWarn = (msg, ...args) =>
       this.#logger.warn
         ? this.#logger.warn(msg, ...args)
-        : console.warn(msg, ...args);
+        : // eslint-disable-next-line no-console
+          console.warn(msg, ...args);
 
     let parsedResponse;
     try {


### PR DESCRIPTION
Summary: Fixed ESLint warnings by adding type imports and parameter descriptions in auxiliary initialization modules. Removed unused log helper and silenced console warnings in loggerConfigLoader.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68602cd3df48833190d69a63bf818492