### PR TITLE
[Agent] Normalize commandResult param

### DIFF
--- a/src/turns/interfaces/ICommandHandlingState.js
+++ b/src/turns/interfaces/ICommandHandlingState.js
@@ -25,11 +25,11 @@ export class ICommandHandlingState {
    *
    * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
    * @param {import('../../entities/entity.js').default} actor
-   * @param {import('../../types/commandResult.js').CommandResult} cmdProcResult
+   * @param {import('../../types/commandResult.js').CommandResult} commandResult
    * @param {string} commandString
    * @returns {Promise<void>}
    */
-  async processCommandResult(handler, actor, cmdProcResult, commandString) {
+  async processCommandResult(handler, actor, commandResult, commandString) {
     throw new Error(
       'ICommandHandlingState.processCommandResult must be implemented.'
     );
@@ -41,10 +41,10 @@ export class ICommandHandlingState {
    * @param {import('./ITurnStateHost.js').ITurnStateHost} handler
    * @param {import('../../entities/entity.js').default} actor
    * @param {import('../constants/turnDirectives.js').default} directive
-   * @param {import('../../types/commandResult.js').CommandResult} [cmdProcResult]
+   * @param {import('../../types/commandResult.js').CommandResult} [commandResult]
    * @returns {Promise<void>}
    */
-  async handleDirective(handler, actor, directive, cmdProcResult) {
+  async handleDirective(handler, actor, directive, commandResult) {
     throw new Error(
       'ICommandHandlingState.handleDirective must be implemented.'
     );

--- a/src/turns/interfaces/ITurnDirectiveStrategy.js
+++ b/src/turns/interfaces/ITurnDirectiveStrategy.js
@@ -29,15 +29,15 @@ export class ITurnDirectiveStrategy {
    * logger, services, and methods like `endTurn()` or `requestTransition()`.
    * @param {TurnDirectiveEnum} directive
    * The directive that selected this strategy.
-   * @param {CommandResult} [cmdProcResult]
+   * @param {CommandResult} [commandResult]
    * Optional: the command-processing result that produced the directive.
    * @returns {Promise<void>} Resolved when the strategy’s work is complete.
    * @throws {Error} If the strategy cannot complete successfully, or if `turnContext.getActor()` returns null/undefined
    * when an actor is expected for the strategy's operation.
    */
-  async execute(turnContext, directive, cmdProcResult) {
+  async execute(turnContext, directive, commandResult) {
     throw new Error(
-      'ITurnDirectiveStrategy.execute(turnContext, directive, cmdProcResult) ' +
+      'ITurnDirectiveStrategy.execute(turnContext, directive, commandResult) ' +
         'must be implemented by concrete strategy classes.'
     );
   }

--- a/src/turns/interfaces/ITurnState.js
+++ b/src/turns/interfaces/ITurnState.js
@@ -101,11 +101,11 @@ export class ITurnState {
    * @async
    * @param {ITurnStateHost} handler         - The host instance.
    * @param {Entity}         actor           - The actor from the current context.
-   * @param {CommandResult}  cmdProcResult   - Processor result.
+   * @param {CommandResult}  commandResult   - Processor result.
    * @param {string}         commandString   - Original command.
    * @returns {Promise<void>}
    */
-  async processCommandResult(handler, actor, cmdProcResult, commandString) {
+  async processCommandResult(handler, actor, commandResult, commandString) {
     throw new Error(
       'ITurnState.processCommandResult must be implemented or is not applicable.'
     );
@@ -118,10 +118,10 @@ export class ITurnState {
    * @param {ITurnStateHost}  handler        - The host instance.
    * @param {Entity}          actor          - The actor.
    * @param {TurnDirectiveEnum} directive    - Directive to handle.
-   * @param {CommandResult}   [cmdProcResult] - Original command result.
+   * @param {CommandResult}   [commandResult] - Original command result.
    * @returns {Promise<void>}
    */
-  async handleDirective(handler, actor, directive, cmdProcResult) {
+  async handleDirective(handler, actor, directive, commandResult) {
     throw new Error(
       'ITurnState.handleDirective must be implemented or is not applicable.'
     );

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -249,7 +249,7 @@ export class AbstractTurnState extends ITurnState {
   }
 
   /** @override */
-  async processCommandResult(handler, actor, cmdProcResult, commandString) {
+  async processCommandResult(handler, actor, commandResult, commandString) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
     const logger = getLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();
@@ -264,7 +264,7 @@ export class AbstractTurnState extends ITurnState {
   }
 
   /** @override */
-  async handleDirective(handler, actor, directive, cmdProcResult) {
+  async handleDirective(handler, actor, directive, commandResult) {
     const turnCtx = this._getTurnContext(); // Actor should come from turnCtx
     const logger = getLogger(turnCtx, handler);
     const contextActor = turnCtx?.getActor();

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -192,7 +192,7 @@ export class TurnIdleState extends AbstractTurnState {
   }
 
   /** @override */
-  async processCommandResult(handler, actor, cmdProcResult, commandString) {
+  async processCommandResult(handler, actor, commandResult, commandString) {
     const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     this._warnNoActiveTurn(
       'processCommandResult called (for ',
@@ -201,16 +201,16 @@ export class TurnIdleState extends AbstractTurnState {
     return super.processCommandResult(
       handler,
       actor,
-      cmdProcResult,
+      commandResult,
       commandString
     );
   }
 
   /** @override */
-  async handleDirective(handler, actor, directive, cmdProcResult) {
+  async handleDirective(handler, actor, directive, commandResult) {
     const actorIdForLog = actor?.id ?? UNKNOWN_ENTITY_ID;
     this._warnNoActiveTurn('handleDirective called (for ', `${actorIdForLog})`);
-    return super.handleDirective(handler, actor, directive, cmdProcResult);
+    return super.handleDirective(handler, actor, directive, commandResult);
   }
 
   /** @override */

--- a/src/turns/strategies/endTurnFailureStrategy.js
+++ b/src/turns/strategies/endTurnFailureStrategy.js
@@ -17,13 +17,19 @@ import {
   resolveTurnEndError,
 } from './strategyHelpers.js';
 
+/**
+ * @class EndTurnFailureStrategy
+ * @description Handles the END_TURN_FAILURE directive by ending the turn with
+ * an error via ITurnContext.
+ */
+
 export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
   /** @override */
   async execute(
     /** @type {ITurnContext} */ turnContext,
     // actor parameter removed as per outcome of Ticket 2
     /** @type {TurnDirectiveEnum}     */ directive,
-    /** @type {CommandResult}    */ cmdProcResult
+    /** @type {CommandResult}    */ commandResult
   ) {
     const { logger, className } = getLoggerAndClass(this, turnContext);
 
@@ -54,7 +60,7 @@ export default class EndTurnFailureStrategy extends ITurnDirectiveStrategy {
     // as the explicit `actor` parameter is removed. The primary concern is now whether `contextActor` exists.
 
     const turnEndError = resolveTurnEndError(
-      cmdProcResult,
+      commandResult,
       contextActor.id,
       directive
     );

--- a/src/turns/strategies/endTurnSuccessStrategy.js
+++ b/src/turns/strategies/endTurnSuccessStrategy.js
@@ -16,13 +16,19 @@ import {
   getLoggerAndClass,
 } from './strategyHelpers.js';
 
+/**
+ * @class EndTurnSuccessStrategy
+ * @description Handles the END_TURN_SUCCESS directive by ending the turn
+ * successfully via ITurnContext.
+ */
+
 export default class EndTurnSuccessStrategy extends ITurnDirectiveStrategy {
   /** @override */
   async execute(
     /** @type {ITurnContext} */ turnContext,
     // actor parameter removed based on Ticket 2 outcome
     /** @type {TurnDirectiveEnum}     */ directive,
-    /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
+    /** @type {CommandResult}    */ commandResult // eslint-disable-line no-unused-vars
   ) {
     const { logger, className } = getLoggerAndClass(this, turnContext);
 

--- a/src/turns/strategies/repromptStrategy.js
+++ b/src/turns/strategies/repromptStrategy.js
@@ -19,8 +19,10 @@ import { AwaitingActorDecisionState } from '../states/awaitingActorDecisionState
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../constants/eventIds.js';
 
 /**
- * Handles TurnDirective.RE_PROMPT by requesting a transition to AwaitingActorDecisionState.
- * Relies solely on ITurnContext to obtain the actor and other necessary services.
+ * @class RepromptStrategy
+ * @description Handles TurnDirective.RE_PROMPT by requesting a transition to
+ * AwaitingActorDecisionState. Relies solely on ITurnContext to obtain the actor
+ * and other necessary services.
  */
 export default class RepromptStrategy extends ITurnDirectiveStrategy {
   /**
@@ -31,14 +33,14 @@ export default class RepromptStrategy extends ITurnDirectiveStrategy {
    * @async
    * @param {ITurnContext} turnContext - The context for the current turn.
    * @param {TurnDirectiveEnum} directive - The directive that triggered this strategy.
-   * @param {CommandResult} [cmdProcResult] - Optional result from command processing.
+   * @param {CommandResult} [commandResult] - Optional result from command processing.
    * @returns {Promise<void>} Resolves when the strategy execution is complete.
    * @throws {Error} If the directive is not RE_PROMPT or if a critical error occurs.
    */
   async execute(
     /** @type {ITurnContext}  */ turnContext,
     /** @type {TurnDirectiveEnum}     */ directive,
-    /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
+    /** @type {CommandResult}    */ commandResult // eslint-disable-line no-unused-vars
   ) {
     const { logger, className } = getLoggerAndClass(this, turnContext);
     const safeEventDispatcher = turnContext.getSafeEventDispatcher();

--- a/src/turns/strategies/strategyHelpers.js
+++ b/src/turns/strategies/strategyHelpers.js
@@ -90,18 +90,18 @@ export function requireContextActor({
 /**
  * Determines the appropriate Error object when ending a turn due to failure.
  *
- * @param {import('../../types/commandResult.js').CommandResult} cmdProcResult -
+ * @param {import('../../types/commandResult.js').CommandResult} commandResult -
  *        Result produced by command processing.
  * @param {string} actorId - ID of the actor whose turn is ending.
  * @param {string} directive - Directive triggering the turn end.
  * @returns {Error} The error instance describing the failure.
  */
-export function resolveTurnEndError(cmdProcResult, actorId, directive) {
-  if (cmdProcResult?.error instanceof Error) {
-    return cmdProcResult.error;
+export function resolveTurnEndError(commandResult, actorId, directive) {
+  if (commandResult?.error instanceof Error) {
+    return commandResult.error;
   }
-  if (cmdProcResult?.error !== undefined && cmdProcResult?.error !== null) {
-    return new Error(String(cmdProcResult.error));
+  if (commandResult?.error !== undefined && commandResult?.error !== null) {
+    return new Error(String(commandResult.error));
   }
   return new Error(
     `Turn for actor ${actorId} ended by directive '${directive}' (failure).`

--- a/src/turns/strategies/waitForTurnEndEventStrategy.js
+++ b/src/turns/strategies/waitForTurnEndEventStrategy.js
@@ -17,6 +17,12 @@ import {
   getLoggerAndClass,
 } from './strategyHelpers.js';
 
+/**
+ * @class WaitForTurnEndEventStrategy
+ * @description Handles the WAIT_FOR_EVENT directive by transitioning to
+ * AwaitingExternalTurnEndState using ITurnContext.
+ */
+
 export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy {
   /**
    * Executes the WaitForTurnEndEventStrategy.
@@ -28,7 +34,7 @@ export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy 
    * @async
    * @param {ITurnContext} turnContext - The context for the current turn.
    * @param {TurnDirectiveEnum} directive - The directive that triggered this strategy.
-   * @param {CommandResult} [cmdProcResult] - Optional result from command processing.
+   * @param {CommandResult} [commandResult] - Optional result from command processing.
    * @returns {Promise<void>} Resolves when the strategy execution is complete.
    * @throws {Error} If the directive is not WAIT_FOR_EVENT or if a critical error occurs.
    */
@@ -36,7 +42,7 @@ export default class WaitForTurnEndEventStrategy extends ITurnDirectiveStrategy 
     /** @type {ITurnContext} */ turnContext,
     // actor parameter removed as per outcome of Ticket 2
     /** @type {TurnDirectiveEnum}     */ directive,
-    /** @type {CommandResult}    */ cmdProcResult // eslint-disable-line no-unused-vars
+    /** @type {CommandResult}    */ commandResult // eslint-disable-line no-unused-vars
   ) {
     const { logger, className } = getLoggerAndClass(this, turnContext);
 

--- a/tests/unit/turns/strategies/endTurnFailureStrategy.test.js
+++ b/tests/unit/turns/strategies/endTurnFailureStrategy.test.js
@@ -39,10 +39,10 @@ describe('EndTurnFailureStrategy', () => {
   describe('execute', () => {
     it('should throw an error if the directive is not END_TURN_FAILURE', async () => {
       const directive = TurnDirective.END_TURN_SUCCESS; // Incorrect directive
-      const cmdProcResult = { success: false, error: null };
+      const commandResult = { success: false, error: null };
 
       await expect(
-        strategy.execute(mockTurnContext, directive, cmdProcResult)
+        strategy.execute(mockTurnContext, directive, commandResult)
       ).rejects.toThrow(
         'EndTurnFailureStrategy: Received wrong directive (END_TURN_SUCCESS). Expected END_TURN_FAILURE.'
       );
@@ -55,11 +55,11 @@ describe('EndTurnFailureStrategy', () => {
     it('should call turnContext.endTurn with an error if contextActor is null', async () => {
       mockTurnContext.getActor.mockReturnValue(null); // Simulate no actor in context
       const directive = TurnDirective.END_TURN_FAILURE;
-      const cmdProcResult = { success: false, error: 'Some minor issue.' };
+      const commandResult = { success: false, error: 'Some minor issue.' };
       const expectedErrorMsg =
         'EndTurnFailureStrategy: No actor found in ITurnContext for END_TURN_FAILURE. Critical issue.';
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.error).toHaveBeenCalledWith(expectedErrorMsg);
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -74,14 +74,14 @@ describe('EndTurnFailureStrategy', () => {
       );
     });
 
-    it('should use cmdProcResult.error if it is an Error instance', async () => {
+    it('should use commandResult.error if it is an Error instance', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
       const specificError = new Error(
         'Command processing failed specifically!'
       );
-      const cmdProcResult = { success: false, error: specificError };
+      const commandResult = { success: false, error: specificError };
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${specificError.message}`
@@ -89,12 +89,12 @@ describe('EndTurnFailureStrategy', () => {
       expect(mockTurnContext.endTurn).toHaveBeenCalledWith(specificError);
     });
 
-    it('should wrap cmdProcResult.error in a new Error if it is a string', async () => {
+    it('should wrap commandResult.error in a new Error if it is a string', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
       const errorString = 'A simple error message from command processor.';
-      const cmdProcResult = { success: false, error: errorString };
+      const commandResult = { success: false, error: errorString };
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${errorString}`
@@ -106,13 +106,13 @@ describe('EndTurnFailureStrategy', () => {
       );
     });
 
-    it('should wrap cmdProcResult.error in a new Error if it is a non-Error, non-string, non-null value', async () => {
+    it('should wrap commandResult.error in a new Error if it is a non-Error, non-string, non-null value', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
       const errorObject = { code: 500, detail: 'Internal server issue' };
-      const cmdProcResult = { success: false, error: errorObject };
+      const commandResult = { success: false, error: errorObject };
       const expectedWrappedErrorMessage = String(errorObject); // How Node's new Error(obj) stringifies it
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${expectedWrappedErrorMessage}`
@@ -124,12 +124,12 @@ describe('EndTurnFailureStrategy', () => {
       );
     });
 
-    it('should create a default error if cmdProcResult.error is null', async () => {
+    it('should create a default error if commandResult.error is null', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
-      const cmdProcResult = { success: false, error: null }; // Explicitly null
+      const commandResult = { success: false, error: null }; // Explicitly null
       const expectedDefaultErrorMessage = `Turn for actor ${mockActor.id} ended by directive '${directive}' (failure).`;
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${expectedDefaultErrorMessage}`
@@ -141,12 +141,12 @@ describe('EndTurnFailureStrategy', () => {
       );
     });
 
-    it('should create a default error if cmdProcResult.error is undefined', async () => {
+    it('should create a default error if commandResult.error is undefined', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
-      const cmdProcResult = { success: false }; // Error property is undefined
+      const commandResult = { success: false }; // Error property is undefined
       const expectedDefaultErrorMessage = `Turn for actor ${mockActor.id} ended by directive '${directive}' (failure).`;
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${expectedDefaultErrorMessage}`
@@ -158,12 +158,12 @@ describe('EndTurnFailureStrategy', () => {
       );
     });
 
-    it('should create a default error if cmdProcResult itself is null', async () => {
+    it('should create a default error if commandResult itself is null', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
-      const cmdProcResult = null; // cmdProcResult is null
+      const commandResult = null; // commandResult is null
       const expectedDefaultErrorMessage = `Turn for actor ${mockActor.id} ended by directive '${directive}' (failure).`;
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         `EndTurnFailureStrategy: Executing END_TURN_FAILURE for actor ${mockActor.id}. Error: ${expectedDefaultErrorMessage}`
@@ -178,9 +178,9 @@ describe('EndTurnFailureStrategy', () => {
     it('should log correctly and call endTurn when execution is successful', async () => {
       const directive = TurnDirective.END_TURN_FAILURE;
       const specificError = new Error('A specific failure occurred.');
-      const cmdProcResult = { success: false, error: specificError };
+      const commandResult = { success: false, error: specificError };
 
-      await strategy.execute(mockTurnContext, directive, cmdProcResult);
+      await strategy.execute(mockTurnContext, directive, commandResult);
 
       expect(mockTurnContext.getLogger).toHaveBeenCalled();
       expect(mockTurnContext.getActor).toHaveBeenCalled();

--- a/tests/unit/turns/strategies/endTurnSuccessStrategy.test.js
+++ b/tests/unit/turns/strategies/endTurnSuccessStrategy.test.js
@@ -78,9 +78,9 @@ describe('EndTurnSuccessStrategy', () => {
 
   test('should correctly execute END_TURN_SUCCESS directive', async () => {
     const directive = TurnDirective.END_TURN_SUCCESS;
-    const cmdProcResult = {}; // Not used by this strategy on success
+    const commandResult = {}; // Not used by this strategy on success
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
@@ -93,10 +93,10 @@ describe('EndTurnSuccessStrategy', () => {
 
   test('should throw error and log if wrong directive is provided', async () => {
     const directive = TurnDirective.RE_PROMPT; // Incorrect directive
-    const cmdProcResult = {};
+    const commandResult = {};
 
     await expect(
-      strategy.execute(mockTurnContext, directive, cmdProcResult)
+      strategy.execute(mockTurnContext, directive, commandResult)
     ).rejects.toThrow(
       'EndTurnSuccessStrategy: Received wrong directive (RE_PROMPT). Expected END_TURN_SUCCESS.'
     );
@@ -113,9 +113,9 @@ describe('EndTurnSuccessStrategy', () => {
     mockTurnContext = new MockTurnContext(null, mockLogger); // No actor in context
 
     const directive = TurnDirective.END_TURN_SUCCESS;
-    const cmdProcResult = {};
+    const commandResult = {};
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);

--- a/tests/unit/turns/strategies/repromptStrategy.test.js
+++ b/tests/unit/turns/strategies/repromptStrategy.test.js
@@ -90,9 +90,9 @@ describe('RepromptStrategy', () => {
 
   test('should correctly execute RE_PROMPT directive and request transition to AwaitingActorDecisionState', async () => {
     const directive = TurnDirective.RE_PROMPT;
-    const cmdProcResult = {}; // Not directly used by this strategy beyond being a parameter
+    const commandResult = {}; // Not directly used by this strategy beyond being a parameter
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
@@ -108,10 +108,10 @@ describe('RepromptStrategy', () => {
 
   test('should throw error and log if wrong directive is provided', async () => {
     const directive = TurnDirective.END_TURN_SUCCESS; // Incorrect directive
-    const cmdProcResult = {};
+    const commandResult = {};
 
     await expect(
-      strategy.execute(mockTurnContext, directive, cmdProcResult)
+      strategy.execute(mockTurnContext, directive, commandResult)
     ).rejects.toThrow(
       'RepromptStrategy: Received wrong directive (END_TURN_SUCCESS). Expected RE_PROMPT.'
     );
@@ -129,9 +129,9 @@ describe('RepromptStrategy', () => {
     mockTurnContext.getActor.mockReturnValue(null); // No actor in context
 
     const directive = TurnDirective.RE_PROMPT;
-    const cmdProcResult = {};
+    const commandResult = {};
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
@@ -161,9 +161,9 @@ describe('RepromptStrategy', () => {
     );
 
     const directive = TurnDirective.RE_PROMPT;
-    const cmdProcResult = {};
+    const commandResult = {};
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);

--- a/tests/unit/turns/strategies/waitForTurnEndEventStrategy.test.js
+++ b/tests/unit/turns/strategies/waitForTurnEndEventStrategy.test.js
@@ -79,9 +79,9 @@ describe('WaitForTurnEndEventStrategy', () => {
 
   test('should correctly execute WAIT_FOR_EVENT directive and request transition', async () => {
     const directive = TurnDirective.WAIT_FOR_EVENT;
-    const cmdProcResult = {};
+    const commandResult = {};
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
@@ -97,10 +97,10 @@ describe('WaitForTurnEndEventStrategy', () => {
 
   test('should throw error and log if wrong directive is provided', async () => {
     const directive = TurnDirective.RE_PROMPT; // Incorrect directive
-    const cmdProcResult = {};
+    const commandResult = {};
 
     await expect(
-      strategy.execute(mockTurnContext, directive, cmdProcResult)
+      strategy.execute(mockTurnContext, directive, commandResult)
     ).rejects.toThrow(
       'WaitForTurnEndEventStrategy: Received wrong directive (RE_PROMPT). Expected WAIT_FOR_EVENT.'
     );
@@ -120,11 +120,11 @@ describe('WaitForTurnEndEventStrategy', () => {
     mockTurnContext = new MockTurnContext(null, mockLogger); // No actor in context
 
     const directive = TurnDirective.WAIT_FOR_EVENT;
-    const cmdProcResult = {};
+    const commandResult = {};
     const expectedErrorMsg =
       'WaitForTurnEndEventStrategy: No actor found in ITurnContext. Cannot transition to AwaitingExternalTurnEndState without an actor.';
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);
@@ -147,10 +147,10 @@ describe('WaitForTurnEndEventStrategy', () => {
     );
 
     const directive = TurnDirective.WAIT_FOR_EVENT;
-    const cmdProcResult = {};
+    const commandResult = {};
     const expectedOverallErrorMsg = `WaitForTurnEndEventStrategy: Failed to request transition to AwaitingExternalTurnEndState for actor ${mockActor.id}. Error: ${transitionErrorMessage}`;
 
-    await strategy.execute(mockTurnContext, directive, cmdProcResult);
+    await strategy.execute(mockTurnContext, directive, commandResult);
 
     expect(mockTurnContext.getLogger).toHaveBeenCalledTimes(1);
     expect(mockTurnContext.getActor).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Summary: Harmonized parameter naming for command results and documented key strategies.

Changes Made:
- Replaced `cmdProcResult` with `commandResult` in turn interfaces, states, strategies and tests.
- Added JSDoc `@class` annotations with descriptions for RepromptStrategy, EndTurnSuccessStrategy, EndTurnFailureStrategy, and WaitForTurnEndEventStrategy.
- Updated helper to use new parameter name.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68619a6a16848331a7035015a61023ca