### PR TITLE
[Agent] Refactor validation to helper utils

### DIFF
--- a/src/modding/modDependencyValidator.js
+++ b/src/modding/modDependencyValidator.js
@@ -2,6 +2,7 @@
 
 import semver from 'semver'; // AC: Use semver@^7
 import ModDependencyError from '../errors/modDependencyError.js'; // AC: Use custom Error type
+import { assertIsMap, assertIsLogger } from '../utils/argValidation.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -28,23 +29,18 @@ class ModDependencyValidator {
    * @param {Map<string, ModManifest>} manifests - Map of mod manifests, keyed by **lower-cased** mod ID.
    * @param {ILogger} logger - Logger instance for warnings.
    * @param {object} [options] - Optional validation options.
-   * @param {{valid: Function, satisfies: Function}} [options.semverLib=semver] - Library used for semver checks.
+   * @param {{valid: Function, satisfies: Function}} [options.semverLib] - Library used for semver checks.
    * @returns {void} - Returns nothing, but throws ModDependencyError on fatal issues.
    * @throws {ModDependencyError} If fatal validation errors occur (missing required, version mismatch, conflict).
    */
   static validate(manifests, logger, { semverLib = semver } = {}) {
     const fatals = []; // AC: Collect fatal messages
 
-    if (!(manifests instanceof Map)) {
-      throw new Error(
-        'ModDependencyValidator.validate: Input `manifests` must be a Map.'
-      );
-    }
-    if (!logger || typeof logger.warn !== 'function') {
-      throw new Error(
-        'ModDependencyValidator.validate: Input `logger` must be a valid ILogger instance.'
-      );
-    }
+    assertIsMap(
+      manifests,
+      'ModDependencyValidator.validate: Input `manifests`'
+    );
+    assertIsLogger(logger, 'ModDependencyValidator.validate: Input `logger`');
 
     // Iterate through each mod that is loaded
     for (const [modIdLower, manifest] of manifests.entries()) {

--- a/src/modding/modLoadOrderResolver.js
+++ b/src/modding/modLoadOrderResolver.js
@@ -6,6 +6,7 @@
 
 import ModDependencyError from '../errors/modDependencyError.js';
 import { CORE_MOD_ID } from '../constants/core';
+import { assertIsLogger, assertIsMap } from '../utils/argValidation.js';
 
 /*─────────────────────────────────────────────────────────────────────────*/
 /* Private Helper Functions                                                */
@@ -172,11 +173,11 @@ export default class ModLoadOrderResolver {
    * @param {ILogger} logger The application's logger instance.
    */
   constructor(logger) {
-    if (!logger || typeof logger.debug !== 'function') {
-      throw new Error(
-        'ModLoadOrderResolver: constructor requires a valid logger instance.'
-      );
-    }
+    assertIsLogger(
+      logger,
+      'logger',
+      'ModLoadOrderResolver: constructor requires a valid logger instance.'
+    );
     this._logger = logger;
   }
 
@@ -200,10 +201,7 @@ export default class ModLoadOrderResolver {
       throw new Error(
         'ModLoadOrderResolver.resolve: `requestedIds` must be an array.'
       );
-    if (!(manifestsMap instanceof Map))
-      throw new Error(
-        'ModLoadOrderResolver.resolve: `manifestsMap` must be a Map.'
-      );
+    assertIsMap(manifestsMap, 'ModLoadOrderResolver.resolve: `manifestsMap`');
 
     /* 1 – Build graph */
     const { nodes, edges } = buildDependencyGraph(requestedIds, manifestsMap);

--- a/src/modding/modVersionValidator.js
+++ b/src/modding/modVersionValidator.js
@@ -4,6 +4,7 @@ import engineVersionSatisfies from '../engine/engineVersionSatisfies.js';
 import ModDependencyError from '../errors/modDependencyError.js';
 import { ENGINE_VERSION } from '../engine/engineVersion.js'; // Import the actual engine version
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+import { assertIsMap, assertIsLogger } from '../utils/argValidation.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
@@ -33,18 +34,8 @@ export default function validateModEngineVersions(
 ) {
   const fatals = []; // Stores incompatibility messages
 
-  if (!(manifests instanceof Map)) {
-    // Basic type check for the input map
-    throw new Error(
-      'validateModEngineVersions: Input `manifests` must be a Map.'
-    );
-  }
-  if (!logger || typeof logger.error !== 'function') {
-    // Basic type check for the logger
-    throw new Error(
-      'validateModEngineVersions: Input `logger` must be a valid ILogger instance.'
-    );
-  }
+  assertIsMap(manifests, 'validateModEngineVersions: Input `manifests`');
+  assertIsLogger(logger, 'validateModEngineVersions: Input `logger`');
   if (
     !safeEventDispatcher ||
     typeof safeEventDispatcher.dispatch !== 'function'

--- a/src/utils/argValidation.js
+++ b/src/utils/argValidation.js
@@ -1,0 +1,47 @@
+// src/utils/argValidation.js
+
+/**
+ * @file Assertion helpers for validating common argument types.
+ */
+
+/**
+ * Assert that a value is a Map instance.
+ *
+ * @param {*} value - Value to check.
+ * @param {string} name - Name used in the error message.
+ * @param {string} [message] - Optional custom error message.
+ * @returns {void}
+ * @throws {Error} If `value` is not a Map.
+ */
+export function assertIsMap(value, name, message) {
+  if (!(value instanceof Map)) {
+    throw new Error(message || `${name} must be a Map.`);
+  }
+}
+
+/**
+ * Assert that a logger implements the ILogger interface.
+ *
+ * @param {*} logger - Logger to validate.
+ * @param {string} name - Name used in the error message.
+ * @param {string} [message] - Optional custom error message.
+ * @returns {void}
+ * @throws {Error} If `logger` does not implement ILogger methods.
+ */
+export function assertIsLogger(logger, name, message) {
+  const valid =
+    logger &&
+    typeof logger.info === 'function' &&
+    typeof logger.warn === 'function' &&
+    typeof logger.error === 'function' &&
+    typeof logger.debug === 'function';
+
+  if (!valid) {
+    throw new Error(message || `${name} must be a valid ILogger instance.`);
+  }
+}
+
+export default {
+  assertIsMap,
+  assertIsLogger,
+};

--- a/tests/unit/utils/argValidation.test.js
+++ b/tests/unit/utils/argValidation.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  assertIsMap,
+  assertIsLogger,
+} from '../../../src/utils/argValidation.js';
+
+describe('argValidation', () => {
+  describe('assertIsMap', () => {
+    it('passes when value is a Map', () => {
+      expect(() => assertIsMap(new Map(), 'context')).not.toThrow();
+    });
+
+    it('throws with message when value is not a Map', () => {
+      expect(() => assertIsMap({}, 'context')).toThrow(
+        'context must be a Map.'
+      );
+    });
+  });
+
+  describe('assertIsLogger', () => {
+    const validLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    it('passes when logger has required methods', () => {
+      expect(() => assertIsLogger(validLogger, 'logger')).not.toThrow();
+    });
+
+    it('throws when logger is missing methods', () => {
+      const invalid = { info: jest.fn() };
+      expect(() => assertIsLogger(invalid, 'logger')).toThrow(
+        'logger must be a valid ILogger instance.'
+      );
+    });
+
+    it('uses custom message when provided', () => {
+      expect(() => assertIsLogger(null, 'logger', 'bad')).toThrow('bad');
+    });
+  });
+});


### PR DESCRIPTION
Summary: Centralize common argument validation logic and update dependent modules.

Changes Made:
- Added `assertIsMap` and `assertIsLogger` in `argValidation.js`.
- Replaced inline checks in mod validators and load order resolver with new helpers.
- Created unit tests for the new utilities.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_686133f5a9ec8331bb57b090da457d71