### PR TITLE
[Agent] add IEventBus interface and update event bus usage

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -4,7 +4,7 @@
 /** @typedef {import('../interfaces/IGameDataRepository.js').IGameDataRepository} IGameDataRepository */
 /** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('../entities/entity.js').default} Entity */
-/** @typedef {import('../events/eventBus.js').default} EventBus */ // Assuming EventBus might be an interface or a concrete type used directly
+/** @typedef {import('../interfaces/IEventBus.js').IEventBus} IEventBus */
 /** @typedef {import('../constants/eventIds.js').ATTEMPT_ACTION_ID} ATTEMPT_ACTION_ID */
 // --- REMOVED Import for ActionTargetContext as it's no longer used here ---
 /** @typedef {import('../interfaces/IGameDataRepository.js').ActionDefinition} ActionDefinition */

--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -64,9 +64,15 @@ export function registerInfrastructure(container) {
     `Infrastructure Registration: Registered ${String(tokens.ActionIndexingService)}.`
   );
 
-  registrar.single(tokens.EventBus, EventBus);
+  const eventBusInstance = new EventBus({ logger: log });
+  registrar.instance(tokens.EventBus, eventBusInstance);
+  container.register(tokens.IEventBus, () => eventBusInstance, {
+    lifecycle: 'singleton',
+  });
   log.debug(
-    `Infrastructure Registration: Registered ${String(tokens.EventBus)}.`
+    `Infrastructure Registration: Registered ${String(tokens.EventBus)} and ${String(
+      tokens.IEventBus
+    )}.`
   );
 
   container.register(

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -12,6 +12,7 @@ import { freeze } from '../utils';
  * @typedef {string} DiToken
  * @property {DiToken} ILogger - Token for the core logging service.
  * @property {DiToken} EventBus - Token for the central event bus (legacy).
+ * @property {DiToken} IEventBus - Token for the event bus interface.
  * @property {DiToken} IDataFetcher - Token for the data fetching service.
  * @property {DiToken} ITextDataFetcher - Token for the text data fetching service.
  * @property {DiToken} IConfiguration - Token for static configuration access.
@@ -167,6 +168,7 @@ export const tokens = freeze({
   // Core Interfaces/Abstractions & Externals
   ILogger: 'ILogger',
   EventBus: 'EventBus', // Legacy
+  IEventBus: 'IEventBus',
   IDataFetcher: 'IDataFetcher',
   ITextDataFetcher: 'ITextDataFetcher',
   IConfiguration: 'IConfiguration',

--- a/src/events/validatedEventDispatcher.js
+++ b/src/events/validatedEventDispatcher.js
@@ -7,7 +7,7 @@
  * as a facade for subscribing and unsubscribing via the EventBus.
  */
 
-/** @typedef {import('./eventBus.js').default} EventBus */
+/** @typedef {import('../interfaces/IEventBus.js').IEventBus} IEventBus */
 /** @typedef {import('./eventBus.js').EventListener} EventListener */ // Added for type hinting
 /** @typedef {import('../data/gameDataRepository.js').GameDataRepository} GameDataRepository */
 /** @typedef {import('../data/gameDataRepository.js').EventDefinition} EventDefinition */
@@ -24,6 +24,7 @@ import { IValidatedEventDispatcher } from '../interfaces/IValidatedEventDispatch
  * Ensures that events are structurally correct before being sent, when possible.
  */
 class ValidatedEventDispatcher extends IValidatedEventDispatcher {
+  /** @type {IEventBus} */
   #eventBus;
   #gameDataRepository;
   #schemaValidator;
@@ -33,7 +34,7 @@ class ValidatedEventDispatcher extends IValidatedEventDispatcher {
    * Creates an instance of ValidatedEventDispatcher.
    *
    * @param {object} dependencies
-   * @param {EventBus} dependencies.eventBus - The main event bus for dispatching and subscriptions.
+   * @param {IEventBus} dependencies.eventBus - The main event bus for dispatching and subscriptions.
    * @param {GameDataRepository} dependencies.gameDataRepository - Repository to access event definitions.
    * @param {ISchemaValidator} dependencies.schemaValidator - Service to validate payloads against JSON schemas.
    * @param {ILogger} dependencies.logger - Service for logging messages.

--- a/src/interfaces/IEventBus.js
+++ b/src/interfaces/IEventBus.js
@@ -1,0 +1,59 @@
+// src/interfaces/IEventBus.js
+
+/**
+ * @file Defines the IEventBus interface describing the contract
+ * for a simple publish/subscribe event bus.
+ */
+
+/**
+ * Represents the function signature for event listeners used by the event bus.
+ *
+ * @typedef {(event: {type: string, payload: any}) => (void|Promise<void>)} EventListener
+ */
+
+export class IEventBus {
+  /**
+   * Dispatches an event to all subscribed listeners.
+   *
+   * @param {string} eventName - The event identifier.
+   * @param {object} payload - Arbitrary data associated with the event.
+   * @returns {Promise<void>}
+   */
+  async dispatch(eventName, payload) {
+    throw new Error('IEventBus.dispatch method not implemented.');
+  }
+
+  /**
+   * Subscribes a listener to a specific event.
+   *
+   * @param {string} eventName - The name of the event to subscribe to.
+   * @param {EventListener} listener - Function invoked when the event is dispatched.
+   * @returns {() => void} Function that unsubscribes the listener when called.
+   */
+  subscribe(eventName, listener) {
+    throw new Error('IEventBus.subscribe method not implemented.');
+  }
+
+  /**
+   * Unsubscribes a listener from a specific event.
+   *
+   * @param {string} eventName - The event identifier.
+   * @param {EventListener} listener - The previously subscribed listener.
+   * @returns {void}
+   */
+  unsubscribe(eventName, listener) {
+    throw new Error('IEventBus.unsubscribe method not implemented.');
+  }
+
+  /**
+   * Returns the number of listeners currently subscribed to an event.
+   *
+   * @param {string} eventName - The event identifier.
+   * @returns {number} Number of subscribed listeners.
+   */
+  listenerCount(eventName) {
+    throw new Error('IEventBus.listenerCount method not implemented.');
+  }
+}
+
+export {};

--- a/src/logic/operationHandlers/dispatchEventHandler.js
+++ b/src/logic/operationHandlers/dispatchEventHandler.js
@@ -2,7 +2,7 @@
 // --- JSDoc Imports ---
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */ // ** Corrected type for 2nd arg **
-/** @typedef {import('../../events/eventBus.js').default} EventBus */
+/** @typedef {import('../../interfaces/IEventBus.js').IEventBus} IEventBus */
 /** @typedef {import('../../events/validatedEventDispatcher.js').default} ValidatedEventDispatcher */
 /** @typedef {import('../defs.js').EventDispatchDeps} EventDispatchDeps */
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
@@ -29,14 +29,14 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
  * @implements {OperationHandler}
  */
 class DispatchEventHandler {
-  /** @type {ValidatedEventDispatcher | EventBus} */
+  /** @type {ValidatedEventDispatcher | IEventBus} */
   #dispatcher;
   /** @type {ILogger} */
   #logger;
 
   /**
    * @param {object} deps
-   * @param {ValidatedEventDispatcher|EventBus} deps.dispatcher
+   * @param {ValidatedEventDispatcher|IEventBus} deps.dispatcher
    * @param {ILogger} deps.logger - The logger service instance.
    * @throws {Error} If dependencies are invalid.
    */

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -18,7 +18,7 @@ import { isEmptyCondition } from '../utils/jsonLogicUtils.js';
  * ------------------------------------------------------------------------- */
 /** @typedef {import('../interfaces/coreServices.js').ILogger}               ILogger */
 /** @typedef {import('../interfaces/coreServices.js').IDataRegistry}         IDataRegistry */
-/** @typedef {import('../events/eventBus.js').default}                       EventBus */
+/** @typedef {import('../interfaces/IEventBus.js').IEventBus}                IEventBus */
 /** @typedef {import('./jsonLogicEvaluationService.js').default}            JsonLogicEvaluationService */
 /** @typedef {import('../entities/entityManager.js').default}               EntityManager */
 /** @typedef {import('./operationInterpreter.js').default}                  OperationInterpreter */
@@ -31,7 +31,7 @@ import { isEmptyCondition } from '../utils/jsonLogicUtils.js';
  * ------------------------------------------------------------------------- */
 class SystemLogicInterpreter extends BaseService {
   /** @type {ILogger} */ #logger;
-  /** @type {EventBus} */ #eventBus;
+  /** @type {IEventBus} */ #eventBus;
   /** @type {IDataRegistry} */ #dataRegistry;
   /** @type {JsonLogicEvaluationService} */ #jsonLogic;
   /** @type {EntityManager} */ #entityManager;

--- a/tests/common/mockFactories/eventBus.js
+++ b/tests/common/mockFactories/eventBus.js
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals';
  *
  * @param {object} [options] - Configuration options
  * @param {boolean} [options.captureEvents] - Whether to capture dispatched events
- * @returns {object} Mock event bus with subscribe, unsubscribe, dispatch methods
+ * @returns {object} Mock event bus with subscribe, unsubscribe, dispatch, listenerCount methods
  */
 export function createEventBus({ captureEvents = false } = {}) {
   const handlers = {};
@@ -38,6 +38,7 @@ export function createEventBus({ captureEvents = false } = {}) {
     unsubscribe: jest.fn((eventType, handler) => {
       handlers[eventType]?.delete(handler);
     }),
+    listenerCount: jest.fn((eventType) => handlers[eventType]?.size || 0),
     _triggerEvent(eventType, payload) {
       (handlers[eventType] || new Set()).forEach((h) => h(payload));
     },

--- a/tests/registrations/registerInterpreters.test.js
+++ b/tests/registrations/registerInterpreters.test.js
@@ -19,10 +19,12 @@ describe('registerInterpreters', () => {
       error: jest.fn(),
     };
     container.register(tokens.ILogger, logger);
-    container.register(tokens.EventBus, {
+    const bus = {
       subscribe: jest.fn(),
       unsubscribe: jest.fn(),
-    });
+    };
+    container.register(tokens.EventBus, bus);
+    container.register(tokens.IEventBus, bus);
     container.register(tokens.IDataRegistry, {
       getAllSystemRules: jest.fn().mockReturnValue([]),
     });

--- a/tests/unit/config/registrations/infrastructureRegistrations.test.js
+++ b/tests/unit/config/registrations/infrastructureRegistrations.test.js
@@ -66,6 +66,7 @@ describe('registerInfrastructure', () => {
     // or the test could clear specific registrations before calling registerInfrastructure.
     // For now, we'll leave them as they demonstrate the "overwrite" but don't break most tests.
     container.register(tokens.EventBus, () => mockEventBus); // Will be overwritten
+    container.register(tokens.IEventBus, () => mockEventBus); // Will be overwritten
     container.register(
       tokens.ISpatialIndexManager,
       () => mockSpatialIndexManager
@@ -112,6 +113,7 @@ describe('registerInfrastructure', () => {
     const eventBus = container.resolve(tokens.EventBus);
     expect(eventBus).toBeDefined();
     // expect(eventBus).toBeInstanceOf(ActualEventBus); // If you import the actual EventBus
+    expect(container.resolve(tokens.IEventBus)).toBe(eventBus);
   });
 
   test('should register ISpatialIndexManager correctly', () => {

--- a/tests/unit/config/registrations/interpreterRegistrations.test.js
+++ b/tests/unit/config/registrations/interpreterRegistrations.test.js
@@ -90,6 +90,9 @@ describe('registerInterpreters', () => {
     mockContainer.register(tokens.EventBus, mockEventBus, {
       lifecycle: 'singleton',
     });
+    mockContainer.register(tokens.IEventBus, mockEventBus, {
+      lifecycle: 'singleton',
+    });
     mockContainer.register(tokens.IDataRegistry, mockDataRegistry, {
       lifecycle: 'singleton',
     });

--- a/tests/unit/dependencyInjection/registrations/interpreterRegistrations.addPerceptionLogEntryHandler.test.js
+++ b/tests/unit/dependencyInjection/registrations/interpreterRegistrations.addPerceptionLogEntryHandler.test.js
@@ -62,6 +62,7 @@ describe('interpreterRegistrations', () => {
       );
       registrar.instance(tokens.OperationRegistry, mockOperationRegistry);
       registrar.instance(tokens.EventBus, mockEventBus);
+      registrar.instance(tokens.IEventBus, mockEventBus);
       registrar.instance(tokens.IDataRegistry, mockDataRegistry);
 
       // Act

--- a/tests/unit/dependencyInjection/registrations/interpreterRegistrations.autoAndMergeHandlers.test.js
+++ b/tests/unit/dependencyInjection/registrations/interpreterRegistrations.autoAndMergeHandlers.test.js
@@ -51,6 +51,7 @@ describe('interpreterRegistrations', () => {
       );
       registrar.instance(tokens.OperationRegistry, mockOperationRegistry);
       registrar.instance(tokens.EventBus, mockEventBus);
+      registrar.instance(tokens.IEventBus, mockEventBus);
       registrar.instance(tokens.IDataRegistry, mockDataRegistry);
 
       container.register(tokens.ClosenessCircleService, { merge: jest.fn() });

--- a/tests/unit/dependencyInjection/registrations/interpreterRegistrations.removeFromClosenessCircleHandler.test.js
+++ b/tests/unit/dependencyInjection/registrations/interpreterRegistrations.removeFromClosenessCircleHandler.test.js
@@ -49,6 +49,7 @@ describe('interpreterRegistrations', () => {
       );
       registrar.instance(tokens.OperationRegistry, mockOperationRegistry);
       registrar.instance(tokens.EventBus, mockEventBus);
+      registrar.instance(tokens.IEventBus, mockEventBus);
       registrar.instance(tokens.IDataRegistry, mockDataRegistry);
 
       // Register a mock closenessCircleService

--- a/tests/unit/events/eventBus.errors.test.js
+++ b/tests/unit/events/eventBus.errors.test.js
@@ -10,10 +10,15 @@ import EventBus from '../../../src/events/eventBus.js';
 
 describe('EventBus error handling', () => {
   let bus;
-  let errorSpy;
+  let logger;
   beforeEach(() => {
-    bus = new EventBus();
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    bus = new EventBus({ logger });
   });
   afterEach(() => {
     jest.restoreAllMocks();
@@ -22,18 +27,18 @@ describe('EventBus error handling', () => {
   it('logs for invalid subscribe arguments', () => {
     bus.subscribe('', () => {});
     bus.subscribe('test', null);
-    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledTimes(2);
   });
 
   it('logs for invalid unsubscribe arguments', () => {
     bus.unsubscribe('', () => {});
     bus.unsubscribe('a', null);
-    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledTimes(2);
   });
 
   it('logs for invalid dispatch name', async () => {
     await bus.dispatch('');
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 
   it('handles listener errors gracefully', async () => {
@@ -41,7 +46,7 @@ describe('EventBus error handling', () => {
       throw new Error('oops');
     });
     await bus.dispatch('x');
-    expect(errorSpy).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('EventBus: Error executing listener'),
       expect.any(Error)
     );
@@ -49,7 +54,7 @@ describe('EventBus error handling', () => {
 
   it('listenerCount logs and returns 0 for invalid name', () => {
     const count = bus.listenerCount('');
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
     expect(count).toBe(0);
   });
 });

--- a/tests/unit/events/eventBus.test.js
+++ b/tests/unit/events/eventBus.test.js
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import EventBus from '../../../src/events/eventBus.js';
 
+const createLogger = () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+});
+
 describe('EventBus', () => {
   let bus;
   beforeEach(() => {
-    bus = new EventBus();
+    bus = new EventBus({ logger: createLogger() });
   });
 
   it('subscribes and dispatches events to specific listeners', async () => {


### PR DESCRIPTION
Summary:
- add `IEventBus` interface with dispatch/subscribe/unsubscribe/listenerCount
- refactor `EventBus` to implement the interface and use injected logger
- register `EventBus` as `tokens.IEventBus`
- update modules and tests to use new interface
- extend event bus mocks

Testing Done:
- `npm run format`
- `npm run lint` *(fails: existing repository issues)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68610a4ed4488331b298e595ddbbf3bf