### PR TITLE
[Agent] add AjvSchemaValidator helper methods

### DIFF
--- a/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
+++ b/tests/unit/services/ajvSchemaValidator.moreBranches.test.js
@@ -84,4 +84,18 @@ describe('AjvSchemaValidator edge branch tests', () => {
       expect.objectContaining({ schemaId: 'some-id', error: removeError })
     );
   });
+
+  it('validate returns schemaNotFound result for invalid schemaId', () => {
+    const result = validator.validate(null, {});
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0].keyword).toBe('schemaNotFound');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('validate called for schemaId')
+    );
+  });
+
+  it('validateSchemaRefs returns false for invalid schemaId', () => {
+    const result = validator.validateSchemaRefs('');
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add private helper methods to AjvSchemaValidator
- use helpers in AjvSchemaValidator methods for instance and schemaId checks
- cover new code paths in AjvSchemaValidator.moreBranches tests

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686132e36f8c8331bb3195cb5dc76cdd