### PR TITLE
[Refactor] consolidate turn strategy helpers

### DIFF
--- a/src/turns/strategies/endTurnFailureStrategy.js
+++ b/src/turns/strategies/endTurnFailureStrategy.js
@@ -10,7 +10,11 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import { assertDirective, requireContextActor } from './strategyHelpers.js';
+import {
+  assertDirective,
+  requireContextActor,
+  getLoggerAndClass,
+} from './strategyHelpers.js';
 
 export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
   /** @override */
@@ -20,8 +24,7 @@ export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
     /** @type {TurnDirectiveEnum}     */ directive,
     /** @type {CommandResult}    */ cmdProcResult
   ) {
-    const className = this.constructor.name;
-    const logger = turnContext.getLogger();
+    const { logger, className } = getLoggerAndClass(this, turnContext);
 
     assertDirective({
       expected: TurnDirective.END_TURN_FAILURE,

--- a/src/turns/strategies/endTurnSuccessStrategy.js
+++ b/src/turns/strategies/endTurnSuccessStrategy.js
@@ -10,7 +10,11 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import { assertDirective, requireContextActor } from './strategyHelpers.js';
+import {
+  assertDirective,
+  requireContextActor,
+  getLoggerAndClass,
+} from './strategyHelpers.js';
 
 export default class EndTurnSuccessStrategy extends ITurnDirectiveStrategy {
   /** @override */
@@ -20,8 +24,7 @@ export default class EndTurnSuccessStrategy extends ITurnDirectiveStrategy {
     /** @type {TurnDirectiveEnum}     */ directive,
     /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
   ) {
-    const className = this.constructor.name;
-    const logger = turnContext.getLogger();
+    const { logger, className } = getLoggerAndClass(this, turnContext);
 
     assertDirective({
       expected: TurnDirective.END_TURN_SUCCESS,

--- a/src/turns/strategies/repromptStrategy.js
+++ b/src/turns/strategies/repromptStrategy.js
@@ -10,7 +10,11 @@
 
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
-import { assertDirective, requireContextActor } from './strategyHelpers.js';
+import {
+  assertDirective,
+  requireContextActor,
+  getLoggerAndClass,
+} from './strategyHelpers.js';
 import { AwaitingActorDecisionState } from '../states/awaitingActorDecisionState.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
@@ -36,8 +40,7 @@ export default class RepromptStrategy extends ITurnDirectiveStrategy {
     /** @type {TurnDirectiveEnum}     */ directive,
     /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
   ) {
-    const className = this.constructor.name;
-    const logger = turnContext.getLogger();
+    const { logger, className } = getLoggerAndClass(this, turnContext);
     const safeEventDispatcher = turnContext.getSafeEventDispatcher();
 
     assertDirective({

--- a/src/turns/strategies/strategyHelpers.js
+++ b/src/turns/strategies/strategyHelpers.js
@@ -9,6 +9,34 @@
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
 /**
+ * Retrieves the logger from the turnContext and the class name from the
+ * provided instance.
+ *
+ * @param {object} instance - The strategy instance (`this`).
+ * @param {ITurnContext} turnContext - Context providing `getLogger`.
+ * @returns {{ logger: ILogger, className: string }} Object containing logger
+ *          and class name.
+ */
+export function getLoggerAndClass(instance, turnContext) {
+  return {
+    logger: turnContext.getLogger(),
+    className: instance.constructor.name,
+  };
+}
+
+/**
+ * Builds a standardized error message when the wrong directive is supplied.
+ *
+ * @param {string} className - Name of the strategy class.
+ * @param {*} actual - The directive provided.
+ * @param {*} expected - The directive expected.
+ * @returns {string} The formatted error message.
+ */
+export function buildWrongDirectiveMessage(className, actual, expected) {
+  return `${className}: Received wrong directive (${actual}). Expected ${expected}.`;
+}
+
+/**
  * Validates that a directive matches the expected value.
  * Throws an error and logs when the directive is unexpected.
  *
@@ -22,7 +50,7 @@
  */
 export function assertDirective({ expected, actual, logger, className }) {
   if (actual !== expected) {
-    const msg = `${className}: Received wrong directive (${actual}). Expected ${expected}.`;
+    const msg = buildWrongDirectiveMessage(className, actual, expected);
     if (logger && typeof logger.error === 'function') {
       logger.error(msg);
     }

--- a/src/turns/strategies/waitForTurnEndEventStrategy.js
+++ b/src/turns/strategies/waitForTurnEndEventStrategy.js
@@ -11,7 +11,11 @@
 import { ITurnDirectiveStrategy } from '../interfaces/ITurnDirectiveStrategy.js';
 import TurnDirective from '../constants/turnDirectives.js';
 import { TURN_ENDED_ID } from '../../constants/eventIds.js';
-import { assertDirective, requireContextActor } from './strategyHelpers.js';
+import {
+  assertDirective,
+  requireContextActor,
+  getLoggerAndClass,
+} from './strategyHelpers.js';
 
 export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy {
   /**
@@ -34,8 +38,7 @@ export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy 
     /** @type {TurnDirectiveEnum}     */ directive,
     /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
   ) {
-    const className = this.constructor.name;
-    const logger = turnContext.getLogger();
+    const { logger, className } = getLoggerAndClass(this, turnContext);
 
     assertDirective({
       expected: TurnDirective.WAIT_FOR_EVENT,

--- a/tests/unit/utils/strategyHelpers.test.js
+++ b/tests/unit/utils/strategyHelpers.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   assertDirective,
   requireContextActor,
+  getLoggerAndClass,
+  buildWrongDirectiveMessage,
 } from '../../../src/turns/strategies/strategyHelpers.js';
 
 describe('strategyHelpers', () => {
@@ -78,6 +80,29 @@ describe('strategyHelpers', () => {
       expect(turnContext.endTurn.mock.calls[0][0]).toBeInstanceOf(Error);
       expect(turnContext.endTurn.mock.calls[0][0].message).toBe(
         'missing actor'
+      );
+    });
+  });
+
+  describe('getLoggerAndClass', () => {
+    it('returns logger and className from context and instance', () => {
+      class Dummy {}
+      const logger = { info: jest.fn() };
+      const turnContext = { getLogger: jest.fn(() => logger) };
+      const instance = new Dummy();
+
+      const result = getLoggerAndClass(instance, turnContext);
+
+      expect(result).toEqual({ logger, className: 'Dummy' });
+      expect(turnContext.getLogger).toHaveBeenCalled();
+    });
+  });
+
+  describe('buildWrongDirectiveMessage', () => {
+    it('formats the directive error message', () => {
+      const msg = buildWrongDirectiveMessage('MyClass', 'BAD', 'GOOD');
+      expect(msg).toBe(
+        'MyClass: Received wrong directive (BAD). Expected GOOD.'
       );
     });
   });


### PR DESCRIPTION
Summary: Adds utilities for turn strategies to reduce boilerplate and unify error messages.

Changes Made:
- Added `getLoggerAndClass` and `buildWrongDirectiveMessage` helpers.
- Refactored directive strategies to use the new helpers.
- Extended strategy helper tests for new utilities.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68613f8f90c08331a8000160e82faa88