### PR TITLE
[Agent] Inject content dependency validator

### DIFF
--- a/src/dependencyInjection/registrations/orchestrationRegistrations.js
+++ b/src/dependencyInjection/registrations/orchestrationRegistrations.js
@@ -14,6 +14,7 @@ import InitializationService from '../../initializers/services/initializationSer
 import ShutdownService from '../../shutdown/services/shutdownService.js'; // Adjusted path
 import { ThoughtPersistenceListener } from '../../ai/thoughtPersistenceListener.js';
 import { NotesPersistenceListener } from '../../ai/notesPersistenceListener.js';
+import ContentDependencyValidator from '../../initializers/services/contentDependencyValidator.js';
 
 // --- DI & Helper Imports ---
 import { tokens } from '../tokens.js';
@@ -82,6 +83,10 @@ export function registerOrchestration(container) {
       dispatcher: safeEventDispatcher,
     });
     const spatialIndexManager = c.resolve(tokens.ISpatialIndexManager);
+    const contentDependencyValidator = new ContentDependencyValidator({
+      gameDataRepository,
+      logger: initLogger,
+    });
     return new InitializationService({
       log: { logger: initLogger },
       events: { validatedEventDispatcher: initDispatcher, safeEventDispatcher },
@@ -101,6 +106,7 @@ export function registerOrchestration(container) {
         dataRegistry,
         systemInitializer,
         worldInitializer,
+        contentDependencyValidator,
       },
     });
   });

--- a/src/initializers/services/initializationService.js
+++ b/src/initializers/services/initializationService.js
@@ -32,7 +32,6 @@ import { buildActionIndex } from '../../utils/initHelpers.js';
 import { setupPersistenceListeners } from './initHelpers.js';
 import { assertNonBlankString } from '../../utils/dependencyUtils.js';
 import { InvalidArgumentError } from '../../errors/invalidArgumentError.js';
-import ContentDependencyValidator from './contentDependencyValidator.js';
 import LlmAdapterInitializer from './llmAdapterInitializer.js';
 import {
   assertFunction,
@@ -88,7 +87,7 @@ class InitializationService extends IInitializationService {
    *   dataRegistry: import('../../data/inMemoryDataRegistry.js').DataRegistry,
    *   systemInitializer: SystemInitializer,
    *   worldInitializer: WorldInitializer,
-   *   contentDependencyValidator: import('./contentDependencyValidator.js').default,
+   *   contentDependencyValidator: import('./contentDependencyValidator.js').default, // Required validator instance
    *   llmAdapterInitializer: LlmAdapterInitializer,
    * }} config.coreSystems - Core engine systems.
    * @description Initializes the complete game system.
@@ -118,10 +117,7 @@ class InitializationService extends IInitializationService {
       dataRegistry,
       systemInitializer,
       worldInitializer,
-      contentDependencyValidator = new ContentDependencyValidator({
-        gameDataRepository,
-        logger,
-      }),
+      contentDependencyValidator,
       llmAdapterInitializer = new LlmAdapterInitializer(),
     } = coreSystems;
     super();


### PR DESCRIPTION
## Summary
- remove direct construction of `ContentDependencyValidator` in `InitializationService`
- instantiate validator when registering `InitializationService`

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6861293d75cc833199acd6c5f43b4bed