### PR TITLE
[Agent] refactor BaseManifestItemLoader processing

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -199,6 +199,25 @@ export class ContentLoadManager {
   }
 
   async processMod(modId, manifest, totalCounts, phaseLoaders, phase) {
+    if (!manifest) {
+      return this.#modProcessor.processMod(
+        modId,
+        null,
+        totalCounts,
+        phaseLoaders,
+        phase
+      );
+    }
+    return this.#executeModProcessing(
+      modId,
+      manifest,
+      totalCounts,
+      phaseLoaders,
+      phase
+    );
+  }
+
+  #executeModProcessing(modId, manifest, totalCounts, phaseLoaders, phase) {
     return this.#modProcessor.processMod(
       modId,
       manifest,


### PR DESCRIPTION
## Summary
- refactor `_processFileWrapper` into smaller helpers and guard calls
- add an early return to `ContentLoadManager.processMod`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3646 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68629beb26848331a1154d1b98b5d3f8