### PR TITLE
[Agent] Document semverLib injection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ and registry purposes.
 
 Dependencies are declared in the `mod-manifest.json` file within the `dependencies` array. Each entry specifies a
 required `modId` and a `version` requirement (using Semantic Versioning ranges).
+The comparison logic is handled by `ModDependencyValidator.validate`, which accepts
+an optional `{ semverLib }` parameter. Supplying a custom library implementing
+`valid()` and `satisfies()` lets you override the default `semver` package during
+dependency checks.
 
 **Rule D1: Missing Dependency**
 


### PR DESCRIPTION
## Summary
- document semverLib injection in README

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3616 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686129aad96083318d6b0d1cf072997d