### PR TITLE
[Agent] rename validation helper params

### DIFF
--- a/src/entities/utils/componentValidation.js
+++ b/src/entities/utils/componentValidation.js
@@ -13,25 +13,25 @@ import {
  * component payloads with consistent error handling.
  * @param {string} componentTypeId - Component type ID.
  * @param {object} data - Raw component data to validate and clone.
- * @param {import('../../interfaces/coreServices.js').IValidator} validator - Schema validator.
+ * @param {import('../../interfaces/coreServices.js').ISchemaValidator} schemaValidator - Schema validator.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for reporting validation errors.
- * @param {string} contextMsg - Context information for error messages.
- * @param {function(object): object} cloner - Function used to deep clone the data.
+ * @param {string} errorContext - Context information for error messages.
+ * @param {function(object): object} clonerFn - Function used to deep clone the data.
  * @returns {object} The validated (and cloned) data.
  */
 export function validateAndClone(
   componentTypeId,
   data,
-  validator,
+  schemaValidator,
   logger,
-  contextMsg,
-  cloner
+  errorContext,
+  clonerFn
 ) {
-  const clone = cloner(data);
-  const result = validator.validate(componentTypeId, clone);
+  const clone = clonerFn(data);
+  const result = schemaValidator.validate(componentTypeId, clone);
   if (!validationSucceeded(result)) {
     const details = formatValidationErrors(result);
-    const msg = `${contextMsg} Errors:\n${details}`;
+    const msg = `${errorContext} Errors:\n${details}`;
     logger.error(msg);
     throw new Error(msg);
   }

--- a/src/entities/utils/createValidateAndClone.js
+++ b/src/entities/utils/createValidateAndClone.js
@@ -3,20 +3,20 @@ import { validateAndClone } from './componentValidation.js';
 /**
  * Factory to create a validate-and-clone helper bound to a logger and validator.
  *
- * @param {import('../../interfaces/coreServices.js').ISchemaValidator} validator - Schema validator.
+ * @param {import('../../interfaces/coreServices.js').ISchemaValidator} schemaValidator - Schema validator.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger instance.
- * @param {import('../../ports/IComponentCloner.js').IComponentCloner} cloner - Component cloner.
- * @returns {(componentTypeId: string, data: object, context: string) => object} Preconfigured helper.
+ * @param {import('../../ports/IComponentCloner.js').IComponentCloner} clonerFn - Component cloner.
+ * @returns {(componentTypeId: string, data: object, errorContext: string) => object} Preconfigured helper.
  */
-export function createValidateAndClone(validator, logger, cloner) {
-  return function validateAndCloneBound(componentTypeId, data, context) {
+export function createValidateAndClone(schemaValidator, logger, clonerFn) {
+  return function validateAndCloneBound(componentTypeId, data, errorContext) {
     return validateAndClone(
       componentTypeId,
       data,
-      validator,
+      schemaValidator,
       logger,
-      context,
-      cloner
+      errorContext,
+      clonerFn
     );
   };
 }

--- a/src/entities/utils/defaultComponentInjector.js
+++ b/src/entities/utils/defaultComponentInjector.js
@@ -17,7 +17,7 @@ import {
  * caller via the provided helper function.
  * @param {import('../entity.js').default} entity - The entity instance to modify.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger used for debug and error output.
- * @param {function(string, object, string): object} validateAndClone - Function that validates component data and returns a cloned payload.
+ * @param {function(string, object, string): object} validateAndClone - Function that validates component data and returns a cloned payload. The third argument is an error context message.
  */
 export function injectDefaultComponents(entity, logger, validateAndClone) {
   if (entity.hasComponent(ACTOR_COMPONENT_ID)) {

--- a/src/entities/utils/portraitUtils.js
+++ b/src/entities/utils/portraitUtils.js
@@ -36,7 +36,7 @@ export function buildAltText(rawAltText) {
  * Builds portrait path and alt text for an entity.
  *
  * @param {import('../entity.js').default} entity - The entity instance to read portrait data from.
- * @param {string} contextMsg - The calling method name for log messages.
+ * @param {string} methodName - The calling method name for log messages.
  * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger for diagnostics.
  * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} safeEventDispatcher - Dispatcher for error events.
  * @param {string} logPrefix - Prefix for log messages.
@@ -44,12 +44,12 @@ export function buildAltText(rawAltText) {
  */
 export function buildPortraitInfo(
   entity,
-  contextMsg,
+  methodName,
   logger,
   safeEventDispatcher,
   logPrefix
 ) {
-  const isLocation = contextMsg === 'getLocationPortraitData';
+  const isLocation = methodName === 'getLocationPortraitData';
   const label = isLocation ? 'Location entity' : 'Entity';
   const successSubject = isLocation
     ? `location '${entity.id}'`
@@ -62,14 +62,14 @@ export function buildPortraitInfo(
     !portraitComponent.imagePath.trim()
   ) {
     logger.debug(
-      `${logPrefix} ${contextMsg}: ${label} '${entity.id}' has no valid PORTRAIT_COMPONENT_ID data or imagePath.`
+      `${logPrefix} ${methodName}: ${label} '${entity.id}' has no valid PORTRAIT_COMPONENT_ID data or imagePath.`
     );
     return null;
   }
 
   if (typeof entity.definitionId !== 'string' || !entity.definitionId) {
     logger.warn(
-      `${logPrefix} ${contextMsg}: Invalid or missing definitionId. Expected string, got:`,
+      `${logPrefix} ${methodName}: Invalid or missing definitionId. Expected string, got:`,
       entity.definitionId
     );
     return null;
@@ -98,7 +98,7 @@ export function buildPortraitInfo(
   const altText = buildAltText(portraitComponent.altText);
 
   logger.debug(
-    `${logPrefix} ${contextMsg}: Constructed portrait path for ${successSubject}: ${fullPath}`
+    `${logPrefix} ${methodName}: Constructed portrait path for ${successSubject}: ${fullPath}`
   );
 
   return { path: fullPath, altText };


### PR DESCRIPTION
## Summary
- clarify parameter names for validateAndClone and builder helpers
- update portraitUtils names for readability
- document errorContext parameter for default component injection

## Testing
- `npm run lint` *(fails: numerous existing warnings/errors)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686067daabf08331ae9cccb3b7f9f970