### PR TITLE
[Agent] consolidate dependency validation

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -16,7 +16,10 @@ import {
   safeDispatchError,
   dispatchValidationError,
 } from '../utils/safeDispatchErrorUtils.js';
-import { validateDependency } from '../utils/dependencyUtils.js';
+import {
+  validateDependency,
+  validateDependencies,
+} from '../utils/dependencyUtils.js';
 
 import { targetFormatterMap } from './formatters/targetFormatters.js';
 
@@ -66,19 +69,30 @@ function checkFormatInputs(
   if (!targetContext) {
     return 'formatActionCommand: Invalid or missing targetContext.';
   }
+
   try {
-    validateDependency(entityManager, 'entityManager', logger, {
-      requiredMethods: ['getEntityInstance'],
-    });
-  } catch {
-    return 'formatActionCommand: Invalid or missing entityManager.';
-  }
-  try {
-    validateDependency(displayNameFn, 'displayNameFn', logger, {
-      isFunction: true,
-    });
-  } catch {
-    return 'formatActionCommand: getEntityDisplayName utility function is not available.';
+    validateDependencies(
+      [
+        {
+          dependency: entityManager,
+          name: 'entityManager',
+          methods: ['getEntityInstance'],
+        },
+        {
+          dependency: displayNameFn,
+          name: 'displayNameFn',
+          isFunction: true,
+        },
+      ],
+      logger
+    );
+  } catch (err) {
+    if (/entityManager/.test(err.message)) {
+      return 'formatActionCommand: Invalid or missing entityManager.';
+    }
+    if (/displayNameFn/.test(err.message)) {
+      return 'formatActionCommand: getEntityDisplayName utility function is not available.';
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary
- import `validateDependencies`
- validate all dependencies in one try/catch

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68603568a268833180145def33259e87