### PR TITLE
[Agent] Refactor UI registration helper

### DIFF
--- a/src/dependencyInjection/registrarHelpers.js
+++ b/src/dependencyInjection/registrarHelpers.js
@@ -1,0 +1,40 @@
+/**
+ * @file Provides helper utilities for dependency injection registrations.
+ */
+
+/** @typedef {import('./appContainer.js').default} AppContainer */
+/** @typedef {import('./tokens.js').DiToken} DiToken */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../utils/registrarHelpers.js').Registrar} Registrar */
+/** @typedef {import('../utils/registrarHelpers.js').FactoryFunction} FactoryFunction */
+/** @typedef {import('../utils/registrarHelpers.js').Constructor<any>} ConstructorAny */
+
+/**
+ * @typedef {import('../dependencyInjection/appContainer.js').RegistrationOptions} RegistrationOptions
+ */
+
+/**
+ * Registers a dependency and logs the action using the provided logger.
+ *
+ * @description This helper reduces boilerplate in registration modules by
+ * calling {@link Registrar#register} and emitting a standardized debug log.
+ * @param {Registrar} registrar - The registrar instance handling the registration.
+ * @param {DiToken} token - The token to register.
+ * @param {FactoryFunction | ConstructorAny | any} factoryOrValueOrClass - The factory,
+ * class constructor or instance/value to register.
+ * @param {RegistrationOptions} [options] - Registration options passed to the registrar.
+ * @param {ILogger} logger - Logger used for debug output.
+ * @returns {void}
+ */
+export function registerWithLog(
+  registrar,
+  token,
+  factoryOrValueOrClass,
+  options,
+  logger
+) {
+  registrar.register(token, factoryOrValueOrClass, options);
+  if (logger && typeof logger.debug === 'function') {
+    logger.debug(`UI Registrations: Registered ${String(token)}.`);
+  }
+}

--- a/src/dependencyInjection/registrations/uiRegistrations.js
+++ b/src/dependencyInjection/registrations/uiRegistrations.js
@@ -8,7 +8,8 @@
 
 // --- Core & Service Imports ---
 import { tokens } from '../tokens.js';
-import { Registrar, registerWithLog } from '../../utils/registrarHelpers.js';
+import { Registrar } from '../../utils/registrarHelpers.js';
+import { registerWithLog } from '../registrarHelpers.js';
 import InputHandler from '../../input/inputHandler.js'; // Legacy Input Handler (Updated Dependency)
 import GlobalKeyHandler from '../../input/globalKeyHandler.js';
 import AlertRouter from '../../alerting/alertRouter.js';
@@ -68,54 +69,65 @@ export function registerDomElements(
   { outputDiv, inputElement, titleElement, document: doc },
   logger
 ) {
-  registerWithLog(registrar, logger, 'instance', tokens.WindowDocument, doc);
-  registerWithLog(registrar, logger, 'instance', tokens.outputDiv, outputDiv);
   registerWithLog(
     registrar,
-    logger,
-    'instance',
+    tokens.WindowDocument,
+    doc,
+    { lifecycle: 'singleton', isInstance: true },
+    logger
+  );
+  registerWithLog(
+    registrar,
+    tokens.outputDiv,
+    outputDiv,
+    { lifecycle: 'singleton', isInstance: true },
+    logger
+  );
+  registerWithLog(
+    registrar,
     tokens.inputElement,
-    inputElement
+    inputElement,
+    { lifecycle: 'singleton', isInstance: true },
+    logger
   );
   registerWithLog(
     registrar,
-    logger,
-    'instance',
     tokens.titleElement,
-    titleElement
+    titleElement,
+    { lifecycle: 'singleton', isInstance: true },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.IDocumentContext,
-    (c) => new DocumentContext(c.resolve(tokens.WindowDocument))
+    (c) => new DocumentContext(c.resolve(tokens.WindowDocument)),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.DomElementFactory,
-    (c) => new DomElementFactory(c.resolve(tokens.IDocumentContext))
+    (c) => new DomElementFactory(c.resolve(tokens.IDocumentContext)),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.IUserPrompt,
-    () => new WindowUserPrompt()
+    () => new WindowUserPrompt(),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'single',
     tokens.AlertRouter,
     AlertRouter,
-    [tokens.ISafeEventDispatcher]
+    { lifecycle: 'singleton', dependencies: [tokens.ISafeEventDispatcher] },
+    logger
   );
 }
 
