### PR TITLE
[Agent] Allow custom CommandProcessingWorkflow via factory

### DIFF
--- a/src/turns/factories/concreteTurnStateFactory.js
+++ b/src/turns/factories/concreteTurnStateFactory.js
@@ -91,7 +91,8 @@ export class ConcreteTurnStateFactory extends ITurnStateFactory {
     commandString,
     turnAction,
     directiveResolver,
-    processingWorkflowFactory
+    processingWorkflowFactory,
+    commandProcessingWorkflowFactory
   ) {
     return new ProcessingCommandState({
       handler,
@@ -101,6 +102,7 @@ export class ConcreteTurnStateFactory extends ITurnStateFactory {
       turnAction,
       directiveResolver,
       processingWorkflowFactory,
+      commandProcessingWorkflowFactory,
     });
   }
 

--- a/src/turns/interfaces/ITurnStateFactory.js
+++ b/src/turns/interfaces/ITurnStateFactory.js
@@ -88,6 +88,7 @@ export class ITurnStateFactory {
    * @param {ITurnAction} turnAction - The chosen turn action.
    * @param {Function} directiveResolver - Resolver for command directives.
    * @param {(state: import('../states/processingCommandState.js').ProcessingCommandState, commandString: string|null, action: ITurnAction|null, setAction: (a: ITurnAction|null) => void, handler: import('../states/helpers/processingExceptionHandler.js').ProcessingExceptionHandler) => import('../states/workflows/processingWorkflow.js').ProcessingWorkflow} [processingWorkflowFactory] - Optional factory for ProcessingWorkflow.
+   * @param {(config: object) => import('../states/helpers/commandProcessingWorkflow.js').CommandProcessingWorkflow} [commandProcessingWorkflowFactory] - Optional factory for CommandProcessingWorkflow.
    * @returns {ProcessingCommandState} A new processing command state instance.
    * @abstract
    */
@@ -96,7 +97,8 @@ export class ITurnStateFactory {
     commandString,
     turnAction,
     directiveResolver,
-    processingWorkflowFactory
+    processingWorkflowFactory,
+    commandProcessingWorkflowFactory
   ) {
     throw new Error(
       'ITurnStateFactory.createProcessingCommandState must be implemented by concrete classes.'

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -172,6 +172,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {ITurnAction} deps.turnAction - Structured turn action.
    * @param {Function} deps.directiveResolver - Resolver for turn directives.
    * @param {(state: ProcessingCommandState, commandString: string|null, action: ITurnAction|null, setAction: (a: ITurnAction|null) => void, handler: ProcessingExceptionHandler) => ProcessingWorkflow} deps.processingWorkflowFactory - Factory for ProcessingWorkflow.
+   * @param {(config: object) => CommandProcessingWorkflow} deps.commandProcessingWorkflowFactory - Factory for CommandProcessingWorkflow.
    * @returns {void}
    */
   _initializeComponents({
@@ -181,6 +182,7 @@ export class ProcessingCommandState extends AbstractTurnState {
     turnAction,
     directiveResolver,
     processingWorkflowFactory,
+    commandProcessingWorkflowFactory,
   }) {
     this.#commandProcessor = commandProcessor;
     this._commandOutcomeInterpreter = commandOutcomeInterpreter;
@@ -194,7 +196,7 @@ export class ProcessingCommandState extends AbstractTurnState {
 
     this._processingWorkflowFactory = processingWorkflowFactory;
 
-    this._processingWorkflow = new CommandProcessingWorkflow({
+    this._processingWorkflow = commandProcessingWorkflowFactory({
       state: this,
       exceptionHandler: this._exceptionHandler,
       commandProcessor: this.#commandProcessor,
@@ -212,6 +214,7 @@ export class ProcessingCommandState extends AbstractTurnState {
    * @param {ITurnAction} deps.turnAction The structured turn action.
    * @param {Function} deps.directiveResolver Resolver for turn directives.
    * @param {(state: ProcessingCommandState, commandString: string|null, action: ITurnAction|null, setAction: (a: ITurnAction|null) => void, handler: ProcessingExceptionHandler) => ProcessingWorkflow} [deps.processingWorkflowFactory] Factory for ProcessingWorkflow.
+   * @param {(config: object) => CommandProcessingWorkflow} [deps.commandProcessingWorkflowFactory] Factory for CommandProcessingWorkflow.
    */
   constructor({
     handler,
@@ -228,6 +231,8 @@ export class ProcessingCommandState extends AbstractTurnState {
       exceptionHandler
     ) =>
       new ProcessingWorkflow(state, cmd, action, setAction, exceptionHandler),
+    commandProcessingWorkflowFactory = (config) =>
+      new CommandProcessingWorkflow(config),
   }) {
     super(handler);
     const deps = {
@@ -237,6 +242,7 @@ export class ProcessingCommandState extends AbstractTurnState {
       turnAction,
       directiveResolver,
       processingWorkflowFactory,
+      commandProcessingWorkflowFactory,
     };
 
     this._validateDependencies(deps);

--- a/tests/unit/turns/states/processingCommandState.constructor.test.js
+++ b/tests/unit/turns/states/processingCommandState.constructor.test.js
@@ -30,4 +30,26 @@ describe('ProcessingCommandState constructor', () => {
     validateSpy.mockRestore();
     initSpy.mockRestore();
   });
+
+  test('uses provided commandProcessingWorkflowFactory', () => {
+    const deps = {
+      handler: { getLogger: () => ({ debug: jest.fn() }) },
+      commandProcessor: {},
+      commandOutcomeInterpreter: {},
+      commandString: 'cmd',
+      turnAction: { actionDefinitionId: 'id', commandString: 'cmd' },
+      directiveResolver: TurnDirectiveStrategyResolver,
+    };
+
+    const mockWorkflow = {};
+    const cpwFactory = jest.fn(() => mockWorkflow);
+
+    const state = new ProcessingCommandState({
+      ...deps,
+      commandProcessingWorkflowFactory: cpwFactory,
+    });
+
+    expect(cpwFactory).toHaveBeenCalled();
+    expect(state._processingWorkflow).toBe(mockWorkflow);
+  });
 });


### PR DESCRIPTION
## Summary
- add `commandProcessingWorkflowFactory` argument to `ProcessingCommandState`
- delegate workflow creation to the passed factory
- expose new parameter in interfaces and factory
- test factory usage in constructor

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3568 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `PORT=8081 npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68610515e7808331930fb4b1e102992f