### PR TITLE
[Agent] fix validatePreconditions jsdoc

### DIFF
--- a/src/domUI/saveGameService.js
+++ b/src/domUI/saveGameService.js
@@ -44,7 +44,6 @@ export default class SaveGameService {
    *
    * @param {SlotDisplayData | null} selectedSlotData - Currently selected slot.
    * @param {string} saveName - Proposed save name.
-   * @param {GameEngine | null} gameEngine - Game engine instance.
    * @returns {string | null} Error message if validation fails, otherwise null.
    */
   validatePreconditions(selectedSlotData, saveName) {


### PR DESCRIPTION
Summary: Fix outdated JSDoc for `validatePreconditions` to reflect two parameters.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint src/domUI/saveGameService.js`
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860e35d1a148331ba5828dfc5102530