### PR TITLE
[Feat] Extract helper to resolve turn end errors

### DIFF
--- a/src/turns/strategies/endTurnFailureStrategy.js
+++ b/src/turns/strategies/endTurnFailureStrategy.js
@@ -14,6 +14,7 @@ import {
   assertDirective,
   requireContextActor,
   getLoggerAndClass,
+  resolveTurnEndError,
 } from './strategyHelpers.js';
 
 export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
@@ -52,21 +53,11 @@ export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
     // The original check `if (!contextActor || contextActor.id !== actor.id)` is simplified
     // as the explicit `actor` parameter is removed. The primary concern is now whether `contextActor` exists.
 
-    let turnEndError;
-    if (cmdProcResult?.error instanceof Error) {
-      turnEndError = cmdProcResult.error;
-    } else if (
-      cmdProcResult?.error !== undefined &&
-      cmdProcResult?.error !== null
-    ) {
-      // If cmdProcResult.error is present but not an Error instance, wrap it in an Error.
-      turnEndError = new Error(String(cmdProcResult.error));
-    } else {
-      // Default error message if cmdProcResult.error is missing or not an Error instance.
-      turnEndError = new Error(
-        `Turn for actor ${contextActor.id} ended by directive '${directive}' (failure).`
-      );
-    }
+    const turnEndError = resolveTurnEndError(
+      cmdProcResult,
+      contextActor.id,
+      directive
+    );
 
     logger.info(
       `${className}: Executing END_TURN_FAILURE for actor ${contextActor.id}. Error: ${turnEndError.message}`

--- a/src/turns/strategies/strategyHelpers.js
+++ b/src/turns/strategies/strategyHelpers.js
@@ -86,3 +86,24 @@ export function requireContextActor({
   }
   return contextActor;
 }
+
+/**
+ * Determines the appropriate Error object when ending a turn due to failure.
+ *
+ * @param {import('../../types/commandResult.js').CommandResult} cmdProcResult -
+ *        Result produced by command processing.
+ * @param {string} actorId - ID of the actor whose turn is ending.
+ * @param {string} directive - Directive triggering the turn end.
+ * @returns {Error} The error instance describing the failure.
+ */
+export function resolveTurnEndError(cmdProcResult, actorId, directive) {
+  if (cmdProcResult?.error instanceof Error) {
+    return cmdProcResult.error;
+  }
+  if (cmdProcResult?.error !== undefined && cmdProcResult?.error !== null) {
+    return new Error(String(cmdProcResult.error));
+  }
+  return new Error(
+    `Turn for actor ${actorId} ended by directive '${directive}' (failure).`
+  );
+}

--- a/tests/unit/utils/strategyHelpers.test.js
+++ b/tests/unit/utils/strategyHelpers.test.js
@@ -4,6 +4,7 @@ import {
   requireContextActor,
   getLoggerAndClass,
   buildWrongDirectiveMessage,
+  resolveTurnEndError,
 } from '../../../src/turns/strategies/strategyHelpers.js';
 
 describe('strategyHelpers', () => {
@@ -103,6 +104,28 @@ describe('strategyHelpers', () => {
       const msg = buildWrongDirectiveMessage('MyClass', 'BAD', 'GOOD');
       expect(msg).toBe(
         'MyClass: Received wrong directive (BAD). Expected GOOD.'
+      );
+    });
+  });
+
+  describe('resolveTurnEndError', () => {
+    it('returns error from command result when instance of Error', () => {
+      const error = new Error('boom');
+      const result = resolveTurnEndError({ error }, 'a1', 'DIR');
+      expect(result).toBe(error);
+    });
+
+    it('wraps non-error value from command result', () => {
+      const result = resolveTurnEndError({ error: 'oops' }, 'a1', 'DIR');
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('oops');
+    });
+
+    it('creates default message when no error provided', () => {
+      const result = resolveTurnEndError({}, 'actor42', 'END_TURN');
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe(
+        "Turn for actor actor42 ended by directive 'END_TURN' (failure)."
       );
     });
   });


### PR DESCRIPTION
Summary: Extracted conditional logic from `EndTurnFailureStrategy.execute` into a new `resolveTurnEndError` helper in `strategyHelpers.js`. Updated strategy to use this helper and added unit tests verifying its behavior.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686185822fdc8331a009360e5f6d6823