### PR TITLE
[Agent] Add service init helper

### DIFF
--- a/src/initializers/serviceInitHelper.js
+++ b/src/initializers/serviceInitHelper.js
@@ -1,0 +1,57 @@
+// src/initializers/serviceInitHelper.js
+
+/**
+ * @module ServiceInitHelper
+ * @description Helper functions for initializing services and handlers.
+ */
+
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../utils/serviceInitializerUtils.js').DependencySpec} DependencySpec */
+
+import { setupPrefixedLogger } from '../utils/loggerUtils.js';
+import { validateDependencies } from '../utils/dependencyUtils.js';
+
+/**
+ * Create a prefixed logger for a service or handler.
+ *
+ * @param {string} serviceName - Name used for log prefixing.
+ * @param {ILogger | undefined | null} logger - Base logger instance.
+ * @returns {ILogger} Prefixed logger instance.
+ */
+export function setupServiceLogger(serviceName, logger) {
+  return setupPrefixedLogger(logger, `${serviceName}: `);
+}
+
+/**
+ * Validate a map of service dependencies.
+ *
+ * @param {string} serviceName - Name used in validation messages.
+ * @param {ILogger} logger - Logger for validation output.
+ * @param {Record<string, DependencySpec>} [dependencyMap] - Dependency spec map.
+ * @returns {void}
+ */
+export function validateServiceDependencies(
+  serviceName,
+  logger,
+  dependencyMap
+) {
+  if (!dependencyMap) return;
+
+  const checks = [];
+  for (const [depName, spec] of Object.entries(dependencyMap)) {
+    if (!spec) continue;
+    checks.push({
+      dependency: spec.value,
+      name: `${serviceName}: ${depName}`,
+      methods: spec.requiredMethods,
+      isFunction: spec.isFunction,
+    });
+  }
+
+  validateDependencies(checks, logger);
+}
+
+export default {
+  setupServiceLogger,
+  validateServiceDependencies,
+};

--- a/tests/unit/utils/serviceInitHelper.test.js
+++ b/tests/unit/utils/serviceInitHelper.test.js
@@ -1,0 +1,68 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+
+import {
+  setupServiceLogger,
+  validateServiceDependencies,
+} from '../../../src/initializers/serviceInitHelper.js';
+import { setupPrefixedLogger } from '../../../src/utils/loggerUtils.js';
+import { validateDependencies } from '../../../src/utils/dependencyUtils.js';
+
+jest.mock('../../../src/utils/dependencyUtils.js', () => ({
+  validateDependencies: jest.fn(),
+}));
+
+jest.mock('../../../src/utils/loggerUtils.js', () => ({
+  setupPrefixedLogger: jest.fn(),
+}));
+
+describe('serviceInitHelper', () => {
+  const baseLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupPrefixedLogger.mockImplementation((logger, prefix) => ({
+      prefix,
+      logger,
+    }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('setupServiceLogger creates prefixed logger', () => {
+    const logger = setupServiceLogger('Svc', baseLogger);
+    expect(setupPrefixedLogger).toHaveBeenCalledWith(baseLogger, 'Svc: ');
+    expect(logger).toEqual({ prefix: 'Svc: ', logger: baseLogger });
+  });
+
+  it('validateServiceDependencies delegates to validateDependencies', () => {
+    const deps = {
+      fnA: { value: () => {}, isFunction: true },
+    };
+    validateServiceDependencies('Svc', baseLogger, deps);
+    expect(validateDependencies).toHaveBeenCalledWith(
+      [
+        {
+          dependency: deps.fnA.value,
+          name: 'Svc: fnA',
+          methods: undefined,
+          isFunction: true,
+        },
+      ],
+      baseLogger
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `serviceInitHelper`
- unit test for service init helper

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686116ad3fd88331a87e9de1308333f2