### PR TITLE
[Agent] Inject DSL parser into TargetResolutionService

### DIFF
--- a/src/dependencyInjection/registrations/commandAndActionRegistrations.js
+++ b/src/dependencyInjection/registrations/commandAndActionRegistrations.js
@@ -76,6 +76,7 @@ export function registerCommandAndAction(container) {
       logger: c.resolve(tokens.ILogger),
       safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
       jsonLogicEvaluationService: c.resolve(tokens.JsonLogicEvaluationService),
+      dslParser: c.resolve(tokens.DslParser),
     });
   });
 

--- a/src/dependencyInjection/registrations/infrastructureRegistrations.js
+++ b/src/dependencyInjection/registrations/infrastructureRegistrations.js
@@ -17,6 +17,7 @@ import ScopeRegistry from '../../scopeDsl/scopeRegistry.js';
 import ScopeEngine from '../../scopeDsl/engine.js';
 import { LRUCache } from 'lru-cache';
 import ScopeCache from '../../scopeDsl/cache.js';
+import DefaultDslParser from '../../scopeDsl/parser/defaultDslParser.js';
 
 /**
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
@@ -132,6 +133,12 @@ export function registerInfrastructure(container) {
   registrar.single(tokens.ScopeEngine, ScopeEngine);
   log.debug(
     `Infrastructure Registration: Registered ${String(tokens.ScopeEngine)}.`
+  );
+
+  // DSL Parser
+  registrar.single(tokens.DslParser, DefaultDslParser);
+  log.debug(
+    `Infrastructure Registration: Registered ${String(tokens.DslParser)}.`
   );
 
   // Scope DSL Cache (wraps ScopeEngine with caching)

--- a/src/dependencyInjection/tokens.js
+++ b/src/dependencyInjection/tokens.js
@@ -419,6 +419,7 @@ export const tokens = freeze({
   // Scope DSL Services
   ScopeEngine: 'ScopeEngine',
   ScopeCache: 'ScopeCache',
+  DslParser: 'DslParser',
 
   // --- Factory Functions ---
   TraceContextFactory: 'TraceContextFactory',

--- a/src/scopeDsl/IDslParser.js
+++ b/src/scopeDsl/IDslParser.js
@@ -1,0 +1,22 @@
+/**
+ * @file IDslParser.js
+ * @description Interface for parsing Scope-DSL expressions into AST objects.
+ */
+
+/**
+ * @interface IDslParser
+ * @description Defines the contract for parsing Scope-DSL expressions.
+ */
+export class IDslParser {
+  /**
+   * Parses a DSL expression string into an AST representation.
+   *
+   * @param {string} expr - The expression to parse.
+   * @returns {object} The parsed AST.
+   */
+  parse(expr) {
+    throw new Error('IDslParser.parse method not implemented.');
+  }
+}
+
+export default IDslParser;

--- a/src/scopeDsl/parser/defaultDslParser.js
+++ b/src/scopeDsl/parser/defaultDslParser.js
@@ -1,0 +1,26 @@
+/**
+ * @file defaultDslParser.js
+ * @description Default implementation of IDslParser using the built-in parser.
+ */
+
+import { parseDslExpression } from './parser.js';
+import { IDslParser } from '../IDslParser.js';
+
+/**
+ * Default DSL parser that delegates to {@link parseDslExpression}.
+ *
+ * @class DefaultDslParser
+ * @augments IDslParser
+ */
+export class DefaultDslParser extends IDslParser {
+  /**
+   * @override
+   * @param {string} expr - DSL expression string.
+   * @returns {object} Parsed AST object.
+   */
+  parse(expr) {
+    return parseDslExpression(expr);
+  }
+}
+
+export default DefaultDslParser;

--- a/tests/integration/scopeEngineSingletonLocationContext.test.js
+++ b/tests/integration/scopeEngineSingletonLocationContext.test.js
@@ -18,6 +18,7 @@ import JsonLogicEvaluationService from '../../src/logic/jsonLogicEvaluationServi
 import InMemoryDataRegistry from '../../src/data/inMemoryDataRegistry.js';
 import { GameDataRepository } from '../../src/data/gameDataRepository.js';
 import { TargetResolutionService } from '../../src/actions/targetResolutionService.js';
