### PR TITLE
[Agent] extract strategy registry and inject into factory

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -53,6 +53,7 @@ import { EnvironmentContext } from '../../llms/environmentContext.js';
 import { ClientApiKeyProvider } from '../../llms/clientApiKeyProvider.js';
 import { RetryHttpClient } from '../../llms/retryHttpClient.js';
 import { LLMStrategyFactory } from '../../llms/LLMStrategyFactory.js';
+import strategyRegistry from '../../llms/strategies/strategyRegistry.js';
 
 // --- AI Turn Handler Import ---
 import ActorTurnHandler from '../../turns/handlers/actorTurnHandler.js';
@@ -151,7 +152,11 @@ export function registerLlmInfrastructure(registrar, logger) {
       safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
     });
     const httpClient = c.resolve(tokens.IHttpClient);
-    const llmStrategyFactory = new LLMStrategyFactory({ httpClient, logger });
+    const llmStrategyFactory = new LLMStrategyFactory({
+      httpClient,
+      logger,
+      strategyMap: strategyRegistry,
+    });
 
     const adapterInstance = new ConfigurableLLMAdapter({
       logger: c.resolve(tokens.ILogger),

--- a/src/llms/strategies/strategyRegistry.js
+++ b/src/llms/strategies/strategyRegistry.js
@@ -1,0 +1,16 @@
+import { OpenRouterJsonSchemaStrategy } from './openRouterJsonSchemaStrategy.js';
+import { OpenRouterToolCallingStrategy } from './openRouterToolCallingStrategy.js';
+
+/**
+ * Default mapping of API types and json output methods to their strategy classes.
+ *
+ * @type {Object<string, Object<string, Function>>}
+ */
+const strategyRegistry = {
+  openrouter: {
+    openrouter_json_schema: OpenRouterJsonSchemaStrategy,
+    openrouter_tool_calling: OpenRouterToolCallingStrategy,
+  },
+};
+
+export default strategyRegistry;

--- a/tests/unit/llms/LLMStrategyFactory.test.js
+++ b/tests/unit/llms/LLMStrategyFactory.test.js
@@ -2,6 +2,7 @@
 // --- CORRECTED FILE START ---
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { LLMStrategyFactory } from '../../../src/llms/LLMStrategyFactory.js';
+import strategyRegistry from '../../../src/llms/strategies/strategyRegistry.js';
 import { ConfigurationError } from '../../../src/errors/configurationError';
 import { LLMStrategyFactoryError } from '../../../src/llms/errors/LLMStrategyFactoryError.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
@@ -75,7 +76,11 @@ describe('LLMStrategyFactory', () => {
     OpenRouterJsonSchemaStrategy.mockClear();
     OpenRouterToolCallingStrategy.mockClear();
 
-    factory = new LLMStrategyFactory({ httpClient, logger });
+    factory = new LLMStrategyFactory({
+      httpClient,
+      logger,
+      strategyMap: strategyRegistry,
+    });
   });
 
   describe('Constructor', () => {
@@ -88,19 +93,35 @@ describe('LLMStrategyFactory', () => {
 
     test('should throw error if logger is invalid or missing', () => {
       expect(
-        () => new LLMStrategyFactory({ httpClient, logger: null })
+        () =>
+          new LLMStrategyFactory({
+            httpClient,
+            logger: null,
+            strategyMap: strategyRegistry,
+          })
       ).toThrow('Missing required dependency: logger.');
       expect(
-        () => new LLMStrategyFactory({ httpClient, logger: undefined })
+        () =>
+          new LLMStrategyFactory({
+            httpClient,
+            logger: undefined,
+            strategyMap: strategyRegistry,
+          })
       ).toThrow('Missing required dependency: logger.');
-      expect(() => new LLMStrategyFactory({ httpClient, logger: {} })).toThrow(
-        LOGGER_INFO_METHOD_ERROR
-      );
+      expect(
+        () =>
+          new LLMStrategyFactory({
+            httpClient,
+            logger: {},
+            strategyMap: strategyRegistry,
+          })
+      ).toThrow(LOGGER_INFO_METHOD_ERROR);
       expect(
         () =>
           new LLMStrategyFactory({
             httpClient,
             logger: { info: 'not a function' },
+            strategyMap: strategyRegistry,
           })
       ).toThrow(LOGGER_INFO_METHOD_ERROR);
     });
@@ -119,6 +140,7 @@ describe('LLMStrategyFactory', () => {
             new LLMStrategyFactory({
               httpClient: /** @type {any} */ (invalidClient),
               logger: tempLogger,
+              strategyMap: strategyRegistry,
             })
         ).toThrow(
           'LLMStrategyFactory: Constructor requires a valid httpClient instance conforming to IHttpClient (must have a request method).'


### PR DESCRIPTION
Summary:
- inject strategy maps into LLMStrategyFactory
- keep default mappings in new strategyRegistry module
- provide strategy registry to DI configuration
- update factory unit tests for new constructor

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 3649 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68629bbdfd68833193f1343d313cc9fd