### PR TITLE
[Agent] update LLMChooser return type

### DIFF
--- a/src/turns/adapters/llmChooser.js
+++ b/src/turns/adapters/llmChooser.js
@@ -54,7 +54,7 @@ export class LLMChooser extends ILLMChooser {
    *   actions:  Array,               // The definitive, indexed list of actions
    *   abortSignal?: AbortSignal
    * }} options
-   * @returns {Promise<{ index: number|null, speech: string|null }>}
+   * @returns {Promise<{ index: number|null, speech: string|null, thoughts: string|null, notes: string[]|null }>}
    */
   async choose({ actor, context, actions, abortSignal }) {
     this.#logger.debug(`LLMChooser.choose → actor=${actor.id}`);

--- a/src/turns/ports/ILLMChooser.js
+++ b/src/turns/ports/ILLMChooser.js
@@ -4,14 +4,14 @@
  * @description Given a prompt, returns which action index the LLM chose.
  * @function choose
  * @param {{ actor: Entity, context: ITurnContext, actions: ActionComposite[], abortSignal: AbortSignal }} params
- * @returns {{ index: number, speech: string|null }}
+ * @returns {{ index: number, speech: string|null, thoughts: string|null, notes: string[]|null }}
  */
 export class ILLMChooser {
   /**
    * Chooses an action based on the provided parameters.
    *
    * @param {{ actor: Entity, context: ITurnContext, actions: ActionComposite[], abortSignal: AbortSignal }} params
-   * @returns {{ index: number, speech: string|null }}
+   * @returns {{ index: number, speech: string|null, thoughts: string|null, notes: string[]|null }}
    */
   choose(params) {
     throw new Error('Interface method');


### PR DESCRIPTION
## Summary
- include thoughts and notes in `ILLMChooser` return type
- update `LLMChooser` adapter JSDoc

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686184dfdc948331a1d5ed621dbfee6e