### PR TITLE
[Agent] fix SaveGameService JSDoc mismatch

### DIFF
--- a/src/domUI/saveGameService.js
+++ b/src/domUI/saveGameService.js
@@ -95,8 +95,7 @@ export default class SaveGameService {
    *
    * @param {SlotDisplayData} selectedSlotData - Slot being saved into.
    * @param {string} saveName - Name to use when saving.
-   * @param {GameEngine} gameEngine - Game engine instance.
-   * @param saveService
+   * @param {ISaveService} saveService - Service responsible for persisting the game.
    * @returns {Promise<{result: any, returnedIdentifier: string | null}>}
    *   Result from the engine and identifier, if provided.
    */
@@ -120,8 +119,7 @@ export default class SaveGameService {
    *
    * @param {SlotDisplayData} selectedSlotData - Slot being saved into.
    * @param {string} saveName - Name to use when saving.
-   * @param {GameEngine} gameEngine - Game engine instance.
-   * @param saveService
+   * @param {ISaveService} saveService - Service responsible for persisting the game.
    * @returns {Promise<{success: boolean, message: string, returnedIdentifier: string | null}>}
    *   Operation outcome details.
    */


### PR DESCRIPTION
Summary:
- sync parameter JSDoc with implementation in SaveGameService

Testing Done:
- [x] Code formatted `npm run format` (single file)
- [x] Lint passes `npm run lint` (fails: 715 errors - existing)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686112dd22cc8331afdf0583beb8113d