### PR TITLE
[Agent] Fix ESLint warnings in select modules

### DIFF
--- a/src/input/globalKeyHandler.js
+++ b/src/input/globalKeyHandler.js
@@ -17,6 +17,8 @@ class GlobalKeyHandler {
   #boundListener;
 
   /**
+   * Creates an instance of GlobalKeyHandler.
+   *
    * @param {Document} document - The DOM document to listen on.
    * @param {IValidatedEventDispatcher} validatedEventDispatcher - Dispatcher for UI events.
    */
@@ -55,6 +57,7 @@ class GlobalKeyHandler {
       this.#validatedEventDispatcher
         .dispatch('ui:toggle_inventory', {})
         .catch((err) =>
+          // eslint-disable-next-line no-console
           console.error(
             "GlobalKeyHandler: Failed to dispatch 'ui:toggle_inventory'",
             err

--- a/src/logging/consoleLogger.js
+++ b/src/logging/consoleLogger.js
@@ -212,7 +212,7 @@ class ConsoleLogger {
    * Displays tabular data in the console if the current log level allows DEBUG.
    *
    * @param {any} data - The data to display in a table.
-   * @param {readonly string[] | undefined} [columns] - An array of strings representing the columns to include.
+   * @param {string[] | undefined} [columns] - An array of strings representing the columns to include.
    */
   table(data, columns) {
     if (this.#currentLogLevel <= LogLevel.DEBUG) {

--- a/src/logic/actionSequence.js
+++ b/src/logic/actionSequence.js
@@ -24,10 +24,10 @@ import { resolvePath } from '../utils/objectUtils.js';
 /**
  * Handles IF flow-control nodes.
  *
- * @param {Operation} node
- * @param {ActionExecutionContext} nestedCtx
- * @param {ILogger} logger
- * @param {OperationInterpreter} operationInterpreter
+ * @param {Operation} node - Operation describing the IF logic.
+ * @param {ActionExecutionContext} nestedCtx - Execution context for nested actions.
+ * @param {ILogger} logger - Logger instance for diagnostics.
+ * @param {OperationInterpreter} operationInterpreter - Interpreter used to execute nested operations.
  */
 function handleIf(node, nestedCtx, logger, operationInterpreter) {
   const {
@@ -72,10 +72,10 @@ function handleIf(node, nestedCtx, logger, operationInterpreter) {
 /**
  * Handles FOR_EACH flow-control nodes.
  *
- * @param {Operation} node
- * @param {ActionExecutionContext} nestedCtx
- * @param {ILogger} logger
- * @param {OperationInterpreter} operationInterpreter
+ * @param {Operation} node - Operation describing the FOR_EACH loop.
+ * @param {ActionExecutionContext} nestedCtx - Execution context for the loop.
+ * @param {ILogger} logger - Logger instance for diagnostics.
+ * @param {OperationInterpreter} operationInterpreter - Interpreter for executing the loop body.
  */
 function handleForEach(node, nestedCtx, logger, operationInterpreter) {
   const {
@@ -209,8 +209,10 @@ export function executeActionSequence(
 }
 
 /**
+ * Identity helper for type clarity.
  *
- * @param node
+ * @param {Operation} node - Operation node to cast.
+ * @returns {Operation} The same operation node.
  */
 function nodeToOperation(node) {
   return node;


### PR DESCRIPTION
## Summary
- address invalid JSDoc type in consoleLogger
- document parameters in actionSequence helpers
- document constructor and silence console warning in globalKeyHandler

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860353521788331a5ffa010b4f6773a