### PR TITLE
[Agent] deduplicate service logger init

### DIFF
--- a/data/mods/anatomy/mod-manifest.json
+++ b/data/mods/anatomy/mod-manifest.json
@@ -37,23 +37,13 @@
         "humanoid_head.entity.json",
         "humanoid_leg.entity.json"
       ],
-      "instances": [
-        "jacqueline_rouxel.entity.json"
-      ]
+      "instances": ["jacqueline_rouxel.entity.json"]
     },
-    "blueprints": [
-      "humanoid_standard.blueprint.json"
-    ],
-    "recipes": [
-      "gorgeous_milf.recipe.json",
-      "humanoid_standard.recipe.json"
-    ],
+    "blueprints": ["humanoid_standard.blueprint.json"],
+    "recipes": ["gorgeous_milf.recipe.json", "humanoid_standard.recipe.json"],
     "anatomyFormatting": [
-      "anatomy-formatting/default.json"
-    ],
-    "anatomy-formatting": [
-      "default.json",
-      "example-alien.json"
+      "anatomy-formatting/default.json",
+      "anatomy-formatting/example-alien.json"
     ]
   }
 }

--- a/src/utils/handlerUtils/serviceUtils.js
+++ b/src/utils/handlerUtils/serviceUtils.js
@@ -7,8 +7,10 @@
 
 /** @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger */
 
-import { validateServiceDeps } from '../serviceInitializerUtils.js';
-import { setupPrefixedLogger } from '../loggerUtils.js';
+import {
+  initializeServiceLogger,
+  validateServiceDeps,
+} from '../serviceInitializerUtils.js';
 
 /**
  * Initialize a handler-specific logger and validate its dependencies.
@@ -20,9 +22,7 @@ import { setupPrefixedLogger } from '../loggerUtils.js';
  * @returns {ILogger} Prefixed logger instance.
  */
 export function initHandlerLogger(handlerName, logger, deps) {
-  const prefixed = setupPrefixedLogger(logger, `${handlerName}: `);
-  validateServiceDeps(handlerName, prefixed, deps);
-  return prefixed;
+  return initializeServiceLogger(handlerName, logger, deps);
 }
 
 export { validateServiceDeps as validateDeps };

--- a/src/utils/serviceBase.js
+++ b/src/utils/serviceBase.js
@@ -1,5 +1,4 @@
-import { validateServiceDeps } from './serviceInitializerUtils.js';
-import { setupPrefixedLogger } from './loggerUtils.js';
+import { initializeServiceLogger } from './serviceInitializerUtils.js';
 
 /**
  * @class BaseService
@@ -18,22 +17,6 @@ export class BaseService {
    * @returns {import('../interfaces/coreServices.js').ILogger} The initialized logger.
    */
   _init(serviceName, logger, deps) {
-    const prefixed = setupPrefixedLogger(logger, `${serviceName}: `);
-    this._validateDeps(serviceName, prefixed, deps);
-    return prefixed;
-  }
-
-  /**
-   * Validate injected dependencies.
-   *
-   * @protected
-   * @param {string} serviceName - Service name for error messages.
-   * @param {import('../interfaces/coreServices.js').ILogger} logger - Logger for validation.
-   * @param {Record<string, import('./serviceInitializerUtils.js').DependencySpec>} [deps]
-   *   - Dependency map to validate.
-   * @returns {void}
-   */
-  _validateDeps(serviceName, logger, deps) {
-    validateServiceDeps(serviceName, logger, deps);
+    return initializeServiceLogger(serviceName, logger, deps);
   }
 }

--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -56,4 +56,18 @@ export function setupService(serviceName, logger, deps) {
   return prefixedLogger;
 }
 
+/**
+ * Initialize and return a service logger.
+ *
+ * @description Thin wrapper around {@link setupService} for shared
+ *   initialization logic across services and handlers.
+ * @param {string} serviceName - Name used for log prefixing.
+ * @param {import('../interfaces/coreServices.js').ILogger} logger - Base logger.
+ * @param {Record<string, DependencySpec>} [deps] - Optional dependencies.
+ * @returns {import('../interfaces/coreServices.js').ILogger} Prefixed logger.
+ */
+export function initializeServiceLogger(serviceName, logger, deps) {
+  return setupService(serviceName, logger, deps);
+}
+
 // --- FILE END ---

--- a/tests/unit/utils/loggerInitUsage.test.js
+++ b/tests/unit/utils/loggerInitUsage.test.js
@@ -27,6 +27,7 @@ function setup(
   const setupPrefixedLogger = jest.fn(() => mockLogger);
   const validateServiceDeps = jest.fn();
   const setupService = jest.fn(() => mockLogger);
+  const initializeServiceLogger = jest.fn(() => mockLogger);
   const baseInitLogger = jest.fn(() => mockLogger);
   jest.doMock('../../../src/utils/serviceInitializerUtils.js', () => {
     const actual = jest.requireActual(
@@ -36,6 +37,7 @@ function setup(
       ...actual,
       validateServiceDeps,
       setupService,
+      initializeServiceLogger,
     };
   });
   jest.doMock('../../../src/utils/loggerUtils.js', () => {
@@ -46,7 +48,12 @@ function setup(
   const Mod = require(modulePath).default || require(modulePath);
   new Mod(ctorArgs);
   if (useHelper) {
-    if (setupService.mock.calls.length) {
+    if (initializeServiceLogger.mock.calls.length) {
+      expect(initializeServiceLogger).toHaveBeenCalled();
+      const call = initializeServiceLogger.mock.calls[0];
+      expect(call[0]).toBe(expectedName);
+      expect(call[1]).toBe(mockLogger);
+    } else if (setupService.mock.calls.length) {
       expect(setupService).toHaveBeenCalled();
       const call = setupService.mock.calls[0];
       expect(call[0]).toBe(expectedName);


### PR DESCRIPTION
## Summary
- add initializeServiceLogger helper to centralize logger setup
- refactor BaseService and handler utils to use initializeServiceLogger
- update loggerInitUsage tests
- fix anatomy mod manifest for schema validation

## Testing Done
- `npm run lint` *(fails: 3670 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686192b09984833181c22258e7a09f42