### PR TITLE
[Agent] add SimpleItemLoader and validation helper

### DIFF
--- a/src/loaders/actionLoader.js
+++ b/src/loaders/actionLoader.js
@@ -4,8 +4,7 @@
  */
 
 // --- Base Class Import ---
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
-import { processAndStoreItem } from './helpers/processAndStoreItem.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
 /** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
@@ -19,7 +18,7 @@ import { processAndStoreItem } from './helpers/processAndStoreItem.js';
  *
  * @augments BaseManifestItemLoader
  */
-class ActionLoader extends BaseManifestItemLoader {
+class ActionLoader extends SimpleItemLoader {
   /**
    * @param {IConfiguration} config - Configuration service instance.
    * @param {IPathResolver} pathResolver - Path resolution service instance.
@@ -45,38 +44,6 @@ class ActionLoader extends BaseManifestItemLoader {
       dataRegistry,
       logger
     );
-  }
-
-  /**
-   * Processes a single fetched action file's data and stores it in the registry.
-   * Delegates ID parsing and storage to {@link processAndStoreItem}.
-   *
-   * @override
-   * @protected
-   * @param {string} modId
-   * @param {string} filename
-   * @param {string} resolvedPath
-   * @param {any} data
-   * @param {string} registryKey
-   * @returns {Promise<{qualifiedId: string, didOverride: boolean}>}
-   */
-  async _processFetchedItem(modId, filename, resolvedPath, data, registryKey) {
-    this._logger.debug(
-      `ActionLoader [${modId}]: Processing fetched item: ${filename} (Type: ${registryKey})`
-    );
-
-    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
-      data,
-      idProp: 'id',
-      category: 'actions',
-      modId,
-      filename,
-    });
-
-    this._logger.debug(
-      `ActionLoader [${modId}]: Successfully processed action from ${filename}. Returning final registry key: ${qualifiedId}, Overwrite: ${didOverride}`
-    );
-    return { qualifiedId, didOverride };
   }
 }
 

--- a/src/loaders/anatomyBlueprintLoader.js
+++ b/src/loaders/anatomyBlueprintLoader.js
@@ -1,6 +1,6 @@
 // src/loaders/anatomyBlueprintLoader.js
 
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 
@@ -17,7 +17,7 @@ import { parseAndValidateId } from '../utils/idUtils.js';
  *
  * @augments BaseManifestItemLoader
  */
