### PR TITLE
[Agent] Process candidate actions concurrently

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -132,29 +132,25 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
    * @returns {Promise<{actions: any[], errors: any[]}>} Result of processing.
    * @private
    */
-  #processCandidate(actionDef, actorEntity, discoveryContext, trace) {
-    return Promise.resolve()
-      .then(() =>
-        this.#actionCandidateProcessor.process(
-          actionDef,
-          actorEntity,
-          discoveryContext,
-          trace
-        )
-      )
-      .then((result) => result ?? { actions: [], errors: [] })
-      .catch((err) => {
-        this.#logger.error(
-          `Error processing candidate action '${actionDef.id}': ${err.message}`,
-          err
-        );
-        return {
-          actions: [],
-          errors: [
-            createDiscoveryError(actionDef.id, extractTargetId(err), err),
-          ],
-        };
-      });
+  async #processCandidate(actionDef, actorEntity, discoveryContext, trace) {
+    try {
+      const result = await this.#actionCandidateProcessor.process(
+        actionDef,
+        actorEntity,
+        discoveryContext,
+        trace
+      );
+      return result ?? { actions: [], errors: [] };
+    } catch (err) {
+      this.#logger.error(
+        `Error processing candidate action '${actionDef.id}': ${err.message}`,
+        err
+      );
+      return {
+        actions: [],
+        errors: [createDiscoveryError(actionDef.id, extractTargetId(err), err)],
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- refactor `#processCandidate` to use async/await
- process candidates concurrently in `getValidActions`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 714 errors)*
- `npm run test` *(fails due to coverage threshold)*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686132fbc08883318eb015eee30ea4ff