### PR TITLE
[Fix] Handle UI dispatch failures

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -447,7 +447,15 @@ class GameEngine {
       this.#logger.debug(
         'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
       );
-      await this.#safeEventDispatcher.dispatch(REQUEST_SHOW_SAVE_GAME_UI, {});
+      const success = await this.#safeEventDispatcher.dispatch(
+        REQUEST_SHOW_SAVE_GAME_UI,
+        {}
+      );
+      if (!success) {
+        this.#logger.warn(
+          'GameEngine.showSaveGameUI: SafeEventDispatcher reported failure when dispatching Save Game UI request.'
+        );
+      }
     } else {
       this.#logger.warn(
         'GameEngine.showSaveGameUI: Saving is not currently allowed.'
@@ -475,7 +483,15 @@ class GameEngine {
     this.#logger.debug(
       'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
     );
-    await this.#safeEventDispatcher.dispatch(REQUEST_SHOW_LOAD_GAME_UI, {});
+    const success = await this.#safeEventDispatcher.dispatch(
+      REQUEST_SHOW_LOAD_GAME_UI,
+      {}
+    );
+    if (!success) {
+      this.#logger.warn(
+        'GameEngine.showLoadGameUI: SafeEventDispatcher reported failure when dispatching Load Game UI request.'
+      );
+    }
   }
 
   getEngineStatus() {

--- a/tests/unit/engine/showLoadGameUI.test.js
+++ b/tests/unit/engine/showLoadGameUI.test.js
@@ -19,6 +19,24 @@ describeEngineSuite('GameEngine', (context) => {
       );
     });
 
+    it('should log warning if dispatcher reports failure', async () => {
+      context.bed
+        .getSafeEventDispatcher()
+        .dispatch.mockResolvedValueOnce(false);
+
+      await context.engine.showLoadGameUI();
+
+      expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
+        'GameEngine.showLoadGameUI: Dispatching request to show Load Game UI.'
+      );
+      expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
+        'GameEngine.showLoadGameUI: SafeEventDispatcher reported failure when dispatching Load Game UI request.'
+      );
+      expectShowLoadGameUIDispatch(
+        context.bed.getSafeEventDispatcher().dispatch
+      );
+    });
+
     generateServiceUnavailableTests(
       [[tokens.GamePersistenceService, GAME_PERSISTENCE_LOAD_UI_UNAVAILABLE]],
       async (bed, engine) => {

--- a/tests/unit/engine/showSaveGameUI.test.js
+++ b/tests/unit/engine/showSaveGameUI.test.js
@@ -29,6 +29,27 @@ describeInitializedEngineSuite(
         );
       });
 
+      it('should log warning if dispatcher reports failure', async () => {
+        context.bed
+          .getGamePersistenceService()
+          .isSavingAllowed.mockReturnValue(true);
+        context.bed
+          .getSafeEventDispatcher()
+          .dispatch.mockResolvedValueOnce(false);
+
+        await context.engine.showSaveGameUI();
+
+        expect(context.bed.getLogger().debug).toHaveBeenCalledWith(
+          'GameEngine.showSaveGameUI: Dispatching request to show Save Game UI.'
+        );
+        expect(context.bed.getLogger().warn).toHaveBeenCalledWith(
+          'GameEngine.showSaveGameUI: SafeEventDispatcher reported failure when dispatching Save Game UI request.'
+        );
+        expectShowSaveGameUIDispatch(
+          context.bed.getSafeEventDispatcher().dispatch
+        );
+      });
+
       it('should dispatch CANNOT_SAVE_GAME_INFO if saving is not allowed and log reason', async () => {
         context.bed
           .getGamePersistenceService()


### PR DESCRIPTION
Summary: log warnings when UI event dispatches fail during save/load prompts.

Changes Made:
- check `dispatch` results in `showSaveGameUI` and `showLoadGameUI`
- warn via logger when dispatch reports failure
- add unit tests covering warning logs for both methods

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` shows existing repo issues)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_68629a39067483318ddca72775ecef36