### PR TITLE
[Agent] Refactor command state and dispatch speech helper

### DIFF
--- a/src/turns/states/helpers/dispatchSpeechEvent.js
+++ b/src/turns/states/helpers/dispatchSpeechEvent.js
@@ -1,0 +1,34 @@
+/**
+ * @file Helper for dispatching speech events.
+ */
+
+/**
+ * @typedef {import('../../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
+ */
+import { ENTITY_SPOKE_ID } from '../../../constants/eventIds.js';
+import { getSafeEventDispatcher } from './contextUtils.js';
+
+/**
+ * Dispatches the ENTITY_SPOKE_ID event using a resolved SafeEventDispatcher.
+ *
+ * @param {ITurnContext|null} turnCtx - Current turn context.
+ * @param {BaseTurnHandler} handler - Handler fallback for dispatcher resolution.
+ * @param {string} actorId - ID of the speaking actor.
+ * @param {object} payloadBase - Base payload from {@link buildSpeechPayload}.
+ * @returns {Promise<void>} Resolves when dispatch completes or dispatcher is missing.
+ */
+export async function dispatchSpeechEvent(
+  turnCtx,
+  handler,
+  actorId,
+  payloadBase
+) {
+  const dispatcher = getSafeEventDispatcher(turnCtx, handler);
+  if (dispatcher) {
+    const payload = { entityId: actorId, ...payloadBase };
+    await dispatcher.dispatch(ENTITY_SPOKE_ID, payload);
+  }
+}
+
+export default dispatchSpeechEvent;

--- a/tests/unit/turns/states/helpers/dispatchSpeechEvent.test.js
+++ b/tests/unit/turns/states/helpers/dispatchSpeechEvent.test.js
@@ -1,0 +1,32 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { dispatchSpeechEvent } from '../../../../../src/turns/states/helpers/dispatchSpeechEvent.js';
+import { ENTITY_SPOKE_ID } from '../../../../../src/constants/eventIds.js';
+
+describe('dispatchSpeechEvent', () => {
+  test('dispatches using context dispatcher', async () => {
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const ctx = { getSafeEventDispatcher: () => dispatcher };
+    await dispatchSpeechEvent(ctx, null, 'a1', { speechContent: 'hi' });
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(ENTITY_SPOKE_ID, {
+      entityId: 'a1',
+      speechContent: 'hi',
+    });
+  });
+
+  test('falls back to handler dispatcher', async () => {
+    const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const ctx = { getSafeEventDispatcher: () => null };
+    const handler = { getSafeEventDispatcher: () => dispatcher };
+    await dispatchSpeechEvent(ctx, handler, 'a1', { speechContent: 'hi' });
+    expect(dispatcher.dispatch).toHaveBeenCalled();
+  });
+
+  test('resolves when dispatcher missing', async () => {
+    const ctx = { getSafeEventDispatcher: () => null };
+    await expect(
+      dispatchSpeechEvent(ctx, { getSafeEventDispatcher: () => null }, 'a1', {
+        speechContent: 'hi',
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/turns/states/processingCommandState.constructor.test.js
+++ b/tests/unit/turns/states/processingCommandState.constructor.test.js
@@ -1,0 +1,33 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { ProcessingCommandState } from '../../../../src/turns/states/processingCommandState.js';
+import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+
+describe('ProcessingCommandState constructor', () => {
+  test('invokes validation and initialization helpers', () => {
+    const deps = {
+      handler: { getLogger: () => ({ debug: jest.fn() }) },
+      commandProcessor: {},
+      commandOutcomeInterpreter: {},
+      commandString: 'cmd',
+      turnAction: { actionDefinitionId: 'id', commandString: 'cmd' },
+      directiveResolver: TurnDirectiveStrategyResolver,
+    };
+
+    const validateSpy = jest.spyOn(
+      ProcessingCommandState.prototype,
+      '_validateDependencies'
+    );
+    const initSpy = jest.spyOn(
+      ProcessingCommandState.prototype,
+      '_initializeComponents'
+    );
+
+    const state = new ProcessingCommandState(deps);
+    expect(state).toBeInstanceOf(ProcessingCommandState);
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(initSpy).toHaveBeenCalledTimes(1);
+
+    validateSpy.mockRestore();
+    initSpy.mockRestore();
+  });
+});

--- a/tests/unit/turns/states/processingCommandState.helpers.test.js
+++ b/tests/unit/turns/states/processingCommandState.helpers.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { ProcessingCommandState } from '../../../../src/turns/states/processingCommandState.js';
 import { ProcessingWorkflow } from '../../../../src/turns/states/workflows/processingWorkflow.js';
 import TurnDirectiveStrategyResolver from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+import * as dispatchSpeechEventModule from '../../../../src/turns/states/helpers/dispatchSpeechEvent.js';
 
 const mockLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
 const mockHandler = {
@@ -111,8 +112,16 @@ describe('ProcessingCommandState helpers', () => {
     const actor = { id: 'a1' };
     const dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
     const ctx = makeCtx(actor, { getSafeEventDispatcher: () => dispatcher });
+    const helperSpy = jest.spyOn(
+      dispatchSpeechEventModule,
+      'dispatchSpeechEvent'
+    );
     await state._dispatchSpeech(ctx, actor, { speech: 'hi' });
+    expect(helperSpy).toHaveBeenCalledWith(ctx, mockHandler, 'a1', {
+      speechContent: 'hi',
+    });
     expect(dispatcher.dispatch).toHaveBeenCalled();
+    helperSpy.mockRestore();
   });
 
   test('_dispatchSpeech warns when dispatcher missing', async () => {


### PR DESCRIPTION
## Summary
- extract dependency checks in `ProcessingCommandState` into `_validateDependencies`
- move component setup into `_initializeComponents`
- create helper `dispatchSpeechEvent`
- refactor `_dispatchSpeech` to use the new helper
- test constructor path and speech helper

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 715 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6860e9ac4de88331938489833963d161