### PR TITLE
[Agent] Add DataRegistryError for registry validation

### DIFF
--- a/src/data/inMemoryDataRegistry.js
+++ b/src/data/inMemoryDataRegistry.js
@@ -6,6 +6,7 @@
 
 /** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 
+import DataRegistryError from '../errors/dataRegistryError.js';
 /**
  * Implements the IDataRegistry interface using in-memory Maps for data storage.
  *
@@ -89,12 +90,12 @@ class InMemoryDataRegistry {
    */
   get(type, id) {
     if (typeof type !== 'string' || type.trim() === '') {
-      throw new Error(
+      throw new DataRegistryError(
         'InMemoryDataRegistry.get: type parameter must be a non-empty string'
       );
     }
     if (typeof id !== 'string' || id.trim() === '') {
-      throw new Error(
+      throw new DataRegistryError(
         'InMemoryDataRegistry.get: id parameter must be a non-empty string'
       );
     }
@@ -109,7 +110,7 @@ class InMemoryDataRegistry {
    */
   getAll(type) {
     if (typeof type !== 'string' || type.trim() === '') {
-      throw new Error(
+      throw new DataRegistryError(
         'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
       );
     }
@@ -198,12 +199,12 @@ class InMemoryDataRegistry {
    */
   getContentSource(type, id) {
     if (typeof type !== 'string' || type.trim() === '') {
-      throw new Error(
+      throw new DataRegistryError(
         'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
       );
     }
     if (typeof id !== 'string' || id.trim() === '') {
-      throw new Error(
+      throw new DataRegistryError(
         'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
       );
     }

--- a/src/errors/dataRegistryError.js
+++ b/src/errors/dataRegistryError.js
@@ -1,0 +1,24 @@
+/**
+ * @file Error class for data registry issues.
+ */
+
+/**
+ * Error thrown when a data registry operation encounters invalid parameters or other issues.
+ *
+ * @class DataRegistryError
+ * @augments {Error}
+ */
+export default class DataRegistryError extends Error {
+  /**
+   * Create a new DataRegistryError.
+   *
+   * @param {string} message - Description of the error.
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'DataRegistryError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DataRegistryError);
+    }
+  }
+}

--- a/tests/unit/services/inMemoryDataRegistry.comprehensive.test.js
+++ b/tests/unit/services/inMemoryDataRegistry.comprehensive.test.js
@@ -1,6 +1,7 @@
 // src/tests/services/inMemoryDataRegistry.comprehensive.test.js
 
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
+import DataRegistryError from '../../../src/errors/dataRegistryError.js';
 import {
   afterEach,
   beforeEach,
@@ -96,16 +97,24 @@ describe('InMemoryDataRegistry', () => {
       expect(console.error).toHaveBeenCalledTimes(4);
       // Check that no data was actually stored for these invalid types
       expect(() => registry.getAll('')).toThrow(
-        'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        )
       );
       expect(() => registry.getAll(' ')).toThrow(
-        'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        )
       );
       expect(() => registry.getAll(null)).toThrow(
-        'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        )
       );
       expect(() => registry.getAll(undefined)).toThrow(
-        'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+        )
       );
     });
 
@@ -118,16 +127,24 @@ describe('InMemoryDataRegistry', () => {
 
       expect(console.error).toHaveBeenCalledTimes(4);
       expect(() => registry.get('validType', '')).toThrow(
-        'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        )
       );
       expect(() => registry.get('validType', ' ')).toThrow(
-        'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        )
       );
       expect(() => registry.get('validType', null)).toThrow(
-        'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        )
       );
       expect(() => registry.get('validType', undefined)).toThrow(
-        'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        new DataRegistryError(
+          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+        )
       );
       expect(registry.getAll('validType')).toEqual([]); // Type might exist but no data stored under invalid IDs
     });

--- a/tests/unit/services/inMemoryDataRegistry.parameterValidation.test.js
+++ b/tests/unit/services/inMemoryDataRegistry.parameterValidation.test.js
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
 
+import DataRegistryError from '../../../src/errors/dataRegistryError.js';
 describe('InMemoryDataRegistry Parameter Validation', () => {
   let registry;
 
@@ -18,7 +19,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get(undefined, 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -26,7 +29,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get(null, 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -34,7 +39,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('', 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -42,7 +49,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('   ', 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -50,7 +59,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get(123, 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -58,7 +69,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get(true, 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -66,7 +79,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get({}, 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -74,7 +89,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get([], 'someId');
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -84,7 +101,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', undefined);
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -92,7 +111,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', null);
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -100,7 +121,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', '');
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -108,7 +131,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', '   ');
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -116,7 +141,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', 123);
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -124,7 +151,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', false);
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -132,7 +161,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', {});
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -140,7 +171,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType', []);
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -150,7 +183,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get();
         }).toThrow(
-          'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -158,7 +193,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.get('testType');
         }).toThrow(
-          'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.get: id parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -192,7 +229,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll(undefined);
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -200,7 +239,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll(null);
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -208,7 +249,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll('');
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -216,7 +259,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll('   ');
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -224,7 +269,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll(123);
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -232,7 +279,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll(true);
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -240,7 +289,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll({});
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -248,7 +299,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll([]);
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -258,7 +311,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getAll();
         }).toThrow(
-          'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getAll: type parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -290,7 +345,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource(undefined, 'testId');
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -298,7 +355,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource(null, 'testId');
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          )
         );
       });
 
@@ -306,7 +365,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource('', 'testId');
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: type parameter must be a non-empty string'
+          )
         );
       });
     });
@@ -316,7 +377,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource('testType', undefined);
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -324,7 +387,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource('testType', null);
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          )
         );
       });
 
@@ -332,7 +397,9 @@ describe('InMemoryDataRegistry Parameter Validation', () => {
         expect(() => {
           registry.getContentSource('testType', '');
         }).toThrow(
-          'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          new DataRegistryError(
+            'InMemoryDataRegistry.getContentSource: id parameter must be a non-empty string'
+          )
         );
       });
     });


### PR DESCRIPTION
## Summary
- add `DataRegistryError` custom class
- use `DataRegistryError` instead of generic Error in `InMemoryDataRegistry`
- update tests to expect the new error type

## Testing Done
- `npx prettier --write src/errors/dataRegistryError.js src/data/inMemoryDataRegistry.js tests/unit/services/inMemoryDataRegistry.parameterValidation.test.js tests/unit/services/inMemoryDataRegistry.comprehensive.test.js`
- `npx eslint src/errors/dataRegistryError.js src/data/inMemoryDataRegistry.js tests/unit/services/inMemoryDataRegistry.parameterValidation.test.js tests/unit/services/inMemoryDataRegistry.comprehensive.test.js`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861793b598c833191cd0f21e0cf7db1