### PR TITLE
[Agent] Refactor ActionDiscoveryService helpers

### DIFF
--- a/tests/unit/actions/actionDiscoveryService.helpers.test.js
+++ b/tests/unit/actions/actionDiscoveryService.helpers.test.js
@@ -1,0 +1,63 @@
+import { expect, it, jest, describe } from '@jest/globals';
+import { createActionDiscoveryBed } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// Tests leveraging custom ActionCandidateProcessor overrides to exercise
+// helper method behavior indirectly through the public API.
+
+describe('ActionDiscoveryService helper methods', () => {
+  const actor = { id: 'actor1' };
+  const defs = [
+    { id: 'a', commandVerb: 'a', scope: 'none' },
+    { id: 'b', commandVerb: 'b', scope: 'none' },
+  ];
+
+  const setupBed = (bed) => {
+    bed.mocks.actionIndex.getCandidateActions.mockReturnValue(defs);
+    bed.mocks.prerequisiteEvaluationService.evaluate.mockReturnValue(true);
+    bed.mocks.targetResolutionService.resolveTargets.mockReturnValue([
+      { type: 'none', entityId: null },
+    ]);
+    bed.mocks.actionCommandFormatter.format.mockReturnValue({
+      ok: true,
+      value: 'cmd',
+    });
+    bed.mocks.getActorLocationFn.mockReturnValue('room');
+  };
+
+  it('calls the candidate processor for each definition', async () => {
+    const actionCandidateProcessor = {
+      process: jest.fn(() => ({ actions: [], errors: [] })),
+    };
+    const bed = createActionDiscoveryBed({ actionCandidateProcessor });
+    setupBed(bed);
+
+    await bed.service.getValidActions(actor, {});
+
+    expect(actionCandidateProcessor.process).toHaveBeenCalledTimes(defs.length);
+    await bed.cleanup();
+  });
+
+  it('aggregates results returned from candidate processing', async () => {
+    const actionCandidateProcessor = {
+      process: jest
+        .fn()
+        .mockReturnValueOnce({
+          actions: [{ id: 'a', command: 'cmd', params: { targetId: null } }],
+          errors: [],
+        })
+        .mockReturnValueOnce({
+          actions: [],
+          errors: [{ actionId: 'b', targetId: null, error: new Error('bad') }],
+        }),
+    };
+    const bed = createActionDiscoveryBed({ actionCandidateProcessor });
+    setupBed(bed);
+
+    const result = await bed.service.getValidActions(actor, {});
+
+    expect(result.actions).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].actionId).toBe('b');
+    await bed.cleanup();
+  });
+});


### PR DESCRIPTION
Summary:
- encapsulate candidate retrieval and processing into private helpers
- orchestrate getValidActions using the new methods
- add unit tests for helper behavior

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint` *(fails: 715 errors)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6860e9be29348331adee2790dfbcee14