### PR TITLE
[Agent] Dispatch error on missing thoughts

### DIFF
--- a/src/ai/thoughtPersistenceListener.js
+++ b/src/ai/thoughtPersistenceListener.js
@@ -2,6 +2,7 @@
 
 import { persistThoughts } from './thoughtPersistenceHook.js';
 import ShortTermMemoryService from './shortTermMemoryService.js';
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
  * @class
@@ -23,11 +24,14 @@ export class ThoughtPersistenceListener {
   constructor({
     logger,
     entityManager,
+    dispatcher,
     stmService = new ShortTermMemoryService(),
     now = () => new Date(),
   }) {
     this.logger = logger;
     this.entityManager = entityManager;
+    /** @type {ISafeEventDispatcher | undefined} */
+    this.dispatcher = dispatcher;
     this.stmService = stmService;
     this.now = now;
   }
@@ -57,6 +61,7 @@ export class ThoughtPersistenceListener {
         { thoughts: extractedData.thoughts },
         actorEntity,
         this.logger,
+        this.dispatcher,
         this.stmService,
         this.now()
       );

--- a/tests/unit/ai/thoughtPersistenceListener.test.js
+++ b/tests/unit/ai/thoughtPersistenceListener.test.js
@@ -41,6 +41,7 @@ describe('ThoughtPersistenceListener', () => {
       { thoughts: 'hi' },
       actorEntity,
       logger,
+      undefined,
       listener.stmService,
       expect.any(Date)
     );


### PR DESCRIPTION
## Summary
- improve `persistThoughts` to notify a dispatcher when thoughts are missing
- thread dispatcher through `ThoughtPersistenceListener`
- adjust tests for `persistThoughts` and `ThoughtPersistenceListener`

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6861121bbad48331a500614a00582a1e