### PR TITLE
[Agent] Add component helper utilities and refactor persistence

### DIFF
--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -8,9 +8,9 @@ import { NOTES_COMPONENT_ID } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { isNonBlankString } from '../utils/textUtils.js';
 import {
-  readComponent,
-  writeComponent,
-} from '../utils/componentAccessUtils.js';
+  fetchComponent,
+  applyComponent,
+} from '../entities/utils/componentHelpers.js';
 
 /**
  * Persists the "notes" produced during an LLM turn into the actor's
@@ -66,7 +66,7 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
     return;
   }
 
-  let notesComp = readComponent(actorEntity, NOTES_COMPONENT_ID);
+  let notesComp = fetchComponent(actorEntity, NOTES_COMPONENT_ID);
 
   if (!notesComp) {
     notesComp = { notes: [] };
@@ -84,6 +84,6 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
       logger.debug(`Added note: "${note.text}" at ${note.timestamp}`);
     });
 
-    writeComponent(actorEntity, NOTES_COMPONENT_ID, updatedNotesComp);
+    applyComponent(actorEntity, NOTES_COMPONENT_ID, updatedNotesComp);
   }
 }

--- a/src/ai/thoughtPersistenceHook.js
+++ b/src/ai/thoughtPersistenceHook.js
@@ -3,9 +3,9 @@
 import ShortTermMemoryService from './shortTermMemoryService.js';
 import { SHORT_TERM_MEMORY_COMPONENT_ID } from '../constants/componentIds.js';
 import {
-  readComponent,
-  writeComponent,
-} from '../utils/componentAccessUtils.js';
+  fetchComponent,
+  applyComponent,
+} from '../entities/utils/componentHelpers.js';
 
 /**
  * Persist the “thoughts” produced during an LLM turn into the actor’s
@@ -31,7 +31,10 @@ export function persistThoughts(action, actorEntity, logger) {
   const thoughtText = String(rawThoughts).trim();
 
   /* ── 2. Retrieve STM component via the public API ───────────────────── */
-  const memoryComp = readComponent(actorEntity, SHORT_TERM_MEMORY_COMPONENT_ID);
+  const memoryComp = fetchComponent(
+    actorEntity,
+    SHORT_TERM_MEMORY_COMPONENT_ID
+  );
 
   if (!memoryComp) {
     logger.warn('STM-002 Missing component');
@@ -47,7 +50,7 @@ export function persistThoughts(action, actorEntity, logger) {
   );
 
   /* ── 4. Push the mutation back to the entity ────────────────────────── */
-  writeComponent(actorEntity, SHORT_TERM_MEMORY_COMPONENT_ID, updatedMem);
+  applyComponent(actorEntity, SHORT_TERM_MEMORY_COMPONENT_ID, updatedMem);
 }
 
 // Convenience default export

--- a/src/entities/utils/componentHelpers.js
+++ b/src/entities/utils/componentHelpers.js
@@ -1,0 +1,35 @@
+// src/entities/utils/componentHelpers.js
+import {
+  readComponent,
+  writeComponent,
+} from '../../utils/componentAccessUtils.js';
+
+/**
+ * Fetch component data from an entity or pseudo-entity.
+ *
+ * @description Wrapper around {@link readComponent} for entity helpers.
+ * @param {object} entity - Entity instance or plain object with components.
+ * @param {string} componentId - Component identifier to retrieve.
+ * @returns {any | null} The component data or `null` when absent.
+ */
+export function fetchComponent(entity, componentId) {
+  return readComponent(entity, componentId);
+}
+
+/**
+ * Apply component data to an entity or pseudo-entity.
+ *
+ * @description Wrapper around {@link writeComponent} for entity helpers.
+ * @param {object} entity - Entity instance or plain object with components.
+ * @param {string} componentId - Component identifier to apply.
+ * @param {any} data - Component data to store.
+ * @returns {boolean} `true` if the component was written, otherwise `false`.
+ */
+export function applyComponent(entity, componentId, data) {
+  return writeComponent(entity, componentId, data);
+}
+
+export default {
+  fetchComponent,
+  applyComponent,
+};

--- a/tests/unit/utils/componentAccessUtils.test.js
+++ b/tests/unit/utils/componentAccessUtils.test.js
@@ -6,6 +6,10 @@ import {
   readComponent,
   writeComponent,
 } from '../../../src/utils/componentAccessUtils.js';
+import {
+  fetchComponent,
+  applyComponent,
+} from '../../../src/entities/utils/componentHelpers.js';
 import { createMockLogger } from '../testUtils.js';
 
 class MockEntity {
@@ -203,5 +207,19 @@ describe('readComponent and writeComponent', () => {
 
   it('returns false for invalid entity', () => {
     expect(writeComponent(null, 'x', {})).toBe(false);
+  });
+});
+
+describe('fetchComponent and applyComponent', () => {
+  it('delegates fetch to readComponent', () => {
+    const ent = { getComponentData: jest.fn().mockReturnValue({ a: 1 }) };
+    expect(fetchComponent(ent, 'foo')).toEqual({ a: 1 });
+  });
+
+  it('delegates apply to writeComponent', () => {
+    const ent = { addComponent: jest.fn(), components: {} };
+    const data = { x: 2 };
+    expect(applyComponent(ent, 'foo', data)).toBe(true);
+    expect(ent.addComponent).toHaveBeenCalledWith('foo', data);
   });
 });


### PR DESCRIPTION
## Summary
- introduce `fetchComponent` and `applyComponent` helpers
- use helpers inside notes and thought persistence hooks
- cover new helpers with unit tests

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 715 errors, 2864 warnings)*
- `npm run test` *(fails due to coverage thresholds, all 844 suites pass)*
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860e8236bc083318d8dfdc5790c3053