### PR TITLE
[Agent] accept optional Ajv instance

### DIFF
--- a/src/dependencyInjection/registrations/loadersRegistrations.js
+++ b/src/dependencyInjection/registrations/loadersRegistrations.js
@@ -120,7 +120,8 @@ export function registerLoaders(container) {
   registrar.singletonFactory(
     tokens.ISchemaValidator,
     (c) =>
-      new AjvSchemaValidator(c.resolve(tokens.ILogger), {
+      new AjvSchemaValidator({
+        logger: c.resolve(tokens.ILogger),
         preloadSchemas: [
           {
             schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,

--- a/src/validation/ajvSchemaValidator.js
+++ b/src/validation/ajvSchemaValidator.js
@@ -25,10 +25,12 @@ class AjvSchemaValidator {
   #logger = null;
 
   /**
-   * @param {import('../interfaces/coreServices.js').ILogger} logger
-   * @param {{ preloadSchemas?: Array<{ schema: object, id: string }> }} [options]
+   * @param {object} [params]
+   * @param {import('../interfaces/coreServices.js').ILogger} params.logger
+   * @param {import('ajv').default} [params.ajvInstance]
+   * @param {Array<{ schema: object, id: string }>} [params.preloadSchemas]
    */
-  constructor(logger, options = {}) {
+  constructor({ logger, ajvInstance, preloadSchemas } = {}) {
     if (
       !logger ||
       typeof logger.info !== 'function' ||
@@ -43,21 +45,26 @@ class AjvSchemaValidator {
     this.#logger = logger;
 
     try {
-      this.#ajv = new Ajv({
-        allErrors: true,
-        strictTypes: false,
-        strict: false,
-        validateFormats: false,
-        allowUnionTypes: true,
-        verbose: true,
-      });
-      addFormats(this.#ajv);
-      this.#logger.debug(
-        'AjvSchemaValidator: Ajv instance created and formats added.'
-      );
+      if (ajvInstance) {
+        this.#ajv = ajvInstance;
+        this.#logger.debug('AjvSchemaValidator: Using provided Ajv instance.');
+      } else {
+        this.#ajv = new Ajv({
+          allErrors: true,
+          strictTypes: false,
+          strict: false,
+          validateFormats: false,
+          allowUnionTypes: true,
+          verbose: true,
+        });
+        addFormats(this.#ajv);
+        this.#logger.debug(
+          'AjvSchemaValidator: Ajv instance created and formats added.'
+        );
+      }
 
-      if (Array.isArray(options.preloadSchemas)) {
-        this.preloadSchemas(options.preloadSchemas);
+      if (Array.isArray(preloadSchemas)) {
+        this.preloadSchemas(preloadSchemas);
       }
     } catch (error) {
       this.#logger.error(

--- a/tests/integration/EndToEndMemoryFlow.test.js
+++ b/tests/integration/EndToEndMemoryFlow.test.js
@@ -130,7 +130,8 @@ describe('End-to-End Short-Term Memory Flow', () => {
       conditionEvaluator: ConditionEvaluator,
     });
 
-    schemaValidator = new AjvSchemaValidator(logger, {
+    schemaValidator = new AjvSchemaValidator({
+      logger: logger,
       preloadSchemas: [
         {
           schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -176,7 +176,8 @@ describe('End-to-End Notes Persistence Flow', () => {
       conditionEvaluator: ConditionEvaluator,
     });
 
-    schemaValidator = new AjvSchemaValidator(logger, {
+    schemaValidator = new AjvSchemaValidator({
+      logger: logger,
       preloadSchemas: [
         {
           schema: LLM_TURN_ACTION_RESPONSE_SCHEMA,

--- a/tests/integration/anatomy/bodyDescriptionGeneration.integration.test.js
+++ b/tests/integration/anatomy/bodyDescriptionGeneration.integration.test.js
@@ -30,7 +30,8 @@ describe('Body Description Generation Integration', () => {
         },
       };
 
-      const description = bodyPartDescriptionBuilder.buildDescription(breastEntity);
+      const description =
+        bodyPartDescriptionBuilder.buildDescription(breastEntity);
       expect(description).toBe('a D-cup, meaty, and firm breast');
     });
 
@@ -49,7 +50,8 @@ describe('Body Description Generation Integration', () => {
         },
       };
 
-      const description = bodyPartDescriptionBuilder.buildDescription(eyeEntity);
+      const description =
+        bodyPartDescriptionBuilder.buildDescription(eyeEntity);
       expect(description).toBe('a cobalt, almond eye');
     });
 
@@ -69,7 +71,8 @@ describe('Body Description Generation Integration', () => {
         },
       };
 
-      const description = bodyPartDescriptionBuilder.buildDescription(hairEntity);
+      const description =
+        bodyPartDescriptionBuilder.buildDescription(hairEntity);
       expect(description).toBe('long, raven-black, and straight hair');
     });
 

--- a/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
+++ b/tests/integration/loaders/modsLoader.entityDefinitions.integration.test.js
@@ -100,7 +100,7 @@ describe('Integration: Entity Definitions and Instances Loader', () => {
       createMockDataFetcher({ fromDisk: true })
     );
     // Register and load AjvSchemaValidator with schemas
-    const schemaValidator = new AjvSchemaValidator(logger);
+    const schemaValidator = new AjvSchemaValidator({ logger: logger });
     await schemaValidator.addSchema(
       commonSchema,
       'http://example.com/schemas/common.schema.json'

--- a/tests/integration/loaders/modsLoader.entityInstances.integration.test.js
+++ b/tests/integration/loaders/modsLoader.entityInstances.integration.test.js
@@ -123,7 +123,7 @@ describe('Integration: Entity Instances Loader and World Initialization', () => 
       tokens.IDataFetcher,
       createMockDataFetcher({ fromDisk: true })
     );
-    const schemaValidator = new AjvSchemaValidator(logger);
+    const schemaValidator = new AjvSchemaValidator({ logger: logger });
     await schemaValidator.addSchema(
       commonSchema,
       'http://example.com/schemas/common.schema.json'
@@ -376,7 +376,7 @@ describe('Integration: EntityInstance componentOverrides are respected during wo
       createMockDataFetcher({ fromDisk: true })
     );
 
-    const schemaValidator = new AjvSchemaValidator(localLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: localLogger });
     // Add all necessary schemas (ensure these paths are correct relative to this file or adjust)
     await schemaValidator.addSchema(
       commonSchema,

--- a/tests/integration/rules/closenessActionAvailability.integration.test.js
+++ b/tests/integration/rules/closenessActionAvailability.integration.test.js
@@ -131,7 +131,7 @@ describe('closeness action availability chain', () => {
     };
     const testLogger = new ConsoleLogger('DEBUG');
     const bus = new EventBus();
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
     const validatedEventDispatcher = new ValidatedEventDispatcher({
       eventBus: bus,
       gameDataRepository: dataRegistry,

--- a/tests/integration/rules/dismissRule.integration.test.js
+++ b/tests/integration/rules/dismissRule.integration.test.js
@@ -147,7 +147,7 @@ describe('core_handle_dismiss rule integration', () => {
 
     const testLogger = new ConsoleLogger('DEBUG');
     const bus = new EventBus();
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
     const validatedEventDispatcher = new ValidatedEventDispatcher({
       eventBus: bus,
       gameDataRepository: dataRegistry,

--- a/tests/integration/rules/followAutoMoveRule.integration.test.js
+++ b/tests/integration/rules/followAutoMoveRule.integration.test.js
@@ -155,7 +155,7 @@ describe('core_handle_follow_auto_move rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/followRule.integration.test.js
+++ b/tests/integration/rules/followRule.integration.test.js
@@ -173,7 +173,7 @@ describe('core_handle_follow rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -140,7 +140,7 @@ describe('intimacy_handle_get_close rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/goRule.integration.test.js
+++ b/tests/integration/rules/goRule.integration.test.js
@@ -153,7 +153,7 @@ describe('core_handle_go rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
+++ b/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
@@ -83,7 +83,7 @@ describe('core_handle_log_perceptible_events rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/stepBackRule.integration.test.js
+++ b/tests/integration/rules/stepBackRule.integration.test.js
@@ -160,7 +160,7 @@ describe('intimacy_handle_step_back rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/stopFollowingRule.integration.test.js
+++ b/tests/integration/rules/stopFollowingRule.integration.test.js
@@ -192,7 +192,7 @@ describe('stop_following rule integration', () => {
     const bus = new EventBus();
 
     // Create actual schema validator
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
 
     // Create actual ValidatedEventDispatcher
     const validatedEventDispatcher = new ValidatedEventDispatcher({

--- a/tests/integration/rules/turnEndedRule.integration.test.js
+++ b/tests/integration/rules/turnEndedRule.integration.test.js
@@ -64,7 +64,7 @@ describe('core_handle_turn_ended rule integration', () => {
     };
     const testLogger = new ConsoleLogger('DEBUG');
     const bus = new EventBus();
-    const schemaValidator = new AjvSchemaValidator(testLogger);
+    const schemaValidator = new AjvSchemaValidator({ logger: testLogger });
     const validatedEventDispatcher = new ValidatedEventDispatcher({
       eventBus: bus,
       gameDataRepository: dataRegistry,

--- a/tests/integration/schemaLoader.operations.integration.test.js
+++ b/tests/integration/schemaLoader.operations.integration.test.js
@@ -12,7 +12,7 @@ describe('Integration – SchemaLoader operations', () => {
     const config = new StaticConfiguration();
     const resolver = new DefaultPathResolver(config);
     const logger = new ConsoleLogger('ERROR');
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const extraOps = [
       'operations/removeFromClosenessCircle.schema.json',

--- a/tests/unit/events/safeEventDispatcher.coreSystemEvents.test.js
+++ b/tests/unit/events/safeEventDispatcher.coreSystemEvents.test.js
@@ -88,7 +88,7 @@ beforeAll(async () => {
   eventBus = new EventBus();
 
   /* Ajv validator and schema preload */
-  const schemaValidator = new AjvSchemaValidator(logger);
+  const schemaValidator = new AjvSchemaValidator({ logger: logger });
   await schemaValidator.addSchema(
     warningEventDef.payloadSchema,
     SYSTEM_WARNING_OCCURRED_ID + '#payload'

--- a/tests/unit/loaders/schemaLoader.integration.test.js
+++ b/tests/unit/loaders/schemaLoader.integration.test.js
@@ -117,7 +117,7 @@ describe('SchemaLoader Integration Tests', () => {
       }),
     };
 
-    schemaValidator = new AjvSchemaValidator(mockLogger);
+    schemaValidator = new AjvSchemaValidator({ logger: mockLogger });
     schemaLoader = new SchemaLoader(
       mockConfig,
       mockPathResolver,
@@ -338,7 +338,7 @@ describe('SchemaLoader Integration Tests', () => {
         fetch: () => Promise.reject(new Error('File not found')),
       };
 
-      const errorValidator = new AjvSchemaValidator(mockLogger);
+      const errorValidator = new AjvSchemaValidator({ logger: mockLogger });
       const errorSchemaLoader = new SchemaLoader(
         errorConfig,
         errorPathResolver,

--- a/tests/unit/services/ajvSchemaValidator.additional.test.js
+++ b/tests/unit/services/ajvSchemaValidator.additional.test.js
@@ -21,7 +21,7 @@ describe('AjvSchemaValidator additional tests', () => {
 
   beforeEach(() => {
     mockLogger = createMockLogger();
-    validator = new AjvSchemaValidator(mockLogger);
+    validator = new AjvSchemaValidator({ logger: mockLogger });
   });
 
   describe('validate method', () => {

--- a/tests/unit/services/ajvSchemaValidator.errorPaths.test.js
+++ b/tests/unit/services/ajvSchemaValidator.errorPaths.test.js
@@ -24,7 +24,7 @@ describe('AjvSchemaValidator error paths', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const schema = { $id: 'test://schemas/err', type: 'object' };
     await expect(validator.addSchema(schema, schema.$id)).rejects.toThrow(
@@ -55,7 +55,7 @@ describe('AjvSchemaValidator error paths', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const result = validator.getValidator('bad-id');
     expect(result).toBeUndefined();
@@ -81,7 +81,7 @@ describe('AjvSchemaValidator error paths', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const validate = validator.getValidator('runtime-id');
     const result = validate({});
@@ -111,7 +111,7 @@ describe('AjvSchemaValidator error paths', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const result = validator.isSchemaLoaded('my-schema');
     expect(result).toBe(false);
@@ -137,7 +137,7 @@ describe('AjvSchemaValidator error paths', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
 
     const result = validator.removeSchema('leftover');
     expect(removeSchema).toHaveBeenCalledWith('leftover');

--- a/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
+++ b/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
@@ -18,7 +18,7 @@ const sampleSchema = {
  */
 function createValidator() {
   const logger = createMockLogger();
-  const validator = new AjvSchemaValidator(logger);
+  const validator = new AjvSchemaValidator({ logger: logger });
   return { validator, logger };
 }
 
@@ -75,7 +75,7 @@ describe('AjvSchemaValidator edge branch tests', () => {
     const AjvSchemaValidatorReloaded =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger2 = createMockLogger();
-    const freshValidator = new AjvSchemaValidatorReloaded(logger2);
+    const freshValidator = new AjvSchemaValidatorReloaded({ logger: logger2 });
 
     const result = freshValidator.removeSchema('some-id');
     expect(result).toBe(false);

--- a/tests/unit/services/ajvSchemaValidator.refsAndBatch.test.js
+++ b/tests/unit/services/ajvSchemaValidator.refsAndBatch.test.js
@@ -8,6 +8,8 @@ import { createMockLogger } from '../testUtils.js';
  * @param {Array<any>} [options.getSchemaReturns] - Values returned by the mocked getSchema in order.
  * @param {Function} [options.addSchemaImpl] - Implementation for addSchema.
  * @param {Function} [options.compileImpl] - Implementation for compile.
+ * @param options.schemaMap
+ * @param options.schemaGetter
  * @returns {{validator: any, logger: ReturnType<typeof createMockLogger>, addSchema: jest.Mock, getSchema: jest.Mock, compile: jest.Mock}}
  * Returns a constructed validator and the mocked functions for assertions.
  */
@@ -37,7 +39,7 @@ function setupMockAjv({
     require('../../../src/validation/ajvSchemaValidator.js').default;
   const logger = createMockLogger();
   return {
-    validator: new AjvSchemaValidator(logger),
+    validator: new AjvSchemaValidator({ logger: logger }),
     logger,
     addSchema,
     getSchema,
@@ -118,7 +120,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
     await expect(validator.addSchemas(null)).rejects.toThrow(
       'addSchemas called with empty or non-array input.'
     );
@@ -135,7 +137,7 @@ describe('AjvSchemaValidator reference and batch operations', () => {
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
     const logger = createMockLogger();
-    const validator = new AjvSchemaValidator(logger);
+    const validator = new AjvSchemaValidator({ logger: logger });
     await expect(validator.addSchemas([{}])).rejects.toThrow(
       'All schemas must be objects with a valid $id.'
     );

--- a/tests/unit/services/ajvSchemaValidator.test.js
+++ b/tests/unit/services/ajvSchemaValidator.test.js
@@ -398,7 +398,7 @@ describe('AjvSchemaValidator', () => {
       debug: jest.fn(),
     };
     // Pass the mock logger to the constructor
-    validator = new AjvSchemaValidator(mockLogger); // <-- Pass mockLogger
+    validator = new AjvSchemaValidator({ logger: mockLogger }); // <-- Pass mockLogger
   });
 
   // --- Task 2: Test constructor ---
@@ -408,12 +408,14 @@ describe('AjvSchemaValidator', () => {
       // so we just need to ensure it didn't throw implicitly.
       // If beforeEach failed, the test wouldn't run.
       // We can add an explicit check for robustness.
-      expect(() => new AjvSchemaValidator(mockLogger)).not.toThrow();
+      expect(
+        () => new AjvSchemaValidator({ logger: mockLogger })
+      ).not.toThrow();
     });
 
     it('should throw an error if an invalid logger is provided', () => {
       // Test missing methods
-      expect(() => new AjvSchemaValidator({})).toThrow(
+      expect(() => new AjvSchemaValidator({ logger: {} })).toThrow(
         /Missing or invalid 'logger' dependency/
       );
       expect(
@@ -425,10 +427,10 @@ describe('AjvSchemaValidator', () => {
           })
       ).toThrow(/Missing or invalid 'logger' dependency/); // Missing debug
       // Test null/undefined
-      expect(() => new AjvSchemaValidator(null)).toThrow(
+      expect(() => new AjvSchemaValidator({ logger: null })).toThrow(
         /Missing or invalid 'logger' dependency/
       );
-      expect(() => new AjvSchemaValidator(undefined)).toThrow(
+      expect(() => new AjvSchemaValidator({ logger: undefined })).toThrow(
         /Missing or invalid 'logger' dependency/
       );
     });

--- a/tests/unit/services/ajvSchemaValidator.uncoveredBranches.test.js
+++ b/tests/unit/services/ajvSchemaValidator.uncoveredBranches.test.js
@@ -21,7 +21,7 @@ function setupMockAjv({ getSchemaReturns = [], addSchemaImpl } = {}) {
     require('../../../src/validation/ajvSchemaValidator.js').default;
   const logger = createMockLogger();
   return {
-    validator: new AjvSchemaValidator(logger),
+    validator: new AjvSchemaValidator({ logger: logger }),
     logger,
     addSchema,
     getSchema,

--- a/tests/unit/services/modManifestLoader.harness.test.js
+++ b/tests/unit/services/modManifestLoader.harness.test.js
@@ -169,7 +169,7 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
     // *** FIX START: Create logger first, then pass it to validator ***
     const mockLogger = createMockLogger(); // Create the logger instance
     // real validator and schema registration, now with logger dependency
-    const schemaValidator = new AjvSchemaValidator(mockLogger); // Pass the logger
+    const schemaValidator = new AjvSchemaValidator({ logger: mockLogger }); // Pass the logger
     await schemaValidator.addSchema(manifestSchema, MOD_SCHEMA_ID);
 
     deps = {

--- a/tests/unit/services/modManifestLoader.test.js
+++ b/tests/unit/services/modManifestLoader.test.js
@@ -170,7 +170,7 @@ describe('ModManifestLoader — integration (AjvSchemaValidator)', () => {
     // *** FIX START: Create logger first, then pass it to validator ***
     const mockLogger = createMockLogger(); // Create the logger instance
     // real validator and schema registration, now with logger dependency
-    const schemaValidator = new AjvSchemaValidator(mockLogger); // Pass the logger
+    const schemaValidator = new AjvSchemaValidator({ logger: mockLogger }); // Pass the logger
     await schemaValidator.addSchema(manifestSchema, MOD_SCHEMA_ID);
 
     deps = {

--- a/tests/unit/turns/services/AIGameStateProvider.bugFixes.test.js
+++ b/tests/unit/turns/services/AIGameStateProvider.bugFixes.test.js
@@ -102,7 +102,7 @@ describe('AIGameStateProvider', () => {
     turnContext.game = { worldId: 'test-world', someOtherData: 'data' };
 
     const actorStateProvider = new ActorStateProvider();
-    
+
     // Create mock dependencies for ActorDataExtractor
     const mockAnatomyDescriptionService = {
       getOrGenerateBodyDescription: jest.fn(),
@@ -110,12 +110,12 @@ describe('AIGameStateProvider', () => {
     const mockEntityFinder = {
       getEntity: jest.fn(),
     };
-    
+
     const actorDataExtractor = new ActorDataExtractor({
       anatomyDescriptionService: mockAnatomyDescriptionService,
       entityFinder: mockEntityFinder,
     });
-    
+
     const perceptionLogProvider = new PerceptionLogProvider();
     const entitySummaryProvider = new EntitySummaryProvider();
     const safeEventDispatcher = { dispatch: jest.fn() };

--- a/tests/unit/turns/services/AIGameStateProvider.test.js
+++ b/tests/unit/turns/services/AIGameStateProvider.test.js
@@ -97,7 +97,7 @@ describe('AIGameStateProvider Integration Tests', () => {
     };
 
     actorStateProvider = new ActorStateProvider();
-    
+
     // Create mock dependencies for ActorDataExtractor
     const mockAnatomyDescriptionService = {
       getOrGenerateBodyDescription: jest.fn(),
@@ -105,12 +105,12 @@ describe('AIGameStateProvider Integration Tests', () => {
     const mockEntityFinder = {
       getEntity: jest.fn(),
     };
-    
+
     actorDataExtractor = new ActorDataExtractor({
       anatomyDescriptionService: mockAnatomyDescriptionService,
       entityFinder: mockEntityFinder,
     });
-    
+
     perceptionLogProvider = new PerceptionLogProvider();
     entitySummaryProvider = new EntitySummaryProvider();
     safeEventDispatcher = { dispatch: jest.fn() };

--- a/tests/unit/turns/strategies/repromptStrategy.test.js
+++ b/tests/unit/turns/strategies/repromptStrategy.test.js
@@ -118,7 +118,9 @@ describe('RepromptStrategy', () => {
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getSafeEventDispatcher).toHaveBeenCalledTimes(1);
-    expect(mockTurnContext._safeEventDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(
+      mockTurnContext._safeEventDispatcher.dispatch
+    ).not.toHaveBeenCalled();
     expect(mockTurnContext.requestTransition).not.toHaveBeenCalled();
     expect(mockTurnContext.endTurn).not.toHaveBeenCalled();
   });

--- a/tests/unit/validation/ajvSchemaValidator.init.test.js
+++ b/tests/unit/validation/ajvSchemaValidator.init.test.js
@@ -33,7 +33,7 @@ describe('AjvSchemaValidator initialization edge cases', () => {
     const logger = createMockLogger();
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
-    expect(() => new AjvSchemaValidator(logger)).toThrow(
+    expect(() => new AjvSchemaValidator({ logger: logger })).toThrow(
       'AjvSchemaValidator: Failed to initialize Ajv.'
     );
     expect(logger.error).toHaveBeenCalledWith(
@@ -52,7 +52,8 @@ describe('AjvSchemaValidator initialization edge cases', () => {
     const logger = createMockLogger();
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
-    new AjvSchemaValidator(logger, {
+    new AjvSchemaValidator({
+      logger: logger,
       preloadSchemas: [{ schema: {}, id: 'test' }],
     });
     expect(addSchema).not.toHaveBeenCalled();
@@ -73,7 +74,8 @@ describe('AjvSchemaValidator initialization edge cases', () => {
     const logger = createMockLogger();
     const AjvSchemaValidator =
       require('../../../src/validation/ajvSchemaValidator.js').default;
-    new AjvSchemaValidator(logger, {
+    new AjvSchemaValidator({
+      logger: logger,
       preloadSchemas: [{ schema: {}, id: 'test' }],
     });
     expect(logger.error).toHaveBeenCalledWith(

--- a/tests/unit/validation/ajvSchemaValidator.world.test.js
+++ b/tests/unit/validation/ajvSchemaValidator.world.test.js
@@ -16,7 +16,7 @@ describe('AjvSchemaValidator World Schema Tests', () => {
 
   beforeEach(() => {
     logger = new ConsoleLogger();
-    schemaValidator = new AjvSchemaValidator(logger);
+    schemaValidator = new AjvSchemaValidator({ logger: logger });
   });
 
   describe('World Schema Validation', () => {


### PR DESCRIPTION
Summary:
- allow passing existing Ajv in AjvSchemaValidator
- register loaders using new parameter form
- update tests for new constructor

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6861246f05e88331a2fced21834e7e72