### PR TITLE
[Agent] hide decision provider dependencies

### DIFF
--- a/src/turns/providers/humanDecisionProvider.js
+++ b/src/turns/providers/humanDecisionProvider.js
@@ -4,6 +4,7 @@
  */
 
 import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
+import { validateDependency } from '../../utils/dependencyUtils.js';
 
 /** @typedef {import('./delegatingDecisionProvider.js').DecisionDelegate} DecisionDelegate */
 
@@ -17,6 +18,8 @@ import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
  * index and any associated metadata (speech, thoughts).
  */
 export class HumanDecisionProvider extends DelegatingDecisionProvider {
+  /** @type {import('../../interfaces/IPromptCoordinator').IPromptCoordinator} */
+  #promptCoordinator;
   /**
    * Creates a new HumanDecisionProvider.
    *
@@ -28,8 +31,11 @@ export class HumanDecisionProvider extends DelegatingDecisionProvider {
    * @returns {void}
    */
   constructor({ promptCoordinator, logger, safeEventDispatcher }) {
+    validateDependency(promptCoordinator, 'promptCoordinator', logger, {
+      requiredMethods: ['prompt'],
+    });
     const delegate = async (actor, _context, actions, abortSignal) => {
-      const res = await promptCoordinator.prompt(actor, {
+      const res = await this.#promptCoordinator.prompt(actor, {
         indexedComposites: actions,
         cancellationSignal: abortSignal,
       });
@@ -39,6 +45,6 @@ export class HumanDecisionProvider extends DelegatingDecisionProvider {
     };
 
     super({ delegate, logger, safeEventDispatcher });
-    this.promptCoordinator = promptCoordinator;
+    this.#promptCoordinator = promptCoordinator;
   }
 }

--- a/src/turns/providers/llmDecisionProvider.js
+++ b/src/turns/providers/llmDecisionProvider.js
@@ -3,6 +3,7 @@
  */
 
 import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
+import { validateDependency } from '../../utils/dependencyUtils.js';
 
 /** @typedef {import('./delegatingDecisionProvider.js').DecisionDelegate} DecisionDelegate */
 
@@ -16,6 +17,11 @@ import { DelegatingDecisionProvider } from './delegatingDecisionProvider.js';
  */
 export class LLMDecisionProvider extends DelegatingDecisionProvider {
   /**
+   * @type {import('../../turns/ports/ILLMChooser').ILLMChooser}
+   * @private
+   */
+  #llmChooser;
+  /**
    * Creates a new LLMDecisionProvider.
    *
    * @param {{
@@ -27,8 +33,11 @@ export class LLMDecisionProvider extends DelegatingDecisionProvider {
    * @returns {void}
    */
   constructor({ llmChooser, logger, safeEventDispatcher }) {
+    validateDependency(llmChooser, 'llmChooser', logger, {
+      requiredMethods: ['choose'],
+    });
     const delegate = (actor, context, actions, abortSignal) =>
-      llmChooser.choose({
+      this.#llmChooser.choose({
         actor,
         context,
         actions,
@@ -36,7 +45,6 @@ export class LLMDecisionProvider extends DelegatingDecisionProvider {
       });
 
     super({ delegate, logger, safeEventDispatcher });
-    /** @protected @type {import('../../turns/ports/ILLMChooser').ILLMChooser} */
-    this.llmChooser = llmChooser;
+    this.#llmChooser = llmChooser;
   }
 }


### PR DESCRIPTION
Summary: use private fields and dependency validation for decision provider classes

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68613ec49214833194fe2319ae65534f