### PR TITLE
[Agent] extract discovery error helpers

### DIFF
--- a/src/actions/actionCandidateProcessor.js
+++ b/src/actions/actionCandidateProcessor.js
@@ -15,6 +15,9 @@
 /** @typedef {import('../data/gameDataRepository.js').ActionDefinition} ActionDefinition */
 /** @typedef {import('../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo} DiscoveredActionInfo */
 
+// Dependency imports
+import { createDiscoveryError } from './utils/discoveryErrorUtils.js';
+
 /**
  * @typedef {object} ProcessResult
  * @property {DiscoveredActionInfo[]} actions - Valid discovered actions
@@ -92,7 +95,7 @@ export class ActionCandidateProcessor {
       );
       return {
         actions: [],
-        errors: [this.#createDiscoveryError(actionDef.id, null, error)],
+        errors: [createDiscoveryError(actionDef.id, null, error)],
       };
     }
 
@@ -193,7 +196,7 @@ export class ActionCandidateProcessor {
         });
       } else {
         errors.push(
-          this.#createDiscoveryError(
+          createDiscoveryError(
             actionDef.id,
             targetContext.entityId,
             formatResult.error,
@@ -206,19 +209,5 @@ export class ActionCandidateProcessor {
       }
     }
     return { actions: validActions, errors };
-  }
-
-  /**
-   * Creates a standardized error object for action discovery.
-   *
-   * @param {string} actionId - ID of the action that failed.
-   * @param {string|null} targetId - ID of the target entity, if available.
-   * @param {Error|string} error - The encountered error instance or message.
-   * @param {any|null} [details] - Optional additional error details.
-   * @returns {{ actionId: string, targetId: string|null, error: Error|string, details: any|null }} The standardized error object.
-   * @private
-   */
-  #createDiscoveryError(actionId, targetId, error, details = null) {
-    return { actionId, targetId, error, details };
   }
 }

--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -14,6 +14,10 @@
 import { IActionDiscoveryService } from '../interfaces/IActionDiscoveryService.js';
 import { setupService } from '../utils/serviceInitializerUtils.js';
 import { getActorLocation } from '../utils/actorLocationUtils.js';
+import {
+  createDiscoveryError,
+  extractTargetId,
+} from './utils/discoveryErrorUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 /**
@@ -157,12 +161,9 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
           errors.push(...result.errors);
         }
       } catch (err) {
-        errors.push({
-          actionId: actionDef.id,
-          targetId: this.#extractTargetId(err),
-          error: err,
-          details: null,
-        });
+        errors.push(
+          createDiscoveryError(actionDef.id, extractTargetId(err), err)
+        );
         this.#logger.error(
           `Error processing candidate action '${actionDef.id}': ${err.message}`,
           err
@@ -179,18 +180,5 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     );
 
     return { actions, errors, trace };
-  }
-
-  /**
-   * Extracts a target entity ID from various error shapes.
-   *
-   * @param {Error} error - The error thrown during action processing.
-   * @returns {string|null} The resolved target entity ID or null if not present.
-   * @private
-   */
-  #extractTargetId(error) {
-    return (
-      error?.targetId ?? error?.target?.entityId ?? error?.entityId ?? null
-    );
   }
 }

--- a/src/actions/utils/discoveryErrorUtils.js
+++ b/src/actions/utils/discoveryErrorUtils.js
@@ -1,0 +1,35 @@
+// src/actions/utils/discoveryErrorUtils.js
+
+/**
+ * @module discoveryErrorUtils
+ * @description Utilities for creating and parsing discovery errors.
+ */
+
+/**
+ * Creates a standardized error object for action discovery.
+ *
+ * @param {string} actionId - ID of the action that failed.
+ * @param {string|null} targetId - ID of the target entity, if available.
+ * @param {Error|string} error - The encountered error instance or message.
+ * @param {any|null} [details] - Optional additional error details.
+ * @returns {{ actionId: string, targetId: string|null, error: Error|string, details: any|null }}
+ *   The standardized error object.
+ */
+export function createDiscoveryError(
+  actionId,
+  targetId,
+  error,
+  details = null
+) {
+  return { actionId, targetId, error, details };
+}
+
+/**
+ * Extracts a target entity ID from various error shapes.
+ *
+ * @param {Error|object} error - The error thrown during action processing.
+ * @returns {string|null} The resolved target entity ID or null if not present.
+ */
+export function extractTargetId(error) {
+  return error?.targetId ?? error?.target?.entityId ?? error?.entityId ?? null;
+}

--- a/tests/unit/actions/discoveryErrorUtils.test.js
+++ b/tests/unit/actions/discoveryErrorUtils.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  createDiscoveryError,
+  extractTargetId,
+} from '../../../src/actions/utils/discoveryErrorUtils.js';
+
+/**
+ * @file tests/unit/actions/discoveryErrorUtils.test.js
+ * @description Unit tests for discoveryErrorUtils.
+ */
+
+describe('discoveryErrorUtils', () => {
+  it('creates standardized discovery error objects', () => {
+    const err = new Error('bad');
+    const result = createDiscoveryError('a1', 't1', err);
+    expect(result).toEqual({
+      actionId: 'a1',
+      targetId: 't1',
+      error: err,
+      details: null,
+    });
+  });
+
+  it('extracts targetId from various error shapes', () => {
+    expect(extractTargetId({ targetId: 'x' })).toBe('x');
+    expect(extractTargetId({ target: { entityId: 'y' } })).toBe('y');
+    expect(extractTargetId({ entityId: 'z' })).toBe('z');
+    expect(extractTargetId({})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- centralize discovery error helper logic in `src/actions/utils`
- use these helpers from action processor and discovery service
- cover new utility with unit tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 715 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860db99d65c8331b09462f2850537c3