### PR TITLE
[Agent] unify persistence execution helper

### DIFF
--- a/src/persistence/gameStateSerializer.js
+++ b/src/persistence/gameStateSerializer.js
@@ -9,7 +9,7 @@ import {
   MSG_DECOMPRESSION_FAILED,
   MSG_DESERIALIZATION_FAILED,
 } from './persistenceMessages.js';
-import { wrapSyncPersistenceOperation } from '../utils/persistenceErrorUtils.js';
+import { executePersistenceOp } from '../utils/persistenceErrorUtils.js';
 import ChecksumService from './checksumService.js';
 
 /**
@@ -163,13 +163,13 @@ class GameStateSerializer extends BaseService {
    * @returns {import('./persistenceTypes.js').PersistenceResult<Uint8Array>} Outcome of decompression.
    */
   decompress(data) {
-    const result = wrapSyncPersistenceOperation(
-      this.#logger,
-      () => pako.ungzip(data),
-      PersistenceErrorCodes.DECOMPRESSION_ERROR,
-      MSG_DECOMPRESSION_FAILED,
-      'Gzip decompression failed:'
-    );
+    const result = executePersistenceOp({
+      syncOperation: () => pako.ungzip(data),
+      logger: this.#logger,
+      errorCode: PersistenceErrorCodes.DECOMPRESSION_ERROR,
+      userMessage: MSG_DECOMPRESSION_FAILED,
+      context: 'Gzip decompression failed:',
+    });
     if (result.success) {
       this.#logger.debug(
         `Decompressed data size: ${result.data.byteLength} bytes`
@@ -185,13 +185,13 @@ class GameStateSerializer extends BaseService {
    * @returns {import('./persistenceTypes.js').PersistenceResult<object>} Outcome of deserialization.
    */
   deserialize(buffer) {
-    const result = wrapSyncPersistenceOperation(
-      this.#logger,
-      () => decode(buffer),
-      PersistenceErrorCodes.DESERIALIZATION_ERROR,
-      MSG_DESERIALIZATION_FAILED,
-      'MessagePack deserialization failed:'
-    );
+    const result = executePersistenceOp({
+      syncOperation: () => decode(buffer),
+      logger: this.#logger,
+      errorCode: PersistenceErrorCodes.DESERIALIZATION_ERROR,
+      userMessage: MSG_DESERIALIZATION_FAILED,
+      context: 'MessagePack deserialization failed:',
+    });
     if (result.success) {
       this.#logger.debug('Successfully deserialized MessagePack');
     }

--- a/src/persistence/savePreparation.js
+++ b/src/persistence/savePreparation.js
@@ -2,7 +2,7 @@
 
 import { cloneValidatedState } from '../utils/saveStateUtils.js';
 import { createPersistenceSuccess } from '../utils/persistenceResultUtils.js';
-import { wrapPersistenceOperation } from '../utils/persistenceErrorUtils.js';
+import { executePersistenceOp } from '../utils/persistenceErrorUtils.js';
 
 /**
  * Deep clones and augments the provided game state for saving.
@@ -47,11 +47,14 @@ export async function prepareState(
     return { success: false, error: cloneResult.error };
   }
 
-  return wrapPersistenceOperation(logger, async () => {
-    const { compressedData } = await serializer.compressPreparedState(
-      cloneResult.data
-    );
-    return { success: true, data: compressedData };
+  return executePersistenceOp({
+    asyncOperation: async () => {
+      const { compressedData } = await serializer.compressPreparedState(
+        cloneResult.data
+      );
+      return { success: true, data: compressedData };
+    },
+    logger,
   });
 }
 


### PR DESCRIPTION
## Summary
- add `executePersistenceOp` for persistence utilities
- refactor sync/async wrappers to use the helper
- update persistence modules and file read utils to call the new API
- keep tests passing

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686199fa0e788331a3272af79ed02beb