### PR TITLE
[Refactor] Add strategy helpers module

### DIFF
--- a/src/turns/strategies/endTurnFailureStrategy.js
+++ b/src/turns/strategies/endTurnFailureStrategy.js
@@ -10,10 +10,7 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import {
-  assertDirective,
-  requireContextActor,
-} from '../../utils/strategyHelpers.js';
+import { assertDirective, requireContextActor } from './strategyHelpers.js';
 
 export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
   /** @override */

--- a/src/turns/strategies/endTurnSuccessStrategy.js
+++ b/src/turns/strategies/endTurnSuccessStrategy.js
@@ -10,10 +10,7 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import {
-  assertDirective,
-  requireContextActor,
-} from '../../utils/strategyHelpers.js';
+import { assertDirective, requireContextActor } from './strategyHelpers.js';
 
 export default class EndTurnSuccessStrategy extends ITurnDirectiveStrategy {
   /** @override */

--- a/src/turns/strategies/repromptStrategy.js
+++ b/src/turns/strategies/repromptStrategy.js
@@ -10,10 +10,7 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import {
-  assertDirective,
-  requireContextActor,
-} from '../../utils/strategyHelpers.js';
+import { assertDirective, requireContextActor } from './strategyHelpers.js';
 import { AwaitingActorDecisionState } from '../states/awaitingActorDecisionState.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 

--- a/src/turns/strategies/strategyHelpers.js
+++ b/src/turns/strategies/strategyHelpers.js
@@ -1,12 +1,12 @@
-// src/utils/strategyHelpers.js
+// src/turns/strategies/strategyHelpers.js
 /**
  * Helper functions shared by turn directive strategies.
  *
  * @module strategyHelpers
  */
 
-/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../turns/interfaces/ITurnContext.js').ITurnContext} ITurnContext */
+/** @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext */
+/** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
 /**
  * Validates that a directive matches the expected value.
@@ -39,7 +39,7 @@ export function assertDirective({ expected, actual, logger, className }) {
  * @param {ILogger} params.logger - Logger for error output.
  * @param {string} params.className - Name of the calling strategy class.
  * @param {string} params.errorMsg - Error message used when the actor is missing.
- * @returns {import('../entities/entity.js').default | null} The actor or null when missing.
+ * @returns {import('../../entities/entity.js').default | null} The actor or null when missing.
  */
 export function requireContextActor({
   turnContext,

--- a/src/turns/strategies/waitForTurnEndEventStrategy.js
+++ b/src/turns/strategies/waitForTurnEndEventStrategy.js
@@ -11,10 +11,7 @@
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
 import { TURN_ENDED_ID } from '../../constants/eventIds.js';
-import {
-  assertDirective,
-  requireContextActor,
-} from '../../utils/strategyHelpers.js';
+import { assertDirective, requireContextActor } from './strategyHelpers.js';
 
 export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy {
   /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -30,4 +30,4 @@ export {
 } from './dependencyUtils.js';
 export { createErrorDetails } from './errorDetails.js';
 export { readComponent, writeComponent } from './componentAccessUtils.js';
-export * from './strategyHelpers.js';
+export * from '../turns/strategies/strategyHelpers.js';

--- a/tests/unit/utils/strategyHelpers.test.js
+++ b/tests/unit/utils/strategyHelpers.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   assertDirective,
   requireContextActor,
-} from '../../../src/utils/strategyHelpers.js';
+} from '../../../src/turns/strategies/strategyHelpers.js';
 
 describe('strategyHelpers', () => {
   describe('assertDirective', () => {


### PR DESCRIPTION
Summary: Consolidate common directive and actor checks into a dedicated helper module.

Changes Made:
- Added `src/turns/strategies/strategyHelpers.js` providing `assertDirective` and `requireContextActor` helpers.
- Updated turn strategy classes to import these helpers.
- Re-exported helpers via `src/utils/index.js` and removed old utils file.
- Adjusted existing unit tests to use the new helper path.

Testing Done:
- [x] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68611dc15c808331bc966e4f185c9bbc