### PR TITLE
[Agent] modularize loader helpers

### DIFF
--- a/src/loaders/ModProcessor.js
+++ b/src/loaders/ModProcessor.js
@@ -1,0 +1,262 @@
+/**
+ * @file Contains ModProcessor which handles manifest validation and loader execution for a single mod.
+ */
+
+import LoadResultAggregator from './LoadResultAggregator.js';
+import { resolvePath } from '../utils/objectUtils.js';
+
+/** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../data/schemas/mod-manifest.schema.json').ModManifest} ModManifest */
+/** @typedef {import('./defaultLoaderConfig.js').LoaderConfigEntry} LoaderConfigEntry */
+/** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
+
+/**
+ * @description Processes all loaders for a single mod within a phase.
+ * @class
+ */
+export class ModProcessor {
+  #logger;
+  #validatedEventDispatcher;
+  #aggregatorFactory;
+  #timer;
+
+  /**
+   * @param {object} deps - Dependencies.
+   * @param {ILogger} deps.logger - Logger instance.
+   * @param {ValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher.
+   * @param {(counts: TotalResultsSummary) => LoadResultAggregator} [deps.aggregatorFactory] - Aggregator factory.
+   * @param {() => number} [deps.timer] - Timer function for duration measurement.
+   */
+  constructor({
+    logger,
+    validatedEventDispatcher,
+    aggregatorFactory = (counts) => new LoadResultAggregator(counts),
+    timer = () => performance.now(),
+  }) {
+    this.#logger = logger;
+    this.#validatedEventDispatcher = validatedEventDispatcher;
+    this.#aggregatorFactory = aggregatorFactory;
+    this.#timer = timer;
+  }
+
+  /**
+   * Processes loaders for a single mod.
+   *
+   * @param {string} modId - Mod identifier.
+   * @param {ModManifest|null} manifest - Manifest for the mod.
+   * @param {TotalResultsSummary} totalCounts - Totals object to update.
+   * @param {Array<LoaderConfigEntry>} phaseLoaders - Loaders configured for this phase.
+   * @param {'definitions' | 'instances'} phase - Current phase.
+   * @returns {Promise<{status:'success'|'skipped'|'failed',updatedTotals:TotalResultsSummary}>}
+   *   Processing result and updated totals.
+   */
+  async processMod(modId, manifest, totalCounts, phaseLoaders, phase) {
+    this.#logger.debug(
+      `--- Loading content for mod: ${modId}, phase: ${phase} ---`
+    );
+    const aggregator = this.#aggregatorFactory(totalCounts);
+    let modDurationMs = 0;
+    /** @type {'success' | 'skipped' | 'failed'} */
+    let status = 'success';
+    let hasContentInPhase = false;
+
+    try {
+      const manifestCheck = await this.#validateManifest(
+        modId,
+        manifest,
+        phase,
+        aggregator
+      );
+      if (manifestCheck.shouldSkip) {
+        return manifestCheck.result;
+      }
+
+      this.#logger.debug(
+        `ModsLoader [${modId}, ${phase}]: Manifest retrieved successfully. Processing content types...`
+      );
+      const start = this.#timer();
+
+      const { hasContent, status: loaderStatus } = await this.#runLoadersForMod(
+        modId,
+        /** @type {ModManifest} */ (manifest),
+        phaseLoaders,
+        phase,
+        aggregator
+      );
+
+      hasContentInPhase = hasContent;
+      status = loaderStatus;
+
+      const end = this.#timer();
+      modDurationMs = end - start;
+      this.#logger.debug(
+        `ModsLoader [${modId}, ${phase}]: Content loading loop took ${modDurationMs.toFixed(2)} ms.`
+      );
+    } catch (error) {
+      this.#logger.error(
+        `ModsLoader [${modId}, ${phase}]: Unexpected error during processing for mod '${modId}' in phase '${phase}'. Skipping remaining content for this mod in this phase.`,
+        { modId, phase, error: error?.message },
+        error
+      );
+      await this.#recordModFailure(
+        modId,
+        `Unexpected error in phase ${phase}: ${error?.message}`,
+        phase
+      );
+      return Promise.reject(error);
+    }
+
+    if (!hasContentInPhase && status !== 'failed') {
+      status = 'skipped';
+    }
+
+    const summaryMessage = this.#buildSummaryMessage(
+      modId,
+      phase,
+      modDurationMs,
+      aggregator
+    );
+    this.#logger.debug(summaryMessage);
+    this.#logger.debug(
+      `--- Finished loading content for mod: ${modId}, phase: ${phase} ---`
+    );
+    return { status, updatedTotals: aggregator.getTotalCounts() };
+  }
+
+  async #validateManifest(modId, manifest, phase, aggregator) {
+    if (!manifest) {
+      const reason = `Manifest not found in registry for mod ID '${modId}'. Skipping content load for phase ${phase}.`;
+      this.#logger.error(`ModsLoader: ${reason}`);
+      await this.#recordModFailure(modId, reason);
+      return {
+        shouldSkip: true,
+        result: {
+          status: 'skipped',
+          updatedTotals: aggregator.getTotalCounts(),
+        },
+      };
+    }
+    return { shouldSkip: false };
+  }
+
+  async #runLoadersForMod(modId, manifest, phaseLoaders, phase, aggregator) {
+    let status = 'success';
+    let hasContentInPhase = false;
+    for (const config of phaseLoaders) {
+      const { loader, contentKey, diskFolder, registryKey } = config;
+      const manifestContent = manifest.content || {};
+      const contentList = resolvePath(manifestContent, contentKey);
+      const hasContentForLoader =
+        Array.isArray(contentList) && contentList.length > 0;
+
+      if (hasContentForLoader) {
+        hasContentInPhase = true;
+        this.#logger.debug(
+          `ModsLoader [${modId}, ${phase}]: Processing ${contentKey} content with ${contentList.length} files...`
+        );
+        this.#logger.debug(
+          `ModsLoader [${modId}, ${phase}]: Found content for '${contentKey}'. Invoking loader '${loader.constructor.name}'.`
+        );
+        try {
+          const result =
+            /** @type {import('./baseManifestItemLoader.js').LoadItemsResult} */ (
+              await loader.loadItemsForMod(
+                modId,
+                manifest,
+                contentKey,
+                diskFolder,
+                registryKey
+              )
+            );
+          if (result && typeof result.count === 'number') {
+            aggregator.aggregate(result, registryKey);
+            if (Array.isArray(result.failures) && result.failures.length > 0) {
+              for (const { file, error } of result.failures) {
+                const msg = error?.message || String(error);
+                this.#logger.error(
+                  `ModsLoader [${modId}, ${phase}]: ${registryKey} file '${file}' failed: ${msg}`,
+                  { modId, registryKey, phase, file, error: msg },
+                  error
+                );
+              }
+            }
+          } else {
+            this.#logger.warn(
+              `ModsLoader [${modId}, ${phase}]: Loader for '${registryKey}' returned an unexpected result format. Assuming 0 counts.`,
+              { result }
+            );
+            aggregator.aggregate(null, registryKey);
+          }
+        } catch (error) {
+          const errorMessage = error?.message || String(error);
+          this.#logger.error(
+            `ModsLoader [${modId}, ${phase}]: Error loading content type '${registryKey}'. Continuing...`,
+            { modId, registryKey, phase, error: errorMessage },
+            error
+          );
+          aggregator.recordFailure(registryKey);
+          await this.#validatedEventDispatcher
+            .dispatch(
+              'initialization:world_loader:content_load_failed',
+              { modId, registryKey, error: errorMessage, phase },
+              { allowSchemaNotFound: true }
+            )
+            .catch((e) =>
+              this.#logger.error(
+                `Failed dispatching content_load_failed event for ${modId}/${registryKey}/${phase}`,
+                e
+              )
+            );
+          status = 'failed';
+        }
+      } else {
+        this.#logger.debug(
+          `ModsLoader [${modId}, ${phase}]: Skipping content type '${registryKey}' (key: '${contentKey}') as it's not defined or empty in the manifest.`
+        );
+      }
+    }
+    return { hasContent: hasContentInPhase, status };
+  }
+
+  async #recordModFailure(modId, reason, phase) {
+    await this.#validatedEventDispatcher
+      .dispatch(
+        'initialization:world_loader:mod_load_failed',
+        { modId, reason },
+        { allowSchemaNotFound: true }
+      )
+      .catch((dispatchError) =>
+        this.#logger.error(
+          `Failed dispatching mod_load_failed event for ${modId}${phase ? ` after unexpected error in phase ${phase}` : ''}: ${dispatchError.message}`,
+          dispatchError
+        )
+      );
+  }
+
+  #buildSummaryMessage(modId, phase, durationMs, aggregator) {
+    const totalModOverrides = Object.values(aggregator.modResults).reduce(
+      (sum, res) => sum + (res.overrides || 0),
+      0
+    );
+    const totalModErrors = Object.values(aggregator.modResults).reduce(
+      (sum, res) => sum + (res.errors || 0),
+      0
+    );
+    const typeCountsString = Object.entries(aggregator.modResults)
+      .filter(([, result]) => result.count > 0 || result.errors > 0)
+      .map(
+        ([t, result]) =>
+          `${t}(${result.count}${result.errors > 0 ? ` E:${result.errors}` : ''})`
+      )
+      .sort()
+      .join(', ');
+    return `Mod '${modId}' phase '${phase}' loaded in ${durationMs.toFixed(2)}ms: ${
+      typeCountsString.length > 0
+        ? typeCountsString
+        : 'No items processed in this phase'
+    }${typeCountsString.length > 0 ? ' ' : ''}-> Overrides(${totalModOverrides}), Errors(${totalModErrors})`;
+  }
+}
+
+export default ModProcessor;

