### PR TITLE
[Agent] use ensureValidLogger in PlaytimeTracker

### DIFF
--- a/src/engine/playtimeTracker.js
+++ b/src/engine/playtimeTracker.js
@@ -4,6 +4,7 @@ import { IPlaytimeTracker } from '../interfaces/IPlaytimeTracker.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../constants/eventIds.js';
 import { ISafeEventDispatcher } from '../interfaces/ISafeEventDispatcher.js';
 import { validateDependency } from '../utils/dependencyUtils.js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -61,28 +62,7 @@ class PlaytimeTracker extends IPlaytimeTracker {
   constructor({ logger, safeEventDispatcher }) {
     super();
 
-    if (!logger || typeof logger.info !== 'function') {
-      // eslint-disable-next-line no-console
-      console.error(
-        'PlaytimeTracker: Logger dependency is missing or invalid. Falling back to console.error.'
-      );
-      // Fallback logger for environments where a full logger isn't available or during initial setup
-      this.#logger = {
-        info: (message) =>
-          console.info(`PlaytimeTracker (fallback): ${message}`),
-
-        warn: (message) =>
-          console.warn(`PlaytimeTracker (fallback): ${message}`),
-
-        error: (message) =>
-          console.error(`PlaytimeTracker (fallback): ${message}`),
-
-        debug: (message) =>
-          console.debug(`PlaytimeTracker (fallback): ${message}`),
-      };
-    } else {
-      this.#logger = logger;
-    }
+    this.#logger = ensureValidLogger(logger, 'PlaytimeTracker');
 
     validateDependency(
       safeEventDispatcher,


### PR DESCRIPTION
Summary: replaced PlaytimeTracker's manual logger fallback with ensureValidLogger and updated tests to verify validation behavior.

Changes Made:
- imported ensureValidLogger in PlaytimeTracker and used it to validate the logger
- removed custom console-based logger creation
- added tests checking ensureValidLogger invocation and fallback

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes on modified files
- [x] Root tests pass (`npm test`) *(coverage thresholds fail)*
- [x] Proxy tests pass (`cd llm-proxy-server && npm test`)
- [x] Manual smoke test `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6860e89b22c88331bd85568371415ebd