### PR TITLE
[Agent] centralize default injector components

### DIFF
--- a/src/entities/utils/defaultComponentInjector.js
+++ b/src/entities/utils/defaultComponentInjector.js
@@ -5,8 +5,17 @@ import {
   SHORT_TERM_MEMORY_COMPONENT_ID,
   NOTES_COMPONENT_ID,
   GOALS_COMPONENT_ID,
-  ANATOMY_BODY_COMPONENT_ID,
 } from '../../constants/componentIds.js';
+
+const COMPONENTS_TO_INJECT = [
+  {
+    id: SHORT_TERM_MEMORY_COMPONENT_ID,
+    data: { thoughts: [], maxEntries: 10 },
+    name: 'STM',
+  },
+  { id: NOTES_COMPONENT_ID, data: { notes: [] }, name: 'Notes' },
+  { id: GOALS_COMPONENT_ID, data: { goals: [] }, name: 'Goals' },
+];
 
 /**
  * Injects engine-level default components (STM, notes, goals) into an entity if needed.
@@ -21,17 +30,7 @@ import {
  */
 export function injectDefaultComponents(entity, logger, validateAndClone) {
   if (entity.hasComponent(ACTOR_COMPONENT_ID)) {
-    const componentsToInject = [
-      {
-        id: SHORT_TERM_MEMORY_COMPONENT_ID,
-        data: { thoughts: [], maxEntries: 10 },
-        name: 'STM',
-      },
-      { id: NOTES_COMPONENT_ID, data: { notes: [] }, name: 'Notes' },
-      { id: GOALS_COMPONENT_ID, data: { goals: [] }, name: 'Goals' },
-    ];
-
-    for (const comp of componentsToInject) {
+    for (const comp of COMPONENTS_TO_INJECT) {
       if (!entity.hasComponent(comp.id)) {
         logger.debug(
           `Injecting ${comp.name} for ${entity.id} (def: ${entity.definitionId})`


### PR DESCRIPTION
## Summary
- move default component list into a constant
- iterate over the constant in `injectDefaultComponents`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many repo errors)*
- `npx eslint src/entities/utils/defaultComponentInjector.js`
- `npm run test` *(fails: global coverage thresholds)*
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860ccd5ae3c83318754bf7020eb78f6