### PR TITLE
[Agent] respect turnEnded in failure outcome

### DIFF
--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -157,9 +157,8 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
 
     this.#validateResult(result, actorId);
 
-    // result.turnEnded from CP is true if CP failed, false if CP succeeded.
     const cpFailureEndsTurn =
-      typeof result.turnEnded === 'boolean' ? result.turnEnded : true; // Default to true for safety on failure
+      typeof result.turnEnded === 'boolean' ? result.turnEnded : true; // Default true for safety
 
     this.#logger.debug(
       `CommandOutcomeInterpreter: Interpreting for ${actorId}. CP_Success=${result.success}, CP_TurnEndedOnFail=${cpFailureEndsTurn}, Input="${originalInput}"`
@@ -176,8 +175,11 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
     } else {
       // CommandProcessor detected failure
 
-      // Any failure detected by CommandProcessor ends the turn.
-      const directive = TurnDirective.END_TURN_FAILURE;
+      const shouldEnd =
+        typeof result.turnEnded === 'boolean' ? result.turnEnded : true;
+      const directive = shouldEnd
+        ? TurnDirective.END_TURN_FAILURE
+        : TurnDirective.RE_PROMPT;
       this.#logger.debug(
         `Actor ${actorId}: CommandProcessor failure for action '${processedActionId}'. Directive: ${directive}.`
       );

--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -63,11 +63,32 @@ describe('CommandOutcomeInterpreter additional branches', () => {
     );
   });
 
-  it('returns END_TURN_FAILURE when command fails', async () => {
+  it('returns RE_PROMPT when command fails but turnEnded is false', async () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     const result = {
       success: false,
       turnEnded: false,
+      actionResult: { actionId: 'fail:action' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.RE_PROMPT);
+  });
+
+  it('returns END_TURN_FAILURE when command fails and turnEnded is true', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    const result = {
+      success: false,
+      turnEnded: true,
+      actionResult: { actionId: 'fail:action' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.END_TURN_FAILURE);
+  });
+
+  it('defaults to END_TURN_FAILURE when turnEnded is missing', async () => {
+    const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    const result = {
+      success: false,
       actionResult: { actionId: 'fail:action' },
     };
     const directive = await interpreter.interpret(result, turnContext);


### PR DESCRIPTION
## Summary
- use `turnEnded` flag when choosing failure directive
- cover the failure branches in CommandOutcomeInterpreter

## Testing Done
- `npm run lint` *(fails: 3633 problems)*
- `npm run test -- --coverageThreshold='{}'`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68613476d99c8331b365c4bd5fab7dc2