### PR TITLE
[Agent] Extract LLM adapter initializer

### DIFF
--- a/src/initializers/services/llmAdapterInitializer.js
+++ b/src/initializers/services/llmAdapterInitializer.js
@@ -1,0 +1,172 @@
+// src/initializers/services/llmAdapterInitializer.js
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../llms/services/llmConfigLoader.js').LlmConfigLoader} LlmConfigLoader */
+
+/**
+ * @description Handles initialization of an LLM adapter by validating the
+ * adapter and its configuration loader, then invoking the adapter's init
+ * method.
+ */
+class LlmAdapterInitializer {
+  /**
+   * Attempts to initialize the given LLM adapter.
+   *
+   * @async
+   * @param {import('../../turns/interfaces/ILLMAdapter.js').ILLMAdapter & {
+   *   init?: Function,
+   *   isInitialized?: Function,
+   *   isOperational?: Function,
+   * }} adapter - The adapter instance to initialize.
+   * @param {LlmConfigLoader} configLoader - Loader for adapter configuration.
+   * @param {ILogger} logger - Logger for debug and error output.
+   * @returns {Promise<boolean>} True if the adapter was initialized and is
+   *   operational, otherwise false.
+   */
+  async initialize(adapter, configLoader, logger) {
+    logger?.debug(
+      'LlmAdapterInitializer: Attempting to initialize ConfigurableLLMAdapter...'
+    );
+
+    if (!this.#adapterExists(adapter, logger)) return false;
+    if (!this.#adapterHasInit(adapter, logger)) return false;
+
+    const initStatus = this.#isAdapterInitialized(adapter, logger);
+    if (typeof initStatus === 'boolean') {
+      return initStatus;
+    }
+
+    return this.#loadLlmConfigs(adapter, configLoader, logger);
+  }
+
+  /**
+   * Validates presence of the adapter.
+   *
+   * @private
+   * @param {*} adapter - The adapter instance.
+   * @param {ILogger} logger - Logger for error output.
+   * @returns {boolean} Whether the adapter exists.
+   */
+  #adapterExists(adapter, logger) {
+    if (!adapter) {
+      logger?.error(
+        'InitializationService: No ILLMAdapter provided. Skipping initialization.'
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Ensures the adapter exposes an init method.
+   *
+   * @private
+   * @param {*} adapter - The adapter instance.
+   * @param {ILogger} logger - Logger for error output.
+   * @returns {boolean} Whether the adapter has a valid init method.
+   */
+  #adapterHasInit(adapter, logger) {
+    if (typeof adapter?.init !== 'function') {
+      logger?.error(
+        'InitializationService: ILLMAdapter missing required init() method.'
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the adapter is already initialized and operational.
+   *
+   * @private
+   * @param {*} adapter - The adapter instance.
+   * @param {ILogger} logger - Logger for debug and warning output.
+   * @returns {boolean|undefined} True if initialized (and operational), false if
+   *   initialized but not operational, otherwise undefined.
+   */
+  #isAdapterInitialized(adapter, logger) {
+    if (
+      typeof adapter.isInitialized === 'function' &&
+      adapter.isInitialized()
+    ) {
+      if (typeof adapter.isOperational === 'function') {
+        if (!adapter.isOperational()) {
+          logger?.warn(
+            'InitializationService: ConfigurableLLMAdapter already initialized but not operational.'
+          );
+          return false;
+        }
+        logger?.debug(
+          'InitializationService: ConfigurableLLMAdapter already initialized. Skipping.'
+        );
+        return true;
+      }
+
+      logger?.debug(
+        'InitializationService: ConfigurableLLMAdapter already initialized (no operational check available).'
+      );
+      return true;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Loads LLM configuration and invokes the adapter's init method.
+   *
+   * @private
+   * @async
+   * @param {*} adapter - The adapter instance.
+   * @param {LlmConfigLoader} configLoader - Configuration loader.
+   * @param {ILogger} logger - Logger for debug and error output.
+   * @returns {Promise<boolean>} True if initialization succeeded and adapter is
+   *   operational, otherwise false.
+   */
+  async #loadLlmConfigs(adapter, configLoader, logger) {
+    if (!configLoader || typeof configLoader.loadConfigs !== 'function') {
+      logger?.error(
+        'InitializationService: LlmConfigLoader missing or invalid. Cannot initialize adapter.'
+      );
+      return false;
+    }
+
+    logger?.debug(
+      'InitializationService: LlmConfigLoader resolved from container for adapter initialization.'
+    );
+
+    try {
+      await adapter.init({ llmConfigLoader: configLoader });
+
+      if (typeof adapter.isOperational === 'function') {
+        if (adapter.isOperational()) {
+          logger?.debug(
+            'InitializationService: ConfigurableLLMAdapter initialized successfully and is operational.'
+          );
+          return true;
+        }
+
+        logger?.warn(
+          'InitializationService: ConfigurableLLMAdapter.init() completed but the adapter is not operational. Check adapter-specific logs (e.g., LlmConfigLoader errors).'
+        );
+        return false;
+      }
+
+      logger?.debug(
+        'InitializationService: ConfigurableLLMAdapter initialized (no operational check available).'
+      );
+      return true;
+    } catch (adapterInitError) {
+      logger?.error(
+        `InitializationService: CRITICAL error during ConfigurableLLMAdapter.init(): ${adapterInitError.message}`,
+        {
+          errorName: adapterInitError.name,
+          errorStack: adapterInitError.stack,
+          errorObj: adapterInitError,
+        }
+      );
+      return false;
+    }
+  }
+}
+
+export default LlmAdapterInitializer;

--- a/tests/unit/initializers/services/initializationService.constructor.test.js
+++ b/tests/unit/initializers/services/initializationService.constructor.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { SystemInitializationError } from '../../../../src/errors/InitializationError.js';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 
@@ -20,6 +21,7 @@ let thoughtListener;
 let notesListener;
 let spatialIndexManager;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -42,6 +44,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService constructor', () => {
@@ -68,6 +71,7 @@ describe('InitializationService constructor', () => {
             systemInitializer,
             worldInitializer,
             contentDependencyValidator,
+            llmAdapterInitializer,
           },
         })
     ).not.toThrow();
@@ -94,6 +98,7 @@ describe('InitializationService constructor', () => {
           systemInitializer,
           worldInitializer,
           contentDependencyValidator,
+          llmAdapterInitializer,
         },
       });
     expect(create).toThrow(SystemInitializationError);
@@ -122,6 +127,7 @@ describe('InitializationService constructor', () => {
           systemInitializer,
           worldInitializer,
           contentDependencyValidator,
+          llmAdapterInitializer,
         },
       });
     expect(createVD).toThrow(SystemInitializationError);

--- a/tests/unit/initializers/services/initializationService.facadeInit.test.js
+++ b/tests/unit/initializers/services/initializationService.facadeInit.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { SystemInitializationError } from '../../../../src/errors/InitializationError.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -17,6 +18,7 @@ let domUiFacade;
 let thoughtListener;
 let notesListener;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -42,6 +44,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService DomUiFacade handling', () => {
@@ -68,6 +71,7 @@ describe('InitializationService DomUiFacade handling', () => {
           systemInitializer,
           worldInitializer,
           contentDependencyValidator,
+          llmAdapterInitializer,
           // spatialIndexManager intentionally missing for this test
         },
       });
@@ -94,6 +98,7 @@ describe('InitializationService DomUiFacade handling', () => {
           systemInitializer,
           worldInitializer,
           contentDependencyValidator,
+          llmAdapterInitializer,
         },
       });
     }).toThrow('InitializationService requires a domUiFacade dependency');

