### PR TITLE
[Agent] refactor display name helpers

### DIFF
--- a/src/entities/entityDisplayDataProvider.js
+++ b/src/entities/entityDisplayDataProvider.js
@@ -2,14 +2,13 @@
 
 import {
   PORTRAIT_COMPONENT_ID,
-  DESCRIPTION_COMPONENT_ID,
   POSITION_COMPONENT_ID,
 } from '../constants/componentIds.js';
 import { validateDependency } from '../utils/dependencyUtils.js';
 import { ensureValidLogger } from '../utils/loggerUtils.js';
-import { getEntityDisplayName } from '../utils/entityUtils.js';
 import { buildPortraitInfo } from './utils/portraitUtils.js';
 import { withEntity } from './utils/entityFetchHelpers.js';
+import { getDisplayName, getDescription } from './utils/displayHelpers.js';
 
 /**
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
@@ -102,14 +101,12 @@ export class EntityDisplayDataProvider {
    * @returns {string} The entity's display name, its ID, or the default name.
    */
   getEntityName(entityId, defaultName = 'Unknown Entity') {
-    return withEntity(
+    return getDisplayName(
       this.#entityManager,
       entityId,
       defaultName,
-      (entity) => getEntityDisplayName(entity, defaultName, this.#logger),
       this.#logger,
-      this._logPrefix,
-      `getEntityName: Entity with ID '${entityId}' not found. Returning default name.`
+      this._logPrefix
     );
   }
 
@@ -151,29 +148,12 @@ export class EntityDisplayDataProvider {
    * @returns {string} The entity's description or the default description.
    */
   getEntityDescription(entityId, defaultDescription = '') {
-    return withEntity(
+    return getDescription(
       this.#entityManager,
       entityId,
       defaultDescription,
-      (entity) => {
-        const descriptionComponent = entity.getComponentData(
-          DESCRIPTION_COMPONENT_ID
-        );
-        if (
-          descriptionComponent &&
-          typeof descriptionComponent.text === 'string'
-        ) {
-          return descriptionComponent.text;
-        }
-
-        this.#logger.debug(
-          `${this._logPrefix} getEntityDescription: Entity '${entityId}' found, but no valid DESCRIPTION_COMPONENT_ID data. Returning default description.`
-        );
-        return defaultDescription;
-      },
       this.#logger,
-      this._logPrefix,
-      `getEntityDescription: Entity with ID '${entityId}' not found. Returning default description.`
+      this._logPrefix
     );
   }
 

--- a/src/entities/services/locationDisplayService.js
+++ b/src/entities/services/locationDisplayService.js
@@ -1,17 +1,15 @@
 // src/entities/services/locationDisplayService.js
 
 import {
-  NAME_COMPONENT_ID,
-  DESCRIPTION_COMPONENT_ID,
   EXITS_COMPONENT_ID,
   PORTRAIT_COMPONENT_ID,
 } from '../../constants/componentIds.js';
 import { validateDependency } from '../../utils/dependencyUtils.js';
 import { ensureValidLogger } from '../../utils/loggerUtils.js';
 import { isNonBlankString } from '../../utils/textUtils.js';
-import { getEntityDisplayName } from '../../utils/entityUtils.js';
 import { buildPortraitInfo } from '../utils/portraitUtils.js';
 import { withEntity } from '../utils/entityFetchHelpers.js';
+import { getDisplayName, getDescription } from '../utils/displayHelpers.js';
 
 /** @typedef {import('../../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('../../interfaces/ILogger.js').ILogger} ILogger */
@@ -83,14 +81,12 @@ export class LocationDisplayService {
    * @returns {string}
    */
   #getEntityName(entityId, defaultName = 'Unknown Entity') {
-    return withEntity(
+    return getDisplayName(
       this.#entityManager,
       entityId,
       defaultName,
-      (entity) => getEntityDisplayName(entity, defaultName, this.#logger),
       this.#logger,
-      this._logPrefix,
-      `getEntityName: Entity with ID '${entityId}' not found. Returning default name.`
+      this._logPrefix
     );
   }
 
@@ -101,29 +97,12 @@ export class LocationDisplayService {
    * @returns {string}
    */
   #getEntityDescription(entityId, defaultDescription = '') {
-    return withEntity(
+    return getDescription(
       this.#entityManager,
       entityId,
       defaultDescription,
-      (entity) => {
-        const descriptionComponent = entity.getComponentData(
-          DESCRIPTION_COMPONENT_ID
-        );
-        if (
-          descriptionComponent &&
-          typeof descriptionComponent.text === 'string'
-        ) {
-          return descriptionComponent.text;
-        }
-
-        this.#logger.debug(
-          `${this._logPrefix} getEntityDescription: Entity '${entityId}' found, but no valid DESCRIPTION_COMPONENT_ID data. Returning default description.`
-        );
-        return defaultDescription;
-      },
       this.#logger,
-      this._logPrefix,
-      `getEntityDescription: Entity with ID '${entityId}' not found. Returning default description.`
+      this._logPrefix
     );
   }
 

--- a/src/entities/utils/displayHelpers.js
+++ b/src/entities/utils/displayHelpers.js
@@ -1,0 +1,86 @@
+// src/entities/utils/displayHelpers.js
+
+import { DESCRIPTION_COMPONENT_ID } from '../../constants/componentIds.js';
+import { getEntityDisplayName } from '../../utils/entityUtils.js';
+import { withEntity } from './entityFetchHelpers.js';
+
+/**
+ * @module displayHelpers
+ * @description Helper functions for retrieving entity display data.
+ */
+
+/**
+ * Retrieve an entity's display name using shared logic.
+ *
+ * @param {import('../interfaces/IEntityManager.js').IEntityManager} entityManager - Entity manager instance.
+ * @param {import('../interfaces/CommonTypes.js').NamespacedId | string} entityId - Identifier of the entity.
+ * @param {string} [defaultName] - Value returned when no name is resolved.
+ * @param {import('../interfaces/ILogger.js').ILogger} logger - Logger for diagnostics.
+ * @param {string} logPrefix - Prefix for log messages.
+ * @returns {string} The resolved display name or the default name.
+ */
+export function getDisplayName(
+  entityManager,
+  entityId,
+  defaultName = 'Unknown Entity',
+  logger,
+  logPrefix
+) {
+  return withEntity(
+    entityManager,
+    entityId,
+    defaultName,
+    (entity) => getEntityDisplayName(entity, defaultName, logger),
+    logger,
+    logPrefix,
+    `getDisplayName: Entity with ID '${entityId}' not found. Returning default name.`
+  );
+}
+
+/**
+ * Retrieve an entity's description using shared logic.
+ *
+ * @param {import('../interfaces/IEntityManager.js').IEntityManager} entityManager - Entity manager instance.
+ * @param {import('../interfaces/CommonTypes.js').NamespacedId | string} entityId - Identifier of the entity.
+ * @param {string} [defaultDescription] - Value returned when no description is found.
+ * @param {import('../interfaces/ILogger.js').ILogger} logger - Logger for diagnostics.
+ * @param {string} logPrefix - Prefix for log messages.
+ * @returns {string} The description or the default description.
+ */
+export function getDescription(
+  entityManager,
+  entityId,
+  defaultDescription = '',
+  logger,
+  logPrefix
+) {
+  return withEntity(
+    entityManager,
+    entityId,
+    defaultDescription,
+    (entity) => {
+      const descriptionComponent = entity.getComponentData(
+        DESCRIPTION_COMPONENT_ID
+      );
+      if (
+        descriptionComponent &&
+        typeof descriptionComponent.text === 'string'
+      ) {
+        return descriptionComponent.text;
+      }
+
+      logger.debug(
+        `${logPrefix} getDescription: Entity '${entityId}' found, but no valid DESCRIPTION_COMPONENT_ID data. Returning default description.`
+      );
+      return defaultDescription;
+    },
+    logger,
+    logPrefix,
+    `getDescription: Entity with ID '${entityId}' not found. Returning default description.`
+  );
+}
+
+export default {
+  getDisplayName,
+  getDescription,
+};

--- a/tests/unit/entities/utils/displayHelpers.test.js
+++ b/tests/unit/entities/utils/displayHelpers.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  getDisplayName,
+  getDescription,
+} from '../../../../src/entities/utils/displayHelpers.js';
+
+const LOG_PREFIX = '[DisplayHelpersTest]';
+
+describe('displayHelpers', () => {
+  let entityManager;
+  let logger;
+
+  beforeEach(() => {
+    entityManager = { getEntityInstance: jest.fn() };
+    logger = { debug: jest.fn(), warn: jest.fn() };
+  });
+
+  describe('getDisplayName', () => {
+    it('returns name from entity when available', () => {
+      const entity = {
+        id: 'e1',
+        getComponentData: jest.fn(() => ({ text: 'Hero' })),
+      };
+      entityManager.getEntityInstance.mockReturnValue(entity);
+      const name = getDisplayName(
+        entityManager,
+        'e1',
+        'Unknown',
+        logger,
+        LOG_PREFIX
+      );
+      expect(name).toBe('Hero');
+      expect(entityManager.getEntityInstance).toHaveBeenCalledWith('e1');
+    });
+
+    it('returns default when entity missing', () => {
+      entityManager.getEntityInstance.mockReturnValue(null);
+      const name = getDisplayName(
+        entityManager,
+        'missing',
+        'Default',
+        logger,
+        LOG_PREFIX
+      );
+      expect(name).toBe('Default');
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Entity with ID 'missing' not found")
+      );
+    });
+
+    it('returns default when entityId is null', () => {
+      const name = getDisplayName(
+        entityManager,
+        null,
+        'Default',
+        logger,
+        LOG_PREFIX
+      );
+      expect(name).toBe('Default');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('called with null or empty entityId')
+      );
+    });
+  });
+
+  describe('getDescription', () => {
+    it('returns description from component', () => {
+      const entity = {
+        id: 'i1',
+        getComponentData: jest.fn(() => ({ text: 'desc' })),
+      };
+      entityManager.getEntityInstance.mockReturnValue(entity);
+      const desc = getDescription(
+        entityManager,
+        'i1',
+        'none',
+        logger,
+        LOG_PREFIX
+      );
+      expect(desc).toBe('desc');
+      expect(entityManager.getEntityInstance).toHaveBeenCalledWith('i1');
+    });
+
+    it('returns default when entity missing', () => {
+      entityManager.getEntityInstance.mockReturnValue(null);
+      const desc = getDescription(
+        entityManager,
+        'missing',
+        'none',
+        logger,
+        LOG_PREFIX
+      );
+      expect(desc).toBe('none');
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Entity with ID 'missing' not found")
+      );
+    });
+
+    it('returns default when entityId is null', () => {
+      const desc = getDescription(
+        entityManager,
+        null,
+        'none',
+        logger,
+        LOG_PREFIX
+      );
+      expect(desc).toBe('none');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('called with null or empty entityId')
+      );
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- add a displayHelpers util for entity name/description
- use the new helpers in EntityDisplayDataProvider and LocationDisplayService
- cover helper behavior with unit tests

Testing Done:
- `npm run format`
- `npm run lint` (fails: many existing warnings/errors)
- `npm run test` *(fails: coverage threshold unmet)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6860c7d4960c8331bd88874836a2934c