@@ -128,24 +140,24 @@ export function registerDomElements(
 export function registerRenderers(registrar, logger) {
   registerWithLog(
     registrar,
-    logger,
-    'single',
     tokens.SpeechBubbleRenderer,
     SpeechBubbleRenderer,
-    [
-      tokens.ILogger,
-      tokens.IDocumentContext,
-      tokens.IValidatedEventDispatcher,
-      tokens.IEntityManager,
-      tokens.DomElementFactory,
-      tokens.EntityDisplayDataProvider,
-    ]
+    {
+      lifecycle: 'singleton',
+      dependencies: [
+        tokens.ILogger,
+        tokens.IDocumentContext,
+        tokens.IValidatedEventDispatcher,
+        tokens.IEntityManager,
+        tokens.DomElementFactory,
+        tokens.EntityDisplayDataProvider,
+      ],
+    },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.TitleRenderer,
     (c) =>
       new TitleRenderer({
@@ -153,13 +165,13 @@ export function registerRenderers(registrar, logger) {
         documentContext: c.resolve(tokens.IDocumentContext),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         titleElement: c.resolve(tokens.titleElement),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.LocationRenderer,
     (c) => {
       const docContext = c.resolve(tokens.IDocumentContext);
@@ -180,13 +192,13 @@ export function registerRenderers(registrar, logger) {
         dataRegistry: c.resolve(tokens.IDataRegistry),
         containerElement: locationContainer,
       });
-    }
+    },
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.ActionButtonsRenderer,
     (c) =>
       new ActionButtonsRenderer({
@@ -196,13 +208,13 @@ export function registerRenderers(registrar, logger) {
         domElementFactory: c.resolve(tokens.DomElementFactory),
         actionButtonsContainerSelector: '#action-buttons',
         sendButtonSelector: '#player-confirm-turn-button',
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.PerceptionLogRenderer,
     (c) =>
       new PerceptionLogRenderer({
@@ -211,13 +223,13 @@ export function registerRenderers(registrar, logger) {
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
         entityManager: c.resolve(tokens.IEntityManager),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.EntityLifecycleMonitor,
     (c) =>
       new EntityLifecycleMonitor({
@@ -225,25 +237,25 @@ export function registerRenderers(registrar, logger) {
         documentContext: c.resolve(tokens.IDocumentContext),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.SaveGameService,
     (c) =>
       new SaveGameService({
         logger: c.resolve(tokens.ILogger),
         userPrompt: c.resolve(tokens.IUserPrompt),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.SaveGameUI,
     (c) =>
       new SaveGameUI({
@@ -253,13 +265,13 @@ export function registerRenderers(registrar, logger) {
         saveLoadService: c.resolve(tokens.ISaveLoadService),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
         saveGameService: c.resolve(tokens.SaveGameService),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.LoadGameUI,
     (c) =>
       new LoadGameUI({
@@ -269,13 +281,13 @@ export function registerRenderers(registrar, logger) {
         saveLoadService: c.resolve(tokens.ISaveLoadService),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
         userPrompt: c.resolve(tokens.IUserPrompt),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.LlmSelectionModal,
     (c) =>
       new LlmSelectionModal({
@@ -284,13 +296,13 @@ export function registerRenderers(registrar, logger) {
         domElementFactory: c.resolve(tokens.DomElementFactory),
         llmAdapter: c.resolve(tokens.LLMAdapter),
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.CurrentTurnActorRenderer,
     (c) =>
       new CurrentTurnActorRenderer({
@@ -299,13 +311,13 @@ export function registerRenderers(registrar, logger) {
         validatedEventDispatcher: c.resolve(tokens.IValidatedEventDispatcher),
         entityManager: c.resolve(tokens.IEntityManager),
         entityDisplayDataProvider: c.resolve(tokens.EntityDisplayDataProvider),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.ChatAlertRenderer,
     (c) =>
       new ChatAlertRenderer({
@@ -314,13 +326,13 @@ export function registerRenderers(registrar, logger) {
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
         alertRouter: c.resolve(tokens.AlertRouter),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.ActionResultRenderer,
     (c) =>
       new ActionResultRenderer({
@@ -328,7 +340,9 @@ export function registerRenderers(registrar, logger) {
         documentContext: c.resolve(tokens.IDocumentContext),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 }
 
@@ -341,8 +355,6 @@ export function registerRenderers(registrar, logger) {
 export function registerControllers(registrar, logger) {
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.InputStateController,
     (c) =>
       new InputStateController({
@@ -350,25 +362,25 @@ export function registerControllers(registrar, logger) {
         documentContext: c.resolve(tokens.IDocumentContext),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         inputElement: c.resolve(tokens.inputElement),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.GlobalKeyHandler,
     (c) =>
       new GlobalKeyHandler(
         c.resolve(tokens.WindowDocument),
         c.resolve(tokens.IValidatedEventDispatcher)
-      )
+      ),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.ProcessingIndicatorController,
     (c) =>
       new ProcessingIndicatorController({
@@ -376,7 +388,9 @@ export function registerControllers(registrar, logger) {
         documentContext: c.resolve(tokens.IDocumentContext),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         domElementFactory: c.resolve(tokens.DomElementFactory),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 }
 
@@ -389,36 +403,38 @@ export function registerControllers(registrar, logger) {
 export function registerFacadeAndManager(registrar, logger) {
   registerWithLog(
     registrar,
-    logger,
-    'single',
     tokens.DomUiFacade,
     DomUiFacade,
-    [
-      tokens.ActionButtonsRenderer,
-      tokens.ActionResultRenderer,
-      tokens.LocationRenderer,
-      tokens.TitleRenderer,
-      tokens.InputStateController,
-      tokens.SpeechBubbleRenderer,
-      tokens.PerceptionLogRenderer,
-      tokens.SaveGameUI,
-      tokens.LoadGameUI,
-      tokens.LlmSelectionModal,
-      tokens.EntityLifecycleMonitor,
-    ]
+    {
+      lifecycle: 'singleton',
+      dependencies: [
+        tokens.ActionButtonsRenderer,
+        tokens.ActionResultRenderer,
+        tokens.LocationRenderer,
+        tokens.TitleRenderer,
+        tokens.InputStateController,
+        tokens.SpeechBubbleRenderer,
+        tokens.PerceptionLogRenderer,
+        tokens.SaveGameUI,
+        tokens.LoadGameUI,
+        tokens.LlmSelectionModal,
+        tokens.EntityLifecycleMonitor,
+      ],
+    },
+    logger
   );
 
   registerWithLog(
     registrar,
-    logger,
-    'singletonFactory',
     tokens.EngineUIManager,
     (c) =>
       new EngineUIManager({
         eventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         domUiFacade: c.resolve(tokens.DomUiFacade),
         logger: c.resolve(tokens.ILogger),
-      })
+      }),
+    { lifecycle: 'singletonFactory' },
+    logger
   );
 }
 

--- a/tests/unit/config/registrations/uiRegistrations.test.js
+++ b/tests/unit/config/registrations/uiRegistrations.test.js
@@ -7,27 +7,20 @@ import { Registrar } from '../../../../src/utils/registrarHelpers.js';
 // --- Mock Registrar Helper ---
 // The key to a robust test is to mock the boundary, in this case, the Registrar.
 // We create mock functions for each of its methods that we expect `registerUI` to call.
-const mockInstance = jest.fn();
-const mockSingle = jest.fn();
-const mockSingletonFactory = jest.fn();
+const mockRegister = jest.fn();
 jest.mock('../../../../src/utils/registrarHelpers.js', () => {
-  // This factory is called by Jest when `new Registrar()` is encountered.
-  // We return an object that has our mock methods on it.
   return {
     Registrar: jest.fn().mockImplementation(() => {
-      return {
-        instance: mockInstance,
-        single: mockSingle,
-        singletonFactory: mockSingletonFactory,
-      };
+      return { register: mockRegister, singletonFactory: jest.fn() };
     }),
-    registerWithLog: jest
-      .fn()
-      .mockImplementation((registrar, _logger, method, token, ...args) => {
-        registrar[method](token, ...args);
-      }),
   };
 });
+
+jest.mock('../../../../src/dependencyInjection/registrarHelpers.js', () => ({
+  registerWithLog: jest.fn((registrar, token, factory, options) => {
+    registrar.register(token, factory, options);
+  }),
+}));
 
 describe('registerUI', () => {
   let mockContainer;
@@ -76,90 +69,101 @@ describe('registerUI', () => {
     expect(Registrar).toHaveBeenCalledWith(mockContainer);
   });
 
-  it('should register essential external dependencies via registrar.instance()', () => {
-    expect(mockInstance).toHaveBeenCalledWith(
+  it('should register essential external dependencies', () => {
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.WindowDocument,
-      mockUiElements.document
+      mockUiElements.document,
+      { lifecycle: 'singleton', isInstance: true }
     );
-    expect(mockInstance).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.outputDiv,
-      mockUiElements.outputDiv
+      mockUiElements.outputDiv,
+      { lifecycle: 'singleton', isInstance: true }
     );
-    expect(mockInstance).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.inputElement,
-      mockUiElements.inputElement
+      mockUiElements.inputElement,
+      { lifecycle: 'singleton', isInstance: true }
     );
-    expect(mockInstance).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.titleElement,
-      mockUiElements.titleElement
+      mockUiElements.titleElement,
+      { lifecycle: 'singleton', isInstance: true }
     );
   });
 
-  it('should register core utilities via registrar.singletonFactory()', () => {
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+  it('should register core utilities via register()', () => {
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.IDocumentContext,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.DomElementFactory,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
   });
 
-  it('should register alerting services via registrar.single()', () => {
-    // Check that AlertRouter is registered correctly
-    expect(mockSingle).toHaveBeenCalledWith(
+  it('should register alerting services via register()', () => {
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.AlertRouter,
       expect.any(Function),
-      [tokens.ISafeEventDispatcher]
+      { lifecycle: 'singleton', dependencies: [tokens.ISafeEventDispatcher] }
     );
   });
 
-  it('should register ChatAlertRenderer via registrar.singletonFactory()', () => {
-    // Verify the specific registration for the class we modified
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+  it('should register ChatAlertRenderer via register()', () => {
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.ChatAlertRenderer,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
   });
 
-  it('should register GlobalKeyHandler via registrar.singletonFactory()', () => {
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+  it('should register GlobalKeyHandler via register()', () => {
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.GlobalKeyHandler,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
   });
 
   it('should register all other UI components', () => {
-    // Spot-check a few other key registrations to ensure they are still present
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.TitleRenderer,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.InputStateController,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.LocationRenderer,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.ActionButtonsRenderer,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.PerceptionLogRenderer,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
-    expect(mockSingle).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.DomUiFacade,
       expect.any(Function),
-      expect.any(Array)
+      expect.objectContaining({ lifecycle: 'singleton' })
     );
-    expect(mockSingletonFactory).toHaveBeenCalledWith(
+    expect(mockRegister).toHaveBeenCalledWith(
       tokens.EngineUIManager,
-      expect.any(Function)
+      expect.any(Function),
+      { lifecycle: 'singletonFactory' }
     );
   });
 


### PR DESCRIPTION
## Summary
- add new DI `registerWithLog` helper with simplified signature
- refactor `uiRegistrations` to use the helper
- update unit tests for new helper behaviour

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686128338b348331996ef3df9bcd912a