### PR TITLE
[Agent] rename targetCtx references

### DIFF
--- a/src/actions/actionCandidateProcessor.js
+++ b/src/actions/actionCandidateProcessor.js
@@ -172,10 +172,10 @@ export class ActionCandidateProcessor {
       safeEventDispatcher: this.#safeEventDispatcher,
     };
 
-    for (const targetCtx of targetContexts) {
+    for (const targetContext of targetContexts) {
       const formatResult = this.#commandFormatter.format(
         actionDef,
-        targetCtx,
+        targetContext,
         this.#entityManager,
         formatterOptions,
         {
@@ -189,19 +189,19 @@ export class ActionCandidateProcessor {
           name: actionDef.name || actionDef.commandVerb,
           command: formatResult.value,
           description: actionDef.description || '',
-          params: { targetId: targetCtx.entityId },
+          params: { targetId: targetContext.entityId },
         });
       } else {
         errors.push(
           this.#createDiscoveryError(
             actionDef.id,
-            targetCtx.entityId,
+            targetContext.entityId,
             formatResult.error,
             formatResult.details
           )
         );
         this.#logger.warn(
-          `Failed to format command for action '${actionDef.id}' with target '${targetCtx.entityId}'.`
+          `Failed to format command for action '${actionDef.id}' with target '${targetContext.entityId}'.`
         );
       }
     }

--- a/src/actions/validation/inputValidators.js
+++ b/src/actions/validation/inputValidators.js
@@ -36,5 +36,5 @@ export function validateActionInputs(actionDefinition, actorEntity, logger) {
     throw new InvalidActorEntityError();
   }
 
-  // Validation for targetCtx has been removed, as prerequisites are now actor-only.
+  // Validation for targetContext has been removed, as prerequisites are now actor-only.
 }

--- a/src/interfaces/IActionCommandFormatter.js
+++ b/src/interfaces/IActionCommandFormatter.js
@@ -15,14 +15,14 @@ export class IActionCommandFormatter {
    * Formats an action command string given an action definition and target context.
    *
    * @param {ActionDefinition} actionDef - The action definition.
-   * @param {ActionTargetContext} targetCtx - The target context describing the action target.
+   * @param {ActionTargetContext} targetContext - The target context describing the action target.
    * @param {EntityManager} entityManager - The entity manager for lookups.
    * @param {object} options - Formatting options (e.g., logger, debug flags).
    * @param {object} extra - Additional dependencies such as formatter map or display name helpers.
    * @returns {FormatActionCommandResult} Result object containing the formatted command or error info.
    * @throws {Error} If the method is not implemented.
    */
-  format(actionDef, targetCtx, entityManager, options, extra) {
+  format(actionDef, targetContext, entityManager, options, extra) {
     throw new Error('IActionCommandFormatter.format method not implemented.');
   }
 }

--- a/tests/integration/actions/actionDiscoveryService.p4-05.test.js
+++ b/tests/integration/actions/actionDiscoveryService.p4-05.test.js
@@ -78,10 +78,13 @@ describe('ADS-P4-05: Streamlined ActionDiscoveryService', () => {
     actorEntity = { id: 'player', name: 'Player' };
 
     // Default mock behaviors for successful formatting
-    mockFormatActionCommandFn.mockImplementation((actionDef, targetCtx) => ({
-      ok: true,
-      value: `${actionDef.commandVerb} ${targetCtx.entityId || ''}`.trim(),
-    }));
+    mockFormatActionCommandFn.mockImplementation(
+      (actionDef, targetContext) => ({
+        ok: true,
+        value:
+          `${actionDef.commandVerb} ${targetContext.entityId || ''}`.trim(),
+      })
+    );
   });
 
   describe('Actor-State Prerequisite Check', () => {


### PR DESCRIPTION
Summary: Renamed the temporary variable `targetCtx` to the clearer `targetContext` in ActionCandidateProcessor, the action command formatter interface, and relevant tests. Updated validation comments accordingly.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 714 errors, 2779 warnings)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6860c4b1b9dc8331a6d66102c8677e2b