-class AnatomyBlueprintLoader extends BaseManifestItemLoader {
+class AnatomyBlueprintLoader extends SimpleItemLoader {
   constructor(
     config,
     pathResolver,

--- a/src/loaders/anatomyRecipeLoader.js
+++ b/src/loaders/anatomyRecipeLoader.js
@@ -1,6 +1,6 @@
 // src/loaders/anatomyRecipeLoader.js
 
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 
@@ -17,7 +17,7 @@ import { parseAndValidateId } from '../utils/idUtils.js';
  *
  * @augments BaseManifestItemLoader
  */
-class AnatomyRecipeLoader extends BaseManifestItemLoader {
+class AnatomyRecipeLoader extends SimpleItemLoader {
   constructor(
     config,
     pathResolver,

--- a/src/loaders/baseManifestItemLoader.js
+++ b/src/loaders/baseManifestItemLoader.js
@@ -20,6 +20,7 @@ import { extractValidFilenames } from '../utils/filenameUtils.js';
 import { summarizeSettledResults } from './helpers/resultsSummary.js';
 import { validateLoadItemsParams } from './helpers/validationHelpers.js';
 import { processFileWrapper } from './helpers/fileProcessing.js';
+import { validateNonEmptyString } from '../utils/stringValidation.js';
 
 // --- Add LoadItemsResult typedef here for clarity ---
 /**
@@ -143,12 +144,15 @@ export class BaseManifestItemLoader extends AbstractLoader {
     );
     super(logger);
 
-    if (typeof contentType !== 'string' || contentType.trim() === '') {
+    const trimmedContentType = validateNonEmptyString(
+      'contentType',
+      contentType
+    );
+    if (trimmedContentType === null) {
       const errorMsg = `BaseManifestItemLoader requires a non-empty string for 'contentType'. Received: ${contentType}`;
       this._logger.error(errorMsg);
       throw new TypeError(errorMsg);
     }
-    const trimmedContentType = contentType.trim();
 
     // --- Store Dependencies ---
     this._config = config;

--- a/src/loaders/conditionLoader.js
+++ b/src/loaders/conditionLoader.js
@@ -13,8 +13,7 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 
 // --- Base Class and Helper Import ---
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
-import { processAndStoreItem } from './helpers/processAndStoreItem.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 
 /**
  * Loads reusable condition definitions from mods.
@@ -24,7 +23,7 @@ import { processAndStoreItem } from './helpers/processAndStoreItem.js';
  * @class ConditionLoader
  * @augments BaseManifestItemLoader
  */
-class ConditionLoader extends BaseManifestItemLoader {
+class ConditionLoader extends SimpleItemLoader {
   /**
    * Creates an instance of ConditionLoader.
    * Passes dependencies and the specific contentType 'conditions' to the base class constructor.
@@ -53,39 +52,6 @@ class ConditionLoader extends BaseManifestItemLoader {
       dataRegistry,
       logger
     );
-  }
-
-  /**
-   * Processes a single fetched condition file's data.
-   *
-   * @override
-   * @protected
-   * @param {string} modId
-   * @param {string} filename
-   * @param {string} resolvedPath
-   * @param {any} data
-   * @param {string} registryKey - The content type registry key ('conditions').
-   * @returns {Promise<{qualifiedId: string, didOverride: boolean}>}
-   */
-  async _processFetchedItem(modId, filename, resolvedPath, data, registryKey) {
-    this._logger.debug(
-      `ConditionLoader [${modId}]: Processing item: ${filename} (Type: ${registryKey})`
-    );
-
-    // Delegate all processing to the generic helper function.
-    // It will use the 'id' property for the ID and store it in the 'conditions' category.
-    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
-      data,
-      idProp: 'id',
-      category: 'conditions',
-      modId,
-      filename,
-    });
-
-    this._logger.debug(
-      `ConditionLoader [${modId}]: Successfully processed condition from ${filename}. Returning final registry key: ${qualifiedId}, Overwrite: ${didOverride}`
-    );
-    return { qualifiedId, didOverride };
   }
 }
 

--- a/src/loaders/goalLoader.js
+++ b/src/loaders/goalLoader.js
@@ -16,8 +16,7 @@
  * Registry cat: `"goals"`
  */
 
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
-import { processAndStoreItem } from './helpers/processAndStoreItem.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 
 /**
  * @typedef {import('../interfaces/coreServices.js').IConfiguration}   IConfiguration
@@ -27,7 +26,7 @@ import { processAndStoreItem } from './helpers/processAndStoreItem.js';
  * @typedef {import('../interfaces/coreServices.js').IDataRegistry}    IDataRegistry
  * @typedef {import('../interfaces/coreServices.js').ILogger}          ILogger
  */
-export default class GoalLoader extends BaseManifestItemLoader {
+export default class GoalLoader extends SimpleItemLoader {
   /**
    * @param {IConfiguration}   config
    * @param {IPathResolver}    pathResolver
@@ -53,31 +52,5 @@ export default class GoalLoader extends BaseManifestItemLoader {
       dataRegistry,
       logger
     );
-  }
-
-  /**
-   * Processes a validated goal data object and stores it in the data registry.
-   * Delegates ID parsing and storage to {@link processAndStoreItem}.
-   *
-   * @protected
-   * @override
-   * @param {string} modId - The ID of the mod owning the file.
-   * @param {string} filename - The original filename from the manifest.
-   * @param {string} resolvedPath - The fully resolved path to the file.
-   * @param {any} data - The validated data fetched from the file.
-   * @param {string} registryKey - The content type registry key ('goals').
-   * @returns {Promise<{qualifiedId: string, didOverride: boolean}>} A promise resolving with the result.
-   */
-  async _processFetchedItem(modId, filename, resolvedPath, data, registryKey) {
-    // schema validation already happened – just persist it
-    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
-      data,
-      idProp: 'id',
-      category: 'goals',
-      modId,
-      filename,
-    });
-
-    return { qualifiedId, didOverride };
   }
 }

--- a/src/loaders/helpers/validationHelpers.js
+++ b/src/loaders/helpers/validationHelpers.js
@@ -3,6 +3,7 @@
  */
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
+import { validateNonEmptyString } from '../../utils/stringValidation.js';
 
 /**
  * Validates parameters for {@link BaseManifestItemLoader.loadItemsForMod}.
@@ -27,12 +28,12 @@ export function validateLoadItemsParams(
   diskFolder,
   registryKey
 ) {
-  if (typeof modId !== 'string' || modId.trim() === '') {
+  const trimmedModId = validateNonEmptyString('modId', modId);
+  if (trimmedModId === null) {
     const msg = `${className}: Programming Error - Invalid 'modId' provided for loading content. Must be a non-empty string. Received: ${modId}`;
     logger.error(msg);
     throw new TypeError(msg);
   }
-  const trimmedModId = modId.trim();
 
   if (!modManifest || typeof modManifest !== 'object') {
     const msg = `${className}: Programming Error - Invalid 'modManifest' provided for loading content for mod '${trimmedModId}'. Must be a non-null object. Received: ${modManifest}`;
@@ -40,26 +41,26 @@ export function validateLoadItemsParams(
     throw new TypeError(msg);
   }
 
-  if (typeof contentKey !== 'string' || contentKey.trim() === '') {
+  const trimmedContentKey = validateNonEmptyString('contentKey', contentKey);
+  if (trimmedContentKey === null) {
     const msg = `${className}: Programming Error - Invalid 'contentKey' provided for loading ${registryKey} for mod '${trimmedModId}'. Must be a non-empty string. Received: ${contentKey}`;
     logger.error(msg);
     throw new TypeError(msg);
   }
-  const trimmedContentKey = contentKey.trim();
 
-  if (typeof diskFolder !== 'string' || diskFolder.trim() === '') {
+  const trimmedDiskFolder = validateNonEmptyString('diskFolder', diskFolder);
+  if (trimmedDiskFolder === null) {
     const msg = `${className}: Programming Error - Invalid 'diskFolder' provided for loading ${registryKey} for mod '${trimmedModId}'. Must be a non-empty string. Received: ${diskFolder}`;
     logger.error(msg);
     throw new TypeError(msg);
   }
-  const trimmedDiskFolder = diskFolder.trim();
 
-  if (typeof registryKey !== 'string' || registryKey.trim() === '') {
+  const trimmedRegistryKey = validateNonEmptyString('registryKey', registryKey);
+  if (trimmedRegistryKey === null) {
     const msg = `${className}: Programming Error - Invalid 'registryKey' provided for loading content for mod '${trimmedModId}'. Must be a non-empty string. Received: ${registryKey}`;
     logger.error(msg);
     throw new TypeError(msg);
   }
-  const trimmedRegistryKey = registryKey.trim();
 
   return {
     modId: trimmedModId,

--- a/src/loaders/macroLoader.js
+++ b/src/loaders/macroLoader.js
@@ -1,6 +1,6 @@
 // src/loaders/macroLoader.js
 
-import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { SimpleItemLoader } from './simpleItemLoader.js';
 import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 
 /**
@@ -19,7 +19,7 @@ import { processAndStoreItem } from './helpers/processAndStoreItem.js';
  * @class MacroLoader
  * @augments BaseManifestItemLoader
  */
-class MacroLoader extends BaseManifestItemLoader {
+class MacroLoader extends SimpleItemLoader {
   /**
    * Creates an instance of MacroLoader.
    *

--- a/src/loaders/simpleItemLoader.js
+++ b/src/loaders/simpleItemLoader.js
@@ -1,0 +1,45 @@
+/**
+ * @file Provides SimpleItemLoader extending BaseManifestItemLoader with
+ * a default _processFetchedItem implementation that parses the item ID
+ * and stores the item using processAndStoreItem.
+ */
+
+import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
+import { processAndStoreItem } from './helpers/processAndStoreItem.js';
+
+/**
+ * Loader base class with default ID parsing and storage logic.
+ * Subclasses may override `_processFetchedItem` for additional behaviour.
+ *
+ * @augments BaseManifestItemLoader
+ */
+export class SimpleItemLoader extends BaseManifestItemLoader {
+  /**
+   * Processes a fetched item by parsing its `id` property and storing
+   * it in the registry using {@link processAndStoreItem}.
+   *
+   * @protected
+   * @override
+   * @async
+   * @param {string} modId - Owning mod ID.
+   * @param {string} filename - Original filename from the manifest.
+   * @param {string} resolvedPath - Resolved file path (unused).
+   * @param {any} data - Parsed item data.
+   * @param {string} registryKey - Registry category key.
+   * @returns {Promise<{qualifiedId: string, didOverride: boolean}>}
+   *   Qualified ID and whether it overwrote an existing entry.
+   */
+  async _processFetchedItem(modId, filename, resolvedPath, data, registryKey) {
+    const { qualifiedId, didOverride } = await processAndStoreItem(this, {
+      data,
+      idProp: 'id',
+      category: registryKey,
+      modId,
+      filename,
+    });
+
+    return { qualifiedId, didOverride };
+  }
+}
+
+export default SimpleItemLoader;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -30,6 +30,7 @@ export {
   validateDependency,
   validateDependencies,
 } from './dependencyUtils.js';
+export { validateNonEmptyString } from './stringValidation.js';
 export { createErrorDetails } from './errorDetails.js';
 export { readComponent, writeComponent } from './componentAccessUtils.js';
 export * from '../turns/strategies/strategyHelpers.js';

--- a/src/utils/stringValidation.js
+++ b/src/utils/stringValidation.js
@@ -1,0 +1,21 @@
+// src/utils/stringValidation.js
+/**
+ * @file Utility validation helpers for common string checks.
+ */
+
+import { isNonBlankString } from './textUtils.js';
+
+/**
+ * Validate that a value is a non-empty string.
+ *
+ * @param {string} name - Name of the parameter being validated.
+ * @param {any} value - Value to check.
+ * @returns {string|null} Trimmed string when valid, otherwise null.
+ */
+export function validateNonEmptyString(name, value) {
+  return typeof value === 'string' && isNonBlankString(value)
+    ? value.trim()
+    : null;
+}
+
+export default { validateNonEmptyString };


### PR DESCRIPTION
## Summary
- create `SimpleItemLoader` with default item processing
- add `validateNonEmptyString` helper and use in manifest item validation
- update loaders to inherit from `SimpleItemLoader`

## Testing
- `npm run format`
- `npm run lint` *(fails: 731 errors, 2928 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6861887a94a083319459e3bb3be165d9