### PR TITLE
[Agent] fix notes normalization regex

### DIFF
--- a/src/ai/notesService.js
+++ b/src/ai/notesService.js
@@ -7,11 +7,11 @@
  * @param {string} text - The original note text.
  * @returns {string} The normalized text.
  */
-function normalizeNoteText(text) {
+export function normalizeNoteText(text) {
   return text
     .trim()
     .toLowerCase()
-    .replace(/[^\w\s]|/g, '')
+    .replace(/[^\w\s]/g, '')
     .replace(/\s+/g, ' ');
 }
 

--- a/tests/unit/ai/notesService.test.js
+++ b/tests/unit/ai/notesService.test.js
@@ -8,7 +8,9 @@ import {
   jest,
   test,
 } from '@jest/globals';
-import NotesService from '../../../src/ai/notesService.js';
+import NotesService, {
+  normalizeNoteText,
+} from '../../../src/ai/notesService.js';
 
 describe('NotesService', () => {
   let notesService;
@@ -94,6 +96,12 @@ describe('NotesService', () => {
     const result = notesService.addNotes(component, newNotes);
 
     expect(result.wasModified).toBe(false);
+  });
+
+  test('normalizeNoteText strips punctuation without affecting regular characters', () => {
+    const input = " Hello, world! It's great. ";
+    const normalized = normalizeNoteText(input);
+    expect(normalized).toBe('hello world its great');
   });
 
   test('should throw a TypeError for a malformed component', () => {


### PR DESCRIPTION
Summary: Fix normalization regex and expose helper for tests. Added unit test covering punctuation stripping.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [x] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68610f487c688331aa6ed37818f1f789