### PR TITLE
[Agent] Refactor AppContainer instantiation helpers

### DIFF
--- a/tests/unit/dependencyInjection/appContainer.helpers.test.js
+++ b/tests/unit/dependencyInjection/appContainer.helpers.test.js
@@ -1,0 +1,38 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import AppContainer from '../../../src/dependencyInjection/appContainer.js';
+
+describe('AppContainer helper methods', () => {
+  /** @type {AppContainer} */
+  let container;
+
+  beforeEach(() => {
+    container = new AppContainer();
+  });
+
+  it('_instantiateClass resolves dependencies', () => {
+    class Service {
+      constructor({ dep }) {
+        this.dep = dep;
+      }
+    }
+    container.register('dep', 42);
+    const instance = container._instantiateClass(Service, {
+      dependencies: ['dep'],
+      registrationKey: 'service',
+    });
+    expect(instance).toBeInstanceOf(Service);
+    expect(instance.dep).toBe(42);
+  });
+
+  it('_invokeFactory calls factory with container', () => {
+    const factory = jest.fn(() => 'value');
+    const result = container._invokeFactory(factory);
+    expect(factory).toHaveBeenCalledWith(container);
+    expect(result).toBe('value');
+  });
+
+  it('_returnValue returns provided value', () => {
+    const value = { a: 1 };
+    expect(container._returnValue(value)).toBe(value);
+  });
+});


### PR DESCRIPTION
## Summary
- extract helper methods from `_createInstance` for clarity
- add tests for `_instantiateClass`, `_invokeFactory`, and `_returnValue`

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68610196934c8331aa57108227462545