--- a/tests/unit/initializers/services/initializationService.failureScenarios.test.js
+++ b/tests/unit/initializers/services/initializationService.failureScenarios.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { WorldInitializationError } from '../../../../src/errors/InitializationError.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -18,6 +19,7 @@ let entityManager;
 let domUiFacade;
 let thoughtListener;
 let notesListener;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -40,6 +42,7 @@ beforeEach(() => {
   domUiFacade = {};
   thoughtListener = { handleEvent: jest.fn() };
   notesListener = { handleEvent: jest.fn() };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService failure scenarios', () => {
@@ -61,6 +64,7 @@ describe('InitializationService failure scenarios', () => {
         contentDependencyValidator: {
           validate: jest.fn().mockResolvedValue(undefined),
         },
+        llmAdapterInitializer,
       },
       llm: {
         llmAdapter: { init: jest.fn() },

--- a/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
+++ b/tests/unit/initializers/services/initializationService.invalidWorldName.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
 import { InvalidArgumentError } from '../../../../src/errors/invalidArgumentError.js';
@@ -18,6 +19,7 @@ let domUiFacade;
 let thoughtListener;
 let notesListener;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn() };
@@ -37,6 +39,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService invalid world name handling', () => {
@@ -65,6 +68,7 @@ describe('InitializationService invalid world name handling', () => {
           systemInitializer,
           worldInitializer,
           contentDependencyValidator,
+          llmAdapterInitializer,
         },
       });
 

--- a/tests/unit/initializers/services/initializationService.llmAdapterHelpers.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterHelpers.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const WORLD = 'helperWorld';
@@ -18,6 +19,7 @@ let domUiFacade;
 let thoughtListener;
 let notesListener;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -43,6 +45,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 const createService = (overrides = {}) =>
@@ -68,6 +71,7 @@ const createService = (overrides = {}) =>
       systemInitializer,
       worldInitializer,
       contentDependencyValidator,
+      llmAdapterInitializer,
     },
     ...(overrides || {}),
   });

--- a/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
+++ b/tests/unit/initializers/services/initializationService.llmAdapterInitRejection.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { UI_SHOW_FATAL_ERROR_ID } from '../../../../src/constants/eventIds.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -19,6 +20,7 @@ let domUiFacade;
 let thoughtListener;
 let notesListener;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -44,6 +46,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService LLM adapter rejection', () => {
@@ -73,6 +76,7 @@ describe('InitializationService LLM adapter rejection', () => {
         systemInitializer,
         worldInitializer,
         contentDependencyValidator,
+        llmAdapterInitializer,
       },
     });
 

--- a/tests/unit/initializers/services/initializationService.success.test.js
+++ b/tests/unit/initializers/services/initializationService.success.test.js
@@ -1,4 +1,5 @@
 import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const MOCK_WORLD = 'testWorld';
@@ -20,6 +21,7 @@ let gameDataRepository;
 let thoughtListener;
 let notesListener;
 let contentDependencyValidator;
+let llmAdapterInitializer;
 
 beforeEach(() => {
   logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
@@ -55,6 +57,7 @@ beforeEach(() => {
   contentDependencyValidator = {
     validate: jest.fn().mockResolvedValue(undefined),
   };
+  llmAdapterInitializer = new LlmAdapterInitializer();
 });
 
 describe('InitializationService success path', () => {
@@ -79,6 +82,7 @@ describe('InitializationService success path', () => {
         systemInitializer,
         worldInitializer,
         contentDependencyValidator,
+        llmAdapterInitializer,
       },
     });
 


### PR DESCRIPTION
Summary: Refactored InitializationService to delegate LLM adapter setup to a new LlmAdapterInitializer class. Updated constructor injection and replaced helper methods. Adjusted related unit tests to use the new initializer.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6860e8e1364883319fa1d0ac21449da9