### PR TITLE
[Agent] factor out persistence listener setup

### DIFF
--- a/src/initializers/services/initHelpers.js
+++ b/src/initializers/services/initHelpers.js
@@ -1,0 +1,35 @@
+// src/initializers/services/initHelpers.js
+
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../../events/safeEventDispatcher.js').default} ISafeEventDispatcher */
+
+/**
+ * @description Registers event listeners with a SafeEventDispatcher for
+ *   persistence-related events.
+ * @param {ISafeEventDispatcher} dispatcher - Dispatcher used to subscribe.
+ * @param {Array<{eventId: string, handler: Function}>} listeners - Listener
+ *   definitions.
+ * @param {ILogger} [logger] - Optional logger for debug output.
+ * @returns {void}
+ * @throws {Error} If dispatcher or listeners are invalid.
+ */
+export function setupPersistenceListeners(dispatcher, listeners, logger) {
+  if (!dispatcher || typeof dispatcher.subscribe !== 'function') {
+    throw new Error('setupPersistenceListeners: invalid dispatcher');
+  }
+  if (!Array.isArray(listeners)) {
+    throw new Error('setupPersistenceListeners: listeners must be an array');
+  }
+
+  for (const { eventId, handler } of listeners) {
+    if (!eventId || typeof handler !== 'function') {
+      throw new Error('setupPersistenceListeners: invalid listener definition');
+    }
+    dispatcher.subscribe(eventId, handler);
+  }
+  logger?.debug('Registered AI persistence listeners.');
+}
+
+export default {
+  setupPersistenceListeners,
+};

--- a/tests/unit/initializers/services/initializationService.persistenceListeners.test.js
+++ b/tests/unit/initializers/services/initializationService.persistenceListeners.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../../../src/initializers/services/initHelpers.js', () => ({
+  setupPersistenceListeners: jest.fn(),
+}));
+
+import { setupPersistenceListeners } from '../../../../src/initializers/services/initHelpers.js';
+import InitializationService from '../../../../src/initializers/services/initializationService.js';
+import LlmAdapterInitializer from '../../../../src/initializers/services/llmAdapterInitializer.js';
+import { ACTION_DECIDED_ID } from '../../../../src/constants/eventIds.js';
+
+const WORLD = 'persistenceWorld';
+
+let logger;
+let dispatcher;
+let modsLoader;
+let scopeRegistry;
+let dataRegistry;
+let llmAdapter;
+let llmConfigLoader;
+let systemInitializer;
+let worldInitializer;
+let safeEventDispatcher;
+let entityManager;
+let domUiFacade;
+let actionIndex;
+let gameDataRepository;
+let thoughtListener;
+let notesListener;
+let contentDependencyValidator;
+let llmAdapterInitializer;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn() };
+  dispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
+  modsLoader = { loadMods: jest.fn().mockResolvedValue({}) };
+  scopeRegistry = { initialize: jest.fn() };
+  dataRegistry = { getAll: jest.fn().mockReturnValue([]) };
+  llmAdapter = {
+    init: jest.fn().mockResolvedValue(undefined),
+    isInitialized: jest.fn().mockReturnValue(false),
+    isOperational: jest.fn().mockReturnValue(true),
+  };
+  llmConfigLoader = { loadConfigs: jest.fn() };
+  systemInitializer = { initializeAll: jest.fn().mockResolvedValue(undefined) };
+  worldInitializer = {
+    initializeWorldEntities: jest.fn().mockReturnValue(true),
+  };
+  safeEventDispatcher = { subscribe: jest.fn() };
+  entityManager = {};
+  domUiFacade = {};
+  actionIndex = { buildIndex: jest.fn() };
+  gameDataRepository = {
+    getAllActionDefinitions: jest.fn().mockReturnValue([]),
+  };
+  thoughtListener = { handleEvent: jest.fn() };
+  notesListener = { handleEvent: jest.fn() };
+  contentDependencyValidator = {
+    validate: jest.fn().mockResolvedValue(undefined),
+  };
+  llmAdapterInitializer = new LlmAdapterInitializer();
+});
+
+describe('InitializationService persistence listener setup', () => {
+  it('calls setupPersistenceListeners with dispatcher, listeners, and logger', async () => {
+    const service = new InitializationService({
+      log: { logger },
+      events: { validatedEventDispatcher: dispatcher, safeEventDispatcher },
+      llm: { llmAdapter, llmConfigLoader },
+      persistence: {
+        entityManager,
+        domUiFacade,
+        actionIndex,
+        gameDataRepository,
+        thoughtListener,
+        notesListener,
+        spatialIndexManager: { buildIndex: jest.fn() },
+      },
+      coreSystems: {
+        modsLoader,
+        scopeRegistry,
+        dataRegistry,
+        systemInitializer,
+        worldInitializer,
+        contentDependencyValidator,
+        llmAdapterInitializer,
+      },
+    });
+
+    await service.runInitializationSequence(WORLD);
+
+    expect(setupPersistenceListeners).toHaveBeenCalledTimes(1);
+    const [dispatcherArg, listenersArg, loggerArg] =
+      setupPersistenceListeners.mock.calls[0];
+    expect(dispatcherArg).toBe(safeEventDispatcher);
+    expect(loggerArg).toBe(logger);
+    expect(Array.isArray(listenersArg)).toBe(true);
+    expect(listenersArg).toEqual([
+      { eventId: ACTION_DECIDED_ID, handler: expect.any(Function) },
+      { eventId: ACTION_DECIDED_ID, handler: expect.any(Function) },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- create `setupPersistenceListeners` helper for persistence setup
- wire InitializationService to use the new helper
- verify persistence listeners registered via dedicated unit test

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68610470187c8331ade6ebe66ae3c892