### PR TITLE
[Agent] enforce actor validation in discovery

### DIFF
--- a/src/actions/actionDiscoveryService.js
+++ b/src/actions/actionDiscoveryService.js
@@ -18,6 +18,8 @@ import {
   createDiscoveryError,
   extractTargetId,
 } from './utils/discoveryErrorUtils.js';
+import { InvalidActorEntityError } from '../errors/invalidActorEntityError.js';
+import { isNonBlankString } from '../utils/textUtils.js';
 
 // ────────────────────────────────────────────────────────────────────────────────
 /**
@@ -168,9 +170,21 @@ export class ActionDiscoveryService extends IActionDiscoveryService {
     const trace = shouldTrace ? this.#traceContextFactory() : null;
     const SOURCE = 'getValidActions';
 
-    if (!actorEntity || typeof actorEntity.id !== 'string') {
-      this.#logger.error('getValidActions called with invalid actor entity.');
-      return { actions: [], errors: [], trace: null };
+    if (!actorEntity || !isNonBlankString(actorEntity.id)) {
+      const message =
+        'ActionDiscoveryService.getValidActions: actorEntity parameter must be an object with a non-empty id';
+      this.#logger.error(message, { actorEntity });
+      throw new InvalidActorEntityError(message);
+    }
+
+    if (
+      baseContext !== undefined &&
+      (typeof baseContext !== 'object' || baseContext === null)
+    ) {
+      const message =
+        'ActionDiscoveryService.getValidActions: baseContext must be an object when provided';
+      this.#logger.error(message, { baseContext });
+      throw new Error(message);
     }
 
     trace?.info(

--- a/tests/integration/scopes/scopeIntegration.test.js
+++ b/tests/integration/scopes/scopeIntegration.test.js
@@ -408,15 +408,18 @@ describe('Scope Integration Tests', () => {
   });
 
   describe('error handling', () => {
-    it('should handle missing actingEntity gracefully', async () => {
+    it('should throw InvalidActorEntityError for missing actingEntity', async () => {
       actionDiscoveryService = createActionDiscoveryService();
-      const resultNull = await actionDiscoveryService.getValidActions(null, {});
-      const resultMissing = await actionDiscoveryService.getValidActions(
-        {},
-        {}
+      await expect(
+        actionDiscoveryService.getValidActions(null, {})
+      ).rejects.toThrow(
+        'ActionDiscoveryService.getValidActions: actorEntity parameter must be an object with a non-empty id'
       );
-      expect(resultNull.actions).toEqual([]);
-      expect(resultMissing.actions).toEqual([]);
+      await expect(
+        actionDiscoveryService.getValidActions({}, {})
+      ).rejects.toThrow(
+        'ActionDiscoveryService.getValidActions: actorEntity parameter must be an object with a non-empty id'
+      );
     });
   });
 });

--- a/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
+++ b/tests/unit/actions/actionDiscoveryService.additionalCoverage.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, expect, it } from '@jest/globals';
 import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+import { InvalidActorEntityError } from '../../../src/errors/invalidActorEntityError.js';
 
 // Additional coverage tests for ActionDiscoveryService
 
@@ -11,20 +12,20 @@ describeActionDiscoverySuite(
       bed.mocks.getActorLocationFn.mockReturnValue('room1');
     });
 
-    it('returns empty result when actor entity is null or missing id', async () => {
+    it('throws InvalidActorEntityError when actor entity is null or missing id', async () => {
       const bed = getBed();
 
-      const resultNull = await bed.service.getValidActions(null, {});
-      const resultMissing = await bed.service.getValidActions({}, {});
-
-      expect(resultNull).toEqual({ actions: [], errors: [], trace: null });
-      expect(resultMissing).toEqual({ actions: [], errors: [], trace: null });
-      expect(bed.mocks.logger.error).toHaveBeenCalledTimes(2);
-      expect(bed.mocks.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'getValidActions called with invalid actor entity.'
+      await expect(bed.service.getValidActions(null, {})).rejects.toThrow(
+        new InvalidActorEntityError(
+          'ActionDiscoveryService.getValidActions: actorEntity parameter must be an object with a non-empty id'
         )
       );
+      await expect(bed.service.getValidActions({}, {})).rejects.toThrow(
+        new InvalidActorEntityError(
+          'ActionDiscoveryService.getValidActions: actorEntity parameter must be an object with a non-empty id'
+        )
+      );
+      expect(bed.mocks.logger.error).toHaveBeenCalledTimes(2);
     });
 
     it('provides a discovery context with getActor helper', async () => {

--- a/tests/unit/actions/actionDiscoveryService.parameterValidation.test.js
+++ b/tests/unit/actions/actionDiscoveryService.parameterValidation.test.js
@@ -1,0 +1,19 @@
+import { test, expect } from '@jest/globals';
+import { describeActionDiscoverySuite } from '../../common/actions/actionDiscoveryServiceTestBed.js';
+
+// Parameter validation tests for ActionDiscoveryService
+
+describeActionDiscoverySuite(
+  'ActionDiscoveryService parameter validation',
+  (getBed) => {
+    const actor = { id: 'actor1' };
+
+    test('throws Error when baseContext is not an object', async () => {
+      const bed = getBed();
+      await expect(bed.service.getValidActions(actor, 5)).rejects.toThrow(
+        'ActionDiscoveryService.getValidActions: baseContext must be an object when provided'
+      );
+      expect(bed.mocks.logger.error).toHaveBeenCalled();
+    });
+  }
+);


### PR DESCRIPTION
Summary: Refactored `ActionDiscoveryService.getValidActions` to throw on invalid `actorEntity` and improper `baseContext`. Updated related tests and added a new suite to verify parameter validation.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint --silent`
- [x] Root tests         `npm test --silent`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6861863296908331bbaf5e604480d84c