### PR TITLE
[Agent] extract helpers for availableActionsProvider

### DIFF
--- a/src/data/providers/availableActionsProvider.js
+++ b/src/data/providers/availableActionsProvider.js
@@ -72,6 +72,60 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
   }
 
   /**
+   * Fetch the current location entity for an actor, if available.
+   *
+   * @private
+   * @param {Entity} actor - Actor whose location should be resolved.
+   * @returns {Promise<Entity|null>} Location entity or `null` when unavailable.
+   */
+  async #getLocationEntity(actor) {
+    const positionComponent = actor.getComponentData(POSITION_COMPONENT_ID);
+    const locationId = positionComponent?.locationId;
+    return locationId
+      ? this.#entityManager.getEntityInstance(locationId)
+      : null;
+  }
+
+  /**
+   * Write a detailed discovery trace to the logger if supported.
+   *
+   * @private
+   * @param {string} actorId - Identifier of the actor.
+   * @param {object} trace - Trace output from discovery service.
+   * @param {ILogger} logger - Logger used for output.
+   * @returns {void}
+   */
+  #logDiscoveryTrace(actorId, trace, logger) {
+    if (trace && logger.table && logger.groupCollapsed && logger.groupEnd) {
+      logger.debug(`[Action Discovery Trace for actor ${actorId}]`);
+      logger.groupCollapsed(`Action Discovery Trace for ${actorId}`);
+      logger.table(trace.logs);
+      logger.groupEnd();
+    }
+  }
+
+  /**
+   * Warn when the available actions list is capped by the configured maximum.
+   *
+   * @private
+   * @param {number} requestedCount - Number of actions discovered.
+   * @param {number} cappedCount - Number of actions returned after capping.
+   * @param {string} actorId - Actor identifier.
+   * @param {ILogger} logger - Logger used for warnings.
+   * @returns {void}
+   */
+  #handleOverflow(requestedCount, cappedCount, actorId, logger) {
+    if (
+      requestedCount > MAX_AVAILABLE_ACTIONS_PER_TURN &&
+      cappedCount === MAX_AVAILABLE_ACTIONS_PER_TURN
+    ) {
+      logger.warn(
+        `[Overflow] actor=${actorId} requested=${requestedCount} capped=${cappedCount}`
+      );
+    }
+  }
+
+  /**
    * Discovers and indexes available actions for the given actor. Results are
    * cached for the duration of the turn.
    *
@@ -101,13 +155,7 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
     logger.debug(`[Cache Miss] Discovering actions for actor ${actor.id}`);
 
     try {
-      const positionComponent = actor.getComponentData(POSITION_COMPONENT_ID);
-      const locationId = positionComponent?.locationId;
-      let locationEntity = null;
-      if (locationId) {
-        locationEntity =
-          await this.#entityManager.getEntityInstance(locationId);
-      }
+      const locationEntity = await this.#getLocationEntity(actor);
 
       // Assembling the context is now much simpler and no longer leaks dependencies.
       const actionCtx = {
@@ -124,12 +172,7 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
         trace: true,
       });
 
-      if (trace && logger.table && logger.groupCollapsed && logger.groupEnd) {
-        logger.debug(`[Action Discovery Trace for actor ${actor.id}]`);
-        logger.groupCollapsed(`Action Discovery Trace for ${actor.id}`);
-        logger.table(trace.logs);
-        logger.groupEnd();
-      }
+      this.#logDiscoveryTrace(actor.id, trace, logger);
 
       // --- Log any formatting errors that occurred ---
       if (errors && errors.length > 0) {
@@ -152,14 +195,7 @@ export class AvailableActionsProvider extends IAvailableActionsProvider {
       const requestedCount = discoveredActions.length;
       const cappedCount = indexedActions.length;
 
-      if (
-        requestedCount > MAX_AVAILABLE_ACTIONS_PER_TURN &&
-        cappedCount === MAX_AVAILABLE_ACTIONS_PER_TURN
-      ) {
-        logger.warn(
-          `[Overflow] actor=${actor.id} requested=${requestedCount} capped=${cappedCount}`
-        );
-      }
+      this.#handleOverflow(requestedCount, cappedCount, actor.id, logger);
 
       this.#cachedActions.set(cacheKey, indexedActions);
 


### PR DESCRIPTION
## Summary
- refactor fetching location entity into a helper
- add trace and overflow logging helpers
- simplify `get()` by delegating to helpers

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many repo-wide lint issues)*
- `npm run test` *(fails due to coverage thresholds but test suites pass)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6860e2bcc514833181b9477f8025f6d0