### PR TITLE
[Agent] Add invalid actor guard to ActionDiscoveryService

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -111,8 +111,8 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     const { trace: shouldTrace = false } = options;
     const trace = shouldTrace ? this.#traceContextFactory() : null;
 
-    if (!actorEntity) {
-      this.#logger.debug('Actor entity is null; returning empty result.');
+    if (!actorEntity || typeof actorEntity.id !== 'string') {
+      this.#logger.error('getValidActions called with invalid actor entity.');
       return { actions: [], errors: [], trace: null };
     }
 

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -408,8 +408,13 @@ describe('Scope Integration Tests', () => {
   describe('error handling', () => {
     it('should handle missing actingEntity gracefully', async () => {
       actionDiscoveryService = createActionDiscoveryService();
-      const result = await actionDiscoveryService.getValidActions(null, {});
-      expect(result.actions).toEqual([]);
+      const resultNull = await actionDiscoveryService.getValidActions(null, {});
+      const resultMissing = await actionDiscoveryService.getValidActions(
+        {},
+        {}
+      );
+      expect(resultNull.actions).toEqual([]);
+      expect(resultMissing.actions).toEqual([]);
     });
   });
 });

--- a/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
+++ b/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it, jest } from '@jest/globals';
+import { beforeEach, expect, it } from '@jest/globals';
 import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
 
 // Additional coverage tests for ActionDiscoveryService
@@ -11,14 +11,19 @@ describeActionDiscoverySuite(
       bed.mocks.getActorLocationFn.mockReturnValue('room1');
     });
 
-    it('returns empty result when actor entity is null', async () => {
+    it('returns empty result when actor entity is null or missing id', async () => {
       const bed = getBed();
 
-      const result = await bed.service.getValidActions(null, {});
+      const resultNull = await bed.service.getValidActions(null, {});
+      const resultMissing = await bed.service.getValidActions({}, {});
 
-      expect(result).toEqual({ actions: [], errors: [], trace: null });
-      expect(bed.mocks.logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('Actor entity is null; returning empty result.')
+      expect(resultNull).toEqual({ actions: [], errors: [], trace: null });
+      expect(resultMissing).toEqual({ actions: [], errors: [], trace: null });
+      expect(bed.mocks.logger.error).toHaveBeenCalledTimes(2);
+      expect(bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'getValidActions called with invalid actor entity.'
+        )
       );
     });
 


### PR DESCRIPTION
Summary: Add defensive check for invalid actorEntity in `getValidActions` and extend tests to cover missing IDs.

Changes Made:
- Return empty result and log error when actor entity is null or lacks `id`.
- Updated unit and integration tests to verify this behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy) *(fails: 713 errors, existing issues)*
- [ ] Root tests pass (`npm run test`) *(coverage thresholds not met)*
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_6860cbc29964833198dea6987481b89e