--- a/src/loaders/helpers/fileProcessing.js
+++ b/src/loaders/helpers/fileProcessing.js
@@ -1,0 +1,66 @@
+/**
+ * @file Helper for wrapping file processing steps used by BaseManifestItemLoader.
+ */
+
+/**
+ * Executes the common steps of resolving, fetching and validating a content file
+ * before delegating to the loader's custom processing method.
+ *
+ * @param {import('../baseManifestItemLoader.js').BaseManifestItemLoader} loader - Loader instance.
+ * @param {string} modId - Owning mod ID.
+ * @param {string} filename - Filename to process.
+ * @param {string} diskFolder - Folder on disk for this content type.
+ * @param {string} registryKey - Registry category key.
+ * @returns {Promise<{qualifiedId:string,didOverride:boolean}>} Result info from the loader.
+ */
+export async function processFileWrapper(
+  loader,
+  modId,
+  filename,
+  diskFolder,
+  registryKey
+) {
+  let resolvedPath = null;
+  try {
+    resolvedPath = loader._pathResolver.resolveModContentPath(
+      modId,
+      diskFolder,
+      filename
+    );
+    loader._logger.debug(
+      `[${modId}] Resolved path for ${filename}: ${resolvedPath}`
+    );
+
+    const data = await loader._dataFetcher.fetch(resolvedPath);
+    loader._logger.debug(`[${modId}] Fetched data from ${resolvedPath}`);
+
+    loader._validatePrimarySchema(data, filename, modId, resolvedPath);
+
+    const result = await loader._processFetchedItem(
+      modId,
+      filename,
+      resolvedPath,
+      data,
+      registryKey
+    );
+    loader._logger.debug(
+      `[${modId}] Successfully processed ${filename}. Result: ID=${result.qualifiedId}, Overwrite=${result.didOverride}`
+    );
+    return result;
+  } catch (error) {
+    loader._logger.error(
+      `Error processing file:`,
+      {
+        modId,
+        filename,
+        path: resolvedPath ?? 'Path not resolved',
+        registryKey,
+        error: error?.message || String(error),
+      },
+      error
+    );
+    throw error;
+  }
+}
+
+export default { processFileWrapper };

