### PR TITLE
[Agent] Introduce IActionCommandFormatter

### DIFF
--- a/src/actions/actionCandidateProcessor.js
+++ b/src/actions/actionCandidateProcessor.js
@@ -5,7 +5,7 @@
 /** @typedef {import('../entities/entity.js').default} Entity */
 /** @typedef {import('../entities/entityManager.js').default} EntityManager */
 /** @typedef {import('./validation/prerequisiteEvaluationService.js').PrerequisiteEvaluationService} PrerequisiteEvaluationService */
-/** @typedef {import('./actionFormatter.js').formatActionCommand} formatActionCommandFn */
+/** @typedef {import('../interfaces/IActionCommandFormatter.js').IActionCommandFormatter} IActionCommandFormatter */
 /** @typedef {import('./actionTypes.js').ActionContext} ActionContext */
 /** @typedef {import('../logging/consoleLogger.js').default} ILogger */
 /** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
@@ -29,7 +29,7 @@ export class ActionCandidateProcessor {
   #prerequisiteEvaluationService;
   #targetResolutionService;
   #entityManager;
-  #formatActionCommandFn;
+  #commandFormatter;
   #safeEventDispatcher;
   #getEntityDisplayNameFn;
   #logger;
@@ -41,7 +41,7 @@ export class ActionCandidateProcessor {
    * @param {PrerequisiteEvaluationService} deps.prerequisiteEvaluationService - Service for evaluating action prerequisites.
    * @param {ITargetResolutionService} deps.targetResolutionService - Service for resolving action targets.
    * @param {EntityManager} deps.entityManager - Manager for entity operations.
-   * @param {formatActionCommandFn} deps.formatActionCommandFn - Function to format action commands.
+   * @param {IActionCommandFormatter} deps.actionCommandFormatter - Service used to format action commands.
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Event dispatcher for error handling.
    * @param {Function} deps.getEntityDisplayNameFn - Function to get entity display names.
    * @param {ILogger} deps.logger - Logger instance for diagnostic output.
@@ -50,7 +50,7 @@ export class ActionCandidateProcessor {
     prerequisiteEvaluationService,
     targetResolutionService,
     entityManager,
-    formatActionCommandFn,
+    actionCommandFormatter,
     safeEventDispatcher,
     getEntityDisplayNameFn,
     logger,
@@ -58,7 +58,7 @@ export class ActionCandidateProcessor {
     this.#prerequisiteEvaluationService = prerequisiteEvaluationService;
     this.#targetResolutionService = targetResolutionService;
     this.#entityManager = entityManager;
-    this.#formatActionCommandFn = formatActionCommandFn;
+    this.#commandFormatter = actionCommandFormatter;
     this.#safeEventDispatcher = safeEventDispatcher;
     this.#getEntityDisplayNameFn = getEntityDisplayNameFn;
     this.#logger = logger;
@@ -173,7 +173,7 @@ export class ActionCandidateProcessor {
     };
 
     for (const targetCtx of targetContexts) {
-      const formatResult = this.#formatActionCommandFn(
+      const formatResult = this.#commandFormatter.format(
         actionDef,
         targetCtx,
         this.#entityManager,

--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -12,6 +12,7 @@
 
 // --- Dependency Imports ---
 import { getEntityDisplayName } from '../utils/entityUtils.js';
+import { IActionCommandFormatter } from '../interfaces/IActionCommandFormatter.js';
 import {
   safeDispatchError,
   dispatchValidationError,
@@ -187,7 +188,7 @@ function finalizeCommand(command, logger, debug) {
  * @param {TargetFormatterMap} [deps.formatterMap] - Map of target types to formatter functions.
  * @returns {FormatActionCommandResult} Result object containing the formatted command or an error.
  */
