### PR TITLE
[Agent] allow custom logger for InMemoryDataRegistry

### DIFF
--- a/src/data/inMemoryDataRegistry.js
+++ b/src/data/inMemoryDataRegistry.js
@@ -12,10 +12,15 @@
  * @implements {IDataRegistry}
  */
 class InMemoryDataRegistry {
+  #logger;
   /**
    * Initializes the internal storage structures.
+   *
+   * @description Creates a new in-memory data registry.
+   * @param {object} [options]
+   * @param {object} [options.logger] Logger implementation
    */
-  constructor() {
+  constructor({ logger = console } = {}) {
     /**
      * @private
      * @type {Map<string, Map<string, object>>}
@@ -27,6 +32,12 @@ class InMemoryDataRegistry {
      * @type {Map<string, Map<string, string>>}
      */
     this.contentOrigins = new Map();
+
+    /**
+     * @type {object}
+     * @private
+     */
+    this.#logger = logger;
   }
 
   /**
@@ -37,19 +48,19 @@ class InMemoryDataRegistry {
    */
   store(type, id, data) {
     if (typeof type !== 'string' || type.trim() === '') {
-      console.error(
+      this.#logger.error(
         'InMemoryDataRegistry.store: Invalid or empty type provided.'
       );
       return false;
     }
     if (typeof id !== 'string' || id.trim() === '') {
-      console.error(
+      this.#logger.error(
         `InMemoryDataRegistry.store: Invalid or empty id provided for type '${type}'.`
       );
       return false;
     }
     if (typeof data !== 'object' || data === null) {
-      console.error(
+      this.#logger.error(
         `InMemoryDataRegistry.store: Invalid data provided for type '${type}', id '${id}'. Must be an object.`
       );
       return false;
@@ -245,7 +256,7 @@ class InMemoryDataRegistry {
     const locationId = playerDef?.components?.['core:position']?.locationId;
 
     if (typeof locationId !== 'string' || !locationId.trim()) {
-      console.warn(
+      this.#logger.warn(
         `Starting player '${playerId}' has no valid locationId in core:position component.`
       );
       return null;

--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -119,7 +119,7 @@ export function registerLoaders(container) {
   );
   registrar.singletonFactory(
     tokens.IDataRegistry,
-    () => new InMemoryDataRegistry()
+    () => new InMemoryDataRegistry({ logger })
   );
   registrar.singletonFactory(
     tokens.IDataFetcher,

--- a/tests/integration/loaders/loaderRegistry.integration.test.js
+++ b/tests/integration/loaders/loaderRegistry.integration.test.js
@@ -159,7 +159,7 @@ describe('Integration: Loaders, Registry State, and Overrides (REFACTOR-8.6)', (
     mockFetcher = createMockDataFetcher();
     mockValidator = createMockSchemaValidator();
     mockLogger = createMockLogger();
-    dataRegistry = new InMemoryDataRegistry(mockLogger);
+    dataRegistry = new InMemoryDataRegistry({ logger: mockLogger });
     jest.clearAllMocks();
     jest.spyOn(dataRegistry, 'store');
     jest.spyOn(dataRegistry, 'get');

--- a/tests/integration/loaders/modsLoader.integration.test.js
+++ b/tests/integration/loaders/modsLoader.integration.test.js
@@ -67,7 +67,7 @@ describe('Integration: ModsLoader Orchestrator Order and Error Propagation', () 
 
   beforeEach(() => {
     mockLogger = createMockLogger();
-    dataRegistry = new InMemoryDataRegistry(mockLogger);
+    dataRegistry = new InMemoryDataRegistry({ logger: mockLogger });
     executionOrder = [];
     phases = [];
   });

--- a/tests/integration/loaders/multiModsWorldLoader.integration.test.js
+++ b/tests/integration/loaders/multiModsWorldLoader.integration.test.js
@@ -28,7 +28,7 @@ function buildEnv(pathToResponse) {
   const fetcher = createMockDataFetcher({ pathToResponse });
   const schemaValidator = createMockSchemaValidator();
   schemaValidator.isSchemaLoaded.mockReturnValue(true);
-  const registry = new InMemoryDataRegistry(logger);
+  const registry = new InMemoryDataRegistry({ logger });
   const defLoader = new EntityDefinitionLoader(
     config,
     resolver,

--- a/tests/unit/loaders/ruleLoader.integration.override.test.js
+++ b/tests/unit/loaders/ruleLoader.integration.override.test.js
@@ -211,7 +211,7 @@ describe('RuleLoader Integration (Rule Override via loadItemsForMod)', () => {
     mockValidator = createMockSchemaValidator();
     mockLogger = createMockLogger();
     // Instantiate a *real* registry to hold state across loads
-    realRegistry = new InMemoryDataRegistry(mockLogger); // Pass mock logger if needed by registry
+    realRegistry = new InMemoryDataRegistry({ logger: mockLogger }); // Pass mock logger if needed by registry
 
     // Ensure rule schema ID is configured via base method
     mockConfig.getContentTypeSchemaId.mockImplementation((registryKey) =>


### PR DESCRIPTION
Summary: InMemoryDataRegistry now accepts an optional logger and uses it instead of console methods. Loaders pass the DI logger and tests updated to reflect the new parameter.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6860e86b98648331bf28f6fa5f5abc15