### PR TITLE
[Agent] Add basic tests for command processor and outcome interpreter

### DIFF
--- a/tests/unit/commands/commandProcessor.dispatchAction.basic.test.js
+++ b/tests/unit/commands/commandProcessor.dispatchAction.basic.test.js
@@ -1,0 +1,80 @@
+import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import CommandProcessor from '../../../src/commands/commandProcessor.js';
+import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
+
+const mkLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('CommandProcessor.dispatchAction basic flows', () => {
+  let logger;
+  let dispatcher;
+  let processor;
+
+  beforeEach(() => {
+    logger = mkLogger();
+    dispatcher = { dispatch: jest.fn().mockResolvedValue(true) };
+    processor = new CommandProcessor({
+      logger,
+      safeEventDispatcher: dispatcher,
+    });
+    jest.clearAllMocks();
+  });
+
+  it('returns success when dispatcher resolves true', async () => {
+    const actor = { id: 'a1' };
+    const action = {
+      actionDefinitionId: 'look',
+      commandString: 'look around',
+      resolvedParameters: { targetId: 'room1' },
+    };
+
+    const result = await processor.dispatchAction(actor, action);
+
+    expect(result).toEqual({
+      success: true,
+      turnEnded: false,
+      originalInput: 'look around',
+      actionResult: { actionId: 'look' },
+    });
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      ATTEMPT_ACTION_ID,
+      expect.objectContaining({
+        actorId: 'a1',
+        actionId: 'look',
+      })
+    );
+  });
+
+  it('returns failure when inputs are invalid', async () => {
+    const result = await processor.dispatchAction(
+      {},
+      { actionDefinitionId: 'id' }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      'Internal error: Malformed action prevented execution.'
+    );
+    expect(dispatcher.dispatch).toHaveBeenCalled();
+  });
+
+  it('returns failure when dispatcher reports failure', async () => {
+    dispatcher.dispatch.mockResolvedValueOnce(false);
+
+    const actor = { id: 'p1' };
+    const action = { actionDefinitionId: 'jump', commandString: 'jump' };
+
+    const result = await processor.dispatchAction(actor, action);
+
+    expect(result.success).toBe(false);
+    expect(result.internalError).toMatch('Dispatcher reported failure');
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      ATTEMPT_ACTION_ID,
+      expect.any(Object)
+    );
+  });
+});

--- a/tests/unit/interpreters/commandOutcomeInterpreter.simple.test.js
+++ b/tests/unit/interpreters/commandOutcomeInterpreter.simple.test.js
@@ -1,0 +1,56 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
+import CommandOutcomeInterpreter from '../../../src/commands/interpreters/commandOutcomeInterpreter.js';
+import TurnDirective from '../../../src/turns/constants/turnDirectives.js';
+
+const mkLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('CommandOutcomeInterpreter.interpret basic cases', () => {
+  let logger;
+  let dispatcher;
+  let interpreter;
+  let turnContext;
+
+  beforeEach(() => {
+    logger = mkLogger();
+    dispatcher = { dispatch: jest.fn() };
+    turnContext = {
+      getActor: jest.fn(() => ({ id: 'actor1' })),
+      getChosenAction: jest.fn(() => ({ actionDefinitionId: 'test:action' })),
+    };
+    interpreter = new CommandOutcomeInterpreter({ dispatcher, logger });
+    jest.clearAllMocks();
+  });
+
+  it('returns WAIT_FOR_EVENT when command result indicates success', async () => {
+    const result = {
+      success: true,
+      turnEnded: false,
+      actionResult: { actionId: 'test:action' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.WAIT_FOR_EVENT);
+  });
+
+  it('returns END_TURN_FAILURE when command result indicates failure', async () => {
+    const result = {
+      success: false,
+      turnEnded: true,
+      actionResult: { actionId: 'test:action' },
+    };
+    const directive = await interpreter.interpret(result, turnContext);
+    expect(directive).toBe(TurnDirective.END_TURN_FAILURE);
+  });
+
+  it('throws when turn context is invalid', async () => {
+    await expect(
+      interpreter.interpret({ success: true, turnEnded: false }, null)
+    ).rejects.toThrow(
+      'CommandOutcomeInterpreter: Invalid turnContext provided.'
+    );
+  });
+});


### PR DESCRIPTION
Summary: Add unit tests validating basic flows in command processor and command outcome interpreter.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes (fails with existing repo issues)
- [x] Root tests pass `npm run test`
- [x] Proxy tests pass `npm run test` in llm-proxy-server
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_686178c8686083319848e8101f9390f2