### PR TITLE
[Agent] Extract logger config loader helper

### DIFF
--- a/tests/registrations/loadLoggerConfig.test.js
+++ b/tests/registrations/loadLoggerConfig.test.js
@@ -1,0 +1,46 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import AppContainer from '../../src/dependencyInjection/appContainer.js';
+import { loadLoggerConfig } from '../../src/dependencyInjection/containerConfig.js';
+import { tokens } from '../../src/dependencyInjection/tokens.js';
+import { LoggerConfigLoader } from '../../src/configuration/loggerConfigLoader.js';
+
+describe('loadLoggerConfig', () => {
+  /** @type {AppContainer} */
+  let container;
+  let logger;
+  let loadConfigSpy;
+
+  beforeEach(() => {
+    container = new AppContainer();
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      setLogLevel: jest.fn(),
+    };
+    container.register(tokens.ILogger, logger);
+    container.register(tokens.ISafeEventDispatcher, { dispatch: jest.fn() });
+    loadConfigSpy = jest.spyOn(LoggerConfigLoader.prototype, 'loadConfig');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('applies log level when configuration specifies a string', async () => {
+    loadConfigSpy.mockResolvedValue({ logLevel: 'WARN' });
+    await loadLoggerConfig(container, logger);
+    expect(logger.setLogLevel).toHaveBeenCalledWith('WARN');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs error when loading configuration throws', async () => {
+    loadConfigSpy.mockRejectedValue(new Error('network'));
+    await loadLoggerConfig(container, logger);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('CRITICAL ERROR'),
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
Summary: Move asynchronous logger setup logic into new `loadLoggerConfig` helper and call it from container configuration. Added unit tests covering success and failure branches of the helper.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 715 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860e2d65b488331afea71c43cade4c6