--- a/src/loaders/helpers/validationHelpers.js
+++ b/src/loaders/helpers/validationHelpers.js
@@ -1,0 +1,72 @@
+/**
+ * @file Helper functions for validating parameters passed to loaders.
+ */
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+
+/**
+ * Validates parameters for {@link BaseManifestItemLoader.loadItemsForMod}.
+ *
+ * @param {ILogger} logger - Logger instance used for error messages.
+ * @param {string} className - Name of the calling class for logs.
+ * @param {string} modId - The mod identifier to validate.
+ * @param {object} modManifest - Parsed mod manifest object.
+ * @param {string} contentKey - Manifest content key.
+ * @param {string} diskFolder - Folder on disk containing content files.
+ * @param {string} registryKey - Registry key for storing items.
+ * @returns {{modId:string,contentKey:string,diskFolder:string,registryKey:string}}
+ *   Trimmed parameter values.
+ * @throws {TypeError} When any required parameter is invalid.
+ */
+export function validateLoadItemsParams(
+  logger,
+  className,
+  modId,
+  modManifest,
+  contentKey,
+  diskFolder,
+  registryKey
+) {
+  if (typeof modId !== 'string' || modId.trim() === '') {
+    const msg = `${className}: Programming Error - Invalid 'modId' provided for loading content. Must be a non-empty string. Received: ${modId}`;
+    logger.error(msg);
+    throw new TypeError(msg);
+  }
+  const trimmedModId = modId.trim();
+
+  if (!modManifest || typeof modManifest !== 'object') {
+    const msg = `${className}: Programming Error - Invalid 'modManifest' provided for loading content for mod '${trimmedModId}'. Must be a non-null object. Received: ${modManifest}`;
+    logger.error(msg);
+    throw new TypeError(msg);
+  }
+
+  if (typeof contentKey !== 'string' || contentKey.trim() === '') {
+    const msg = `${className}: Programming Error - Invalid 'contentKey' provided for loading ${registryKey} for mod '${trimmedModId}'. Must be a non-empty string. Received: ${contentKey}`;
+    logger.error(msg);
+    throw new TypeError(msg);
+  }
+  const trimmedContentKey = contentKey.trim();
+
+  if (typeof diskFolder !== 'string' || diskFolder.trim() === '') {
+    const msg = `${className}: Programming Error - Invalid 'diskFolder' provided for loading ${registryKey} for mod '${trimmedModId}'. Must be a non-empty string. Received: ${diskFolder}`;
+    logger.error(msg);
+    throw new TypeError(msg);
+  }
+  const trimmedDiskFolder = diskFolder.trim();
+
+  if (typeof registryKey !== 'string' || registryKey.trim() === '') {
+    const msg = `${className}: Programming Error - Invalid 'registryKey' provided for loading content for mod '${trimmedModId}'. Must be a non-empty string. Received: ${registryKey}`;
+    logger.error(msg);
+    throw new TypeError(msg);
+  }
+  const trimmedRegistryKey = registryKey.trim();
+
+  return {
+    modId: trimmedModId,
+    contentKey: trimmedContentKey,
+    diskFolder: trimmedDiskFolder,
+    registryKey: trimmedRegistryKey,
+  };
+}
+
+export default { validateLoadItemsParams };


### PR DESCRIPTION
Summary: Added helper modules for validation and file processing, extracted ModProcessor class and refactored ContentLoadManager and BaseManifestItemLoader to use it. Adjusted code to reduce duplication.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npx eslint src/loaders/baseManifestItemLoader.js src/loaders/ContentLoadManager.js src/loaders/ModProcessor.js src/loaders/helpers/fileProcessing.js src/loaders/helpers/validationHelpers.js`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6860e8fe9cac833196a96df96bdd86c8