### PR TITLE
[Agent] use createErrorDetails in commandOutcomeInterpreter

### DIFF
--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -20,6 +20,7 @@ import TurnDirective from '../../turns/constants/turnDirectives.js';
 import { ICommandOutcomeInterpreter } from '../interfaces/ICommandOutcomeInterpreter.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { initLogger } from '../../utils/index.js';
+import { createErrorDetails } from '../../utils/errorDetails.js';
 import { validateDependency } from '../../utils/dependencyUtils.js';
 
 /**
@@ -73,9 +74,11 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
     if (!turnContext || typeof turnContext.getActor !== 'function') {
       const errorMsg = `CommandOutcomeInterpreter: Invalid turnContext provided.`;
       const details = {
-        raw: `turnContext was ${turnContext === null ? 'null' : typeof turnContext}. Expected ITurnContext object.`,
-        stack: new Error().stack,
-        timestamp: new Date().toISOString(),
+        ...createErrorDetails(
+          `turnContext was ${
+            turnContext === null ? 'null' : typeof turnContext
+          }. Expected ITurnContext object.`
+        ),
         receivedContextType: typeof turnContext,
       };
       this.#reportInvalidInput(errorMsg, details);
@@ -85,9 +88,9 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
     if (!actor || !actor.id) {
       const errorMsg = `CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.`;
       const details = {
-        raw: `Actor object in context was ${JSON.stringify(actor)}.`,
-        stack: new Error().stack,
-        timestamp: new Date().toISOString(),
+        ...createErrorDetails(
+          `Actor object in context was ${JSON.stringify(actor)}.`
+        ),
         actorInContext: actor,
       };
       this.#reportInvalidInput(errorMsg, details);
@@ -109,9 +112,9 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
     if (!result || typeof result.success !== 'boolean') {
       const baseErrorMsg = `CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: ${actorId}.`;
       const details = {
-        raw: `Actor ${actorId}, Received Result: ${JSON.stringify(result)}`,
-        stack: new Error().stack,
-        timestamp: new Date().toISOString(),
+        ...createErrorDetails(
+          `Actor ${actorId}, Received Result: ${JSON.stringify(result)}`
+        ),
         receivedResult: result,
       };
       this.#reportInvalidInput(baseErrorMsg, details);

--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -54,7 +54,12 @@ describe('CommandOutcomeInterpreter additional branches', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       expect.stringContaining('Invalid CommandResult'),
-      expect.any(Object)
+      {
+        raw: 'Actor actor-1, Received Result: {}',
+        timestamp: expect.any(String),
+        stack: expect.any(String),
+        receivedResult: {},
+      }
     );
   });
 
@@ -106,7 +111,12 @@ describe('CommandOutcomeInterpreter additional branches', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       'CommandOutcomeInterpreter: Invalid turnContext provided.',
-      expect.any(Object)
+      {
+        raw: 'turnContext was object. Expected ITurnContext object.',
+        timestamp: expect.any(String),
+        stack: expect.any(String),
+        receivedContextType: 'object',
+      }
     );
     expect(logger.error).toHaveBeenCalledWith(
       'CommandOutcomeInterpreter: Invalid turnContext provided.',
@@ -123,7 +133,12 @@ describe('CommandOutcomeInterpreter additional branches', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.',
-      expect.any(Object)
+      {
+        raw: 'Actor object in context was {}.',
+        timestamp: expect.any(String),
+        stack: expect.any(String),
+        actorInContext: {},
+      }
     );
     expect(logger.error).toHaveBeenCalledWith(
       'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.',

--- a/tests/unit/interpreters/commandOutcomeInterpreter.helpers.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.helpers.test.js
@@ -35,7 +35,12 @@ describe('CommandOutcomeInterpreter helper logic via interpret', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       'CommandOutcomeInterpreter: Invalid turnContext provided.',
-      expect.any(Object)
+      {
+        raw: 'turnContext was object. Expected ITurnContext object.',
+        timestamp: expect.any(String),
+        stack: expect.any(String),
+        receivedContextType: 'object',
+      }
     );
   });
 
@@ -47,7 +52,12 @@ describe('CommandOutcomeInterpreter helper logic via interpret', () => {
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
       expect.stringContaining('Invalid CommandResult'),
-      expect.any(Object)
+      {
+        raw: 'Actor actor-1, Received Result: {}',
+        timestamp: expect.any(String),
+        stack: expect.any(String),
+        receivedResult: {},
+      }
     );
   });
 


### PR DESCRIPTION
## Summary
- incorporate `createErrorDetails` in `commandOutcomeInterpreter`
- expect richer details when validation fails in related unit tests

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861017738d4833188ff6f15a12f2666