### PR TITLE
[Agent] convert helper methods to JS private

### DIFF
--- a/src/engine/gameSessionManager.js
+++ b/src/engine/gameSessionManager.js
@@ -78,7 +78,7 @@ class GameSessionManager {
    * @param {any} [payload] - Payload for the dispatched event.
    * @returns {Promise<void>} Resolves when preparation completes.
    */
-  async _prepareEngineForOperation(uiEventId, payload) {
+  async #prepareEngineForOperation(uiEventId, payload) {
     if (this.#state.isInitialized || this.#state.isGameLoopRunning) {
       await this.#stopFn();
     }
@@ -105,7 +105,7 @@ class GameSessionManager {
         'GameSessionManager.prepareForNewGameSession: Engine already initialized. Stopping existing game before starting new.'
       );
     }
-    await this._prepareEngineForOperation(null);
+    await this.#prepareEngineForOperation(null);
 
     this.#state.activeWorld = worldName;
     this.#logger.debug(
@@ -120,7 +120,7 @@ class GameSessionManager {
    * @param {string} worldName - Name of the world being started.
    * @returns {Promise<void>} Resolves when setup is complete.
    */
-  async _finalizeGameStart(worldName) {
+  async #finalizeGameStart(worldName) {
     this.#startEngineFn(worldName);
 
     if (this.#playtimeTracker) {
@@ -164,7 +164,7 @@ class GameSessionManager {
     this.#logger.debug(
       `GameSessionManager.finalizeNewGameSuccess: Initialization successful for world "${worldName}". Finalizing new game setup.`
     );
-    await this._finalizeGameStart(worldName);
+    await this.#finalizeGameStart(worldName);
     this.#logger.debug(
       `GameSessionManager.finalizeNewGameSuccess: New game started and ready (World: ${this.#state.activeWorld}).`
     );
@@ -183,7 +183,7 @@ class GameSessionManager {
 
     const shortSaveName = saveIdentifier.split(/[/\\]/).pop() || saveIdentifier;
 
-    await this._prepareEngineForOperation(ENGINE_OPERATION_IN_PROGRESS_UI, {
+    await this.#prepareEngineForOperation(ENGINE_OPERATION_IN_PROGRESS_UI, {
       titleMessage: `Loading ${shortSaveName}...`,
       inputDisabledMessage: `Loading game from ${shortSaveName}...`,
     });
@@ -204,7 +204,7 @@ class GameSessionManager {
 
     this.#state.activeWorld =
       loadedSaveData.metadata?.gameTitle || 'Restored Game';
-    await this._finalizeGameStart(this.#state.activeWorld);
+    await this.#finalizeGameStart(this.#state.activeWorld);
     this.#logger.debug(
       `GameSessionManager.finalizeLoadSuccess: Game loaded from "${saveIdentifier}" (World: ${this.#state.activeWorld}) and resumed.`
     );

--- a/src/engine/persistenceCoordinator.js
+++ b/src/engine/persistenceCoordinator.js
@@ -69,7 +69,7 @@ class PersistenceCoordinator {
    * @param {string} saveName - Name of the save being created.
    * @returns {Promise<void>} Resolves when the event is dispatched.
    */
-  async _dispatchSavingUI(saveName) {
+  async #dispatchSavingUI(saveName) {
     this.#logger.debug(
       `GameEngine.triggerManualSave: Dispatching ENGINE_OPERATION_IN_PROGRESS_UI for save: "${saveName}".`
     );
@@ -86,7 +86,7 @@ class PersistenceCoordinator {
    * @param {string} saveName - Save name.
    * @returns {Promise<SaveResult & {saveName: string}>} Result from the persistence service.
    */
-  async _performSave(saveName) {
+  async #performSave(saveName) {
     try {
       const result = await this.#persistenceService.saveGame(
         saveName,
@@ -116,7 +116,7 @@ class PersistenceCoordinator {
    * @param {SaveResult & {saveName: string}} saveResult - Result of the save operation.
    * @returns {Promise<void>} Resolves when UI updates have been dispatched.
    */
-  async _dispatchSaveResult(saveResult) {
+  async #dispatchSaveResult(saveResult) {
     const { saveName } = saveResult;
     if (saveResult.success) {
       this.#logger.debug(
@@ -175,11 +175,11 @@ class PersistenceCoordinator {
       return { success: false, error: errorMsg };
     }
 
-    await this._dispatchSavingUI(saveName);
+    await this.#dispatchSavingUI(saveName);
 
-    const saveResultWithName = await this._performSave(saveName);
+    const saveResultWithName = await this.#performSave(saveName);
 
-    await this._dispatchSaveResult(saveResultWithName);
+    await this.#dispatchSaveResult(saveResultWithName);
 
     const { saveName: _ignored, ...result } = saveResultWithName;
     return result;
@@ -191,7 +191,7 @@ class PersistenceCoordinator {
    * @param {string} saveIdentifier - Identifier of the save to load.
    * @returns {Promise<import('../interfaces/IGamePersistenceService.js').LoadAndRestoreResult>} Outcome of the load.
    */
-  async _executeLoadAndRestore(saveIdentifier) {
+  async #executeLoadAndRestore(saveIdentifier) {
     this.#logger.debug(
       `GameEngine._executeLoadAndRestore: Calling IGamePersistenceService.loadAndRestoreGame for "${saveIdentifier}"...`
     );
@@ -225,7 +225,7 @@ class PersistenceCoordinator {
 
     try {
       await this.#sessionManager.prepareForLoadGameSession(saveIdentifier);
-      const restoreOutcome = await this._executeLoadAndRestore(saveIdentifier);
+      const restoreOutcome = await this.#executeLoadAndRestore(saveIdentifier);
 
       if (restoreOutcome.success && restoreOutcome.data) {
         const loadedSaveData = /** @type {SaveGameStructure} */ (


### PR DESCRIPTION
Summary:
- refactor helper methods in game engine modules to use class-private `#` syntax
- adjust internal references for new method names

Testing Done:
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68617bd3ecf88331973dcab0ecc516c3