### PR TITLE
[Agent] centralize RuntimeContext typedef

### DIFF
--- a/src/actions/targetResolutionService.js
+++ b/src/actions/targetResolutionService.js
@@ -9,6 +9,7 @@
 /** @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 /** @typedef {import('./tracing/traceContext.js').TraceContext} TraceContext */
 /** @typedef {import('../logic/jsonLogicEvaluationService.js').default} JsonLogicEvaluationService */
+/** @typedef {import('../types/runtimeContext.js').RuntimeContext} RuntimeContext */
 
 import { ITargetResolutionService } from '../interfaces/ITargetResolutionService.js';
 import { ActionTargetContext } from '../models/actionTargetContext.js';
@@ -181,7 +182,7 @@ export class TargetResolutionService extends ITargetResolutionService {
    *
    * @param {Entity} actorEntity The current actor entity.
    * @param {ActionContext} discoveryContext Context for scope resolution.
-   * @returns {object} The runtime context for scope evaluation.
+   * @returns {RuntimeContext} The runtime context for scope evaluation.
    * @private
    */
   #buildRuntimeContext(actorEntity, discoveryContext) {

--- a/src/interfaces/IScopeEngine.js
+++ b/src/interfaces/IScopeEngine.js
@@ -1,6 +1,7 @@
 // src/interfaces/IScopeEngine.js
 
 /** @typedef {import('../actions/tracing/traceContext.js').TraceContext} TraceContext */
+/** @typedef {import('../types/runtimeContext.js').RuntimeContext} RuntimeContext */
 
 /**
  * @file IScopeEngine.js
@@ -17,7 +18,7 @@ export class IScopeEngine {
    *
    * @param {object} ast - The parsed AST
    * @param {object} actorEntity - The acting entity instance
-   * @param {object} runtimeCtx - Runtime context with services
+   * @param {RuntimeContext} runtimeCtx - Runtime context with services
    * @param {TraceContext} [trace] - Optional trace context for logging
    * @returns {Set<string>} Set of entity IDs
    * @abstract

--- a/src/scopeDsl/cache.js
+++ b/src/scopeDsl/cache.js
@@ -6,6 +6,8 @@
 import { TURN_STARTED_ID } from '../constants/eventIds.js';
 import { IScopeEngine } from '../interfaces/IScopeEngine.js';
 
+/** @typedef {import('../types/runtimeContext.js').RuntimeContext} RuntimeContext */
+
 /**
  * Scope-DSL Cache that provides memoization for scope resolution
  * Acts as a caching wrapper around ScopeEngine with automatic cache invalidation
@@ -79,7 +81,7 @@ class ScopeCache extends IScopeEngine {
    *
    * @param {string} actorId - Actor ID
    * @param {object} ast - The parsed AST
-   * @param {object} runtimeCtx - Runtime context containing location
+   * @param {RuntimeContext} runtimeCtx - Runtime context containing location
    * @returns {string} Cache key
    * @private
    */
@@ -100,7 +102,7 @@ class ScopeCache extends IScopeEngine {
    *
    * @param {object} ast - The parsed AST
    * @param {object} actorEntity - The acting entity instance
-   * @param {object} runtimeCtx - Runtime context with services
+   * @param {RuntimeContext} runtimeCtx - Runtime context with services
    * @returns {Set<string>} Set of entity IDs
    */
   resolve(ast, actorEntity, runtimeCtx) {

--- a/src/scopeDsl/engine.js
+++ b/src/scopeDsl/engine.js
@@ -17,20 +17,14 @@ import createFilterResolver from './nodes/filterResolver.js';
 import createUnionResolver from './nodes/unionResolver.js';
 import createArrayIterationResolver from './nodes/arrayIterationResolver.js';
 
+/** @typedef {import('../types/runtimeContext.js').RuntimeContext} RuntimeContext */
+
 /**
  * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
  * @typedef {import('../interfaces/ISpatialIndexManager.js').ISpatialIndexManager} ISpatialIndexManager
  * @typedef {import('../logic/jsonLogicEvaluationService.js').default} JsonLogicEval
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../actions/tracing/traceContext.js').TraceContext} TraceContext
- */
-
-/**
- * @typedef {object} RuntimeContext
- * @property {IEntityManager} entityManager
- * @property {ISpatialIndexManager} spatialIndexManager
- * @property {JsonLogicEval} jsonLogicEval
- * @property {ILogger} logger
  */
 
 /**

--- a/src/types/runtimeContext.js
+++ b/src/types/runtimeContext.js
@@ -1,0 +1,17 @@
+/**
+ * @typedef {import('../interfaces/IEntityManager.js').IEntityManager} IEntityManager
+ * @typedef {import('../interfaces/ISpatialIndexManager.js').ISpatialIndexManager} ISpatialIndexManager
+ * @typedef {import('../logic/jsonLogicEvaluationService.js').default} JsonLogicEval
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ * @typedef {import('../actions/tracing/traceContext.js').TraceContext} TraceContext
+ */
+
+/**
+ * @typedef {object} RuntimeContext
+ * @property {IEntityManager} entityManager
+ * @property {ISpatialIndexManager} spatialIndexManager
+ * @property {JsonLogicEval} jsonLogicEval
+ * @property {ILogger} logger
+ */
+
+export {};


### PR DESCRIPTION
## Summary
- extract `RuntimeContext` JSDoc to a dedicated module
- reference `RuntimeContext` typedef across modules

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686113c3b44083319c440f7f559218d0