### PR TITLE
[Agent] Refactor entity service initialization

### DIFF
--- a/src/entities/spatialIndexSynchronizer.js
+++ b/src/entities/spatialIndexSynchronizer.js
@@ -48,25 +48,26 @@ export class SpatialIndexSynchronizer {
     /** @private */
     this.logger = logger;
 
-    safeEventDispatcher.subscribe(
-      ENTITY_CREATED_ID,
-      this.onEntityAdded.bind(this)
-    );
-    safeEventDispatcher.subscribe(
-      ENTITY_REMOVED_ID,
-      this.onEntityRemoved.bind(this)
-    );
-    safeEventDispatcher.subscribe(
-      COMPONENT_ADDED_ID,
-      this.onPositionChanged.bind(this)
-    );
-    safeEventDispatcher.subscribe(
-      COMPONENT_REMOVED_ID,
-      this.onPositionChanged.bind(this)
-    );
+    this.#subscribeToEvents(safeEventDispatcher);
 
     this.logger.debug(
       'SpatialIndexSynchronizer initialized and listening for events.'
+    );
+  }
+
+  /**
+   * Subscribe to entity lifecycle and component events.
+   *
+   * @private
+   * @param {ISafeEventDispatcher} dispatcher
+   */
+  #subscribeToEvents(dispatcher) {
+    dispatcher.subscribe(ENTITY_CREATED_ID, this.onEntityAdded.bind(this));
+    dispatcher.subscribe(ENTITY_REMOVED_ID, this.onEntityRemoved.bind(this));
+    dispatcher.subscribe(COMPONENT_ADDED_ID, this.onPositionChanged.bind(this));
+    dispatcher.subscribe(
+      COMPONENT_REMOVED_ID,
+      this.onPositionChanged.bind(this)
     );
   }
 

--- a/tests/unit/entities/services/componentMutationService.test.js
+++ b/tests/unit/entities/services/componentMutationService.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import ComponentMutationService from '../../../../src/entities/services/componentMutationService.js';
+import { COMPONENT_ADDED_ID } from '../../../../src/constants/eventIds.js';
+import { EntityNotFoundError } from '../../../../src/errors/entityNotFoundError.js';
+import { ValidationError } from '../../../../src/errors/validationError.js';
+
+const createService = ({ entity } = {}) => {
+  const entityRepository = { get: jest.fn(() => entity) };
+  const validator = { validate: jest.fn(() => ({ isValid: true })) };
+  const logger = {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  };
+  const eventDispatcher = { dispatch: jest.fn() };
+  const cloner = jest.fn((d) => ({ ...d }));
+
+  const service = new ComponentMutationService({
+    entityRepository,
+    validator,
+    logger,
+    eventDispatcher,
+    cloner,
+  });
+
+  return {
+    service,
+    entityRepository,
+    validator,
+    logger,
+    eventDispatcher,
+    cloner,
+  };
+};
+
+describe('ComponentMutationService.addComponent', () => {
+  let entity;
+
+  beforeEach(() => {
+    entity = {
+      addComponent: jest.fn(() => true),
+      getComponentData: jest.fn(() => undefined),
+    };
+  });
+
+  it('adds a component and emits event', () => {
+    const { service, eventDispatcher, cloner } = createService({ entity });
+    const data = { hp: 5 };
+
+    service.addComponent('e1', 'core:health', data);
+
+    expect(entity.addComponent).toHaveBeenCalledWith('core:health', { hp: 5 });
+    expect(cloner).toHaveBeenCalled();
+    expect(eventDispatcher.dispatch).toHaveBeenCalledWith(COMPONENT_ADDED_ID, {
+      entity,
+      componentTypeId: 'core:health',
+      componentData: { hp: 5 },
+      oldComponentData: undefined,
+    });
+  });
+
+  it('throws EntityNotFoundError when entity missing', () => {
+    const { service, eventDispatcher } = createService({ entity: undefined });
+    expect(() => service.addComponent('missing', 'c', {})).toThrow(
+      EntityNotFoundError
+    );
+    expect(eventDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError when validation fails', () => {
+    const { service, validator } = createService({ entity });
+    validator.validate.mockReturnValue({ isValid: false, errors: ['bad'] });
+    expect(() => service.addComponent('e1', 'c', {})).toThrow(ValidationError);
+  });
+
+  it('throws when entity update fails', () => {
+    entity.addComponent.mockReturnValue(false);
+    const { service } = createService({ entity });
+    expect(() => service.addComponent('e1', 'c', {})).toThrow(
+      "Failed to add component 'c' to entity 'e1'. Internal entity update failed."
+    );
+  });
+});


### PR DESCRIPTION
Summary:
- factor out dependency and service setup in EntityManager
- add helper methods within ComponentMutationService
- subscribe SpatialIndexSynchronizer events via new method
- cover new helpers with unit tests

Testing Done:
- `npm run format`
- `npm run lint`
- `npx jest --env=jsdom --runInBand --silent`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6860e3d65e2c8331ac9ed2e3b3c689a9