### PR TITLE
[Agent] Refactor constructor validations

### DIFF
--- a/src/prompting/AIPromptContentProvider.js
+++ b/src/prompting/AIPromptContentProvider.js
@@ -28,6 +28,7 @@ import {
   ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING,
 } from '../constants/textDefaults.js';
 import { SHORT_TERM_MEMORY_COMPONENT_ID } from '../constants/componentIds.js';
+import { validateDependencies } from '../utils/dependencyUtils.js';
 
 /**
  * @class AIPromptContentProvider
@@ -59,20 +60,36 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
     gameStateValidationService,
   }) {
     super();
-    if (!logger)
-      throw new Error('AIPromptContentProvider: Logger is required.');
-    if (!promptStaticContentService)
-      throw new Error(
-        'AIPromptContentProvider: PromptStaticContentService is required.'
-      );
-    if (!perceptionLogFormatter)
-      throw new Error(
-        'AIPromptContentProvider: PerceptionLogFormatter is required.'
-      );
-    if (!gameStateValidationService)
-      throw new Error(
-        'AIPromptContentProvider: GameStateValidationServiceForPrompting is required.'
-      );
+    validateDependencies(
+      [
+        {
+          dependency: logger,
+          name: 'AIPromptContentProvider: logger',
+          methods: ['info', 'warn', 'error', 'debug'],
+        },
+        {
+          dependency: promptStaticContentService,
+          name: 'AIPromptContentProvider: promptStaticContentService',
+          methods: [
+            'getCoreTaskDescriptionText',
+            'getCharacterPortrayalGuidelines',
+            'getNc21ContentPolicyText',
+            'getFinalLlmInstructionText',
+          ],
+        },
+        {
+          dependency: perceptionLogFormatter,
+          name: 'AIPromptContentProvider: perceptionLogFormatter',
+          methods: ['format'],
+        },
+        {
+          dependency: gameStateValidationService,
+          name: 'AIPromptContentProvider: gameStateValidationService',
+          methods: ['validate'],
+        },
+      ],
+      logger
+    );
 
     this.#logger = logger;
     this.#promptStaticContentService = promptStaticContentService;

--- a/src/prompting/AIPromptPipeline.js
+++ b/src/prompting/AIPromptPipeline.js
@@ -2,6 +2,7 @@
 // --- FILE START ---
 
 import { IAIPromptPipeline } from './interfaces/IAIPromptPipeline.js';
+import { validateDependencies } from '../utils/dependencyUtils.js';
 
 /** @typedef {import('../turns/interfaces/ILLMAdapter.js').ILLMAdapter} ILLMAdapter */
 /** @typedef {import('../turns/interfaces/IAIGameStateProvider.js').IAIGameStateProvider} IAIGameStateProvider */
