### PR TITLE
[Agent] validate logger in EntityInstanceData

### DIFF
--- a/src/entities/entityInstanceData.js
+++ b/src/entities/entityInstanceData.js
@@ -5,6 +5,8 @@
 
 import { cloneDeep } from 'lodash';
 import { freeze } from '../utils/cloneUtils.js';
+import { validateDependency } from '../utils/dependencyUtils.js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 import EntityDefinition from './entityDefinition.js';
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -56,7 +58,7 @@ class EntityInstanceData {
    * @param {string} instanceId - The unique runtime identifier for this instance.
    * @param {EntityDefinition} definition - The EntityDefinition this instance is based on.
    * @param {Record<string, object>} [initialOverrides] - Optional initial component overrides.
-   * @param {ILogger} [logger] - Logger for warnings and diagnostics.
+   * @param {ILogger} [logger] - Logger conforming to {@link ILogger} for warnings and diagnostics.
    * @throws {Error} If instanceId is not a valid string.
    * @throws {Error} If definition is not an instance of EntityDefinition.
    */
@@ -72,7 +74,10 @@ class EntityInstanceData {
 
     this.instanceId = instanceId;
     this.definition = definition;
-    this.#logger = logger;
+    validateDependency(logger, 'ILogger', console, {
+      requiredMethods: ['info', 'warn', 'error', 'debug'],
+    });
+    this.#logger = ensureValidLogger(logger, 'EntityInstanceData');
     // Use cloneDeep for initialOverrides to ensure deep copy and freeze to
     // discourage external mutation.
     this.overrides = freeze(

--- a/tests/unit/entities/EntityInstanceData.test.js
+++ b/tests/unit/entities/EntityInstanceData.test.js
@@ -67,6 +67,14 @@ describe('EntityInstanceData', () => {
     ).toThrow('EntityInstanceData requires a valid EntityDefinition object.');
   });
 
+  it('should throw an error if logger lacks required methods', () => {
+    const invalidLogger = {};
+    expect(
+      () =>
+        new EntityInstanceData(validInstanceId, entityDef, {}, invalidLogger)
+    ).toThrow("Invalid or missing method 'info' on dependency 'ILogger'.");
+  });
+
   describe('getComponentData', () => {
     it('should return data from definition if no override exists', () => {
       const instanceData = new EntityInstanceData(


### PR DESCRIPTION
## Summary
- validate logger dependency in `EntityInstanceData`
- ensure logger is safe via `ensureValidLogger`
- test that constructor rejects invalid loggers

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6860ccc343648331b8c313d0eb3ca835