-export function formatActionCommand(
+function formatActionCommand(
   actionDefinition,
   targetContext,
   entityManager,
@@ -252,4 +253,32 @@ export function formatActionCommand(
 
   // --- 3. Return Formatted String ---
   return finalizeCommand(command, logger, debug);
+}
+
+/**
+ * Default implementation of {@link IActionCommandFormatter}.
+ *
+ * @class ActionCommandFormatter
+ * @description Formats action commands using the standard logic.
+ * @augments IActionCommandFormatter
+ */
+export default class ActionCommandFormatter extends IActionCommandFormatter {
+  /**
+   * @inheritdoc
+   */
+  format(
+    actionDefinition,
+    targetContext,
+    entityManager,
+    options = {},
+    deps = {}
+  ) {
+    return formatActionCommand(
+      actionDefinition,
+      targetContext,
+      entityManager,
+      options,
+      deps
+    );
+  }
 }

--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -31,7 +31,7 @@ import CommandProcessor from '../../commands/commandProcessor.js';
 import { TraceContext as TraceContextImpl } from '../../actions/tracing/traceContext.js';
 
 // --- Helper Function Imports ---
-import { formatActionCommand } from '../../actions/actionFormatter.js';
+import ActionCommandFormatter from '../../actions/actionFormatter.js';
 import { getActorLocation } from '../../utils/actorLocationUtils.js';
 import { getEntityDisplayName } from '../../utils/entityUtils.js';
 
@@ -97,7 +97,7 @@ export function registerCommandAndAction(container) {
       ),
       targetResolutionService: c.resolve(tokens.ITargetResolutionService),
       entityManager: c.resolve(tokens.IEntityManager),
-      formatActionCommandFn: formatActionCommand,
+      actionCommandFormatter: new ActionCommandFormatter(),
       safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       getEntityDisplayNameFn: getEntityDisplayName,
       logger: c.resolve(tokens.ILogger),

--- a/src/interfaces/IActionCommandFormatter.js
+++ b/src/interfaces/IActionCommandFormatter.js
@@ -1,0 +1,28 @@
+// src/interfaces/IActionCommandFormatter.js
+
+/** @typedef {import('../data/gameDataRepository.js').ActionDefinition} ActionDefinition */
+/** @typedef {import('../models/actionTargetContext.js').ActionTargetContext} ActionTargetContext */
+/** @typedef {import('./coreServices.js').ILogger} ILogger */
+/** @typedef {import('../entities/entityManager.js').default} EntityManager */
+/** @typedef {import('../actions/formatters/formatActionTypedefs.js').FormatActionCommandResult} FormatActionCommandResult */
+
+/**
+ * @interface IActionCommandFormatter
+ * @description Interface defining how action commands should be formatted.
+ */
+export class IActionCommandFormatter {
+  /**
+   * Formats an action command string given an action definition and target context.
+   *
+   * @param {ActionDefinition} actionDef - The action definition.
+   * @param {ActionTargetContext} targetCtx - The target context describing the action target.
+   * @param {EntityManager} entityManager - The entity manager for lookups.
+   * @param {object} options - Formatting options (e.g., logger, debug flags).
+   * @param {object} extra - Additional dependencies such as formatter map or display name helpers.
+   * @returns {FormatActionCommandResult} Result object containing the formatted command or error info.
+   * @throws {Error} If the method is not implemented.
+   */
+  format(actionDef, targetCtx, entityManager, options, extra) {
+    throw new Error('IActionCommandFormatter.format method not implemented.');
+  }
+}

--- a/tests/common/actions/actionCandidateProcessorTestBed.js
+++ b/tests/common/actions/actionCandidateProcessorTestBed.js
@@ -10,7 +10,7 @@ import {
   createMockPrerequisiteEvaluationService,
   createMockTargetResolutionService,
   createMockSafeEventDispatcher,
-  createMockFormatActionCommandFn,
+  createMockActionCommandFormatter,
 } from '../mockFactories';
 import { createServiceFactoryMixin } from '../serviceFactoryTestBedMixin.js';
 import { createTestBedHelpers } from '../createTestBedHelpers.js';
@@ -23,7 +23,7 @@ const ServiceFactoryMixin = createServiceFactoryMixin(
     prerequisiteEvaluationService: createMockPrerequisiteEvaluationService,
     targetResolutionService: createMockTargetResolutionService,
     safeEventDispatcher: createMockSafeEventDispatcher,
-    formatActionCommandFn: createMockFormatActionCommandFn,
+    actionCommandFormatter: createMockActionCommandFormatter,
     getEntityDisplayNameFn: () => jest.fn(),
   },
   (mocks, overrides = {}) =>
@@ -31,7 +31,7 @@ const ServiceFactoryMixin = createServiceFactoryMixin(
       prerequisiteEvaluationService: mocks.prerequisiteEvaluationService,
       targetResolutionService: mocks.targetResolutionService,
       entityManager: mocks.entityManager,
-      formatActionCommandFn: mocks.formatActionCommandFn,
+      actionCommandFormatter: mocks.actionCommandFormatter,
       safeEventDispatcher: mocks.safeEventDispatcher,
       getEntityDisplayNameFn: mocks.getEntityDisplayNameFn,
       logger: mocks.logger,

--- a/tests/common/actions/actionDiscoveryServiceTestBed.js
+++ b/tests/common/actions/actionDiscoveryServiceTestBed.js
@@ -12,7 +12,7 @@ import {
   createMockActionIndex,
   createMockTargetResolutionService,
   createMockSafeEventDispatcher,
-  createMockFormatActionCommandFn,
+  createMockActionCommandFormatter,
 } from '../mockFactories';
 import { createServiceFactoryMixin } from '../serviceFactoryTestBedMixin.js';
 import { createTestBedHelpers } from '../createTestBedHelpers.js';
@@ -26,7 +26,7 @@ const ServiceFactoryMixin = createServiceFactoryMixin(
     actionIndex: createMockActionIndex,
     targetResolutionService: createMockTargetResolutionService,
     safeEventDispatcher: createMockSafeEventDispatcher,
-    formatActionCommandFn: createMockFormatActionCommandFn,
+    actionCommandFormatter: createMockActionCommandFormatter,
     getActorLocationFn: () => jest.fn(),
     getEntityDisplayNameFn: () => jest.fn(),
   },
@@ -38,7 +38,7 @@ const ServiceFactoryMixin = createServiceFactoryMixin(
         prerequisiteEvaluationService: mocks.prerequisiteEvaluationService,
         targetResolutionService: mocks.targetResolutionService,
         entityManager: mocks.entityManager,
-        formatActionCommandFn: mocks.formatActionCommandFn,
+        actionCommandFormatter: mocks.actionCommandFormatter,
         safeEventDispatcher: mocks.safeEventDispatcher,
         getEntityDisplayNameFn: mocks.getEntityDisplayNameFn,
         logger: mocks.logger,

--- a/tests/common/mockFactories/actions.js
+++ b/tests/common/mockFactories/actions.js
@@ -39,4 +39,12 @@ export const createMockTargetResolutionService = () =>
  * @description Returns a jest.fn used to format action commands in tests.
  * @returns {jest.Mock} Mock formatting function
  */
-export const createMockFormatActionCommandFn = () => jest.fn();
+
+/**
+ * Creates a mock action command formatter implementing a `format` method.
+ *
+ * @returns {{ format: jest.Mock }} Mock formatter instance
+ */
+export const createMockActionCommandFormatter = () => ({
+  format: jest.fn(),
+});

--- a/tests/integration/actions/actionDiscoveryService.p4-05.test.js
+++ b/tests/integration/actions/actionDiscoveryService.p4-05.test.js
@@ -58,7 +58,7 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
       prerequisiteEvaluationService: mockPrereqService,
       targetResolutionService: mockTargetResolutionService,
       entityManager: mockEntityManager,
-      formatActionCommandFn: mockFormatActionCommandFn,
+      actionCommandFormatter: { format: mockFormatActionCommandFn },
       safeEventDispatcher: mockEventDispatcher,
       getEntityDisplayNameFn: mockGetEntityDisplayNameFn,
       logger: mockLogger,

--- a/tests/integration/scopeEngineSingletonLocationContext.test.js
+++ b/tests/integration/scopeEngineSingletonLocationContext.test.js
@@ -8,7 +8,7 @@ import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import { SimpleEntityManager } from '../common/entities/index.js';
 import { ActionDiscoveryService } from '../../src/actions/actionDiscoveryService.js';
 import { ActionCandidateProcessor } from '../../src/actions/actionCandidateProcessor.js';
-import { formatActionCommand } from '../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../src/actions/actionFormatter.js';
 import { getEntityDisplayName } from '../../src/utils/entityUtils.js';
 import { SafeEventDispatcher } from '../../src/events/safeEventDispatcher.js';
 import ScopeRegistry from '../../src/scopeDsl/scopeRegistry.js';
@@ -201,7 +201,7 @@ describe('Singleton Scope Engine Location Context', () => {
       prerequisiteEvaluationService,
       targetResolutionService,
       entityManager,
-      formatActionCommandFn: formatActionCommand,
+      actionCommandFormatter: new ActionCommandFormatter(),
       safeEventDispatcher,
       getEntityDisplayNameFn: getEntityDisplayName,
       logger,

--- a/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
+++ b/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
@@ -14,7 +14,7 @@ import {
 import { SimpleEntityManager } from '../../common/entities/index.js';
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
 import { ActionCandidateProcessor } from '../../../src/actions/actionCandidateProcessor.js';
-import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
 import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
@@ -197,7 +197,7 @@ describe('Scope Integration Tests', () => {
       prerequisiteEvaluationService,
       targetResolutionService,
       entityManager,
-      formatActionCommandFn: formatActionCommand,
+      actionCommandFormatter: new ActionCommandFormatter(),
       safeEventDispatcher,
       getEntityDisplayNameFn: getEntityDisplayName,
       logger,

--- a/tests/integration/scopes/environmentScope.integration.test.js
+++ b/tests/integration/scopes/environmentScope.integration.test.js
@@ -13,7 +13,7 @@ import {
 import { SimpleEntityManager } from '../../common/entities/index.js';
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
 import { ActionCandidateProcessor } from '../../../src/actions/actionCandidateProcessor.js';
-import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
 import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
@@ -154,7 +154,7 @@ describe('Scope Integration Tests', () => {
       prerequisiteEvaluationService,
       targetResolutionService,
       entityManager,
-      formatActionCommandFn: formatActionCommand,
+      actionCommandFormatter: new ActionCommandFormatter(),
       safeEventDispatcher,
       getEntityDisplayNameFn: getEntityDisplayName,
       logger,

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -14,7 +14,7 @@ import {
 import { SimpleEntityManager } from '../../common/entities/index.js';
 import { ActionDiscoveryService } from '../../../src/actions/actionDiscoveryService.js';
 import { ActionCandidateProcessor } from '../../../src/actions/actionCandidateProcessor.js';
-import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
 import { getEntityDisplayName } from '../../../src/utils/entityUtils.js';
 import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js';
@@ -160,7 +160,7 @@ describe('Scope Integration Tests', () => {
       prerequisiteEvaluationService,
       targetResolutionService,
       entityManager,
-      formatActionCommandFn: formatActionCommand,
+      actionCommandFormatter: new ActionCommandFormatter(),
       safeEventDispatcher,
       getEntityDisplayNameFn: getEntityDisplayName,
       logger,

--- a/tests/unit/actions/actionCandidateProcessor.test.js
+++ b/tests/unit/actions/actionCandidateProcessor.test.js
@@ -5,7 +5,7 @@ describeActionCandidateProcessorSuite('ActionCandidateProcessor', (getBed) => {
   beforeEach(() => {
     const bed = getBed();
     bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-    bed.mocks.formatActionCommandFn.mockReturnValue({
+    bed.mocks.actionCommandFormatter.format.mockReturnValue({
       ok: true,
       value: 'doit',
     });
@@ -40,10 +40,12 @@ describeActionCandidateProcessorSuite('ActionCandidateProcessor', (getBed) => {
         { type: 'entity', entityId: 'enemy1' },
         { type: 'entity', entityId: 'enemy2' },
       ]);
-      bed.mocks.formatActionCommandFn.mockImplementation((def, target) => ({
-        ok: true,
-        value: `${def.commandVerb} ${target.entityId}`,
-      }));
+      bed.mocks.actionCommandFormatter.format.mockImplementation(
+        (def, target) => ({
+          ok: true,
+          value: `${def.commandVerb} ${target.entityId}`,
+        })
+      );
 
       const result = bed.service.process(actionDef, actorEntity, context);
 
@@ -127,16 +129,18 @@ describeActionCandidateProcessorSuite('ActionCandidateProcessor', (getBed) => {
         { type: 'entity', entityId: 'target1' },
         { type: 'entity', entityId: 'target2' },
       ]);
-      bed.mocks.formatActionCommandFn.mockImplementation((def, target) => {
-        if (target.entityId === 'target1') {
-          return { ok: true, value: 'test target1' };
+      bed.mocks.actionCommandFormatter.format.mockImplementation(
+        (def, target) => {
+          if (target.entityId === 'target1') {
+            return { ok: true, value: 'test target1' };
+          }
+          return {
+            ok: false,
+            error: 'Format failed',
+            details: { targetId: target.entityId },
+          };
         }
-        return {
-          ok: false,
-          error: 'Format failed',
-          details: { targetId: target.entityId },
-        };
-      });
+      );
 
       const result = bed.service.process(actionDef, actorEntity, context);
 

--- a/tests/unit/actions/actionDiscoveryService.actionId.test.js
+++ b/tests/unit/actions/actionDiscoveryService.actionId.test.js
@@ -21,7 +21,7 @@ describeActionDiscoverySuite(
       bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'rat123' },
       ]);
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: true,
         value: 'attack rat123',
       });

--- a/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
+++ b/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
@@ -36,7 +36,7 @@ describeActionDiscoverySuite(
           return [{ type: 'none', entityId: null }];
         }
       );
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: true,
         value: 'wait',
       });
@@ -54,7 +54,7 @@ describeActionDiscoverySuite(
       bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 't1' },
       ]);
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: false,
         error: new Error('nope'),
         details: { reason: 'bad' },

--- a/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
+++ b/tests/unit/actions/actionDiscoveryService.errorExtraction.test.js
@@ -19,7 +19,7 @@ describeActionDiscoverySuite(
       const bed = getBed();
       const def = { id: 'bad', commandVerb: 'bad', scope: 'none' };
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
-      bed.mocks.formatActionCommandFn.mockImplementation(() => {
+      bed.mocks.actionCommandFormatter.format.mockImplementation(() => {
         const err = new Error('boom');
         err.target = { entityId: 'target-123' };
         throw err;
@@ -39,7 +39,7 @@ describeActionDiscoverySuite(
       const bed = getBed();
       const def = { id: 'bad', commandVerb: 'bad', scope: 'none' };
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([def]);
-      bed.mocks.formatActionCommandFn.mockImplementation(() => {
+      bed.mocks.actionCommandFormatter.format.mockImplementation(() => {
         const err = new Error('boom');
         err.entityId = 'target-456';
         throw err;

--- a/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
+++ b/tests/unit/actions/actionDiscoveryService.locationRetrieval.test.js
@@ -40,7 +40,7 @@ describeActionDiscoverySuite(
           return [];
         }
       );
-      bed.mocks.formatActionCommandFn.mockImplementation((def, ctx) => {
+      bed.mocks.actionCommandFormatter.format.mockImplementation((def, ctx) => {
         return ctx.entityId
           ? { ok: true, value: `${def.commandVerb} ${ctx.entityId}` }
           : { ok: true, value: def.commandVerb };

--- a/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
+++ b/tests/unit/actions/actionDiscoveryService.processActionDefinition.test.js
@@ -10,7 +10,7 @@ describeActionDiscoverySuite(
     beforeEach(() => {
       const bed = getBed();
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: true,
         value: 'doit',
       });
@@ -64,7 +64,7 @@ describeActionDiscoverySuite(
       bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'entity', entityId: 'monster1' },
       ]);
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: true,
         value: 'attack monster1',
       });
@@ -111,7 +111,7 @@ describeActionDiscoverySuite(
       bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
         { type: 'none', entityId: null },
       ]);
-      bed.mocks.formatActionCommandFn.mockImplementation((def) => {
+      bed.mocks.actionCommandFormatter.format.mockImplementation((def) => {
         if (def.id === 'bad') throw new Error('boom');
         return { ok: true, value: def.commandVerb };
       });

--- a/tests/unit/actions/actionDiscoveryService.tracing.test.js
+++ b/tests/unit/actions/actionDiscoveryService.tracing.test.js
@@ -92,7 +92,7 @@ describeActionDiscoverySuite(
           return [];
         }
       );
-      bed.mocks.formatActionCommandFn.mockReturnValue({
+      bed.mocks.actionCommandFormatter.format.mockReturnValue({
         ok: true,
         value: 'do action',
       });

--- a/tests/unit/actions/actionDiscoverySystem.go.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.go.test.js
@@ -73,12 +73,14 @@ describeActionDiscoverySuite(
       // FIX: Default prerequisite checks to pass for this test
       bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
 
-      bed.mocks.formatActionCommandFn.mockImplementation((actionDef) => {
-        if (actionDef.id === 'core:wait') return { ok: true, value: 'wait' };
-        if (actionDef.id === 'core:go')
-          return { ok: true, value: 'go to The Town' };
-        return { ok: false, error: 'invalid' };
-      });
+      bed.mocks.actionCommandFormatter.format.mockImplementation(
+        (actionDef) => {
+          if (actionDef.id === 'core:wait') return { ok: true, value: 'wait' };
+          if (actionDef.id === 'core:go')
+            return { ok: true, value: 'go to The Town' };
+          return { ok: false, error: 'invalid' };
+        }
+      );
 
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
         coreWaitActionDefinition,
@@ -141,7 +143,7 @@ describeActionDiscoverySuite(
         null
       );
 
-      expect(bed.mocks.formatActionCommandFn).toHaveBeenCalledWith(
+      expect(bed.mocks.actionCommandFormatter.format).toHaveBeenCalledWith(
         coreGoActionDefinition,
         expectedGoTargetContext,
         expect.any(Object),

--- a/tests/unit/actions/actionDiscoverySystem.wait.test.js
+++ b/tests/unit/actions/actionDiscoverySystem.wait.test.js
@@ -41,12 +41,14 @@ describeActionDiscoverySuite(
         }
       );
 
-      bed.mocks.formatActionCommandFn.mockImplementation((actionDef) => {
-        if (actionDef.id === 'core:wait') {
-          return { ok: true, value: 'wait' };
+      bed.mocks.actionCommandFormatter.format.mockImplementation(
+        (actionDef) => {
+          if (actionDef.id === 'core:wait') {
+            return { ok: true, value: 'wait' };
+          }
+          return { ok: false, error: 'invalid' };
         }
-        return { ok: false, error: 'invalid' };
-      });
+      );
 
       bed.mocks.actionIndex.getCandidateActions.mockReturnValue([
         coreWaitActionDefinition,
@@ -77,7 +79,7 @@ describeActionDiscoverySuite(
       expect(
         bed.mocks.prerequisiteEvaluationService.evaluate
       ).not.toHaveBeenCalled();
-      expect(bed.mocks.formatActionCommandFn).toHaveBeenCalledTimes(1);
+      expect(bed.mocks.actionCommandFormatter.format).toHaveBeenCalledTimes(1);
     });
 
     it('should return an empty array if core:wait action prerequisites fail', async () => {
@@ -95,7 +97,7 @@ describeActionDiscoverySuite(
 
       // FIX: Now that `evaluate` is called and returns false, the actions array should be empty.
       expect(result.actions).toEqual([]);
-      expect(bed.mocks.formatActionCommandFn).not.toHaveBeenCalled();
+      expect(bed.mocks.actionCommandFormatter.format).not.toHaveBeenCalled();
       expect(
         bed.mocks.prerequisiteEvaluationService.evaluate
       ).toHaveBeenCalledTimes(1);
@@ -111,7 +113,7 @@ describeActionDiscoverySuite(
       expect(
         bed.mocks.prerequisiteEvaluationService.evaluate
       ).not.toHaveBeenCalled();
-      expect(bed.mocks.formatActionCommandFn).not.toHaveBeenCalled();
+      expect(bed.mocks.actionCommandFormatter.format).not.toHaveBeenCalled();
     });
 
     it('should return structured info for core:wait even if other invalid actions are present', async () => {
@@ -139,7 +141,7 @@ describeActionDiscoverySuite(
       expect(
         bed.mocks.prerequisiteEvaluationService.evaluate
       ).toHaveBeenCalledTimes(1);
-      expect(bed.mocks.formatActionCommandFn).toHaveBeenCalledTimes(1);
+      expect(bed.mocks.actionCommandFormatter.format).toHaveBeenCalledTimes(1);
     });
   }
 );

--- a/tests/unit/actions/actionFormatter.additional.test.js
+++ b/tests/unit/actions/actionFormatter.additional.test.js
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
-import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
 import { targetFormatterMap } from '../../../src/actions/formatters/targetFormatters.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import {
@@ -19,12 +19,14 @@ describe('formatActionCommand additional cases', () => {
   let logger;
   let dispatcher;
   let displayNameFn;
+  let formatter;
 
   beforeEach(() => {
     entityManager = { getEntityInstance: jest.fn() };
     logger = createMockLogger();
     dispatcher = { dispatch: jest.fn() };
     displayNameFn = jest.fn();
+    formatter = new ActionCommandFormatter();
     jest.clearAllMocks();
   });
 
@@ -41,7 +43,7 @@ describe('formatActionCommand additional cases', () => {
     const actionDef = { id: 'core:use', template: 'use {target}' };
     const context = { type: TARGET_TYPE_ENTITY };
 
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       context,
       entityManager,
@@ -65,7 +67,7 @@ describe('formatActionCommand additional cases', () => {
     };
     const context = { type: TARGET_TYPE_NONE };
 
-    formatActionCommand(
+    formatter.format(
       actionDef,
       context,
       entityManager,
@@ -88,7 +90,7 @@ describe('formatActionCommand additional cases', () => {
       throw new Error('boom');
     });
 
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       context,
       entityManager,
@@ -117,7 +119,7 @@ describe('formatActionCommand additional cases', () => {
       entity: jest.fn(() => ({ ok: true, value: 'test-value' })),
     };
 
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       context,
       entityManager,

--- a/tests/unit/actions/actionFormatter.branches.test.js
+++ b/tests/unit/actions/actionFormatter.branches.test.js
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
-import { formatActionCommand } from '../../../src/actions/actionFormatter.js';
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
 import { targetFormatterMap } from '../../../src/actions/formatters/targetFormatters.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import {
@@ -14,18 +14,20 @@ describe('formatActionCommand uncovered branches', () => {
   let logger;
   let dispatcher;
   let displayNameFn;
+  let formatter;
 
   beforeEach(() => {
     entityManager = { getEntityInstance: jest.fn() };
     logger = createMockLogger();
     dispatcher = { dispatch: jest.fn() };
     displayNameFn = jest.fn();
+    formatter = new ActionCommandFormatter();
     jest.clearAllMocks();
   });
 
   it('returns validation error when targetContext is missing', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       null,
       entityManager,
@@ -47,7 +49,7 @@ describe('formatActionCommand uncovered branches', () => {
   it('returns validation error when displayNameFn is not a function', () => {
     const actionDef = { id: 'core:inspect', template: 'inspect {target}' };
     const context = { type: TARGET_TYPE_ENTITY, entityId: 'e1' };
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       context,
       entityManager,
@@ -75,7 +77,7 @@ describe('formatActionCommand uncovered branches', () => {
       ...targetFormatterMap,
       entity: jest.fn(() => 'custom'),
     };
-    const result = formatActionCommand(
+    const result = formatter.format(
       actionDef,
       context,
       entityManager,
@@ -87,7 +89,7 @@ describe('formatActionCommand uncovered branches', () => {
 
   it('throws when logger is missing and inputs are invalid', () => {
     const actionDef = { id: 'core:test', template: 'test {target}' };
-    expect(() => formatActionCommand(actionDef, null, entityManager)).toThrow(
+    expect(() => formatter.format(actionDef, null, entityManager)).toThrow(
       'formatActionCommand: logger is required.'
     );
   });
@@ -96,7 +98,7 @@ describe('formatActionCommand uncovered branches', () => {
     const actionDef = { id: 'core:wait', template: 'wait' };
     const context = { type: TARGET_TYPE_NONE };
     expect(() =>
-      formatActionCommand(actionDef, context, entityManager, { logger })
+      formatter.format(actionDef, context, entityManager, { logger })
     ).toThrow('Missing required dependency: safeEventDispatcher.');
   });
 });


### PR DESCRIPTION
## Summary
- add IActionCommandFormatter interface
- implement ActionCommandFormatter class and update dependencies
- wire new formatter into DI and test mocks
- adjust ActionCandidateProcessor and ActionDiscoveryService usage
- update tests for new formatter interface

## Testing Done
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test` *(fails coverage thresholds but all suites pass)*
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68606c2f29488331b69edb3e963a8307