### PR TITLE
[Agent] inject LoadResultAggregator dependency

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -5,10 +5,10 @@
  * using configured content loaders.
  */
 
-import LoadResultAggregator from './LoadResultAggregator.js';
 import ModProcessor from './ModProcessor.js';
 
 /** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
+/** @typedef {import('./LoadResultAggregator.js').default} LoadResultAggregator */
 
 /** @typedef {import('../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
@@ -25,11 +25,13 @@ export class ContentLoadManager {
   #modProcessor;
 
   /**
+   * Creates a new ContentLoadManager.
+   *
    * @param {object} deps - Constructor dependencies.
    * @param {ILogger} deps.logger - Logging service.
    * @param {ValidatedEventDispatcher} deps.validatedEventDispatcher - Event dispatcher.
    * @param {Array<LoaderConfigEntry>} deps.contentLoadersConfig - Loader configuration.
-   * @param {(counts: TotalResultsSummary) => LoadResultAggregator} [deps.aggregatorFactory] -
+   * @param {(counts: TotalResultsSummary) => LoadResultAggregator} deps.aggregatorFactory -
    *   Factory for creating {@link LoadResultAggregator} instances.
    * @param {() => number} [deps.timer] -
    *   Optional function returning a high resolution timestamp.
@@ -38,9 +40,12 @@ export class ContentLoadManager {
     logger,
     validatedEventDispatcher,
     contentLoadersConfig,
-    aggregatorFactory = (counts) => new LoadResultAggregator(counts),
+    aggregatorFactory,
     timer = () => performance.now(),
   }) {
+    if (typeof aggregatorFactory !== 'function') {
+      throw new Error('aggregatorFactory must be provided');
+    }
     this.#logger = logger;
     this.#contentLoadersConfig = contentLoadersConfig;
     this.#modProcessor = new ModProcessor({

--- a/src/loaders/WorldLoadSummaryLogger.js
+++ b/src/loaders/WorldLoadSummaryLogger.js
@@ -6,12 +6,13 @@
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
+/** @typedef {import('./helpers/resultsSummary.js').TotalsSummary} TotalsSummary */
 
 /**
  * Computes summed totals across all registry keys.
  *
  * @param {TotalResultsSummary} totals - Map of content type totals.
- * @returns {{count: number, overrides: number, errors: number}} Grand totals.
+ * @returns {TotalsSummary} Grand totals.
  */
 export function computeTotalsSummary(totals) {
   const summary = { count: 0, overrides: 0, errors: 0 };

--- a/src/loaders/helpers/resultsSummary.js
+++ b/src/loaders/helpers/resultsSummary.js
@@ -5,10 +5,19 @@
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
 /**
+ * Summary counts for content loading totals.
+ *
+ * @typedef {object} TotalsSummary
+ * @property {number} count - Number of items processed.
+ * @property {number} overrides - Number of items that replaced existing ones.
+ * @property {number} errors - Number of failed items.
+ */
+
+/**
  * Aggregates results from Promise.allSettled and logs a summary.
  *
  * @param {ILogger} logger - Logger for output.
- * @param {PromiseSettledResult<{qualifiedId:string,didOverride:boolean}>[]} settledResults - Results from processing.
+ * @param {globalThis.PromiseSettledResult<{qualifiedId:string,didOverride:boolean}>[]} settledResults - Results from processing.
  * @param {string[]} filenames - Original filenames corresponding to the results.
  * @param {string} modId - Owning mod ID for context.
  * @param {string} contentKey - Content key for logging purposes.

--- a/tests/integration/loaders/multiModsWorldLoader.integration.test.js
+++ b/tests/integration/loaders/multiModsWorldLoader.integration.test.js
@@ -11,6 +11,7 @@ import EntityDefinitionLoader from '../../../src/loaders/entityDefinitionLoader.
 import EntityInstanceLoader from '../../../src/loaders/entityInstanceLoader.js';
 import WorldLoader from '../../../src/loaders/worldLoader.js';
 import ContentLoadManager from '../../../src/loaders/ContentLoadManager.js';
+import LoadResultAggregator from '../../../src/loaders/LoadResultAggregator.js';
 import { createContentLoadersConfig } from '../../../src/loaders/defaultLoaderConfig.js';
 
 /**
@@ -62,6 +63,7 @@ function buildEnv(pathToResponse) {
     logger,
     validatedEventDispatcher: dispatcher,
     contentLoadersConfig,
+    aggregatorFactory: (counts) => new LoadResultAggregator(counts),
   });
   return { logger, registry, manager, worldLoader };
 }


### PR DESCRIPTION
Summary: 
- remove direct construction of `LoadResultAggregator`
- document new `TotalsSummary` typedef
- update world summary to use new typedef
- include aggregator factory in multi-mod loader integration test

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686104a160e483319e2610391ebe8b67