### PR TITLE
[Agent] handle candidate retrieval failure

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -122,10 +122,20 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       { withTrace: shouldTrace }
     );
 
-    const candidateDefs = this.#actionIndex.getCandidateActions(
-      actorEntity,
-      trace
-    );
+    let candidateDefs = [];
+    try {
+      candidateDefs = this.#actionIndex.getCandidateActions(actorEntity, trace);
+    } catch (err) {
+      this.#logger.error(
+        `Error retrieving candidate actions: ${err.message}`,
+        err
+      );
+      return {
+        actions: [],
+        errors: [new Error('Candidate retrieval failed')],
+        trace,
+      };
+    }
     const actions = [];
     const errors = [];
     const discoveryContext = this.#prepareDiscoveryContext(

--- a/tests/unit/actions/actionDiscoveryService.candidateRetrievalError.test.js
+++ b/tests/unit/actions/actionDiscoveryService.candidateRetrievalError.test.js
@@ -1,0 +1,36 @@
+import { beforeEach, expect, it } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// Test handling of errors thrown by the action index
+
+describeActionDiscoverySuite(
+  'ActionDiscoveryService candidate retrieval errors',
+  (getBed) => {
+    beforeEach(() => {
+      const bed = getBed();
+      bed.mocks.getActorLocationFn.mockReturnValue('room1');
+    });
+
+    it('returns error result when action index throws', async () => {
+      const bed = getBed();
+      bed.mocks.actionIndex.getCandidateActions.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      const { actions, errors, trace } = await bed.service.getValidActions(
+        { id: 'actor' },
+        {}
+      );
+
+      expect(actions).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+      expect(errors[0].message).toBe('Candidate retrieval failed');
+      expect(trace).toBeNull();
+      expect(bed.mocks.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error retrieving candidate actions'),
+        expect.any(Error)
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- safeguard `getCandidateActions` call in `ActionDiscoveryService`
- return a consistent error result when candidate retrieval fails
- test that candidate retrieval errors are handled

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860d36944cc83318e224b0300924d2f