### PR TITLE
[Agent] factor out failure result helper and align tests

### DIFF
--- a/tests/unit/commands/commandProcessor.test.js
+++ b/tests/unit/commands/commandProcessor.test.js
@@ -100,7 +100,7 @@ describe('CommandProcessor.dispatchAction', () => {
         originalInput: 'look',
       })
     );
-    expect(result.actionResult).toBeUndefined();
+    expect(result.actionResult).toEqual({ actionId: 'look' });
     expect(safeDispatchError).toHaveBeenCalledWith(
       safeEventDispatcher,
       'Internal error: Malformed action prevented execution.',
@@ -148,6 +148,26 @@ describe('CommandProcessor.dispatchAction', () => {
       expect.any(Object),
       logger
     );
+  });
+
+  it('returns identical CommandResult structures for missing and invalid actor ids', async () => {
+    const resultMissing = await processor.dispatchAction(
+      {},
+      {
+        actionDefinitionId: 'look',
+        resolvedParameters: {},
+        commandString: 'look',
+      }
+    );
+    const resultInvalid = await processor.dispatchAction(
+      { id: '   ' },
+      {
+        actionDefinitionId: 'look',
+        resolvedParameters: {},
+        commandString: 'look',
+      }
+    );
+    expect(Object.keys(resultMissing)).toEqual(Object.keys(resultInvalid));
   });
 
   it('AC3: returns failure when dispatcher reports failure', async () => {


### PR DESCRIPTION
## Summary
- add `#buildFailureResult` helper to CommandProcessor
- use helper for validation and dispatch failure paths
- update tests for `dispatchAction` failure cases and add check for identical structures

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6860e85e1e648331975612276c77d9bc