### PR TITLE
[Agent] Use JSON assertion import in version test

### DIFF
--- a/tests/unit/engine/engineVersion.test.js
+++ b/tests/unit/engine/engineVersion.test.js
@@ -9,7 +9,7 @@ import { ENGINE_VERSION } from '../../../src/engine/engineVersion.js';
 // Import package.json directly to compare against its version
 // Ensure your Jest setup can handle JSON imports with import assertions.
 // If not, you might need to use require() or fs.readFileSync + JSON.parse.
-import pkg from '../../../package.json';
+import pkg from '../../../package.json' assert { type: 'json' };
 
 describe('ENGINE_VERSION constant', () => {
   it('should strictly equal the version specified in package.json', () => {


### PR DESCRIPTION
## Summary
- update `engineVersion` test to import package.json with JSON assertion

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68613591fcb083319a7060ae30bc8ffe