### PR TITLE
[Agent] Clarify config validation return description

### DIFF
--- a/src/llms/llmConfigService.js
+++ b/src/llms/llmConfigService.js
@@ -158,7 +158,7 @@ export class LLMConfigService {
    *
    * @private
    * @param {any} config - The configuration object to validate.
-   * @returns {boolean} True if the dependencyInjection is valid, false otherwise.
+   * @returns {boolean} True if the configuration object is valid, false otherwise.
    */
   #isValidConfig(config) {
     if (!config || typeof config !== 'object') {


### PR DESCRIPTION
Summary: Adjusts documentation for the config validation helper to reference the configuration object instead of dependency injection.

Changes Made:
- Updated the JSDoc return description in `llmConfigService`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6861846290d08331bb554187a5ade5a9