### PR TITLE
[Agent] Centralize event dispatch error handling

### DIFF
--- a/src/utils/eventDispatchHelper.js
+++ b/src/utils/eventDispatchHelper.js
@@ -1,0 +1,74 @@
+/**
+ * @file Helper for dispatching events with error handling and logging.
+ */
+
+/**
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+import { ensureValidLogger } from './loggerUtils.js';
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+import { createErrorDetails } from './errorDetails.js';
+
+/**
+ * Dispatches an event using the provided dispatcher and logs the outcome.
+ *
+ * @description
+ * Mimics the error handling behavior originally embedded in CommandProcessor.
+ * On success, a debug message is logged. When the dispatcher returns `false`, a
+ * warning is logged. On exception, a system error event is dispatched and the
+ * function returns `false`.
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to emit the event.
+ * @param {string} eventName - Name of the event to dispatch.
+ * @param {object} payload - Payload for the event.
+ * @param {ILogger} [logger] - Logger for debug/error output.
+ * @param {string} context - Contextual identifier used in log messages.
+ * @returns {Promise<boolean>} `true` if the dispatcher reported success, `false` otherwise.
+ */
+export async function dispatchWithErrorHandling(
+  dispatcher,
+  eventName,
+  payload,
+  logger,
+  context
+) {
+  const log = ensureValidLogger(logger, 'dispatchWithErrorHandling');
+  log.debug(
+    `dispatchWithErrorHandling: Attempting dispatch: ${context} ('${eventName}')`
+  );
+  try {
+    const success = await dispatcher.dispatch(eventName, payload);
+    if (success) {
+      log.debug(
+        `dispatchWithErrorHandling: Dispatch successful for ${context}.`
+      );
+    } else {
+      log.warn(
+        `dispatchWithErrorHandling: SafeEventDispatcher reported failure for ${context} (likely VED validation failure). Payload: ${JSON.stringify(
+          payload
+        )}`
+      );
+    }
+    return success;
+  } catch (error) {
+    log.error(
+      `dispatchWithErrorHandling: CRITICAL - Error during dispatch for ${context}. Error: ${error.message}`,
+      error
+    );
+    safeDispatchError(
+      dispatcher,
+      'System error during event dispatch.',
+      createErrorDetails(
+        `Exception in dispatch for ${eventName}`,
+        error?.stack || new Error().stack
+      ),
+      log
+    );
+    return false;
+  }
+}
+
+// --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,6 +18,7 @@ export * from './jsonCleaning.js';
 export * from './jsonRepair.js';
 export * from './evaluationContextUtils.js';
 export * from './eventDispatchUtils.js';
+export { dispatchWithErrorHandling } from './eventDispatchHelper.js';
 export {
   assertPresent,
   assertFunction,

--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -54,7 +54,7 @@ describe('CommandProcessor.dispatchAction', () => {
       })
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      'CommandProcessor.#dispatchWithErrorHandling: Dispatch successful for ATTEMPT_ACTION_ID dispatch for pre-resolved action look.'
+      'dispatchWithErrorHandling: Dispatch successful for ATTEMPT_ACTION_ID dispatch for pre-resolved action look.'
     );
   });
 
@@ -176,7 +176,7 @@ describe('CommandProcessor.dispatchAction', () => {
     );
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        'CommandProcessor.#dispatchWithErrorHandling: SafeEventDispatcher reported failure for ATTEMPT_ACTION_ID dispatch for pre-resolved action take'
+        'dispatchWithErrorHandling: SafeEventDispatcher reported failure for ATTEMPT_ACTION_ID dispatch for pre-resolved action take'
       )
     );
   });
@@ -236,7 +236,7 @@ describe('CommandProcessor.dispatchAction', () => {
       logger
     );
     expect(logger.error).toHaveBeenCalledWith(
-      'CommandProcessor.#dispatchWithErrorHandling: CRITICAL - Error during dispatch for ATTEMPT_ACTION_ID dispatch for pre-resolved action jump. Error: boom',
+      'dispatchWithErrorHandling: CRITICAL - Error during dispatch for ATTEMPT_ACTION_ID dispatch for pre-resolved action jump. Error: boom',
       expect.any(Error)
     );
   });

--- a/tests/unit/utils/eventDispatchHelper.test.js
+++ b/tests/unit/utils/eventDispatchHelper.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { dispatchWithErrorHandling } from '../../../src/utils/eventDispatchHelper.js';
+import { createMockLogger } from '../../common/mockFactories/loggerMocks.js';
+import * as loggerUtils from '../../../src/utils/loggerUtils.js';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../src/utils/loggerUtils.js');
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  safeDispatchError: jest.fn(),
+}));
+
+describe('dispatchWithErrorHandling', () => {
+  it('logs success when dispatcher resolves true', async () => {
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    const logger = createMockLogger();
+    loggerUtils.ensureValidLogger.mockReturnValue(logger);
+
+    const result = await dispatchWithErrorHandling(
+      dispatcher,
+      'evt',
+      { foo: 1 },
+      logger,
+      'ctx'
+    );
+
+    expect(result).toBe(true);
+    expect(loggerUtils.ensureValidLogger).toHaveBeenCalledWith(
+      logger,
+      'dispatchWithErrorHandling'
+    );
+    expect(dispatcher.dispatch).toHaveBeenCalledWith('evt', { foo: 1 });
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      1,
+      "dispatchWithErrorHandling: Attempting dispatch: ctx ('evt')"
+    );
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      2,
+      'dispatchWithErrorHandling: Dispatch successful for ctx.'
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(safeDispatchError).not.toHaveBeenCalled();
+  });
+
+  it('logs warning when dispatcher returns false', async () => {
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(false) };
+    const logger = createMockLogger();
+    loggerUtils.ensureValidLogger.mockReturnValue(logger);
+
+    const result = await dispatchWithErrorHandling(
+      dispatcher,
+      'evt',
+      { bar: 2 },
+      logger,
+      'ctx'
+    );
+
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'dispatchWithErrorHandling: SafeEventDispatcher reported failure for ctx'
+      )
+    );
+    expect(safeDispatchError).not.toHaveBeenCalled();
+  });
+
+  it('handles exception by logging and dispatching system error', async () => {
+    const error = new Error('boom');
+    const dispatcher = { dispatch: jest.fn().mockRejectedValue(error) };
+    const logger = createMockLogger();
+    loggerUtils.ensureValidLogger.mockReturnValue(logger);
+
+    const result = await dispatchWithErrorHandling(
+      dispatcher,
+      'evt',
+      { baz: 3 },
+      logger,
+      'ctx'
+    );
+
+    expect(result).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'dispatchWithErrorHandling: CRITICAL - Error during dispatch for ctx. Error: boom',
+      error
+    );
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      'System error during event dispatch.',
+      expect.any(Object),
+      logger
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `dispatchWithErrorHandling` utility
- use helper from `CommandProcessor` instead of local methods
- update command processor tests for new log messages
- cover helper utility with unit tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686035547e6083318d7e127e261feccf