### PR TITLE
[Agent] Add optional clearAll method and update adapter

### DIFF
--- a/src/entities/entityManagerAdapter.js
+++ b/src/entities/entityManagerAdapter.js
@@ -107,14 +107,10 @@ export class EntityManagerAdapter extends IEntityManager {
 
   /**
    * Clears all active entities via the wrapped EntityManager.
-   * This method is not part of {@link IEntityManager} but required by
-   * subsystems like GameStateRestorer.
+   * This method is required by subsystems like GameStateRestorer.
    */
   clearAll() {
-    if (typeof this.#entityManager.clearAll === 'function') {
-      return this.#entityManager.clearAll();
-    }
-    return undefined;
+    return this.#entityManager.clearAll();
   }
 }
 

--- a/src/interfaces/IEntityManager.js
+++ b/src/interfaces/IEntityManager.js
@@ -170,4 +170,15 @@ export class IEntityManager {
       'IEntityManager.getAllComponentTypesForEntity not implemented.'
     );
   }
+
+  /**
+   * (Optional) Clears all entity instances and related caches.
+   * Implementations required by modules like GameStateRestorer should
+   * remove all active entities from memory.
+   *
+   * @returns {void}
+   */
+  clearAll() {
+    throw new Error('IEntityManager.clearAll not implemented.');
+  }
 }

--- a/tests/unit/entities/entityManagerAdapter.branches.test.js
+++ b/tests/unit/entities/entityManagerAdapter.branches.test.js
@@ -2,17 +2,6 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { EntityManagerAdapter } from '../../../src/entities/entityManagerAdapter.js';
 
 describe('EntityManagerAdapter additional coverage', () => {
-  it('returns undefined when clearAll is not implemented', () => {
-    const entityManager = {};
-    const locationQueryService = { getEntitiesInLocation: jest.fn() };
-    const adapter = new EntityManagerAdapter({
-      entityManager,
-      locationQueryService,
-    });
-    const result = adapter.clearAll();
-    expect(result).toBeUndefined();
-  });
-
   it('delegates various methods to the wrapped entity manager', () => {
     const entityManager = {
       getEntityInstance: jest.fn(() => 'e1'),


### PR DESCRIPTION
## Summary
- define optional clearAll in IEntityManager
- simplify EntityManagerAdapter.clearAll
- adjust branch and GameStateRestorer tests to use adapter clearing

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3530 problems, but existing issues; none from modified files)*
- `npm test` *(tests pass; coverage thresholds not met)*
- `cd llm-proxy-server && npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860e0c78f448331be0395c09205f50e