### PR TITLE
[Test] add coverage for FnLoadOrderResolverAdapter

### DIFF
--- a/tests/unit/adapters/fnLoadOrderResolverAdapter.test.js
+++ b/tests/unit/adapters/fnLoadOrderResolverAdapter.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from '@jest/globals';
+import FnLoadOrderResolverAdapter from '../../../src/adapters/fnLoadOrderResolverAdapter.js';
+
+describe('FnLoadOrderResolverAdapter', () => {
+  it('wraps a function and delegates resolve()', () => {
+    const mockFn = jest.fn(() => ['b', 'a']);
+    const adapter = new FnLoadOrderResolverAdapter(mockFn);
+    const ids = ['a', 'b'];
+    const manifests = new Map();
+    const result = adapter.resolve(ids, manifests);
+    expect(result).toEqual(['b', 'a']);
+    expect(mockFn).toHaveBeenCalledWith(ids, manifests);
+  });
+
+  it('throws when constructed with a non-function', () => {
+    expect(() => new FnLoadOrderResolverAdapter(null)).toThrow(
+      'FnLoadOrderResolverAdapter requires a function.'
+    );
+    expect(() => new FnLoadOrderResolverAdapter(42)).toThrow(
+      'FnLoadOrderResolverAdapter requires a function.'
+    );
+  });
+});


### PR DESCRIPTION
Summary: Adds a unit test for `FnLoadOrderResolverAdapter` to ensure both success and error branches are covered.

Changes Made:
- Created `tests/unit/adapters/fnLoadOrderResolverAdapter.test.js` with positive and negative constructor cases.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_68603944f4508331a90979a56cdb492b