### PR TITLE
[Agent] centralize error snippet utility

### DIFF
--- a/src/scopeDsl/parser/errorSnippet.js
+++ b/src/scopeDsl/parser/errorSnippet.js
@@ -1,0 +1,21 @@
+/**
+ * @file errorSnippet.js
+ * @description Utility for generating formatted error snippets used in parser
+ *   diagnostics. Provides a helper function that extracts the relevant line
+ *   from the original source and places a caret under the offending column.
+ */
+
+/**
+ * Generates a code snippet with a pointer for error messages.
+ *
+ * @param {string} input - The full source code string.
+ * @param {number} line - The line number (1-based).
+ * @param {number} column - The column number (1-based).
+ * @returns {string} The formatted code snippet.
+ */
+export function generateErrorSnippet(input, line, column) {
+  const lineContent = input.split('\n')[line - 1] || '';
+  return `${lineContent}\n${' '.repeat(column - 1)}^`;
+}
+
+export default generateErrorSnippet;

--- a/src/scopeDsl/parser/parser.js
+++ b/src/scopeDsl/parser/parser.js
@@ -24,6 +24,7 @@
 
 import { Tokenizer, ScopeSyntaxError } from './tokenizer.js';
 import createDepthGuard from '../core/depthGuard.js';
+import { generateErrorSnippet } from './errorSnippet.js';
 
 //────────────────────────────────────────────────────────────────────────────
 // Type annotations (JSDoc – kept succinct for readability)
@@ -46,10 +47,6 @@ export { ScopeSyntaxError };
  * @param {number} column - The column number (1-based).
  * @returns {string} The formatted code snippet.
  */
-function generateErrorSnippet(input, line, column) {
-  const lineContent = input.split('\n')[line - 1] || '';
-  return `${lineContent}\n${' '.repeat(column - 1)}^`;
-}
 
 //────────────────────────────────────────────────────────────────────────────
 // PARSER

--- a/src/scopeDsl/parser/tokenizer.js
+++ b/src/scopeDsl/parser/tokenizer.js
@@ -24,18 +24,7 @@ export class ScopeSyntaxError extends Error {
   }
 }
 
-/**
- * Generates a code snippet with a pointer for error messages.
- *
- * @param {string} input - The full source code string.
- * @param {number} line - The line number (1-based).
- * @param {number} column - The column number (1-based).
- * @returns {string} The formatted code snippet.
- */
-function generateErrorSnippet(input, line, column) {
-  const lineContent = input.split('\n')[line - 1] || '';
-  return `${lineContent}\n${' '.repeat(column - 1)}^`;
-}
+import { generateErrorSnippet } from './errorSnippet.js';
 
 export class Tokenizer {
   /** @param {string} input */


### PR DESCRIPTION
## Summary
- add `errorSnippet.js` for code snippet generation
- use the new utility in `parser.js` and `tokenizer.js`

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686186ee02488331882181f77fa47536