### PR TITLE
[Agent] note mutation docs and tests

### DIFF
--- a/src/ai/notesService.js
+++ b/src/ai/notesService.js
@@ -32,7 +32,7 @@ export default class NotesService {
   /**
    * Adds new notes to a notes component data object, skipping duplicates.
    *
-   * @param {object} notesComp - The notes component data to update.
+   * @param {object} notesComp - The notes component data to update. This object is mutated in place.
    * @param {Array<{text: string, timestamp: string}>} notesComp.notes - The list of existing notes.
    * @param {string[]} newNotesText - An array of new note strings to add.
    * @param {Date} [now] - The current date/time; defaults to new Date().

--- a/src/ai/shortTermMemoryService.js
+++ b/src/ai/shortTermMemoryService.js
@@ -22,7 +22,7 @@ export default class ShortTermMemoryService {
   /**
    * Add a thought if it isn’t already present.
    *
-   * @param {object} mem The memory object to update.
+   * @param {object} mem The memory object to update. This object is mutated in place.
    * @param {Array<{text:string,timestamp:string}>} mem.thoughts The list of existing thought entries.
    * @param {number} mem.maxEntries The maximum number of entries allowed in the memory.
    * @param {string} mem.entityId The identifier for the entity owning this memory.

--- a/tests/unit/ai/notesService.test.js
+++ b/tests/unit/ai/notesService.test.js
@@ -34,6 +34,7 @@ describe('NotesService', () => {
     const result = notesService.addNotes(component, newNotes);
 
     expect(result.wasModified).toBe(true);
+    expect(result.component).toBe(component); // same reference returned
     expect(result.component.notes).toHaveLength(1);
     expect(result.component.notes[0]).toEqual({
       text: 'First note',
@@ -66,6 +67,7 @@ describe('NotesService', () => {
     const result = notesService.addNotes(component, newNotes);
 
     expect(result.wasModified).toBe(false);
+    expect(result.component).toBe(component); // reference should not change
     expect(result.component.notes).toHaveLength(1);
   });
 
@@ -80,6 +82,7 @@ describe('NotesService', () => {
     const result = notesService.addNotes(component, newNotes);
 
     expect(result.wasModified).toBe(true);
+    expect(result.component).toBe(component); // same reference returned
     expect(result.component.notes).toHaveLength(2);
     expect(result.component.notes.map((n) => n.text)).toEqual([
       'Alpha',
@@ -96,6 +99,7 @@ describe('NotesService', () => {
     const result = notesService.addNotes(component, newNotes);
 
     expect(result.wasModified).toBe(false);
+    expect(result.component).toBe(component); // object reused
   });
 
   test('normalizeNoteText strips punctuation without affecting regular characters', () => {

--- a/tests/unit/services/shortTermMemoryService.test.js
+++ b/tests/unit/services/shortTermMemoryService.test.js
@@ -60,6 +60,7 @@ describe('ShortTermMemoryService.addThought – core logic', () => {
       new Date('2025-06-03T09:05:00.000Z')
     );
 
+    expect(result).toBe(mem); // reference should be unchanged
     expect(wasAdded).toBe(false);
     expect(result.thoughts).toHaveLength(1); // still only the original entry
     expect(result.thoughts[0].text).toBe('hello world'); // unchanged


### PR DESCRIPTION
Summary: Adds explicit mention in JSDoc that notes and memory components are mutated in place. Unit tests updated to check same object references are returned.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes (`npm run lint` has numerous pre-existing issues)
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686124ac3bc08331b0c91e2b5dbe0816