### PR TITLE
[Agent] Improve invalid input error type

### DIFF
--- a/src/commands/interpreters/commandOutcomeInterpreter.js
+++ b/src/commands/interpreters/commandOutcomeInterpreter.js
@@ -22,6 +22,7 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { initLogger } from '../../utils/index.js';
 import { createErrorDetails } from '../../utils/errorDetails.js';
 import { validateDependency } from '../../utils/dependencyUtils.js';
+import { InvalidArgumentError } from '../../errors/invalidArgumentError.js';
 
 /**
  * @class CommandOutcomeInterpreter
@@ -53,13 +54,13 @@ class CommandOutcomeInterpreter extends ICommandOutcomeInterpreter {
    * @param {string} message - Human readable error message.
    * @param {object} [details] - Structured diagnostic details.
    * @returns {never} Throws an error; does not return.
-   * @throws {Error} Always throws with the provided message.
+   * @throws {InvalidArgumentError} Always throws with the provided message.
    * @private
    */
   #reportInvalidInput(message, details) {
     safeDispatchError(this.#dispatcher, message, details);
     this.#logger.error(message, details);
-    throw new Error(message);
+    throw new InvalidArgumentError(message);
   }
 
   /**

--- a/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.additional.test.js
@@ -8,6 +8,7 @@ import CommandOutcomeInterpreter from '../../../src/commands/interpreters/comman
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 let logger;
 let dispatcher;
@@ -49,7 +50,9 @@ describe('CommandOutcomeInterpreter additional branches', () => {
   it('dispatches error when result lacks success flag', async () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     await expect(interpreter.interpret({}, turnContext)).rejects.toThrow(
-      "CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: actor-1."
+      new InvalidArgumentError(
+        "CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: actor-1."
+      )
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
@@ -127,7 +130,9 @@ describe('CommandOutcomeInterpreter additional branches', () => {
   it('dispatches error when turnContext is missing getActor', async () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     await expect(interpreter.interpret({}, {})).rejects.toThrow(
-      'CommandOutcomeInterpreter: Invalid turnContext provided.'
+      new InvalidArgumentError(
+        'CommandOutcomeInterpreter: Invalid turnContext provided.'
+      )
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
@@ -149,7 +154,9 @@ describe('CommandOutcomeInterpreter additional branches', () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     turnContext.getActor.mockReturnValue({});
     await expect(interpreter.interpret({}, turnContext)).rejects.toThrow(
-      'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+      new InvalidArgumentError(
+        'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+      )
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,

--- a/tests/unit/interpreters/commandOutcomeInterpreter.helpers.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.helpers.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import CommandOutcomeInterpreter from '../../../src/commands/interpreters/commandOutcomeInterpreter.js';
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
 import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
   safeDispatchError: jest.fn(() => Promise.resolve()),
@@ -30,7 +31,9 @@ describe('CommandOutcomeInterpreter helper logic via interpret', () => {
   it('validateTurnContext dispatches error for invalid context', async () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     await expect(interpreter.interpret({}, {})).rejects.toThrow(
-      'CommandOutcomeInterpreter: Invalid turnContext provided.'
+      new InvalidArgumentError(
+        'CommandOutcomeInterpreter: Invalid turnContext provided.'
+      )
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,
@@ -47,7 +50,9 @@ describe('CommandOutcomeInterpreter helper logic via interpret', () => {
   it('validateResult dispatches error when success flag missing', async () => {
     const interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
     await expect(interpreter.interpret({}, turnContext)).rejects.toThrow(
-      "CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: actor-1."
+      new InvalidArgumentError(
+        "CommandOutcomeInterpreter: Invalid CommandResult - 'success' boolean is missing. Actor: actor-1."
+      )
     );
     expect(safeDispatchError).toHaveBeenCalledWith(
       dispatcher,

--- a/tests/unit/interpreters/commandOutcomeInterpreter.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.test.js
@@ -4,6 +4,7 @@ import CommandOutcomeInterpreter from '../../../src/commands/interpreters/comman
 import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
+import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
 // Mocks
 const mockLogger = {
@@ -42,36 +43,48 @@ describe('CommandOutcomeInterpreter', () => {
     it('should throw if turnContext is invalid or actor cannot be retrieved from turnContext', async () => {
       // Test for null turnContext
       await expect(interpreter.interpret({}, null)).rejects.toThrow(
-        'CommandOutcomeInterpreter: Invalid turnContext provided.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Invalid turnContext provided.'
+        )
       );
 
       // Test for turnContext without getActor method
       await expect(interpreter.interpret({}, {})).rejects.toThrow(
-        'CommandOutcomeInterpreter: Invalid turnContext provided.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Invalid turnContext provided.'
+        )
       );
 
       // Test for turnContext.getActor() returning null
       mockTurnContext.getActor.mockReturnValue(null);
       await expect(interpreter.interpret({}, mockTurnContext)).rejects.toThrow(
-        'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        )
       );
 
       // Test for turnContext.getActor() returning an actor without an id
       mockTurnContext.getActor.mockReturnValue({});
       await expect(interpreter.interpret({}, mockTurnContext)).rejects.toThrow(
-        'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        )
       );
 
       // Test for turnContext.getActor() returning an actor with a null id
       mockTurnContext.getActor.mockReturnValue({ id: null });
       await expect(interpreter.interpret({}, mockTurnContext)).rejects.toThrow(
-        'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        )
       );
 
       // Test for turnContext.getActor() returning an actor with an empty string id
       mockTurnContext.getActor.mockReturnValue({ id: '' });
       await expect(interpreter.interpret({}, mockTurnContext)).rejects.toThrow(
-        'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        new InvalidArgumentError(
+          'CommandOutcomeInterpreter: Could not retrieve a valid actor or actor ID from turnContext.'
+        )
       );
     });
   });


### PR DESCRIPTION
Summary: Replace generic Error with InvalidArgumentError in CommandOutcomeInterpreter to improve error specificity.

Changes Made:
- imported InvalidArgumentError and updated #reportInvalidInput implementation
- updated unit tests to expect InvalidArgumentError

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and llm-proxy-server)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_686171788adc8331a4d5f8a46451dc6f