### PR TITLE
[Refactor] Extract engine error utils

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -8,7 +8,7 @@ import {
   REQUEST_SHOW_LOAD_GAME_UI,
   CANNOT_SAVE_GAME_INFO,
 } from '../constants/eventIds.js';
-import { processOperationFailure } from './engineErrorUtils.js';
+import { processOperationFailure } from '../utils/engineErrorUtils.js';
 import EngineState from './engineState.js';
 import GameSessionManager from './gameSessionManager.js';
 import PersistenceCoordinator from './persistenceCoordinator.js';

--- a/src/utils/engineErrorUtils.js
+++ b/src/utils/engineErrorUtils.js
@@ -1,4 +1,9 @@
-// src/engine/engineErrorUtils.js
+// src/utils/engineErrorUtils.js
+/**
+ * @module engineErrorUtils
+ * @description Utilities for dispatching failure UI events and standardizing
+ * engine errors.
+ */
 import { ENGINE_OPERATION_FAILED_UI } from '../constants/eventIds.js';
 
 /**


### PR DESCRIPTION
Summary: Move error handling helpers out of GameEngine.

Changes Made:
- Added `src/utils/engineErrorUtils.js` with reusable failure dispatch and error processing helpers.
- Updated GameEngine to import helpers from new utils module.
- Removed old `engineErrorUtils` from engine directory.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6861131e4590833194d55858fdcbb801