### PR TITLE
[Agent] rename attempt action payload helper

### DIFF
--- a/src/commands/commandProcessor.js
+++ b/src/commands/commandProcessor.js
@@ -93,7 +93,7 @@ class CommandProcessor extends ICommandProcessor {
     );
 
     // --- Payload Construction ---
-    const payload = this.#buildAttemptActionPayload(actor, turnAction);
+    const payload = this.#createAttemptActionPayload(actor, turnAction);
 
     // --- Dispatch ---
     const dispatchSuccess = await dispatchEventWithErrorHandling(
@@ -169,12 +169,12 @@ class CommandProcessor extends ICommandProcessor {
   }
 
   /**
-   * @description Builds the payload for an action attempt dispatch.
+   * @description Creates the payload for an action attempt dispatch.
    * @param {Entity} actor - The entity performing the action.
    * @param {ITurnAction} turnAction - The resolved turn action.
    * @returns {object} The payload for the `ATTEMPT_ACTION_ID` event.
    */
-  #buildAttemptActionPayload(actor, turnAction) {
+  #createAttemptActionPayload(actor, turnAction) {
     const { actionDefinitionId, resolvedParameters, commandString } =
       turnAction;
     return {


### PR DESCRIPTION
Summary: Renamed the private helper that constructs the ATTEMPT_ACTION_ID payload in `commandProcessor.js` to `#createAttemptActionPayload`. Updated `dispatchAction` to call this new method.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68603959c0848331a274a4bcdc25e598