@@ -37,41 +38,36 @@ export class AIPromptPipeline extends IAIPromptPipeline {
   }) {
     super();
 
-    if (
-      !llmAdapter ||
-      typeof llmAdapter.getAIDecision !== 'function' ||
-      typeof llmAdapter.getCurrentActiveLlmId !== 'function'
-    ) {
-      throw new Error(
-        'AIPromptPipeline: Constructor requires a valid ILLMAdapter.'
-      );
-    }
-    if (
-      !gameStateProvider ||
-      typeof gameStateProvider.buildGameState !== 'function'
-    ) {
-      throw new Error(
-        'AIPromptPipeline: Constructor requires a valid IAIGameStateProvider.'
-      );
-    }
-    if (
-      !promptContentProvider ||
-      typeof promptContentProvider.getPromptData !== 'function'
-    ) {
-      throw new Error(
-        'AIPromptPipeline: Constructor requires a valid IAIPromptContentProvider instance with a getPromptData method.'
-      );
-    }
-    if (!promptBuilder || typeof promptBuilder.build !== 'function') {
-      throw new Error(
-        'AIPromptPipeline: Constructor requires a valid IPromptBuilder instance with a build method.'
-      );
-    }
-    if (!logger || typeof logger.info !== 'function') {
-      throw new Error(
-        'AIPromptPipeline: Constructor requires a valid ILogger instance.'
-      );
-    }
+    validateDependencies(
+      [
+        {
+          dependency: llmAdapter,
+          name: 'AIPromptPipeline: llmAdapter',
+          methods: ['getAIDecision', 'getCurrentActiveLlmId'],
+        },
+        {
+          dependency: gameStateProvider,
+          name: 'AIPromptPipeline: gameStateProvider',
+          methods: ['buildGameState'],
+        },
+        {
+          dependency: promptContentProvider,
+          name: 'AIPromptPipeline: promptContentProvider',
+          methods: ['getPromptData'],
+        },
+        {
+          dependency: promptBuilder,
+          name: 'AIPromptPipeline: promptBuilder',
+          methods: ['build'],
+        },
+        {
+          dependency: logger,
+          name: 'AIPromptPipeline: logger',
+          methods: ['info'],
+        },
+      ],
+      logger
+    );
 
     this.#llmAdapter = llmAdapter;
     this.#gameStateProvider = gameStateProvider;

--- a/tests/common/prompting/pipelineHelpers.js
+++ b/tests/common/prompting/pipelineHelpers.js
@@ -18,22 +18,22 @@ import { expect } from '@jest/globals';
  */
 export const AIPromptPipelineDependencySpec = {
   llmAdapter: {
-    error: /ILLMAdapter/,
+    error: /AIPromptPipeline: llmAdapter/,
     methods: ['getAIDecision', 'getCurrentActiveLlmId'],
   },
   gameStateProvider: {
-    error: /IAIGameStateProvider/,
+    error: /AIPromptPipeline: gameStateProvider/,
     methods: ['buildGameState'],
   },
   promptContentProvider: {
-    error: /IAIPromptContentProvider/,
+    error: /AIPromptPipeline: promptContentProvider/,
     methods: ['getPromptData'],
   },
   promptBuilder: {
-    error: /IPromptBuilder/,
+    error: /AIPromptPipeline: promptBuilder/,
     methods: ['build'],
   },
-  logger: { error: /ILogger/, methods: ['info'] },
+  logger: { error: /AIPromptPipeline: logger/, methods: ['info'] },
 };
 
 /**

--- a/tests/unit/prompting/AIPromptContentProvider.test.js
+++ b/tests/unit/prompting/AIPromptContentProvider.test.js
@@ -182,7 +182,9 @@ describe('AIPromptContentProvider', () => {
             perceptionLogFormatter: mockPerceptionLogFormatterInstance,
             gameStateValidationService: mockGameStateValidationServiceInstance,
           })
-      ).toThrow('AIPromptContentProvider: Logger is required.');
+      ).toThrow(
+        'Missing required dependency: AIPromptContentProvider: logger.'
+      );
     });
 
     test('should throw error if PromptStaticContentService is not provided', () => {
@@ -196,7 +198,7 @@ describe('AIPromptContentProvider', () => {
             gameStateValidationService: mockGameStateValidationServiceInstance,
           })
       ).toThrow(
-        'AIPromptContentProvider: PromptStaticContentService is required.'
+        'Missing required dependency: AIPromptContentProvider: promptStaticContentService.'
       );
     });
 
@@ -210,7 +212,9 @@ describe('AIPromptContentProvider', () => {
             perceptionLogFormatter: null,
             gameStateValidationService: mockGameStateValidationServiceInstance,
           })
-      ).toThrow('AIPromptContentProvider: PerceptionLogFormatter is required.');
+      ).toThrow(
+        'Missing required dependency: AIPromptContentProvider: perceptionLogFormatter.'
+      );
     });
 
     test('should throw error if GameStateValidationServiceForPrompting is not provided', () => {
@@ -224,7 +228,7 @@ describe('AIPromptContentProvider', () => {
             gameStateValidationService: null,
           })
       ).toThrow(
-        'AIPromptContentProvider: GameStateValidationServiceForPrompting is required.'
+        'Missing required dependency: AIPromptContentProvider: gameStateValidationService.'
       );
     });
   });


### PR DESCRIPTION
## Summary
- use `validateDependencies` to enforce constructor checks in `AIPromptContentProvider`
- apply same pattern to `AIPromptPipeline`
- update pipeline helper specs and related unit tests

## Testing Done
- `npm run lint` *(fails: 715 errors, 2852 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686104d707dc8331b6b9de2f4daf7bde