### PR TITLE
[Agent] add DecisionDelegate typedef

### DIFF
--- a/src/turns/providers/delegatingDecisionProvider.js
+++ b/src/turns/providers/delegatingDecisionProvider.js
@@ -9,6 +9,16 @@ import { validateDependency } from '../../utils/dependencyUtils.js';
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
+ * @typedef {(
+ *  actor: import('../../entities/entity.js').default,
+ *  context: import('../interfaces/ITurnContext.js').ITurnContext,
+ *  actions: import('../dtos/actionComposite.js').ActionComposite[],
+ *  abortSignal?: AbortSignal
+ * ) => Promise<{ index: number, speech?: string|null, thoughts?: string|null, notes?: string[]|null }>} DecisionDelegate
+ * Callback used by decision providers to select an action.
+ */
+
+/**
  * @class DelegatingDecisionProvider
  * @augments AbstractDecisionProvider
  * @description
@@ -17,25 +27,18 @@ import { validateDependency } from '../../utils/dependencyUtils.js';
  */
 export class DelegatingDecisionProvider extends AbstractDecisionProvider {
   /**
-   * @type {(actor: import('../../entities/entity.js').default,
-   *  context: import('../interfaces/ITurnContext.js').ITurnContext,
-   *  actions: import('../dtos/actionComposite.js').ActionComposite[],
-   *  abortSignal?: AbortSignal
-   * ) => Promise<{ index: number, speech?: string|null, thoughts?: string|null, notes?: string[]|null }>}
+   * @type {DecisionDelegate}
    * @private
    */
   #delegate;
 
   /**
    * @param {object} deps - Constructor dependencies
-   * @param {(actor: import('../../entities/entity.js').default,
-   *  context: import('../interfaces/ITurnContext.js').ITurnContext,
-   *  actions: import('../dtos/actionComposite.js').ActionComposite[],
-   *  abortSignal?: AbortSignal
-   * ) => Promise<{ index: number, speech?: string|null, thoughts?: string|null, notes?: string[]|null }>} deps.delegate
+   * @param {DecisionDelegate} deps.delegate -
    *        Delegate function performing the actual choice logic.
    * @param {import('../../interfaces/coreServices').ILogger} deps.logger - Logger for error reporting
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Event dispatcher for validation errors
+   * @returns {void}
    */
   constructor({ delegate, logger, safeEventDispatcher }) {
     super({ logger, safeEventDispatcher });

--- a/src/turns/providers/goapDecisionProvider.js
+++ b/src/turns/providers/goapDecisionProvider.js
@@ -4,6 +4,8 @@
 
 import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
 
+/** @typedef {import('./delegatingDecisionProvider.js').DecisionDelegate} DecisionDelegate */
+
 /**
  * @class GoapDecisionProvider
  * @augments DelegatingDecisionProvider
@@ -18,6 +20,8 @@ export class GoapDecisionProvider extends DelegatingDecisionProvider {
    * @param {object} deps - Constructor dependencies
    * @param {import('../../interfaces/coreServices').ILogger} deps.logger - Logger for debug output
    * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} deps.safeEventDispatcher - Dispatcher for validation errors
+   * @see DecisionDelegate
+   * @returns {void}
    */
   constructor({ logger, safeEventDispatcher }) {
     const delegate = async (_actor, _context, _actions) => {

--- a/src/turns/providers/humanDecisionProvider.js
+++ b/src/turns/providers/humanDecisionProvider.js
@@ -5,6 +5,8 @@
 
 import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
 
+/** @typedef {import('./delegatingDecisionProvider.js').DecisionDelegate} DecisionDelegate */
+
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
@@ -22,6 +24,8 @@ export class HumanDecisionProvider extends DelegatingDecisionProvider {
    * @param {import('../../interfaces/IPromptCoordinator').IPromptCoordinator} deps.promptCoordinator - Coordinator used to prompt the player
    * @param {import('../../interfaces/coreServices').ILogger} deps.logger - Logger for debug output
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher - Event dispatcher for error reporting
+   * @see DecisionDelegate
+   * @returns {void}
    */
   constructor({ promptCoordinator, logger, safeEventDispatcher }) {
     const delegate = async (actor, _context, actions, abortSignal) => {

--- a/src/turns/providers/llmDecisionProvider.js
+++ b/src/turns/providers/llmDecisionProvider.js
@@ -4,6 +4,8 @@
 
 import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
 
+/** @typedef {import('./delegatingDecisionProvider.js').DecisionDelegate} DecisionDelegate */
+
 /** @typedef {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
 
 /**
@@ -21,6 +23,8 @@ export class LLMDecisionProvider extends DelegatingDecisionProvider {
    *  logger: import('../../interfaces/coreServices').ILogger,
    *  safeEventDispatcher: ISafeEventDispatcher
    * }} deps - Constructor dependencies
+   * @see DecisionDelegate
+   * @returns {void}
    */
   constructor({ llmChooser, logger, safeEventDispatcher }) {
     const delegate = (actor, context, actions, abortSignal) =>


### PR DESCRIPTION
## Summary
- define `DecisionDelegate` JSDoc typedef
- use `DecisionDelegate` in decision provider constructors

## Testing
- `npm run lint` *(fails: 714 errors, 2919 warnings)*
- `npm run test` *(fails: coverage threshold)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861322170d08331ad12f72963530ae5