### PR TITLE
[Agent] refactor action indexing service

### DIFF
--- a/src/turns/services/actionIndexingService.js
+++ b/src/turns/services/actionIndexingService.js
@@ -1,5 +1,65 @@
 import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../constants/core.js';
 
+/**
+ * Remove duplicate actions by id and params.
+ *
+ * @description Deduplicate discovered actions by id and params.
+ * @param {import('../../interfaces/IActionDiscoveryService.js').DiscoveredActionInfo[]} discovered - Array of actions discovered for an actor.
+ * @returns {{ uniqueArr: { actionId: string, commandString: string, params: any, description: string }[], duplicatesSuppressed: number }} Object containing the unique actions and the number of suppressed duplicates.
+ */
+function deduplicateActions(discovered) {
+  const unique = new Map();
+  for (const raw of discovered) {
+    const actionId = raw.id;
+    const commandString = raw.command;
+    const params = raw.params ?? {};
+    const description = raw.description ?? '';
+    const key = `${actionId}:${JSON.stringify(params)}`;
+    if (!unique.has(key)) {
+      unique.set(key, { actionId, commandString, params, description });
+    }
+  }
+  return {
+    uniqueArr: Array.from(unique.values()),
+    duplicatesSuppressed: discovered.length - unique.size,
+  };
+}
+
+/**
+ * Limit the list of unique actions to the configured maximum.
+ *
+ * @description Truncate the list of unique actions if it exceeds the maximum.
+ * @param {{ actionId: string, commandString: string, params: any, description: string }[]} uniqueArr - Unique actions after deduplication.
+ * @returns {{ truncatedArr: { actionId: string, commandString: string, params: any, description: string }[], truncatedCount: number }} Object containing the possibly truncated array and count of removed actions.
+ */
+function truncateActions(uniqueArr) {
+  if (uniqueArr.length > MAX_AVAILABLE_ACTIONS_PER_TURN) {
+    const truncatedCount = uniqueArr.length - MAX_AVAILABLE_ACTIONS_PER_TURN;
+    return {
+      truncatedArr: uniqueArr.slice(0, MAX_AVAILABLE_ACTIONS_PER_TURN),
+      truncatedCount,
+    };
+  }
+  return { truncatedArr: uniqueArr, truncatedCount: 0 };
+}
+
+/**
+ * Transform unique actions into indexed composites.
+ *
+ * @description Convert an array of unique actions into indexed composites.
+ * @param {{ actionId: string, commandString: string, params: any, description: string }[]} uniqueArr - List of unique actions after truncation.
+ * @returns {import('../dtos/actionComposite.js').ActionComposite[]} Array of composites ready for indexing.
+ */
+function buildComposites(uniqueArr) {
+  return uniqueArr.map((u, idx) => ({
+    index: idx + 1,
+    actionId: u.actionId,
+    commandString: u.commandString,
+    params: u.params,
+    description: u.description,
+  }));
+}
+
 export class ActionIndexingService {
   /**
    * @param {{ logger: import('../../interfaces/ILogger.js').ILogger }} deps
@@ -72,21 +132,7 @@ export class ActionIndexingService {
     }
 
     /* ── deduplicate by (id + params) ─────────────────────────────────── */
-    const unique = new Map(); // key ⇒ representative action
-    for (const raw of discovered) {
-      // The tests still send `{ actionId, commandString }`; production sends
-      // `{ id, command }`.  We normalise so both worlds work.
-      const actionId = raw.id;
-      const commandString = raw.command;
-      const params = raw.params ?? {};
-      const description = raw.description ?? '';
-      const key = `${actionId}:${JSON.stringify(params)}`;
-      if (!unique.has(key)) {
-        unique.set(key, { actionId, commandString, params, description });
-      }
-    }
-
-    const duplicatesSuppressed = discovered.length - unique.size;
+    const { uniqueArr, duplicatesSuppressed } = deduplicateActions(discovered);
     if (duplicatesSuppressed > 0) {
       this.#log.info(
         `ActionIndexingService: actor "${actorId}" suppressed ${duplicatesSuppressed} duplicate actions`
@@ -94,23 +140,15 @@ export class ActionIndexingService {
     }
 
     /* ── cap the list if it's over the maximum ─────────────────────────── */
-    let uniqueArr = Array.from(unique.values());
-    if (uniqueArr.length > MAX_AVAILABLE_ACTIONS_PER_TURN) {
-      const truncated = uniqueArr.length - MAX_AVAILABLE_ACTIONS_PER_TURN;
-      uniqueArr = uniqueArr.slice(0, MAX_AVAILABLE_ACTIONS_PER_TURN);
+    const { truncatedArr, truncatedCount } = truncateActions(uniqueArr);
+    if (truncatedCount > 0) {
       this.#log.warn(
-        `ActionIndexingService: actor "${actorId}" truncated ${truncated} actions, processing only the first ${MAX_AVAILABLE_ACTIONS_PER_TURN}`
+        `ActionIndexingService: actor "${actorId}" truncated ${truncatedCount} actions, processing only the first ${MAX_AVAILABLE_ACTIONS_PER_TURN}`
       );
     }
 
     /* ── build composites ─────────────────────────────────────────────── */
-    const composites = uniqueArr.map((u, idx) => ({
-      index: idx + 1,
-      actionId: u.actionId,
-      commandString: u.commandString,
-      params: u.params,
-      description: u.description,
-    }));
+    const composites = buildComposites(truncatedArr);
 
     /* ── cache and return ─────────────────────────────────────────────── */
     this.#actorCache.set(actorId, composites);


### PR DESCRIPTION
Summary: Refactored actionIndexingService by extracting deduplication, truncation, and composite building logic into separate helper functions. Updated indexActions to orchestrate these helpers without altering existing behavior.

Testing Done:
- [x] Code formatted `npx prettier --write src/turns/services/actionIndexingService.js`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6861050ba08c83319420beae8ecfc280