### PR TITLE
[Agent] Add fetcher and repository tests

### DIFF
--- a/tests/unit/data/baseFetcher.test.js
+++ b/tests/unit/data/baseFetcher.test.js
@@ -1,0 +1,90 @@
+import {
+  describe,
+  beforeEach,
+  afterEach,
+  it,
+  expect,
+  jest,
+} from '@jest/globals';
+import WorkspaceDataFetcher from '../../../src/data/workspaceDataFetcher.js';
+import TextDataFetcher from '../../../src/data/textDataFetcher.js';
+
+describe('WorkspaceDataFetcher', () => {
+  let fetcher;
+  let originalFetch;
+
+  beforeEach(() => {
+    fetcher = new WorkspaceDataFetcher();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('returns parsed JSON when fetch succeeds', async () => {
+    const data = { foo: 'bar' };
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue(data),
+    };
+    global.fetch.mockResolvedValue(mockResponse);
+
+    await expect(fetcher.fetch('/path')).resolves.toEqual(data);
+    expect(global.fetch).toHaveBeenCalledWith('/path');
+    expect(mockResponse.json).toHaveBeenCalled();
+  });
+
+  it('propagates fetch errors', async () => {
+    global.fetch.mockRejectedValue(new Error('Failed to fetch'));
+
+    await expect(fetcher.fetch('/bad')).rejects.toThrow(
+      'WorkspaceDataFetcher failed for /bad: Failed to fetch'
+    );
+  });
+});
+
+describe('TextDataFetcher', () => {
+  let fetcher;
+  let originalFetch;
+
+  beforeEach(() => {
+    fetcher = new TextDataFetcher();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('returns text when fetch succeeds', async () => {
+    const text = 'hello world';
+    const mockResponse = {
+      ok: true,
+      text: jest.fn().mockResolvedValue(text),
+    };
+    global.fetch.mockResolvedValue(mockResponse);
+
+    await expect(fetcher.fetch('/file')).resolves.toBe(text);
+    expect(global.fetch).toHaveBeenCalledWith('/file');
+    expect(mockResponse.text).toHaveBeenCalled();
+  });
+
+  it('throws on http error', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: jest.fn().mockResolvedValue('missing'),
+    };
+    global.fetch.mockResolvedValue(mockResponse);
+
+    await expect(fetcher.fetch('/missing')).rejects.toThrow(
+      'HTTP error! status: 404 (Not Found) fetching /missing. Response body: missing'
+    );
+  });
+});

--- a/tests/unit/data/gameDataRepository.test.js
+++ b/tests/unit/data/gameDataRepository.test.js
@@ -59,8 +59,6 @@ describe('GameDataRepository', () => {
 
   test('constructor validates logger and registry', () => {
     expect(() => new GameDataRepository(registry, {})).toThrow();
-    // Re-create a valid registry for the second check
-    const validRegistry = createRegistry();
     expect(() => new GameDataRepository({}, logger)).toThrow();
   });
 
@@ -121,6 +119,57 @@ describe('GameDataRepository', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       'GameDataRepository: listContentByMod not supported by registry'
     );
+  });
+
+  describe('invalid id handling', () => {
+    const invalidIds = [null, undefined, '', '   '];
+    const cases = [
+      ['getWorld', 'getWorldDefinition', 'getWorld called with invalid ID:'],
+      [
+        'getEntityDefinition',
+        'getEntityDefinition',
+        'getEntityDefinition called with invalid ID:',
+      ],
+      [
+        'getEventDefinition',
+        'getEventDefinition',
+        'getEventDefinition called with invalid ID:',
+      ],
+      [
+        'getComponentDefinition',
+        'getComponentDefinition',
+        'getComponentDefinition called with invalid ID:',
+      ],
+      [
+        'getConditionDefinition',
+        'getConditionDefinition',
+        'getConditionDefinition called with invalid ID:',
+      ],
+      [
+        'getGoalDefinition',
+        'getGoalDefinition',
+        'getGoalDefinition called with invalid ID:',
+      ],
+      [
+        'getEntityInstanceDefinition',
+        'getEntityInstanceDefinition',
+        'getEntityInstanceDefinition called with invalid ID:',
+      ],
+    ];
+
+    cases.forEach(([method, registryMethod, warn]) => {
+      invalidIds.forEach((id) => {
+        test(`${method} warns and returns null for invalid id ${id}`, () => {
+          const result = repo[method](id);
+          expect(result).toBeNull();
+          expect(logger.warn).toHaveBeenCalledWith(
+            `GameDataRepository: ${warn} ${id}`
+          );
+          expect(registry[registryMethod]).not.toHaveBeenCalled();
+          jest.clearAllMocks();
+        });
+      });
+    });
   });
 
   describe('get', () => {


### PR DESCRIPTION
Summary: Added unit tests for WorkspaceDataFetcher and TextDataFetcher in `baseFetcher.test.js`. Extended `gameDataRepository.test.js` with invalid ID handling checks. Updated constructor test for unused variable.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 3669 problems)*
- [ ] Root tests         `npm run test` *(fails: 2 suites)*
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   *(not run)*

🚫 tests failing—needs human review

------
https://chatgpt.com/codex/tasks/task_e_68618f6703848331b9c5e860c038a70e