### PR TITLE
[Agent] Add entity component utils and refactor STM service

### DIFF
--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -7,6 +7,10 @@ import NotesService from './notesService.js';
 import { NOTES_COMPONENT_ID } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { isNonBlankString } from '../utils/textUtils.js';
+import {
+  readComponent,
+  writeComponent,
+} from '../utils/componentAccessUtils.js';
 
 /**
  * Persists the "notes" produced during an LLM turn into the actor's
@@ -62,10 +66,7 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
     return;
   }
 
-  const hasGetter = typeof actorEntity?.getComponentData === 'function';
-  let notesComp = hasGetter
-    ? actorEntity.getComponentData(NOTES_COMPONENT_ID)
-    : actorEntity?.components?.[NOTES_COMPONENT_ID];
+  let notesComp = readComponent(actorEntity, NOTES_COMPONENT_ID);
 
   if (!notesComp) {
     notesComp = { notes: [] };
@@ -83,10 +84,6 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
       logger.debug(`Added note: "${note.text}" at ${note.timestamp}`);
     });
 
-    if (typeof actorEntity?.addComponent === 'function') {
-      actorEntity.addComponent(NOTES_COMPONENT_ID, updatedNotesComp);
-    } else if (actorEntity?.components) {
-      actorEntity.components[NOTES_COMPONENT_ID] = updatedNotesComp;
-    }
+    writeComponent(actorEntity, NOTES_COMPONENT_ID, updatedNotesComp);
   }
 }

--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -146,4 +146,45 @@ export function resolveEntityInstance(entityOrId, entityManager, logger) {
   return null;
 }
 
+/**
+ * @description Retrieves component data from an entity. Works with full
+ * Entity instances exposing `getComponentData` as well as plain objects that
+ * store data under a `components` property.
+ * @param {object} entity - Target entity instance or pseudo-entity.
+ * @param {string} componentId - ID of the component to fetch.
+ * @returns {any | null} The component data if found, otherwise `null`.
+ */
+export function readComponent(entity, componentId) {
+  if (!entity) {
+    return null;
+  }
+  if (typeof entity.getComponentData === 'function') {
+    return entity.getComponentData(componentId);
+  }
+  return entity.components?.[componentId] ?? null;
+}
+
+/**
+ * @description Writes component data back to an entity. Uses `addComponent`
+ * when available, falling back to direct assignment on a `components` bag.
+ * @param {object} entity - Target entity instance or pseudo-entity.
+ * @param {string} componentId - ID of the component to write.
+ * @param {any} data - Data to store.
+ * @returns {boolean} `true` if the data was stored, otherwise `false`.
+ */
+export function writeComponent(entity, componentId, data) {
+  if (!entity) {
+    return false;
+  }
+  if (typeof entity.addComponent === 'function') {
+    entity.addComponent(componentId, data);
+    return true;
+  }
+  if (entity.components && typeof entity.components === 'object') {
+    entity.components[componentId] = data;
+    return true;
+  }
+  return false;
+}
+
 // --- FILE END ---

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,3 +29,4 @@ export {
   validateDependencies,
 } from './dependencyUtils.js';
 export { createErrorDetails } from './errorDetails.js';
+export { readComponent, writeComponent } from './componentAccessUtils.js';

--- a/tests/unit/utils/componentAccessUtils.test.js
+++ b/tests/unit/utils/componentAccessUtils.test.js
@@ -3,6 +3,8 @@ import {
   getComponentFromEntity,
   getComponentFromManager,
   resolveEntityInstance,
+  readComponent,
+  writeComponent,
 } from '../../../src/utils/componentAccessUtils.js';
 import { createMockLogger } from '../testUtils.js';
 
@@ -172,5 +174,34 @@ describe('resolveEntityInstance', () => {
     expect(logger.debug).toHaveBeenCalledWith(
       '[componentAccessUtils] resolveEntityInstance: provided value is not a valid entity.'
     );
+  });
+});
+
+describe('readComponent and writeComponent', () => {
+  it('reads via getComponentData when available', () => {
+    const ent = { getComponentData: jest.fn().mockReturnValue({ a: 1 }) };
+    expect(readComponent(ent, 'foo')).toEqual({ a: 1 });
+  });
+
+  it('reads from components bag when no getter', () => {
+    const ent = { components: { bar: 2 } };
+    expect(readComponent(ent, 'bar')).toBe(2);
+  });
+
+  it('writes via addComponent when available', () => {
+    const ent = { addComponent: jest.fn(), components: {} };
+    const data = { x: 3 };
+    expect(writeComponent(ent, 'foo', data)).toBe(true);
+    expect(ent.addComponent).toHaveBeenCalledWith('foo', data);
+  });
+
+  it('writes to components bag when no addComponent', () => {
+    const ent = { components: {} };
+    expect(writeComponent(ent, 'bar', 5)).toBe(true);
+    expect(ent.components.bar).toBe(5);
+  });
+
+  it('returns false for invalid entity', () => {
+    expect(writeComponent(null, 'x', {})).toBe(false);
   });
 });


### PR DESCRIPTION
Summary: Extracted reusable helpers for reading and writing entity components and decoupled event dispatching from short‑term memory mutations.

Changes Made:
- Added `readComponent` and `writeComponent` utilities with exports.
- Updated note and thought persistence hooks to use new helpers.
- Refactored `ShortTermMemoryService.addThought` to return a result and added `emitThoughtAdded` for event dispatch.
- Updated related unit tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint ... --fix`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6860e248c06883318939877ff8290478