### PR TITLE
[Refactor] centralize getValidActions trace source

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -166,6 +166,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
   async getValidActions(actorEntity, baseContext = {}, options = {}) {
     const { trace: shouldTrace = false } = options;
     const trace = shouldTrace ? this.#traceContextFactory() : null;
+    const SOURCE = 'getValidActions';
 
     if (!actorEntity || typeof actorEntity.id !== 'string') {
       this.#logger.error('getValidActions called with invalid actor entity.');
@@ -174,7 +175,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
 
     trace?.info(
       `Starting action discovery for actor '${actorEntity.id}'.`,
-      'getValidActions',
+      SOURCE,
       { withTrace: shouldTrace }
     );
 
@@ -210,7 +211,7 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     );
     trace?.info(
       `Finished discovery. Found ${actions.length} valid actions.`,
-      'getValidActions'
+      SOURCE
     );
 
     return { actions, errors, trace };


### PR DESCRIPTION
Summary: Replace hard-coded "getValidActions" strings with a local constant for clearer tracing.

Changes Made:
- added `SOURCE` constant inside `getValidActions` and reused it in trace messages.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (root and proxy)
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68613fc105b08331929724da7200a3eb