### PR TITLE
[Feat] Refactor OpenRouter helpers

### DIFF
--- a/tests/unit/llms/strategies/openRouterJsonSchemaStrategy.test.js
+++ b/tests/unit/llms/strategies/openRouterJsonSchemaStrategy.test.js
@@ -258,6 +258,29 @@ describe('OpenRouterJsonSchemaStrategy', () => {
         const result = await strategy.execute(params);
         expect(result).toBe(JSON.stringify(expectedOutputJsonObject));
       });
+
+      it('should call _extractJsonOutput during execute', async () => {
+        const response = {
+          choices: [{ message: { content: expectedOutputJsonString } }],
+        };
+        mockHttpClient.request.mockResolvedValueOnce(response);
+        const extractionSpy = jest
+          .spyOn(strategy, '_extractJsonOutput')
+          .mockResolvedValue(expectedOutputJsonString);
+        const params = {
+          gameSummary: mockGameSummary,
+          llmConfig: { ...baseLlmConfig },
+          apiKey: mockApiKey,
+          environmentContext: mockEnvironmentContext,
+        };
+        const result = await strategy.execute(params);
+        expect(result).toBe(expectedOutputJsonString);
+        expect(extractionSpy).toHaveBeenCalledWith(
+          response,
+          params.llmConfig,
+          expect.any(Object)
+        );
+      });
     });
 
     describe('Successful Execution - Proxied API Call (Client-side)', () => {

--- a/tests/unit/llms/strategies/openRouterToolCallingStrategy.test.js
+++ b/tests/unit/llms/strategies/openRouterToolCallingStrategy.test.js
@@ -112,4 +112,34 @@ describe('OpenRouterToolCallingStrategy', () => {
       expect.objectContaining({ llmId: llmConfig.configId })
     );
   });
+
+  it('execute invokes _extractJsonOutput', async () => {
+    const execConfig = {
+      configId: 'exec',
+      apiType: 'openrouter',
+      endpointUrl: 'https://openrouter.ai/api',
+      modelIdentifier: 'model-x',
+      defaultParameters: {},
+      providerSpecificHeaders: {},
+      jsonOutputStrategy: { toolName: 'tool_exec' },
+    };
+    const response = { choices: [{ message: { tool_calls: [] } }] };
+    mockHttpClient.request.mockResolvedValueOnce(response);
+    const extractionSpy = jest
+      .spyOn(strategy, '_extractJsonOutput')
+      .mockResolvedValue('{}');
+    const params = {
+      gameSummary: 'summary',
+      llmConfig: execConfig,
+      apiKey: 'key',
+      environmentContext: { isClient: jest.fn().mockReturnValue(false) },
+    };
+    const result = await strategy.execute(params);
+    expect(result).toBe('{}');
+    expect(extractionSpy).toHaveBeenCalledWith(
+      response,
+      execConfig,
+      expect.any(Object)
+    );
+  });
 });


### PR DESCRIPTION
Summary: Implemented helper methods for OpenRouter strategies to centralize request/response logic.

Changes Made:
- Added `#sendRequest`, `#extractJson`, and `#logAndWrapError` to `BaseOpenRouterStrategy`.
- Updated `#handleResponse` to use new helpers.
- Created unit tests ensuring `_extractJsonOutput` invocation during `execute`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6861048469948331927c3d38afdfff51