### PR TITLE
[Agent] throw InvalidArgumentError on action validation

### DIFF
--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -96,7 +96,7 @@ describe('CommandProcessor.dispatchAction', () => {
         turnEnded: true,
         error: 'Internal error: Malformed action prevented execution.',
         internalError:
-          "dispatchAction failed: CommandProcessor.dispatchAction: Invalid ID '   '. Expected non-blank string.",
+          "CommandProcessor.dispatchAction: Invalid ID '   '. Expected non-blank string.",
         originalInput: 'look',
       })
     );
@@ -138,7 +138,7 @@ describe('CommandProcessor.dispatchAction', () => {
         turnEnded: true,
         error: 'Internal error: Malformed action prevented execution.',
         internalError:
-          'dispatchAction failed: actor must have id and turnAction must include actionDefinitionId.',
+          'actor must have id and turnAction must include actionDefinitionId.',
       })
     );
     expect(safeDispatchError).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- use InvalidArgumentError within `#validateActionInputs`
- catch validation failures inside `dispatchAction`
- expect new error messages in commandProcessor tests

## Testing Done
- `npm run format`
- `npx eslint src/commands/commandProcessor.js tests/unit/commands/commandProcessor.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68604497e1f08331b2263dd90c9878e0