+import DefaultDslParser from '../../src/scopeDsl/parser/defaultDslParser.js';
 import { createTraceContext } from '../../src/actions/tracing/traceContext.js';
 import {
   POSITION_COMPONENT_ID,
@@ -181,6 +182,7 @@ describe('Singleton Scope Engine Location Context', () => {
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      dslParser: new DefaultDslParser(),
     });
 
     // Mock prerequisite evaluation service

--- a/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
+++ b/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
@@ -33,6 +33,7 @@ import path from 'path';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
 import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
+import DefaultDslParser from '../../../src/scopeDsl/parser/defaultDslParser.js';
 
 // Import actions
 import dismissAction from '../../../data/mods/core/actions/dismiss.action.json';
@@ -190,6 +191,7 @@ describe('Scope Integration Tests', () => {
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      dslParser: new DefaultDslParser(),
     });
 
     // Create the ActionCandidateProcessor

--- a/tests/integration/scopes/environmentScope.integration.test.js
+++ b/tests/integration/scopes/environmentScope.integration.test.js
@@ -20,6 +20,7 @@ import { SafeEventDispatcher } from '../../../src/events/safeEventDispatcher.js'
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
 import ScopeEngine from '../../../src/scopeDsl/engine.js';
 import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionParser.js';
+import DefaultDslParser from '../../../src/scopeDsl/parser/defaultDslParser.js';
 import {
   POSITION_COMPONENT_ID,
   NAME_COMPONENT_ID,
@@ -147,6 +148,7 @@ describe('Scope Integration Tests', () => {
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      dslParser: new DefaultDslParser(),
     });
 
     // Create the ActionCandidateProcessor

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -32,6 +32,7 @@ import path from 'path';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
 import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
+import DefaultDslParser from '../../../src/scopeDsl/parser/defaultDslParser.js';
 
 jest.unmock('../../../src/scopeDsl/scopeRegistry.js');
 
@@ -153,6 +154,7 @@ describe('Scope Integration Tests', () => {
       logger,
       safeEventDispatcher,
       jsonLogicEvaluationService: jsonLogicEval,
+      dslParser: new DefaultDslParser(),
     });
 
     // Create the ActionCandidateProcessor

--- a/tests/unit/actions/targetResolutionService.branches.test.js
+++ b/tests/unit/actions/targetResolutionService.branches.test.js
@@ -30,6 +30,7 @@ describe('TargetResolutionService - additional branches', () => {
     };
     mockSafeDispatcher = { dispatch: jest.fn() };
     mockJsonLogic = { evaluate: jest.fn() };
+    const mockDslParser = { parse: jest.fn(() => generateMockAst('')) };
 
     service = new TargetResolutionService({
       scopeRegistry: mockScopeRegistry,
@@ -38,6 +39,7 @@ describe('TargetResolutionService - additional branches', () => {
       logger: mockLogger,
       safeEventDispatcher: mockSafeDispatcher,
       jsonLogicEvaluationService: mockJsonLogic,
+      dslParser: mockDslParser,
     });
   });
 

--- a/tests/unit/actions/targetResolutionService.scope-loading.test.js
+++ b/tests/unit/actions/targetResolutionService.scope-loading.test.js
@@ -12,6 +12,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
   let mockLogger;
   let mockSafeEventDispatcher;
   let mockJsonLogicEvalService;
+  let mockDslParser;
 
   beforeEach(() => {
     mockScopeRegistry = {
@@ -39,6 +40,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
     mockJsonLogicEvalService = {
       evaluate: jest.fn(),
     };
+    mockDslParser = { parse: jest.fn((expr) => generateMockAst(expr)) };
 
     targetResolutionService = new TargetResolutionService({
       scopeRegistry: mockScopeRegistry,
@@ -47,6 +49,7 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       logger: mockLogger,
       safeEventDispatcher: mockSafeEventDispatcher,
       jsonLogicEvaluationService: mockJsonLogicEvalService,
+      dslParser: mockDslParser,
     });
   });
 
@@ -162,16 +165,9 @@ describe('TargetResolutionService - Scope Loading Issue', () => {
       );
 
       expect(result).toHaveLength(0);
-      expect(mockSafeEventDispatcher.dispatch).toHaveBeenCalledWith(
-        'core:system_error_occurred',
-        expect.objectContaining({
-          message: expect.stringContaining(
-            "Error resolving scope 'core:clear_directions'"
-          ),
-          details: expect.objectContaining({
-            error: expect.stringContaining('missing the required AST property'),
-          }),
-        })
+      expect(mockSafeEventDispatcher.dispatch).not.toHaveBeenCalled();
+      expect(mockDslParser.parse).toHaveBeenCalledWith(
+        'location.core:exits[].target'
       );
     });
   });

--- a/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/commandAndActionRegistrations.test.js
@@ -43,6 +43,7 @@ describe('registerCommandAndAction', () => {
   const mockSafeEventDispatcher = mockDeep();
   const mockScopeRegistry = mockDeep();
   const mockScopeEngine = mockDeep();
+  const mockDslParser = { parse: jest.fn() };
 
   beforeEach(() => {
     container = new AppContainer();
@@ -73,6 +74,7 @@ describe('registerCommandAndAction', () => {
     );
     container.register(tokens.IScopeRegistry, () => mockScopeRegistry);
     container.register(tokens.IScopeEngine, () => mockScopeEngine);
+    container.register(tokens.DslParser, () => mockDslParser);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add `IDslParser` interface and default parser implementation
- inject DSL parser into `TargetResolutionService`
- wire new dependency in DI registrations
- update tests to use injected parser

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 714 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68612492662083319b183bcf68632c3b