### PR TITLE
[Agent] add IMoveEntityHandler interface

### DIFF
--- a/src/dependencyInjection/registrations/operationHandlerRegistrations.js
+++ b/src/dependencyInjection/registrations/operationHandlerRegistrations.js
@@ -157,6 +157,11 @@ export function registerOperationHandlers(registrar) {
         }),
     ],
     [
+      tokens.IMoveEntityHandler,
+      SystemMoveEntityHandler,
+      (c) => c.resolve(tokens.SystemMoveEntityHandler),
+    ],
+    [
       tokens.GetTimestampHandler,
       GetTimestampHandler,
       (c, Handler) => new Handler({ logger: c.resolve(tokens.ILogger) }),
@@ -296,7 +301,7 @@ export function registerOperationHandlers(registrar) {
         new Handler({
           logger: c.resolve(tokens.ILogger),
           entityManager: c.resolve(tokens.IEntityManager),
-          systemMoveEntityHandler: c.resolve(tokens.SystemMoveEntityHandler),
+          moveEntityHandler: c.resolve(tokens.IMoveEntityHandler),
           safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
         }),
     ],

--- a/src/dependencyInjection/tokens/tokens-core.js
+++ b/src/dependencyInjection/tokens/tokens-core.js
@@ -128,6 +128,7 @@ export const coreTokens = freeze({
   SetVariableHandler: 'SetVariableHandler',
   EndTurnHandler: 'EndTurnHandler',
   SystemMoveEntityHandler: 'SystemMoveEntityHandler',
+  IMoveEntityHandler: 'IMoveEntityHandler',
   GetTimestampHandler: 'GetTimestampHandler',
   GetNameHandler: 'GetNameHandler',
   RebuildLeaderListCacheHandler: 'RebuildLeaderListCacheHandler',

--- a/src/interfaces/IMoveEntityHandler.js
+++ b/src/interfaces/IMoveEntityHandler.js
@@ -1,0 +1,22 @@
+/**
+ * @file Interface for handlers that move an entity between locations.
+ */
+
+/** @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext */
+
+/**
+ * @interface IMoveEntityHandler
+ * @description Defines a contract for moving an entity from one location to another.
+ */
+export class IMoveEntityHandler {
+  /**
+   * Execute a move operation.
+   *
+   * @param {object} params - Parameters for the move operation.
+   * @param {ExecutionContext} executionContext - The execution context.
+   * @returns {Promise<void>|void}
+   */
+  execute(params, executionContext) {
+    throw new Error('IMoveEntityHandler.execute not implemented.');
+  }
+}

--- a/src/logic/operationHandlers/autoMoveFollowersHandler.js
+++ b/src/logic/operationHandlers/autoMoveFollowersHandler.js
@@ -14,9 +14,9 @@ import {
   LEADING_COMPONENT_ID,
 } from '../../constants/componentIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
-import SystemMoveEntityHandler from './systemMoveEntityHandler.js';
 import BaseOperationHandler from './baseOperationHandler.js';
 import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
+/** @typedef {import('../../interfaces/IMoveEntityHandler.js').IMoveEntityHandler} IMoveEntityHandler */
 
 /**
  * @implements {OperationHandler}
@@ -24,19 +24,19 @@ import { assertParamsObject } from '../../utils/handlerUtils/indexUtils.js';
 class AutoMoveFollowersHandler extends BaseOperationHandler {
   /** @type {EntityManager} */ #entityManager;
   /** @type {ISafeEventDispatcher} */ #dispatcher;
-  /** @type {SystemMoveEntityHandler} */ #moveHandler;
+  /** @type {IMoveEntityHandler} */ #moveHandler;
 
   /**
    * @param {object} deps
    * @param {ILogger} deps.logger
    * @param {EntityManager} deps.entityManager
-   * @param {SystemMoveEntityHandler} deps.systemMoveEntityHandler
+   * @param {IMoveEntityHandler} deps.moveEntityHandler
    * @param {ISafeEventDispatcher} deps.safeEventDispatcher
    */
   constructor({
     logger,
     entityManager,
-    systemMoveEntityHandler,
+    moveEntityHandler,
     safeEventDispatcher,
   }) {
     super('AutoMoveFollowersHandler', {
@@ -45,8 +45,8 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
         value: entityManager,
         requiredMethods: ['getEntitiesWithComponent', 'getComponentData'],
       },
-      systemMoveEntityHandler: {
-        value: systemMoveEntityHandler,
+      moveEntityHandler: {
+        value: moveEntityHandler,
         requiredMethods: ['execute'],
       },
       safeEventDispatcher: {
@@ -56,7 +56,7 @@ class AutoMoveFollowersHandler extends BaseOperationHandler {
     });
 
     this.#entityManager = entityManager;
-    this.#moveHandler = systemMoveEntityHandler;
+    this.#moveHandler = moveEntityHandler;
     this.#dispatcher = safeEventDispatcher;
   }
 

--- a/tests/unit/dependencyInjection/registrations/interpreterRegistrations.autoAndMergeHandlers.test.js
+++ b/tests/unit/dependencyInjection/registrations/interpreterRegistrations.autoAndMergeHandlers.test.js
@@ -36,7 +36,7 @@ describe('interpreterRegistrations', () => {
       registrar.instance(tokens.ILogger, mockLogger);
       registrar.instance(tokens.IEntityManager, mockEntityManager);
       registrar.instance(
-        tokens.SystemMoveEntityHandler,
+        tokens.IMoveEntityHandler,
         mockSystemMoveEntityHandler
       );
       registrar.instance(tokens.ISafeEventDispatcher, mockSafeEventDispatcher);

--- a/tests/unit/dependencyInjection/registrations/operationHandlerRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/operationHandlerRegistrations.test.js
@@ -37,6 +37,7 @@ describe('registerOperationHandlers', () => {
       tokens.SetVariableHandler,
       tokens.EndTurnHandler,
       tokens.SystemMoveEntityHandler,
+      tokens.IMoveEntityHandler,
       tokens.GetTimestampHandler,
       tokens.GetNameHandler,
       tokens.RebuildLeaderListCacheHandler,

--- a/tests/unit/logic/operationHandlers/autoMoveFollowersHandler.test.js
+++ b/tests/unit/logic/operationHandlers/autoMoveFollowersHandler.test.js
@@ -39,7 +39,7 @@ beforeEach(() => {
   handler = new AutoMoveFollowersHandler({
     logger,
     entityManager,
-    systemMoveEntityHandler: moveHandler,
+    moveEntityHandler: moveHandler,
     safeEventDispatcher: dispatcher,
   });
 });


### PR DESCRIPTION
Summary: introduce minimal IMoveEntityHandler interface and use it in AutoMoveFollowersHandler for loose coupling. Updated DI registration and related tests.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686187632f5083319bd2dd31e9f8cc68