### PR TITLE
[Agent] Add logger test for InMemoryDataRegistry

### DIFF
--- a/tests/unit/services/inMemoryDataRegistry.logger.test.js
+++ b/tests/unit/services/inMemoryDataRegistry.logger.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
+
+describe('InMemoryDataRegistry logger usage', () => {
+  it('uses provided logger for errors and warnings', () => {
+    const mockLogger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const registry = new InMemoryDataRegistry({ logger: mockLogger });
+
+    // Trigger error via invalid store parameters
+    registry.store('', 'id', {});
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+
+    // Store a player definition without a valid locationId to trigger warn
+    registry.store('entityDefinitions', 'player:1', {
+      id: 'player:1',
+      components: {
+        'core:player': {},
+        'core:position': { locationId: '' },
+      },
+    });
+    registry.getStartingLocationId();
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Summary:
- test that InMemoryDataRegistry uses injected logger for warnings and errors

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 714 errors)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6861281809f48331898dfca48534b422