### PR TITLE
[Agent] refactor LLMConfigService with cache

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -63,6 +63,7 @@ import { GameStateValidationServiceForPrompting } from '../../validation/gameSta
 import { HttpConfigurationProvider } from '../../configuration/httpConfigurationProvider.js';
 import { LLMConfigService } from '../../llms/llmConfigService.js';
 import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
+import { LlmConfigCache } from '../../llms/services/LlmConfigCache.js';
 import { PlaceholderResolver } from '../../utils/placeholderResolverUtils.js';
 import { StandardElementAssembler } from '../../prompting/assembling/standardElementAssembler.js';
 import {
@@ -136,6 +137,9 @@ export function registerLlmInfrastructure(registrar, logger) {
     `AI Systems Registration: Registered ${tokens.LlmConfigLoader}.`
   );
 
+  registrar.singletonFactory(tokens.LlmConfigCache, () => new LlmConfigCache());
+  logger.debug(`AI Systems Registration: Registered ${tokens.LlmConfigCache}.`);
+
   registrar.singletonFactory(tokens.LLMAdapter, (c) => {
     logger.debug('AI Systems Registration: Starting LLM Adapter setup...');
     const environmentContext = new EnvironmentContext({
@@ -207,7 +211,8 @@ export function registerPromptingEngine(registrar, logger) {
   registrar.singletonFactory(tokens.LLMConfigService, (c) => {
     return new LLMConfigService({
       logger: c.resolve(tokens.ILogger),
-      configurationProvider: c.resolve(tokens.IConfigurationProvider),
+      loader: c.resolve(tokens.LlmConfigLoader),
+      cache: c.resolve(tokens.LlmConfigCache),
       configSourceIdentifier: './config/llm-configs.json',
     });
   });

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -71,6 +71,7 @@ import { freeze } from '../utils';
  * @property {DiToken} GameConfigLoader - Token for loading the main game configuration file.
  * @property {DiToken} PromptTextLoader - Token for loading the core prompt text used by the AI system.
  * @property {DiToken} LlmConfigLoader - Token for loading LLM prompt configurations.
+ * @property {DiToken} LlmConfigCache - Token for caching LLM configurations.
  * @property {DiToken} ModManifestLoader - Token for loading mod manifests.
  * @property {DiToken} ModDependencyValidator - Token for the mod dependency validator service.
  * @property {DiToken} ILoadCache - Token for the load cache service.
@@ -226,6 +227,7 @@ export const tokens = freeze({
   GameConfigLoader: 'GameConfigLoader',
   PromptTextLoader: 'PromptTextLoader',
   LlmConfigLoader: 'LlmConfigLoader',
+  LlmConfigCache: 'LlmConfigCache',
   ModManifestLoader: 'ModManifestLoader',
   ModDependencyValidator: 'ModDependencyValidator',
   ILoadCache: 'ILoadCache',

--- a/src/llms/services/LlmConfigCache.js
+++ b/src/llms/services/LlmConfigCache.js
@@ -1,0 +1,68 @@
+// src/llms/services/LlmConfigCache.js
+// --- FILE START ---
+
+/**
+ * @file Manages in-memory storage for LLM configurations.
+ */
+
+/**
+ * @typedef {import('../llmConfigService.js').LLMConfig} LLMConfig
+ */
+
+/**
+ * @class LlmConfigCache
+ * @description Simple cache for storing and retrieving LLM configuration objects.
+ */
+export class LlmConfigCache {
+  /**
+   * @type {Map<string, LLMConfig>}
+   * @private
+   */
+  #cache = new Map();
+
+  /**
+   * Adds or updates configurations in the cache.
+   *
+   * @param {LLMConfig[]} configs - Array of configs to add or update.
+   * @returns {void}
+   */
+  addOrUpdateConfigs(configs = []) {
+    if (!Array.isArray(configs)) return;
+    for (const cfg of configs) {
+      if (cfg && typeof cfg.configId === 'string') {
+        this.#cache.set(cfg.configId, { ...cfg });
+      }
+    }
+  }
+
+  /**
+   * Retrieves a configuration by its ID.
+   *
+   * @param {string} id - Config identifier.
+   * @returns {LLMConfig | undefined} The configuration or undefined.
+   */
+  getConfig(id) {
+    const cfg = this.#cache.get(id);
+    return cfg ? { ...cfg } : undefined;
+  }
+
+  /**
+   * Clears all cached configurations.
+   *
+   * @returns {void}
+   */
+  resetCache() {
+    this.#cache.clear();
+  }
+
+  /**
+   * Exposes the underlying cache for internal consumers.
+   *
+   * @returns {Map<string, LLMConfig>}
+   */
+  getCache() {
+    return this.#cache;
+  }
+}
+
+// --- FILE END ---


### PR DESCRIPTION
## Summary
- introduce `LlmConfigCache` for storing configs
- refactor `LLMConfigService` to depend on loader and cache
- register new cache service in DI
- update tokens for `LlmConfigCache`
- adjust unit tests for new constructor

## Testing Done
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `npm run test` *(fails: sh: 1: jest: not found)*
- `cd llm-proxy-server && npm run test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686119ad10788331b4c085cb291ea5aa