### PR TITLE
[Agent] add shared id validation utils

### DIFF
--- a/src/entities/spatialIndexManager.js
+++ b/src/entities/spatialIndexManager.js
@@ -3,7 +3,7 @@
 import { POSITION_COMPONENT_ID } from '../constants/componentIds.js';
 import { ISpatialIndexManager } from '../interfaces/ISpatialIndexManager.js';
 import { MapManager } from '../utils/mapManagerUtils.js';
-import { assertValidId } from '../utils/dependencyUtils.js';
+import { isValidId } from './utils/idValidation.js';
 
 /**
  * Manages a spatial index mapping location IDs to the entities present
@@ -29,40 +29,6 @@ class SpatialIndexManager extends MapManager {
      */
     this.locationIndex = this.items; // Inherits `items` from MapManager
     this.logger.info('SpatialIndexManager initialized.');
-  }
-
-  /**
-   * @description Validate an ID using assertValidId.
-   * @private
-   * @param {any} id - ID to validate.
-   * @param {string} context - Context for error messages.
-   * @returns {boolean} `true` if valid, otherwise `false`.
-   */
-  #isValidId(id, context) {
-    try {
-      assertValidId(id, context, this.logger);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * @description Validate an entity ID.
-   * @param {any} id - ID to validate.
-   * @returns {boolean} `true` if valid, otherwise `false`.
-   */
-  #isValidEntityId(id) {
-    return this.#isValidId(id, 'SpatialIndexManager.#isValidEntityId');
-  }
-
-  /**
-   * @description Validate a location ID.
-   * @param {any} id - Location ID to validate.
-   * @returns {boolean} `true` if valid, otherwise `false`.
-   */
-  #isValidLocationId(id) {
-    return this.#isValidId(id, 'SpatialIndexManager.#isValidLocationId');
   }
 
   /**
@@ -103,14 +69,14 @@ class SpatialIndexManager extends MapManager {
    * @param {string | null | undefined} locationId - The location ID where the entity is present. Should be a valid string to be indexed.
    */
   addEntity(entityId, locationId) {
-    if (!this.#isValidEntityId(entityId)) {
+    if (!isValidId(entityId, 'SpatialIndexManager.addEntity', this.logger)) {
       this.logger.warn(
         `SpatialIndexManager.addEntity: Invalid entityId (${entityId}). Skipping.`
       );
       return;
     }
 
-    if (!this.#isValidLocationId(locationId)) {
+    if (!isValidId(locationId, 'SpatialIndexManager.addEntity', this.logger)) {
       return;
     }
 
@@ -132,14 +98,16 @@ class SpatialIndexManager extends MapManager {
    * @param {string | null | undefined} locationId - The location ID from which to remove the entity. Should typically be the entity's last valid location.
    */
   removeEntity(entityId, locationId) {
-    if (!this.#isValidEntityId(entityId)) {
+    if (!isValidId(entityId, 'SpatialIndexManager.removeEntity', this.logger)) {
       this.logger.warn(
         `SpatialIndexManager.removeEntity: Invalid entityId (${entityId}). Skipping.`
       );
       return;
     }
 
-    if (!this.#isValidLocationId(locationId)) {
+    if (
+      !isValidId(locationId, 'SpatialIndexManager.removeEntity', this.logger)
+    ) {
       return;
     }
 
@@ -161,17 +129,31 @@ class SpatialIndexManager extends MapManager {
    * @param {string | null | undefined} newLocationId - The new location ID (can be null/undefined).
    */
   updateEntityLocation(entityId, oldLocationId, newLocationId) {
-    if (!this.#isValidEntityId(entityId)) {
+    if (
+      !isValidId(
+        entityId,
+        'SpatialIndexManager.updateEntityLocation',
+        this.logger
+      )
+    ) {
       this.logger.warn(
         'SpatialIndexManager.updateEntityLocation: Invalid entityId. Skipping.'
       );
       return;
     }
 
-    const effectiveOldLocationId = this.#isValidLocationId(oldLocationId)
+    const effectiveOldLocationId = isValidId(
+      oldLocationId,
+      'SpatialIndexManager.updateEntityLocation',
+      this.logger
+    )
       ? oldLocationId.trim()
       : null;
-    const effectiveNewLocationId = this.#isValidLocationId(newLocationId)
+    const effectiveNewLocationId = isValidId(
+      newLocationId,
+      'SpatialIndexManager.updateEntityLocation',
+      this.logger
+    )
       ? newLocationId.trim()
       : null;
 
@@ -196,7 +178,13 @@ class SpatialIndexManager extends MapManager {
    * @returns {Set<string>} A *copy* of the Set of entity IDs in the location, or an empty Set if the location is not indexed, empty, or the provided locationId is invalid/null.
    */
   getEntitiesInLocation(locationId) {
-    if (!this.#isValidLocationId(locationId)) {
+    if (
+      !isValidId(
+        locationId,
+        'SpatialIndexManager.getEntitiesInLocation',
+        this.logger
+      )
+    ) {
       return new Set();
     }
 

--- a/src/entities/utils/idValidation.js
+++ b/src/entities/utils/idValidation.js
@@ -1,0 +1,54 @@
+// src/entities/utils/idValidation.js
+
+import {
+  assertValidId,
+  assertNonBlankString,
+} from '../../utils/dependencyUtils.js';
+import { InvalidArgumentError } from '../../errors/invalidArgumentError.js';
+
+/**
+ * Determine if a given value is a valid non-blank string ID.
+ *
+ * @param {any} id - Value to validate.
+ * @param {string} context - Error context for logging.
+ * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger instance.
+ * @returns {boolean} True if the ID is valid, otherwise false.
+ */
+export function isValidId(id, context, logger) {
+  try {
+    assertValidId(id, context, logger);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate both an entity instance ID and a component type ID.
+ *
+ * @param {string} instanceId - Entity instance ID to validate.
+ * @param {string} componentTypeId - Component type ID to validate.
+ * @param {import('../../interfaces/coreServices.js').ILogger} logger - Logger instance.
+ * @param {string} [context] - Error context.
+ * @throws {InvalidArgumentError} If either ID is invalid.
+ * @returns {void}
+ */
+export function validateInstanceAndComponent(
+  instanceId,
+  componentTypeId,
+  logger,
+  context = 'idValidation.validateInstanceAndComponent'
+) {
+  try {
+    assertValidId(instanceId, context, logger);
+    assertNonBlankString(componentTypeId, 'componentTypeId', context, logger);
+  } catch (err) {
+    logger.error(err);
+    throw new InvalidArgumentError(`Invalid ID: ${err.message}`);
+  }
+}
+
+export default {
+  isValidId,
+  validateInstanceAndComponent,
+};

--- a/src/entities/utils/parameterValidators.js
+++ b/src/entities/utils/parameterValidators.js
@@ -10,6 +10,7 @@ import {
   assertValidId,
   assertNonBlankString,
 } from '../../utils/dependencyUtils.js';
+import { validateInstanceAndComponent } from './idValidation.js';
 import { isNonBlankString } from '../../utils/textUtils.js';
 import { InvalidArgumentError } from '../../errors/invalidArgumentError.js';
 import { SerializedEntityError } from '../../errors/serializedEntityError.js';
@@ -27,13 +28,7 @@ import { InvalidInstanceIdError } from '../../errors/invalidInstanceIdError.js';
  * @private
  */
 function _assertIds(context, instanceId, componentTypeId, logger) {
-  try {
-    assertValidId(instanceId, context, logger);
-    assertNonBlankString(componentTypeId, 'componentTypeId', context, logger);
-  } catch (err) {
-    logger.error(err);
-    throw new InvalidArgumentError(`Invalid ID: ${err.message}`);
-  }
+  validateInstanceAndComponent(instanceId, componentTypeId, logger, context);
 }
 
 /**

--- a/tests/unit/entities/utils/idValidation.test.js
+++ b/tests/unit/entities/utils/idValidation.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  isValidId,
+  validateInstanceAndComponent,
+} from '../../../../src/entities/utils/idValidation.js';
+import { InvalidArgumentError } from '../../../../src/errors/invalidArgumentError.js';
+
+describe('idValidation utilities', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { error: jest.fn(), warn: jest.fn() };
+  });
+
+  describe('isValidId', () => {
+    it('returns true for valid ids', () => {
+      const result = isValidId('foo', 'test', logger);
+      expect(result).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('returns false and logs for invalid ids', () => {
+      const result = isValidId('', 'test', logger);
+      expect(result).toBe(false);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateInstanceAndComponent', () => {
+    it('does not throw for valid ids', () => {
+      expect(() =>
+        validateInstanceAndComponent('ent1', 'comp1', logger, 'ctx')
+      ).not.toThrow();
+    });
+
+    it('throws InvalidArgumentError for invalid instanceId', () => {
+      expect(() =>
+        validateInstanceAndComponent('', 'comp1', logger, 'ctx')
+      ).toThrow(InvalidArgumentError);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('throws InvalidArgumentError for invalid componentTypeId', () => {
+      expect(() =>
+        validateInstanceAndComponent('ent1', '', logger, 'ctx')
+      ).toThrow(InvalidArgumentError);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- create idValidation helpers for shared ID checks
- update SpatialIndexManager to use shared utilities
- refactor parameter validators to leverage new helper
- add idValidation unit test suite

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm test`
- [ ] Proxy tests (not applicable)
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6860e8bad9508331a83eeeabf86ff25d