### PR TITLE
[Agent] drop deprecated override check parameter

### DIFF
--- a/src/entities/entity.js
+++ b/src/entities/entity.js
@@ -98,21 +98,10 @@ class Entity {
    * considering both its definition and instance overrides.
    *
    * @param {string} componentTypeId - The unique string identifier for the component type.
-   * @param {boolean} [checkOverrideOnly] - DEPRECATED. If true, only checks
-   * instance overrides.
    * @returns {boolean} True if the entity has data for this component type, false otherwise.
    */
-  hasComponent(componentTypeId, checkOverrideOnly = false) {
-    if (arguments.length === 2) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Entity.hasComponent: The checkOverrideOnly flag is deprecated. Use hasComponentOverride(componentTypeId) instead.'
-      );
-      if (checkOverrideOnly) {
-        return this.hasComponentOverride(componentTypeId);
-      }
-    }
-    return this.#data.hasComponent(componentTypeId); // Use #data
+  hasComponent(componentTypeId) {
+    return this.#data.hasComponent(componentTypeId);
   }
 
   /**

--- a/tests/unit/entities/entity.test.js
+++ b/tests/unit/entities/entity.test.js
@@ -156,16 +156,6 @@ describe('Entity Class', () => {
       spy.mockRestore();
     });
 
-    it('should pass checkOverrideOnly to _instanceData.hasComponent', () => {
-      const componentTypeId = 'core:health';
-      const spy = jest.spyOn(mockInstanceData, 'hasComponent');
-      const result = entity.hasComponent(componentTypeId);
-
-      expect(spy).toHaveBeenCalledWith(componentTypeId);
-      expect(result).toBe(true);
-      spy.mockRestore();
-    });
-
     it('should return true if component in definition (via instanceData)', () => {
       expect(entity.hasComponent('core:name')).toBe(true);
     });

--- a/tests/unit/entities/entityManager.hasComponent.test.js
+++ b/tests/unit/entities/entityManager.hasComponent.test.js
@@ -53,7 +53,7 @@ describeEntityManagerSuite('EntityManager - hasComponent', (getBed) => {
       em.hasComponent(instanceId, componentTypeId)
     );
 
-    describe('with checkOverrideOnly flag', () => {
+    describe('hasComponentOverride (legacy checkOverrideOnly flag)', () => {
       it.each([
         ['component only on definition', false],
         ['component as override', true],


### PR DESCRIPTION
## Summary
- remove deprecated `checkOverrideOnly` arg from `Entity.hasComponent`
- drop related entity test for override flag
- reword entity manager test description

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860d8854b3083318c8996bb23d0c83a