### PR TITLE
[Agent] decouple schema preloading

### DIFF
--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -42,6 +42,10 @@ import AjvSchemaValidator from '../../validation/ajvSchemaValidator.js';
 import InMemoryDataRegistry from '../../data/inMemoryDataRegistry.js';
 import WorkspaceDataFetcher from '../../data/workspaceDataFetcher.js';
 import TextDataFetcher from '../../data/textDataFetcher.js';
+import {
+  LLM_TURN_ACTION_RESPONSE_SCHEMA,
+  LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+} from '../../turns/schemas/llmOutputSchemas.js';
 
 // --- Loader Imports ---
 import ActionLoader from '../../loaders/actionLoader.js';
@@ -115,7 +119,15 @@ export function registerLoaders(container) {
   );
   registrar.singletonFactory(
     tokens.ISchemaValidator,
-    (c) => new AjvSchemaValidator(c.resolve(tokens.ILogger))
+    (c) =>
+      new AjvSchemaValidator(c.resolve(tokens.ILogger), {
+        preloadSchemas: [
+          {
+            schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,
+            id: LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+          },
+        ],
+      })
   );
   registrar.singletonFactory(
     tokens.IDataRegistry,

--- a/tests/integration/EndToEndMemoryFlow.test.js
+++ b/tests/integration/EndToEndMemoryFlow.test.js
@@ -11,6 +11,10 @@ import { PromptStaticContentService } from '../../src/prompting/promptStaticCont
 import AjvSchemaValidator from '../../src/validation/ajvSchemaValidator.js';
 import { LLMResponseProcessor } from '../../src/turns/services/LLMResponseProcessor.js';
 import { SHORT_TERM_MEMORY_COMPONENT_ID } from '../../src/constants/componentIds.js';
+import {
+  LLM_TURN_ACTION_RESPONSE_SCHEMA,
+  LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+} from '../../src/turns/schemas/llmOutputSchemas.js';
 
 // New imports for builder adjustments
 import { AssemblerRegistry } from '../../src/prompting/assemblerRegistry.js';
@@ -126,7 +130,14 @@ describe('End-to-End Short-Term Memory Flow', () => {
       conditionEvaluator: ConditionEvaluator,
     });
 
-    schemaValidator = new AjvSchemaValidator(logger);
+    schemaValidator = new AjvSchemaValidator(logger, {
+      preloadSchemas: [
+        {
+          schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,
+          id: LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+        },
+      ],
+    });
     const safeEventDispatcher = { dispatch: jest.fn() };
     responseProcessor = new LLMResponseProcessor({
       schemaValidator,

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -10,6 +10,10 @@ import { PlaceholderResolver } from '../../src/utils/placeholderResolverUtils.js
 import { PromptStaticContentService } from '../../src/prompting/promptStaticContentService.js';
 import AjvSchemaValidator from '../../src/validation/ajvSchemaValidator.js';
 import { LLMResponseProcessor } from '../../src/turns/services/LLMResponseProcessor.js';
+import {
+  LLM_TURN_ACTION_RESPONSE_SCHEMA,
+  LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+} from '../../src/turns/schemas/llmOutputSchemas.js';
 import Entity from '../../src/entities/entity.js';
 import EntityDefinition from '../../src/entities/entityDefinition.js';
 import EntityInstanceData from '../../src/entities/entityInstanceData.js';
@@ -172,7 +176,14 @@ describe('End-to-End Notes Persistence Flow', () => {
       conditionEvaluator: ConditionEvaluator,
     });
 
-    schemaValidator = new AjvSchemaValidator(logger);
+    schemaValidator = new AjvSchemaValidator(logger, {
+      preloadSchemas: [
+        {
+          schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,
+          id: LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
+        },
+      ],
+    });
     const safeEventDispatcher = { dispatch: jest.fn() };
     processor = new LLMResponseProcessor({
       schemaValidator,

--- a/tests/unit/services/ajvSchemaValidator.errorPaths.test.js
+++ b/tests/unit/services/ajvSchemaValidator.errorPaths.test.js
@@ -127,7 +127,6 @@ describe('AjvSchemaValidator error paths', () => {
   it('logs error when schema persists after removeSchema', () => {
     const getSchema = jest
       .fn()
-      .mockReturnValueOnce({}) // constructor preload check
       .mockReturnValueOnce({}) // existence check
       .mockReturnValueOnce({}); // still present after removal
     const removeSchema = jest.fn();

--- a/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
+++ b/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
@@ -63,10 +63,7 @@ describe('AjvSchemaValidator edge branch tests', () => {
 
   it('logs and returns false if removeSchema throws', () => {
     const removeError = new Error('remove fail');
-    const getSchema = jest
-      .fn()
-      .mockReturnValueOnce(null) // constructor preload check
-      .mockReturnValueOnce({});
+    const getSchema = jest.fn().mockReturnValueOnce({});
     const removeSchema = jest.fn(() => {
       throw removeError;
     });

--- a/tests/unit/services/ajvSchemaValidator.refsAndBatch.test.js
+++ b/tests/unit/services/ajvSchemaValidator.refsAndBatch.test.js
@@ -12,7 +12,7 @@ import { createMockLogger } from '../testUtils.js';
  * Returns a constructed validator and the mocked functions for assertions.
  */
 function setupMockAjv({
-  getSchemaReturns = [null],
+  getSchemaReturns = [],
   addSchemaImpl,
   compileImpl,
 } = {}) {
@@ -46,7 +46,7 @@ afterEach(() => {
 describe('AjvSchemaValidator reference and batch operations', () => {
   it('validateSchemaRefs warns and returns false when schema is missing', () => {
     const { validator, logger } = setupMockAjv({
-      getSchemaReturns: [null, null],
+      getSchemaReturns: [null],
     });
     const result = validator.validateSchemaRefs('missing');
     expect(result).toBe(false);
@@ -58,7 +58,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
   it('validateSchemaRefs returns true when compilation succeeds', () => {
     const schemaObj = { schema: {} };
     const { validator, compile } = setupMockAjv({
-      getSchemaReturns: [null, schemaObj],
+      getSchemaReturns: [schemaObj],
       compileImpl: () => ({}),
     });
     const result = validator.validateSchemaRefs('good');
@@ -70,7 +70,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
     const error = new Error('boom');
     const schemaObj = { schema: {} };
     const { validator, logger } = setupMockAjv({
-      getSchemaReturns: [null, schemaObj],
+      getSchemaReturns: [schemaObj],
       compileImpl: () => {
         throw error;
       },
@@ -149,7 +149,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
 
   it('addSchemas resolves and logs on success', async () => {
     const { validator, logger, addSchema } = setupMockAjv({
-      getSchemaReturns: [null],
+      getSchemaReturns: [],
     });
     const schemas = [{ $id: 'a' }, { $id: 'b' }];
     await expect(validator.addSchemas(schemas)).resolves.toBeUndefined();
@@ -163,7 +163,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
     const error = new Error('batch');
     error.errors = [{ message: 'oops' }];
     const { validator, logger } = setupMockAjv({
-      getSchemaReturns: [null],
+      getSchemaReturns: [],
       addSchemaImpl: () => {
         throw error;
       },

--- a/tests/unit/services/ajvSchemaValidator.uncoveredBranches.test.js
+++ b/tests/unit/services/ajvSchemaValidator.uncoveredBranches.test.js
@@ -7,7 +7,7 @@ import { createMockLogger } from '../testUtils.js';
  * @param root0.getSchemaReturns
  * @param root0.addSchemaImpl
  */
-function setupMockAjv({ getSchemaReturns = [null], addSchemaImpl } = {}) {
+function setupMockAjv({ getSchemaReturns = [], addSchemaImpl } = {}) {
   const getSchema = jest.fn();
   getSchemaReturns.forEach((val) => getSchema.mockReturnValueOnce(val));
   const addSchema = jest.fn(addSchemaImpl);
@@ -37,7 +37,7 @@ afterEach(() => {
 describe('AjvSchemaValidator uncovered branches', () => {
   it('warns when schema is added but cannot be retrieved', async () => {
     const { validator, logger } = setupMockAjv({
-      getSchemaReturns: [null, null, null],
+      getSchemaReturns: [null, null],
     });
     const schema = { $id: 'test://schemas/missing', type: 'object' };
     await expect(
@@ -50,7 +50,7 @@ describe('AjvSchemaValidator uncovered branches', () => {
 
   it('wraps non-Error thrown by addSchema', async () => {
     const { validator } = setupMockAjv({
-      getSchemaReturns: [null, null],
+      getSchemaReturns: [null],
       addSchemaImpl: () => {
         throw 'boom';
       },

--- a/tests/unit/validation/ajvSchemaValidator.init.test.js
+++ b/tests/unit/validation/ajvSchemaValidator.init.test.js
@@ -52,7 +52,9 @@ describe('AjvSchemaValidator initialization edge cases', () => {
     const logger = createMockLogger();
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
-    new AjvSchemaValidator(logger);
+    new AjvSchemaValidator(logger, {
+      preloadSchemas: [{ schema: {}, id: 'test' }],
+    });
     expect(addSchema).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('already loaded. Skipping.')
@@ -71,7 +73,9 @@ describe('AjvSchemaValidator initialization edge cases', () => {
     const logger = createMockLogger();
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
-    new AjvSchemaValidator(logger);
+    new AjvSchemaValidator(logger, {
+      preloadSchemas: [{ schema: {}, id: 'test' }],
+    });
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Failed to preload schema'),
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- refactor AjvSchemaValidator to accept optional schemas to preload
- inject LLM turn response schema via dependency registration
- adapt integration tests and unit tests for new preload behaviour

## Testing
- `npm run lint` *(fails: 715 errors)*
- `npm run test`
- `cd llm-proxy-server && npm install && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610be415848331b625b411c54365c5