### PR TITLE
[Agent] add tests for validators and adapters

### DIFF
--- a/tests/unit/adapters/gameEngineAdapters.test.js
+++ b/tests/unit/adapters/gameEngineAdapters.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import GameEngineLoadAdapter from '../../../src/adapters/GameEngineLoadAdapter.js';
+import GameEngineSaveAdapter from '../../../src/adapters/GameEngineSaveAdapter.js';
+
+describe('GameEngineLoadAdapter', () => {
+  it('delegates load to the engine', async () => {
+    const engine = { loadGame: jest.fn().mockResolvedValue('result') };
+    const adapter = new GameEngineLoadAdapter(engine);
+    await expect(adapter.load('foo')).resolves.toBe('result');
+    expect(engine.loadGame).toHaveBeenCalledWith('foo');
+  });
+});
+
+describe('GameEngineSaveAdapter', () => {
+  it('delegates save to the engine', async () => {
+    const engine = { triggerManualSave: jest.fn().mockResolvedValue('saved') };
+    const adapter = new GameEngineSaveAdapter(engine);
+    await expect(adapter.save('slot', 'name')).resolves.toBe('saved');
+    expect(engine.triggerManualSave).toHaveBeenCalledWith('name', 'slot');
+  });
+});

--- a/tests/unit/anatomy/anatomyGenerationService.earlyReturns.test.js
+++ b/tests/unit/anatomy/anatomyGenerationService.earlyReturns.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AnatomyGenerationService } from '../../../src/anatomy/anatomyGenerationService.js';
+
+describe('AnatomyGenerationService early return cases', () => {
+  let service;
+  let em;
+  let registry;
+  let logger;
+  let factory;
+  let descService;
+
+  beforeEach(() => {
+    em = {
+      getEntityInstance: jest.fn(),
+      addComponent: jest.fn(),
+    };
+    registry = { get: jest.fn() };
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    factory = { createAnatomyGraph: jest.fn() };
+    descService = { generateAllDescriptions: jest.fn() };
+    service = new AnatomyGenerationService({
+      entityManager: em,
+      dataRegistry: registry,
+      logger,
+      bodyBlueprintFactory: factory,
+      anatomyDescriptionService: descService,
+    });
+  });
+
+  it('returns false if entity is not found', async () => {
+    em.getEntityInstance.mockReturnValue(null);
+    const result = await service.generateAnatomyIfNeeded('x');
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('returns false if entity lacks body component', async () => {
+    em.getEntityInstance.mockReturnValue({
+      hasComponent: jest.fn().mockReturnValue(false),
+    });
+    const result = await service.generateAnatomyIfNeeded('x');
+    expect(result).toBe(false);
+  });
+
+  it('warns if recipeId missing', async () => {
+    const entity = {
+      hasComponent: jest.fn().mockReturnValue(true),
+      getComponentData: jest.fn().mockReturnValue({}),
+    };
+    em.getEntityInstance.mockReturnValue(entity);
+    const result = await service.generateAnatomyIfNeeded('x');
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('does nothing when anatomy already generated', async () => {
+    const entity = {
+      hasComponent: jest.fn().mockReturnValue(true),
+      getComponentData: jest.fn().mockReturnValue({ recipeId: 'r', body: {} }),
+    };
+    em.getEntityInstance.mockReturnValue(entity);
+    const result = await service.generateAnatomyIfNeeded('x');
+    expect(result).toBe(false);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/anatomy/graphIntegrityValidator.test.js
+++ b/tests/unit/anatomy/graphIntegrityValidator.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { GraphIntegrityValidator } from '../../../src/anatomy/graphIntegrityValidator.js';
+
+describe('GraphIntegrityValidator', () => {
+  let em;
+  let logger;
+  let validator;
+
+  beforeEach(() => {
+    em = {
+      getComponentData: jest.fn(),
+      getEntityInstance: jest.fn(),
+      getComponentsForEntity: jest.fn(() => ({})),
+    };
+    logger = { debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    validator = new GraphIntegrityValidator({ entityManager: em, logger });
+  });
+
+  it('detects socket count violations', async () => {
+    em.getComponentData.mockImplementation((id, comp) => {
+      if (comp === 'anatomy:sockets') {
+        return { sockets: [{ id: 's1', maxCount: 1 }] };
+      }
+      return null;
+    });
+    const result = await validator.validateGraph(
+      ['e1'],
+      {},
+      new Map([['e1:s1', 2]])
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('exceeds maxCount');
+  });
+
+  it('warns for orphaned parts', async () => {
+    em.getComponentData.mockImplementation((id, comp) => {
+      if (comp === 'anatomy:joint') {
+        return { parentId: 'missing', socketId: 's1', jointType: 'ball' };
+      }
+      if (comp === 'anatomy:sockets') {
+        return { sockets: [] };
+      }
+      return null;
+    });
+    const result = await validator.validateGraph(['child'], {}, new Map());
+    expect(result.warnings[0]).toContain('orphaned');
+  });
+});

--- a/tests/unit/llms/services/LlmConfigCache.test.js
+++ b/tests/unit/llms/services/LlmConfigCache.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from '@jest/globals';
+import { LlmConfigCache } from '../../../../src/llms/services/LlmConfigCache.js';
+
+describe('LlmConfigCache', () => {
+  const validCfg = {
+    configId: 'id1',
+    modelIdentifier: 'gpt',
+    promptElements: [],
+    promptAssemblyOrder: [],
+  };
+
+  it('stores and returns copies of valid configs', () => {
+    const cache = new LlmConfigCache();
+    cache.addOrUpdateConfigs([validCfg]);
+    const result = cache.getConfig('id1');
+    expect(result).toEqual(validCfg);
+    expect(result).not.toBe(validCfg);
+  });
+
+  it('ignores invalid configs and invalid ids', () => {
+    const cache = new LlmConfigCache();
+    cache.addOrUpdateConfigs([
+      {
+        configId: '',
+        modelIdentifier: '',
+        promptElements: null,
+        promptAssemblyOrder: [],
+      },
+    ]);
+    expect(cache.getConfig('')).toBeUndefined();
+  });
+
+  it('handles non-array input gracefully', () => {
+    const cache = new LlmConfigCache();
+    cache.addOrUpdateConfigs(null);
+    expect(cache.getConfig('id1')).toBeUndefined();
+  });
+
+  it('can reset the cache', () => {
+    const cache = new LlmConfigCache();
+    cache.addOrUpdateConfigs([validCfg]);
+    cache.resetCache();
+    expect(cache.getConfig('id1')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for GameEngineLoadAdapter and GameEngineSaveAdapter
- cover LlmConfigCache behaviors
- add GraphIntegrityValidator tests
- cover early return paths in AnatomyGenerationService

## Testing Done
- `npm run format` (root)
- `npm run lint` *(fails: 3633 problems)*
- `npm run test` *(fails: uncovered count for statements (1693) exceeds global threshold (1650))*
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686135cc1a688331affef9f19066a3cc