### PR TITLE
[Agent] make save/load UI functions async

### DIFF
--- a/src/bootstrapper/stages/uiStages.js
+++ b/src/bootstrapper/stages/uiStages.js
@@ -94,9 +94,9 @@ export async function setupMenuButtonListenersStage(
     setupButtonListener(
       documentRef,
       'open-save-game-button',
-      () => {
+      async () => {
         logger.debug(`${stageName}: "Open Save Game UI" button clicked.`);
-        gameEngine.showSaveGameUI();
+        await gameEngine.showSaveGameUI();
       },
       logger,
       stageName
@@ -105,9 +105,9 @@ export async function setupMenuButtonListenersStage(
     setupButtonListener(
       documentRef,
       'open-load-game-button',
-      () => {
+      async () => {
         logger.debug(`${stageName}: "Open Load Game UI" button clicked.`);
-        gameEngine.showLoadGameUI();
+        await gameEngine.showLoadGameUI();
       },
       logger,
       stageName

--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -427,7 +427,15 @@ class GameEngine {
     }
   }
 
-  showSaveGameUI() {
+  /**
+   * Requests that the UI present the Save Game screen.
+   *
+   * @description Dispatches either {@link REQUEST_SHOW_SAVE_GAME_UI} or
+   * {@link CANNOT_SAVE_GAME_INFO} based on the persistence service state.
+   * @async
+   * @returns {Promise<void>} Resolves when dispatching completes.
+   */
+  async showSaveGameUI() {
     const persistenceService = this._ensurePersistenceServiceAvailable(
       'GameEngine.showSaveGameUI: GamePersistenceService is unavailable. Cannot show Save Game UI.'
     );
@@ -439,16 +447,24 @@ class GameEngine {
       this.#logger.debug(
         'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
       );
-      this.#safeEventDispatcher.dispatch(REQUEST_SHOW_SAVE_GAME_UI, {});
+      await this.#safeEventDispatcher.dispatch(REQUEST_SHOW_SAVE_GAME_UI, {});
     } else {
       this.#logger.warn(
         'GameEngine.showSaveGameUI: Saving is not currently allowed.'
       );
-      this.#safeEventDispatcher.dispatch(CANNOT_SAVE_GAME_INFO);
+      await this.#safeEventDispatcher.dispatch(CANNOT_SAVE_GAME_INFO);
     }
   }
 
-  showLoadGameUI() {
+  /**
+   * Requests that the UI present the Load Game screen.
+   *
+   * @description Dispatches {@link REQUEST_SHOW_LOAD_GAME_UI} when the
+   * persistence service is available.
+   * @async
+   * @returns {Promise<void>} Resolves when dispatching completes.
+   */
+  async showLoadGameUI() {
     if (
       !this._ensurePersistenceServiceAvailable(
         'GameEngine.showLoadGameUI: GamePersistenceService is unavailable. Cannot show Load Game UI.'
@@ -459,7 +475,7 @@ class GameEngine {
     this.#logger.debug(
       'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
     );
-    this.#safeEventDispatcher.dispatch(REQUEST_SHOW_LOAD_GAME_UI, {});
+    await this.#safeEventDispatcher.dispatch(REQUEST_SHOW_LOAD_GAME_UI, {});
   }
 
   getEngineStatus() {

--- a/src/main.js
+++ b/src/main.js
@@ -217,7 +217,7 @@ export async function beginGame(showLoadUI = false) {
     const startResult = await startGameStage(gameEngine, ACTIVE_WORLD, logger);
     if (!startResult.success) throw startResult.error;
     if (showLoadUI && typeof gameEngine.showLoadGameUI === 'function') {
-      gameEngine.showLoadGameUI();
+      await gameEngine.showLoadGameUI();
     }
   } catch (error) {
     displayFatalStartupError(

--- a/tests/unit/anatomy/graphIntegrityValidator.test.js
+++ b/tests/unit/anatomy/graphIntegrityValidator.test.js
@@ -31,13 +31,15 @@ describe('GraphIntegrityValidator', () => {
 
   describe('constructor', () => {
     it('should throw error if entityManager is not provided', () => {
-      expect(() => new GraphIntegrityValidator({ logger: mockLogger }))
-        .toThrow(InvalidArgumentError);
+      expect(() => new GraphIntegrityValidator({ logger: mockLogger })).toThrow(
+        InvalidArgumentError
+      );
     });
 
     it('should throw error if logger is not provided', () => {
-      expect(() => new GraphIntegrityValidator({ entityManager: mockEntityManager }))
-        .toThrow(InvalidArgumentError);
+      expect(
+        () => new GraphIntegrityValidator({ entityManager: mockEntityManager })
+      ).toThrow(InvalidArgumentError);
     });
   });
 
@@ -74,16 +76,22 @@ describe('GraphIntegrityValidator', () => {
     it('should log when validation fails with errors', async () => {
       // Setup to trigger socket limit error
       const socketOccupancy = new Map([['parent-1:socket-1', 3]]);
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', maxCount: 2 }],
-          };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1', maxCount: 2 }],
+            };
+          }
+          return null;
         }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1'], {}, socketOccupancy);
+      const result = await validator.validateGraph(
+        ['parent-1'],
+        {},
+        socketOccupancy
+      );
 
       expect(result.valid).toBe(false);
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -105,7 +113,11 @@ describe('GraphIntegrityValidator', () => {
       mockEntityManager.getComponentData.mockReturnValue(null);
       mockEntityManager.getAllComponentTypesForEntity.mockReturnValue([]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
       expect(result.warnings).toHaveLength(1);
@@ -118,17 +130,23 @@ describe('GraphIntegrityValidator', () => {
   describe('validateSocketLimits', () => {
     it('should validate socket occupancy within limits', async () => {
       const socketOccupancy = new Map([['parent-1:socket-1', 1]]);
-      
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', maxCount: 2 }],
-          };
-        }
-        return null;
-      });
 
-      const result = await validator.validateGraph(['parent-1'], {}, socketOccupancy);
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1', maxCount: 2 }],
+            };
+          }
+          return null;
+        }
+      );
+
+      const result = await validator.validateGraph(
+        ['parent-1'],
+        {},
+        socketOccupancy
+      );
 
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
@@ -136,17 +154,23 @@ describe('GraphIntegrityValidator', () => {
 
     it('should error when socket occupancy exceeds maxCount', async () => {
       const socketOccupancy = new Map([['parent-1:socket-1', 3]]);
-      
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', maxCount: 2 }],
-          };
-        }
-        return null;
-      });
 
-      const result = await validator.validateGraph(['parent-1'], {}, socketOccupancy);
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1', maxCount: 2 }],
+            };
+          }
+          return null;
+        }
+      );
+
+      const result = await validator.validateGraph(
+        ['parent-1'],
+        {},
+        socketOccupancy
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -156,17 +180,23 @@ describe('GraphIntegrityValidator', () => {
 
     it('should error when socket not found', async () => {
       const socketOccupancy = new Map([['parent-1:missing-socket', 1]]);
-      
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'other-socket', maxCount: 1 }],
-          };
-        }
-        return null;
-      });
 
-      const result = await validator.validateGraph(['parent-1'], {}, socketOccupancy);
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'other-socket', maxCount: 1 }],
+            };
+          }
+          return null;
+        }
+      );
+
+      const result = await validator.validateGraph(
+        ['parent-1'],
+        {},
+        socketOccupancy
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -176,17 +206,23 @@ describe('GraphIntegrityValidator', () => {
 
     it('should use default maxCount of 1 when not specified', async () => {
       const socketOccupancy = new Map([['parent-1:socket-1', 2]]);
-      
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1' }], // No maxCount specified
-          };
-        }
-        return null;
-      });
 
-      const result = await validator.validateGraph(['parent-1'], {}, socketOccupancy);
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1' }], // No maxCount specified
+            };
+          }
+          return null;
+        }
+      );
+
+      const result = await validator.validateGraph(
+        ['parent-1'],
+        {},
+        socketOccupancy
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -199,7 +235,11 @@ describe('GraphIntegrityValidator', () => {
     it('should skip validation if recipe has no constraints', async () => {
       const recipe = {}; // No constraints
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
@@ -218,7 +258,11 @@ describe('GraphIntegrityValidator', () => {
         'tag-2',
       ]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
@@ -236,11 +280,15 @@ describe('GraphIntegrityValidator', () => {
         'tag-1', // Only has tag-1, missing tag-2
       ]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
-        "Co-presence constraint violated: have [tag-1] but missing [tag-2]"
+        'Co-presence constraint violated: have [tag-1] but missing [tag-2]'
       );
     });
 
@@ -257,7 +305,11 @@ describe('GraphIntegrityValidator', () => {
         'tag-1', // Only has one of the excluded tags
       ]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
@@ -276,11 +328,15 @@ describe('GraphIntegrityValidator', () => {
         'tag-2', // Has both excluded tags
       ]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
-        "Mutual exclusion constraint violated: cannot have both [tag-1, tag-2]"
+        'Mutual exclusion constraint violated: cannot have both [tag-1, tag-2]'
       );
     });
 
@@ -292,16 +348,22 @@ describe('GraphIntegrityValidator', () => {
       };
 
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:part') {
-          if (entityId === 'entity-1') return { subType: 'arm' };
-          if (entityId === 'entity-2') return { subType: 'hand' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:part') {
+            if (entityId === 'entity-1') return { subType: 'arm' };
+            if (entityId === 'entity-2') return { subType: 'hand' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
       mockEntityManager.getAllComponentTypesForEntity.mockReturnValue([]);
 
-      const result = await validator.validateGraph(['entity-1', 'entity-2'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1', 'entity-2'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
@@ -317,15 +379,21 @@ describe('GraphIntegrityValidator', () => {
       };
 
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:part' && entityId === 'entity-1') {
-          return { subType: 'arm' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:part' && entityId === 'entity-1') {
+            return { subType: 'arm' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
       mockEntityManager.getAllComponentTypesForEntity.mockReturnValue([]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
       expect(result.warnings).toContain(
@@ -344,15 +412,21 @@ describe('GraphIntegrityValidator', () => {
       };
 
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:part' && entityId === 'entity-1') {
-          return { subType: 'arm' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:part' && entityId === 'entity-1') {
+            return { subType: 'arm' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
       mockEntityManager.getAllComponentTypesForEntity.mockReturnValue([]);
 
-      const result = await validator.validateGraph(['entity-1'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
       expect(result.warnings).toContain(
@@ -372,15 +446,21 @@ describe('GraphIntegrityValidator', () => {
       };
 
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:part') {
-          return { subType: 'arm' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:part') {
+            return { subType: 'arm' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
       mockEntityManager.getAllComponentTypesForEntity.mockReturnValue([]);
 
-      const result = await validator.validateGraph(['entity-1', 'entity-2'], recipe, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1', 'entity-2'],
+        recipe,
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
       expect(result.warnings).toContain(
@@ -392,113 +472,202 @@ describe('GraphIntegrityValidator', () => {
   describe('validateNoCycles', () => {
     it('should pass for acyclic graph', async () => {
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:joint') {
-          if (entityId === 'child-1') return { parentId: 'parent-1', socketId: 'socket-1', jointType: 'fixed' };
-          if (entityId === 'child-2') return { parentId: 'parent-1', socketId: 'socket-2', jointType: 'fixed' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:joint') {
+            if (entityId === 'child-1')
+              return {
+                parentId: 'parent-1',
+                socketId: 'socket-1',
+                jointType: 'fixed',
+              };
+            if (entityId === 'child-2')
+              return {
+                parentId: 'parent-1',
+                socketId: 'socket-2',
+                jointType: 'fixed',
+              };
+          }
+          if (componentId === 'anatomy:sockets' && entityId === 'parent-1') {
+            return {
+              sockets: [
+                { id: 'socket-1', allowedTypes: ['child'], jointType: 'fixed' },
+                { id: 'socket-2', allowedTypes: ['child'], jointType: 'fixed' },
+              ],
+            };
+          }
+          if (componentId === 'anatomy:part') {
+            return { subType: 'child' };
+          }
+          return null;
         }
-        if (componentId === 'anatomy:sockets' && entityId === 'parent-1') {
-          return {
-            sockets: [
-              { id: 'socket-1', allowedTypes: ['child'], jointType: 'fixed' },
-              { id: 'socket-2', allowedTypes: ['child'], jointType: 'fixed' },
-            ],
-          };
-        }
-        if (componentId === 'anatomy:part') {
-          return { subType: 'child' };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'child-1', 'child-2'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'child-1', 'child-2'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
 
     it('should detect direct cycle', async () => {
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:joint') {
-          if (entityId === 'entity-1') return { parentId: 'entity-2', socketId: 'socket-1', jointType: 'fixed' };
-          if (entityId === 'entity-2') return { parentId: 'entity-1', socketId: 'socket-2', jointType: 'fixed' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:joint') {
+            if (entityId === 'entity-1')
+              return {
+                parentId: 'entity-2',
+                socketId: 'socket-1',
+                jointType: 'fixed',
+              };
+            if (entityId === 'entity-2')
+              return {
+                parentId: 'entity-1',
+                socketId: 'socket-2',
+                jointType: 'fixed',
+              };
+          }
+          if (componentId === 'anatomy:sockets') {
+            return {
+              sockets: [
+                {
+                  id: 'socket-1',
+                  allowedTypes: ['entity'],
+                  jointType: 'fixed',
+                },
+                {
+                  id: 'socket-2',
+                  allowedTypes: ['entity'],
+                  jointType: 'fixed',
+                },
+              ],
+            };
+          }
+          if (componentId === 'anatomy:part') {
+            return { subType: 'entity' };
+          }
+          return null;
         }
-        if (componentId === 'anatomy:sockets') {
-          return {
-            sockets: [
-              { id: 'socket-1', allowedTypes: ['entity'], jointType: 'fixed' },
-              { id: 'socket-2', allowedTypes: ['entity'], jointType: 'fixed' },
-            ],
-          };
-        }
-        if (componentId === 'anatomy:part') {
-          return { subType: 'entity' };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['entity-1', 'entity-2'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1', 'entity-2'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('Cycle detected:'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('Cycle detected:'))).toBe(
+        true
+      );
     });
 
     it('should detect indirect cycle', async () => {
       mockEntityManager.getEntityInstance.mockReturnValue({});
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (componentId === 'anatomy:joint') {
-          if (entityId === 'entity-1') return { parentId: 'entity-3', socketId: 'socket-1', jointType: 'fixed' };
-          if (entityId === 'entity-2') return { parentId: 'entity-1', socketId: 'socket-2', jointType: 'fixed' };
-          if (entityId === 'entity-3') return { parentId: 'entity-2', socketId: 'socket-3', jointType: 'fixed' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (componentId === 'anatomy:joint') {
+            if (entityId === 'entity-1')
+              return {
+                parentId: 'entity-3',
+                socketId: 'socket-1',
+                jointType: 'fixed',
+              };
+            if (entityId === 'entity-2')
+              return {
+                parentId: 'entity-1',
+                socketId: 'socket-2',
+                jointType: 'fixed',
+              };
+            if (entityId === 'entity-3')
+              return {
+                parentId: 'entity-2',
+                socketId: 'socket-3',
+                jointType: 'fixed',
+              };
+          }
+          if (componentId === 'anatomy:sockets') {
+            return {
+              sockets: [
+                {
+                  id: 'socket-1',
+                  allowedTypes: ['entity'],
+                  jointType: 'fixed',
+                },
+                {
+                  id: 'socket-2',
+                  allowedTypes: ['entity'],
+                  jointType: 'fixed',
+                },
+                {
+                  id: 'socket-3',
+                  allowedTypes: ['entity'],
+                  jointType: 'fixed',
+                },
+              ],
+            };
+          }
+          if (componentId === 'anatomy:part') {
+            return { subType: 'entity' };
+          }
+          return null;
         }
-        if (componentId === 'anatomy:sockets') {
-          return {
-            sockets: [
-              { id: 'socket-1', allowedTypes: ['entity'], jointType: 'fixed' },
-              { id: 'socket-2', allowedTypes: ['entity'], jointType: 'fixed' },
-              { id: 'socket-3', allowedTypes: ['entity'], jointType: 'fixed' },
-            ],
-          };
-        }
-        if (componentId === 'anatomy:part') {
-          return { subType: 'entity' };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['entity-1', 'entity-2', 'entity-3'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['entity-1', 'entity-2', 'entity-3'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('Cycle detected'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('Cycle detected'))).toBe(
+        true
+      );
     });
   });
 
   describe('validateJointConsistency', () => {
     it('should pass for valid joints', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'child-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'parent-1', socketId: 'socket-1', jointType: 'ball' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'child-1' && componentId === 'anatomy:joint') {
+            return {
+              parentId: 'parent-1',
+              socketId: 'socket-1',
+              jointType: 'ball',
+            };
+          }
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1', jointType: 'ball' }],
+            };
+          }
+          return null;
         }
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', jointType: 'ball' }],
-          };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'child-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'child-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
 
     it('should error for non-existent parent', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'child-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'missing-parent', socketId: 'socket-1' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'child-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'missing-parent', socketId: 'socket-1' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
 
       const result = await validator.validateGraph(['child-1'], {}, new Map());
 
@@ -509,19 +678,25 @@ describe('GraphIntegrityValidator', () => {
     });
 
     it('should error for non-existent socket', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'child-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'parent-1', socketId: 'missing-socket' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'child-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'parent-1', socketId: 'missing-socket' };
+          }
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'other-socket' }],
+            };
+          }
+          return null;
         }
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'other-socket' }],
-          };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'child-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'child-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -530,19 +705,29 @@ describe('GraphIntegrityValidator', () => {
     });
 
     it('should error for joint type mismatch', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'child-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'parent-1', socketId: 'socket-1', jointType: 'hinge' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'child-1' && componentId === 'anatomy:joint') {
+            return {
+              parentId: 'parent-1',
+              socketId: 'socket-1',
+              jointType: 'hinge',
+            };
+          }
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'socket-1', jointType: 'ball' }],
+            };
+          }
+          return null;
         }
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', jointType: 'ball' }],
-          };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'child-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'child-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -553,25 +738,33 @@ describe('GraphIntegrityValidator', () => {
 
   describe('validateNoOrphans', () => {
     it('should not warn for connected parts', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'child-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'parent-1', socketId: 'socket-1' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'child-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'parent-1', socketId: 'socket-1' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'child-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'child-1'],
+        {},
+        new Map()
+      );
 
       expect(result.warnings).toEqual([]);
     });
 
     it('should warn for orphaned parts', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'orphan-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'missing-parent', socketId: 'socket-1' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'orphan-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'missing-parent', socketId: 'socket-1' };
+          }
+          return null;
         }
-        return null;
-      });
+      );
 
       const result = await validator.validateGraph(['orphan-1'], {}, new Map());
 
@@ -583,43 +776,55 @@ describe('GraphIntegrityValidator', () => {
 
   describe('validatePartTypeCompatibility', () => {
     it('should pass for compatible part types', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'arm-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'torso-1', socketId: 'shoulder' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'arm-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'torso-1', socketId: 'shoulder' };
+          }
+          if (entityId === 'arm-1' && componentId === 'anatomy:part') {
+            return { subType: 'arm' };
+          }
+          if (entityId === 'torso-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'shoulder', allowedTypes: ['arm', 'wing'] }],
+            };
+          }
+          return null;
         }
-        if (entityId === 'arm-1' && componentId === 'anatomy:part') {
-          return { subType: 'arm' };
-        }
-        if (entityId === 'torso-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'shoulder', allowedTypes: ['arm', 'wing'] }],
-          };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['torso-1', 'arm-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['torso-1', 'arm-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(true);
     });
 
     it('should error for incompatible part types', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'leg-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'torso-1', socketId: 'shoulder' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'leg-1' && componentId === 'anatomy:joint') {
+            return { parentId: 'torso-1', socketId: 'shoulder' };
+          }
+          if (entityId === 'leg-1' && componentId === 'anatomy:part') {
+            return { subType: 'leg' };
+          }
+          if (entityId === 'torso-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [{ id: 'shoulder', allowedTypes: ['arm', 'wing'] }],
+            };
+          }
+          return null;
         }
-        if (entityId === 'leg-1' && componentId === 'anatomy:part') {
-          return { subType: 'leg' };
-        }
-        if (entityId === 'torso-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'shoulder', allowedTypes: ['arm', 'wing'] }],
-          };
-        }
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['torso-1', 'leg-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['torso-1', 'leg-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
@@ -628,71 +833,34 @@ describe('GraphIntegrityValidator', () => {
     });
 
     it('should skip validation for missing data', async () => {
-      mockEntityManager.getComponentData.mockImplementation((entityId, componentId) => {
-        if (entityId === 'part-1' && componentId === 'anatomy:joint') {
-          return { parentId: 'parent-1', socketId: 'socket-1', jointType: 'fixed' };
+      mockEntityManager.getComponentData.mockImplementation(
+        (entityId, componentId) => {
+          if (entityId === 'part-1' && componentId === 'anatomy:joint') {
+            return {
+              parentId: 'parent-1',
+              socketId: 'socket-1',
+              jointType: 'fixed',
+            };
+          }
+          if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
+            return {
+              sockets: [
+                { id: 'socket-1', allowedTypes: ['any'], jointType: 'fixed' },
+              ],
+            };
+          }
+          // No anatomy:part component
+          return null;
         }
-        if (entityId === 'parent-1' && componentId === 'anatomy:sockets') {
-          return {
-            sockets: [{ id: 'socket-1', allowedTypes: ['any'], jointType: 'fixed' }],
-          };
-        }
-        // No anatomy:part component
-        return null;
-      });
+      );
 
-      const result = await validator.validateGraph(['parent-1', 'part-1'], {}, new Map());
+      const result = await validator.validateGraph(
+        ['parent-1', 'part-1'],
+        {},
+        new Map()
+      );
 
       expect(result.valid).toBe(true); // Should not error on missing data
     });
-  });
-});
-=======
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { GraphIntegrityValidator } from '../../../src/anatomy/graphIntegrityValidator.js';
-
-describe('GraphIntegrityValidator', () => {
-  let em;
-  let logger;
-  let validator;
-
-  beforeEach(() => {
-    em = {
-      getComponentData: jest.fn(),
-      getEntityInstance: jest.fn(),
-      getComponentsForEntity: jest.fn(() => ({})),
-    };
-    logger = { debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
-    validator = new GraphIntegrityValidator({ entityManager: em, logger });
-  });
-
-  it('detects socket count violations', async () => {
-    em.getComponentData.mockImplementation((id, comp) => {
-      if (comp === 'anatomy:sockets') {
-        return { sockets: [{ id: 's1', maxCount: 1 }] };
-      }
-      return null;
-    });
-    const result = await validator.validateGraph(
-      ['e1'],
-      {},
-      new Map([['e1:s1', 2]])
-    );
-    expect(result.valid).toBe(false);
-    expect(result.errors[0]).toContain('exceeds maxCount');
-  });
-
-  it('warns for orphaned parts', async () => {
-    em.getComponentData.mockImplementation((id, comp) => {
-      if (comp === 'anatomy:joint') {
-        return { parentId: 'missing', socketId: 's1', jointType: 'ball' };
-      }
-      if (comp === 'anatomy:sockets') {
-        return { sockets: [] };
-      }
-      return null;
-    });
-    const result = await validator.validateGraph(['child'], {}, new Map());
-    expect(result.warnings[0]).toContain('orphaned');
   });
 });

--- a/tests/unit/common/engine/gameEngineHelpers.test.js
+++ b/tests/unit/common/engine/gameEngineHelpers.test.js
@@ -125,8 +125,8 @@ describe('runUnavailableServiceTest', () => {
       [tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE],
     ];
 
-    const testCases = runUnavailableServiceTest(cases, (bed, engine) => {
-      engine.showLoadGameUI();
+    const testCases = runUnavailableServiceTest(cases, async (bed, engine) => {
+      await engine.showLoadGameUI();
       return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
     });
 

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -8,8 +8,8 @@ import { GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE } from '../../common/engine/unavai
 
 describeEngineSuite('GameEngine', (context) => {
   describe('showLoadGameUI', () => {
-    it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', () => {
-      context.engine.showLoadGameUI(); // Method is now sync
+    it('should dispatch REQUEST_SHOW_LOAD_GAME_UI and log intent if persistence service is available', async () => {
+      await context.engine.showLoadGameUI();
 
       expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
         'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
@@ -21,8 +21,8 @@ describeEngineSuite('GameEngine', (context) => {
 
     generateServiceUnavailableTests(
       [[tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE]],
-      (bed, engine) => {
-        engine.showLoadGameUI();
+      async (bed, engine) => {
+        await engine.showLoadGameUI();
         return [bed.getLogger().error, bed.getSafeEventDispatcher().dispatch];
       },
       {}

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -12,11 +12,11 @@ describeInitializedEngineSuite(
   'GameEngine',
   (context) => {
     describe('showSaveGameUI', () => {
-      it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', () => {
+      it('should dispatch REQUEST_SHOW_SAVE_GAME_UI if saving is allowed and log intent', async () => {
         context.bed
           .getGamePersistenceService()
           .isSavingAllowed.mockReturnValue(true);
-        context.engine.showSaveGameUI(); // Method is now sync
+        await context.engine.showSaveGameUI();
 
         expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
@@ -29,11 +29,11 @@ describeInitializedEngineSuite(
         );
       });
 
-      it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', () => {
+      it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', async () => {
         context.bed
           .getGamePersistenceService()
           .isSavingAllowed.mockReturnValue(false);
-        context.engine.showSaveGameUI(); // Method is now sync
+        await context.engine.showSaveGameUI();
 
         expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
           'GameEngine.showSaveGameUI: Saving is not currently allowed.'
@@ -51,8 +51,8 @@ describeInitializedEngineSuite(
 
       generateServiceUnavailableTests(
         [[tokens.GamePersistenceService, GAME_PERSISTENCE_SAVE_UI_UNAVAILABLE]],
-        (bed, engine) => {
-          engine.showSaveGameUI();
+        async (bed, engine) => {
+          await engine.showSaveGameUI();
           // eslint-disable-next-line jest/no-standalone-expect
           expect(
             bed.getGamePersistenceService().isSavingAllowed


### PR DESCRIPTION
## Summary
- make `showSaveGameUI` and `showLoadGameUI` async
- await UI dispatch calls after starting the game
- update button listeners to await save/load UI calls
- fix unit tests expecting async behavior
- clean up duplicate test code

## Testing Done
- `npm run lint` *(fails: 717 errors, 2933 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686143df0b348331859c65fc5ecc097e