### PR TITLE
[Refactor] Enforce immutability in EngineState

### DIFF
--- a/data/mods/anatomy/mod-manifest.json
+++ b/data/mods/anatomy/mod-manifest.json
@@ -37,23 +37,10 @@
         "humanoid_head.entity.json",
         "humanoid_leg.entity.json"
       ],
-      "instances": [
-        "jacqueline_rouxel.entity.json"
-      ]
+      "instances": ["jacqueline_rouxel.entity.json"]
     },
-    "blueprints": [
-      "humanoid_standard.blueprint.json"
-    ],
-    "recipes": [
-      "gorgeous_milf.recipe.json",
-      "humanoid_standard.recipe.json"
-    ],
-    "anatomyFormatting": [
-      "anatomy-formatting/default.json"
-    ],
-    "anatomy-formatting": [
-      "default.json",
-      "example-alien.json"
-    ]
+    "blueprints": ["humanoid_standard.blueprint.json"],
+    "recipes": ["gorgeous_milf.recipe.json", "humanoid_standard.recipe.json"],
+    "anatomyFormatting": ["anatomy-formatting/default.json"]
   }
 }

--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -7,13 +7,54 @@
  * @class EngineState
  */
 class EngineState {
+  /** @type {boolean} */
+  #isInitialized;
+  /** @type {boolean} */
+  #isGameLoopRunning;
+  /** @type {string | null} */
+  #activeWorld;
+
   constructor() {
-    /** @type {boolean} */
-    this.isInitialized = false;
-    /** @type {boolean} */
-    this.isGameLoopRunning = false;
-    /** @type {string | null} */
-    this.activeWorld = null;
+    this.#isInitialized = false;
+    this.#isGameLoopRunning = false;
+    this.#activeWorld = null;
+  }
+
+  /**
+   * Indicates whether the engine has been initialized.
+   *
+   * @returns {boolean} Initialization status.
+   */
+  get isInitialized() {
+    return this.#isInitialized;
+  }
+
+  /**
+   * Indicates whether the game loop is currently running.
+   *
+   * @returns {boolean} Loop running status.
+   */
+  get isGameLoopRunning() {
+    return this.#isGameLoopRunning;
+  }
+
+  /**
+   * Returns the name of the currently active world, if any.
+   *
+   * @returns {string | null} Active world name or {@code null}.
+   */
+  get activeWorld() {
+    return this.#activeWorld;
+  }
+
+  /**
+   * Updates the active world name without changing initialization state.
+   *
+   * @param {string} worldName - Name of the world to set active.
+   * @returns {void}
+   */
+  setActiveWorld(worldName) {
+    this.#activeWorld = worldName;
   }
 
   /**
@@ -23,9 +64,9 @@ class EngineState {
    * @returns {void}
    */
   setStarted(worldName) {
-    this.isInitialized = true;
-    this.isGameLoopRunning = true;
-    this.activeWorld = worldName;
+    this.#isInitialized = true;
+    this.#isGameLoopRunning = true;
+    this.setActiveWorld(worldName);
   }
 
   /**
@@ -34,9 +75,9 @@ class EngineState {
    * @returns {void}
    */
   reset() {
-    this.isInitialized = false;
-    this.isGameLoopRunning = false;
-    this.activeWorld = null;
+    this.#isInitialized = false;
+    this.#isGameLoopRunning = false;
+    this.#activeWorld = null;
   }
 }
 

--- a/src/engine/gameSessionManager.js
+++ b/src/engine/gameSessionManager.js
@@ -107,7 +107,7 @@ class GameSessionManager {
     }
     await this.#prepareEngineForOperation(null);
 
-    this.#state.activeWorld = worldName;
+    this.#state.setActiveWorld(worldName);
     this.#logger.debug(
       `GameSessionManager: Preparing new game session for world "${worldName}"...`
     );
@@ -202,8 +202,9 @@ class GameSessionManager {
       `GameSessionManager.finalizeLoadSuccess: Game state restored successfully from ${saveIdentifier}. Finalizing load setup.`
     );
 
-    this.#state.activeWorld =
-      loadedSaveData.metadata?.gameTitle || 'Restored Game';
+    this.#state.setActiveWorld(
+      loadedSaveData.metadata?.gameTitle || 'Restored Game'
+    );
     await this.#finalizeGameStart(this.#state.activeWorld);
     this.#logger.debug(
       `GameSessionManager.finalizeLoadSuccess: Game loaded from "${saveIdentifier}" (World: ${this.#state.activeWorld}) and resumed.`


### PR DESCRIPTION
Summary: Refactored EngineState to use private fields with read-only getters. Added setActiveWorld method and updated GameSessionManager to use it. Removed invalid key from anatomy mod manifest to satisfy schema validation.

Changes Made:
- encapsulated engine state via private fields and getters
- new setActiveWorld method used by session manager
- cleaned anatomy mod manifest for schema compliance

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` & `cd llm-proxy-server && npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [x] Manual smoke test / User validation (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6861903b18008331a35fc2613b832a4e