### PR TITLE
[Agent] Modularize LocationRenderer event handler

### DIFF
--- a/src/domUI/locationRenderer.js
+++ b/src/domUI/locationRenderer.js
@@ -10,7 +10,6 @@ import {
   // NAME_COMPONENT_ID, // Handled by EntityDisplayDataProvider
   // DESCRIPTION_COMPONENT_ID, // Handled by EntityDisplayDataProvider
   // EXITS_COMPONENT_ID, // Handled by EntityDisplayDataProvider
-  ACTOR_COMPONENT_ID, // Still needed to filter characters
   // PORTRAIT_COMPONENT_ID might be implicitly used by EntityDisplayDataProvider
 } from '../constants/componentIds.js';
 
@@ -200,7 +199,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       this.logger.warn(
         `${this._logPrefix} '${event.type}' event is missing entityId. Cannot update location display.`
       );
-      this.#clearAllDisplaysOnErrorWithMessage('No entity specified for turn.');
+      this.#clearDisplayWithError('No entity specified for turn.');
       return;
     }
 
@@ -209,35 +208,14 @@ export class LocationRenderer extends BoundDomRendererBase {
     let currentLocationInstanceId;
     try {
       currentLocationInstanceId =
-        this.locationDataService.resolveLocationInstanceId(
-          currentActorEntityId
-        );
+        this.#resolveCurrentLocationId(currentActorEntityId);
       if (!currentLocationInstanceId) {
-        this.#clearAllDisplaysOnErrorWithMessage(
-          `Location for ${currentActorEntityId} is unknown.`
-        );
         return;
       }
 
-      const locationDetails = this.entityDisplayDataProvider.getLocationDetails(
-        currentLocationInstanceId
-      );
-
-      const portraitData =
-        this.entityDisplayDataProvider.getLocationPortraitData(
-          currentLocationInstanceId
-        );
-
-      const charactersInLocation =
-        this.locationDataService.gatherLocationCharacters(
-          currentLocationInstanceId,
-          currentActorEntityId
-        );
-
-      const displayPayload = buildLocationDisplayPayload(
-        locationDetails,
-        portraitData,
-        charactersInLocation
+      const displayPayload = this.#buildDisplayPayload(
+        currentLocationInstanceId,
+        currentActorEntityId
       );
 
       this.render(displayPayload);
@@ -246,7 +224,7 @@ export class LocationRenderer extends BoundDomRendererBase {
         this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `${this._logPrefix} Location details for ID '${currentLocationInstanceId}' not found.`,
         });
-        this.#clearAllDisplaysOnErrorWithMessage(
+        this.#clearDisplayWithError(
           `Location data for '${currentLocationInstanceId}' missing.`
         );
         return;
@@ -255,22 +233,60 @@ export class LocationRenderer extends BoundDomRendererBase {
         message: `${this._logPrefix} Error processing '${event.type}' for entity '${currentActorEntityId}': ${error.message}`,
         details: { stack: error.stack },
       });
-      this.#clearAllDisplaysOnErrorWithMessage(
-        'Error retrieving location details.'
-      );
+      this.#clearDisplayWithError('Error retrieving location details.');
     }
   }
 
   /**
-   * Resolve the location instance ID for the given actor.
+   * Resolve the location instance ID for the given actor and handle missing cases.
    *
    * @private
    * @param {import('../interfaces/CommonTypes').NamespacedId} actorId - Actor entity ID.
-   * @returns {string|null} Instance ID or null when the actor lacks a valid
-   * POSITION_COMPONENT or the entity cannot be located.
+   * @returns {string|null} Resolved location ID or null if not found.
+   */
+  #resolveCurrentLocationId(actorId) {
+    const locId = this.locationDataService.resolveLocationInstanceId(actorId);
+    if (!locId) {
+      this.#clearDisplayWithError(`Location for ${actorId} is unknown.`);
+      return null;
+    }
+    return locId;
+  }
+
+  /**
+   * Build the LocationDisplayPayload for rendering.
+   *
+   * @private
+   * @param {string} locationId - Resolved location instance ID.
+   * @param {import('../interfaces/CommonTypes').NamespacedId} actorId - Actor entity ID.
+   * @returns {LocationDisplayPayload} Structured payload for rendering.
+   */
+  #buildDisplayPayload(locationId, actorId) {
+    const locationDetails =
+      this.entityDisplayDataProvider.getLocationDetails(locationId);
+
+    const portraitData =
+      this.entityDisplayDataProvider.getLocationPortraitData(locationId);
+
+    const charactersInLocation =
+      this.locationDataService.gatherLocationCharacters(locationId, actorId);
+
+    return buildLocationDisplayPayload(
+      locationDetails,
+      portraitData,
+      charactersInLocation
+    );
+  }
+
+  /**
+   * Clear all display elements and show an error message.
+   *
+   * @private
+   * @param {string} message - Error message to display.
+   * @returns {void}
    */
 
-  #clearAllDisplaysOnErrorWithMessage(message) {
+  #clearDisplayWithError(message) {
     const elementsAndDefaults = {
       nameDisplay: `(${DEFAULT_LOCATION_NAME})`,
       // No default for portrait, it will be hidden by render logic
@@ -504,7 +520,7 @@ export class LocationRenderer extends BoundDomRendererBase {
         this.safeEventDispatcher.dispatch(SYSTEM_ERROR_OCCURRED_ID, {
           message: `${this._logPrefix} Cannot render, required DOM element '${elKey}' is missing.`,
         });
-        // Potentially call #clearAllDisplaysOnErrorWithMessage or a similar specific error display
+        // Potentially call #clearDisplayWithError or a similar specific error display
         return;
       }
     }
@@ -513,7 +529,7 @@ export class LocationRenderer extends BoundDomRendererBase {
       this.logger.warn(
         `${this._logPrefix} Received null location DTO. Clearing display.`
       );
-      this.#clearAllDisplaysOnErrorWithMessage('(No location data to display)');
+      this.#clearDisplayWithError('(No location data to display)');
       return;
     }
 


### PR DESCRIPTION
Summary: Refactored `LocationRenderer` to decompose `#handleTurnStarted` into smaller helpers, improving readability and cohesion. Added `#resolveCurrentLocationId` and `#buildDisplayPayload`, renamed error helper to `#clearDisplayWithError`, and updated method calls.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68617bb8f5048331818a803c6434237b