### PR TITLE
[Agent] Structured candidate retrieval error

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -136,7 +136,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
       );
       return {
         actions: [],
-        errors: [new Error('Candidate retrieval failed')],
+        errors: [createDiscoveryError('candidateRetrieval', null, err)],
         trace,
       };
     }

--- a/tests/unit/actions/actionDiscoveryService.candidateRetrievalError.test.js
+++ b/tests/unit/actions/actionDiscoveryService.candidateRetrievalError.test.js
@@ -24,8 +24,13 @@ describeActionDiscoverySuite(
 
       expect(actions).toEqual([]);
       expect(errors).toHaveLength(1);
-      expect(errors[0]).toBeInstanceOf(Error);
-      expect(errors[0].message).toBe('Candidate retrieval failed');
+      expect(errors[0]).toEqual({
+        actionId: 'candidateRetrieval',
+        targetId: null,
+        error: expect.any(Error),
+        details: null,
+      });
+      expect(errors[0].error.message).toBe('boom');
       expect(trace).toBeNull();
       expect(bed.mocks.logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Error retrieving candidate actions'),


### PR DESCRIPTION
## Summary
- return discovery errors with `createDiscoveryError` when candidate retrieval fails
- update candidate retrieval error test

## Testing
- `npx jest --env=jsdom --silent`
- `cd llm-proxy-server && npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_6860e0f2a9848331a2cece4ac1659cba