### PR TITLE
[Agent] replace safeCall usage

### DIFF
--- a/src/utils/componentAccessUtils.js
+++ b/src/utils/componentAccessUtils.js
@@ -11,7 +11,7 @@ import {
   isValidEntity,
 } from './entityValidationUtils.js';
 import { isNonBlankString } from './textUtils.js';
-import { safeCall } from './safeExecutionUtils.js';
+import { safeExecute } from './safeExecutionUtils.js';
 
 /** @typedef {import('../entities/entity.js').default} Entity */
 
@@ -35,7 +35,7 @@ export function getComponentFromEntity(entity, componentId, logger) {
     return null;
   }
 
-  const { success, result, error } = safeCall(() =>
+  const { success, result, error } = safeExecute(() =>
     entity.getComponentData(componentId)
   );
   if (success) {
@@ -85,7 +85,7 @@ export function getComponentFromManager(
     return null;
   }
 
-  const { success, result, error } = safeCall(() =>
+  const { success, result, error } = safeExecute(() =>
     entityManager.getComponentData(entityId, componentId)
   );
   if (success) {

--- a/src/utils/contextVariableUtils.js
+++ b/src/utils/contextVariableUtils.js
@@ -4,7 +4,7 @@ import { getModuleLogger } from './loggerUtils.js';
 import { safeDispatchError } from './safeDispatchErrorUtils.js';
 import { resolveSafeDispatcher } from './dispatcherUtils.js';
 import { isNonBlankString } from './textUtils.js';
-import { safeCall } from './safeExecutionUtils.js';
+import { safeExecute } from './safeExecutionUtils.js';
 import {
   getEvaluationContext,
   ensureEvaluationContext,
@@ -40,7 +40,7 @@ function _validateVariableName(variableName) {
  * @returns {{success: boolean, error?: Error}} Result of the assignment.
  */
 export function setContextValue(context, key, value) {
-  const { success, error } = safeCall(() => {
+  const { success, error } = safeExecute(() => {
     context[key] = value;
   });
   return success ? { success: true } : { success: false, error };
@@ -65,7 +65,7 @@ export function withUpdatedContext(context, key, value) {
     };
   }
 
-  const { success, result, error } = safeCall(() => ({
+  const { success, result, error } = safeExecute(() => ({
     ...context,
     [key]: value,
   }));

--- a/src/utils/safeExecutionUtils.js
+++ b/src/utils/safeExecutionUtils.js
@@ -11,10 +11,6 @@
  * @param {string} [context] - Context message for logging.
  * @returns {{success: boolean, result?: any, error?: any}} Execution result.
  */
-export function safeCall(fn, logger, context = 'safeCall') {
-  return safeExecute(fn, logger, context);
-}
-
 /**
  * Safely executes a synchronous or asynchronous function.
  *

--- a/tests/unit/utils/safeExecutionUtils.test.js
+++ b/tests/unit/utils/safeExecutionUtils.test.js
@@ -1,52 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import {
-  safeCall,
-  safeExecute,
-} from '../../../src/utils/safeExecutionUtils.js';
-
-describe('safeCall', () => {
-  test('returns success result when function executes without error', () => {
-    const logger = { debug: jest.fn() };
-    const result = safeCall(() => 42, logger, 'ctx');
-    expect(result).toEqual({ success: true, result: 42 });
-    expect(logger.debug).not.toHaveBeenCalled();
-  });
-
-  test('captures error and logs when function throws', () => {
-    const logger = { debug: jest.fn() };
-    const err = new Error('boom');
-    const result = safeCall(
-      () => {
-        throw err;
-      },
-      logger,
-      'ctx'
-    );
-    expect(result).toEqual({ success: false, error: err });
-    expect(logger.debug).toHaveBeenCalledWith('ctx: operation failed', err);
-  });
-
-  test('handles missing logger gracefully', () => {
-    const err = new Error('oops');
-    const result = safeCall(() => {
-      throw err;
-    });
-    expect(result).toEqual({ success: false, error: err });
-  });
-
-  test('ignores logger when debug is not a function', () => {
-    const logger = { debug: true };
-    const err = new Error('bad');
-    const result = safeCall(
-      () => {
-        throw err;
-      },
-      logger,
-      'ctx'
-    );
-    expect(result).toEqual({ success: false, error: err });
-  });
-});
+import { safeExecute } from '../../../src/utils/safeExecutionUtils.js';
 
 describe('safeExecute', () => {
   test('handles synchronous success', () => {
@@ -87,5 +40,26 @@ describe('safeExecute', () => {
     );
     expect(result).toEqual({ success: false, error: err });
     expect(logger.debug).toHaveBeenCalledWith('async: operation failed', err);
+  });
+
+  test('handles missing logger gracefully', () => {
+    const err = new Error('oops');
+    const result = safeExecute(() => {
+      throw err;
+    });
+    expect(result).toEqual({ success: false, error: err });
+  });
+
+  test('ignores logger when debug is not a function', () => {
+    const logger = { debug: true };
+    const err = new Error('bad');
+    const result = safeExecute(
+      () => {
+        throw err;
+      },
+      logger,
+      'ctx'
+    );
+    expect(result).toEqual({ success: false, error: err });
   });
 });


### PR DESCRIPTION
## Summary
- remove `safeCall` utility and switch to `safeExecute`
- update modules to import and use `safeExecute`
- adjust unit tests for new `safeExecute` API

## Testing Done
- `npm run lint` *(fails: 3576 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686120df7dc48331b5fc48f5687a7ade