### PR TITLE
[Agent] Inject semver library into ModDependencyValidator

### DIFF
--- a/src/modding/modDependencyValidator.js
+++ b/src/modding/modDependencyValidator.js
@@ -27,10 +27,12 @@ class ModDependencyValidator {
    *
    * @param {Map<string, ModManifest>} manifests - Map of mod manifests, keyed by **lower-cased** mod ID.
    * @param {ILogger} logger - Logger instance for warnings.
+   * @param {object} [options] - Optional validation options.
+   * @param {{valid: Function, satisfies: Function}} [options.semverLib=semver] - Library used for semver checks.
    * @returns {void} - Returns nothing, but throws ModDependencyError on fatal issues.
    * @throws {ModDependencyError} If fatal validation errors occur (missing required, version mismatch, conflict).
    */
-  static validate(manifests, logger) {
+  static validate(manifests, logger, { semverLib = semver } = {}) {
     const fatals = []; // AC: Collect fatal messages
 
     if (!(manifests instanceof Map)) {
@@ -72,7 +74,7 @@ class ModDependencyValidator {
             const targetVersion = targetManifest.version;
             const requiredVersionRange = dep.version;
 
-            if (!semver.valid(targetVersion)) {
+            if (!semverLib.valid(targetVersion)) {
               const msg = `Mod '${manifest.id}' dependency '${dep.id}' has an invalid version format: '${targetVersion}'.`;
               if (required) {
                 fatals.push(msg);
@@ -85,8 +87,8 @@ class ModDependencyValidator {
               continue; // Skip satisfaction check if version is invalid
             }
 
-            // AC: Use semver.satisfies for version check
-            if (!semver.satisfies(targetVersion, requiredVersionRange)) {
+            // AC: Use semverLib.satisfies for version check
+            if (!semverLib.satisfies(targetVersion, requiredVersionRange)) {
               const msg = `Mod '${manifest.id}' requires dependency '${dep.id}' version '${requiredVersionRange}', but found version '${targetVersion}'.`;
               if (required) {
                 // AC: Fatal: Required version mismatch

--- a/tests/unit/services/modDependencyValidator.test.js
+++ b/tests/unit/services/modDependencyValidator.test.js
@@ -233,6 +233,29 @@ describe('ModDependencyValidator', () => {
     expect(mockLogger.info).not.toHaveBeenCalled();
   });
 
+  it('5c. uses injected semver library', () => {
+    const modB = { id: 'ModB', version: '1.0.0' };
+    const modA = {
+      id: 'ModA',
+      version: '1.0.0',
+      dependencies: [{ id: 'ModB', version: '^1.0.0' }],
+    };
+    const manifests = createManifestMap([modA, modB]);
+
+    const fakeSemver = {
+      valid: jest.fn(() => true),
+      satisfies: jest.fn(() => false),
+    };
+
+    expect(() =>
+      ModDependencyValidator.validate(manifests, mockLogger, {
+        semverLib: fakeSemver,
+      })
+    ).toThrow(/requires dependency 'ModB' version '\^1.0.0'/);
+    expect(fakeSemver.valid).toHaveBeenCalledWith('1.0.0');
+    expect(fakeSemver.satisfies).toHaveBeenCalledWith('1.0.0', '^1.0.0');
+  });
+
   it('6. Conflict declared by A only', () => {
     const modB = { id: 'ModB', version: '1.0.0' };
     const modA = { id: 'ModA', version: '1.0.0', conflicts: ['ModB'] };


### PR DESCRIPTION
Summary:
- allow overriding semver in ModDependencyValidator.validate
- added tests for injected semver library

Testing Done:
- `npx prettier -w src/modding/modDependencyValidator.js tests/unit/services/modDependencyValidator.test.js`
- `npx eslint src/modding/modDependencyValidator.js tests/unit/services/modDependencyValidator.test.js`
- `npm run test --silent`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686104c296388331ab67ba17228b88f9