### PR TITLE
[Agent] encapsulate entity overrides

### DIFF
--- a/src/entities/entityInstanceData.js
+++ b/src/entities/entityInstanceData.js
@@ -49,8 +49,9 @@ class EntityInstanceData {
    * updated. Treat it as immutable and avoid direct mutation.
    *
    * @type {Readonly<Record<string, object>>}
+   * @private
    */
-  overrides;
+  #overrides;
 
   /**
    * Creates a new EntityInstanceData instance.
@@ -80,7 +81,7 @@ class EntityInstanceData {
     this.#logger = ensureValidLogger(logger, 'EntityInstanceData');
     // Use cloneDeep for initialOverrides to ensure deep copy and freeze to
     // discourage external mutation.
-    this.overrides = freeze(
+    this.#overrides = freeze(
       initialOverrides ? cloneDeep(initialOverrides) : {}
     );
   }
@@ -97,7 +98,7 @@ class EntityInstanceData {
   getComponentData(componentTypeId) {
     const definitionComponent =
       this.definition.getComponentTemplate(componentTypeId);
-    const overrideComponent = this.overrides[componentTypeId];
+    const overrideComponent = this.#overrides[componentTypeId];
 
     // If the override is explicitly null, it means the component is effectively removed or nullified for this instance.
     if (overrideComponent === null) {
@@ -135,10 +136,10 @@ class EntityInstanceData {
     }
     // Replace overrides object to keep it immutable for external consumers.
     const updated = {
-      ...this.overrides,
+      ...this.#overrides,
       [componentTypeId]: cloneDeep(componentData),
     };
-    this.overrides = freeze(updated);
+    this.#overrides = freeze(updated);
   }
 
   /**
@@ -153,15 +154,17 @@ class EntityInstanceData {
       return false; // Invalid componentTypeId
     }
 
-    if (typeof this.overrides !== 'object' || this.overrides === null) {
-      this.overrides = freeze({});
+    if (typeof this.#overrides !== 'object' || this.#overrides === null) {
+      this.#overrides = freeze({});
       return false;
     }
 
-    if (Object.prototype.hasOwnProperty.call(this.overrides, componentTypeId)) {
-      const updated = { ...this.overrides };
+    if (
+      Object.prototype.hasOwnProperty.call(this.#overrides, componentTypeId)
+    ) {
+      const updated = { ...this.#overrides };
       delete updated[componentTypeId];
-      this.overrides = freeze(updated);
+      this.#overrides = freeze(updated);
       return true;
     }
     return false; // Key not found in overrides
@@ -192,7 +195,7 @@ class EntityInstanceData {
     }
 
     const overrideExists = Object.prototype.hasOwnProperty.call(
-      this.overrides,
+      this.#overrides,
       componentTypeId
     );
 
@@ -219,10 +222,19 @@ class EntityInstanceData {
     }
 
     const overrideExists = Object.prototype.hasOwnProperty.call(
-      this.overrides,
+      this.#overrides,
       componentTypeId
     );
-    return overrideExists && this.overrides[componentTypeId] !== null;
+    return overrideExists && this.#overrides[componentTypeId] !== null;
+  }
+
+  /**
+   * Provides read-only access to the component overrides for this instance.
+   *
+   * @returns {Readonly<Record<string, object>>}
+   */
+  get overrides() {
+    return this.#overrides;
   }
 
   /**
@@ -233,7 +245,7 @@ class EntityInstanceData {
    */
   get allComponentTypeIds() {
     const keys = new Set(Object.keys(this.definition.components));
-    Object.keys(this.overrides).forEach((key) => keys.add(key));
+    Object.keys(this.#overrides).forEach((key) => keys.add(key));
     return Array.from(keys);
   }
 }

--- a/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
+++ b/tests/unit/entities/entityInstanceData.removeComponentOverride.test.js
@@ -117,16 +117,14 @@ describe('EntityInstanceData', () => {
       expect(instance.overrides).toEqual(originalOverrides);
     });
 
-    it('should handle cases where the overrides object is null or not an object', () => {
-      // Arrange
-      instance.overrides = null;
-
-      // Act
-      const result = instance.removeComponentOverride('core:position');
-
-      // Assert
-      expect(result).toBe(false);
-      expect(instance.overrides).toEqual({}); // Should be reset to a safe empty object
+    it('should prevent direct mutation of overrides', () => {
+      const original = instance.overrides;
+      // verify frozen
+      expect(Object.isFrozen(original)).toBe(true);
+      expect(() => {
+        instance.overrides = {};
+      }).toThrow(TypeError);
+      expect(instance.overrides).toBe(original);
     });
 
     it('should cause getComponentData to fall back to the definition after removal', () => {


### PR DESCRIPTION
## Summary
- make entity instance overrides private
- return frozen overrides via accessor
- prevent direct mutation of overrides in tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 715 errors, 2814 warnings)*
- `npm run test` *(fails: global coverage thresholds)*
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860d8a437708331829f0947c4416568