### PR TITLE
[Agent] inject services into persistence hooks

### DIFF
--- a/src/ai/notesPersistenceHook.js
+++ b/src/ai/notesPersistenceHook.js
@@ -7,10 +7,7 @@ import NotesService from './notesService.js';
 import { NOTES_COMPONENT_ID } from '../constants/componentIds.js';
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { isNonBlankString } from '../utils/textUtils.js';
-import {
-  fetchComponent,
-  applyComponent,
-} from '../utils/componentHelpers.js';
+import { fetchComponent, applyComponent } from '../utils/componentHelpers.js';
 
 /**
  * Persists the "notes" produced during an LLM turn into the actor's
@@ -20,8 +17,15 @@ import {
  * @param {object} actorEntity - Entity instance (or test double) that generated the action.
  * @param {import('../interfaces/coreServices.js').ILogger} logger - Application-wide logger.
  * @param {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher - Safe dispatcher for error events.
+ * @param {NotesService} [notesService] - Service used to persist notes.
  */
-export function persistNotes(action, actorEntity, logger, dispatcher) {
+export function persistNotes(
+  action,
+  actorEntity,
+  logger,
+  dispatcher,
+  /** @type {NotesService} */ notesService = new NotesService()
+) {
   // Gracefully do nothing if the 'notes' key is entirely absent.
   if (!action || !Object.prototype.hasOwnProperty.call(action, 'notes')) {
     return;
@@ -72,7 +76,6 @@ export function persistNotes(action, actorEntity, logger, dispatcher) {
     notesComp = { notes: [] };
   }
 
-  const notesService = new NotesService();
   const {
     wasModified,
     component: updatedNotesComp,

--- a/src/ai/thoughtPersistenceHook.js
+++ b/src/ai/thoughtPersistenceHook.js
@@ -2,10 +2,7 @@
 
 import ShortTermMemoryService from './shortTermMemoryService.js';
 import { SHORT_TERM_MEMORY_COMPONENT_ID } from '../constants/componentIds.js';
-import {
-  fetchComponent,
-  applyComponent,
-} from '../utils/componentHelpers.js';
+import { fetchComponent, applyComponent } from '../utils/componentHelpers.js';
 
 /**
  * Persist the “thoughts” produced during an LLM turn into the actor’s
@@ -16,8 +13,14 @@ import {
  * @param {object} action       – The structured action returned by the LLM.
  * @param {object} actorEntity  – Entity instance (or test double) that generated the action.
  * @param {object} logger       – Application-wide logger (expects .warn()).
+ * @param {ShortTermMemoryService} [stmService] – Service used to manage short-term memory.
  */
-export function persistThoughts(action, actorEntity, logger) {
+export function persistThoughts(
+  action,
+  actorEntity,
+  logger,
+  /** @type {ShortTermMemoryService} */ stmService = new ShortTermMemoryService()
+) {
   /* ── 1. Validate thoughts ───────────────────────────────────────────── */
   const rawThoughts = action?.thoughts;
   if (
@@ -42,7 +45,6 @@ export function persistThoughts(action, actorEntity, logger) {
   }
 
   /* ── 3. Mutate in place using the service ───────────────────────────── */
-  const stmService = new ShortTermMemoryService();
   const { mem: updatedMem } = stmService.addThought(
     memoryComp,
     thoughtText,


### PR DESCRIPTION
## Summary
- allow persistence hooks to receive service instances
- remove direct service instantiation

## Testing
- `npm run lint` *(fails: 3567 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861015cb02c8331857b378e2d3ff4be