### PR TITLE
[Agent] Centralize operation parameter validation

### DIFF
--- a/src/logic/operationHandlers/componentOperationHandler.js
+++ b/src/logic/operationHandlers/componentOperationHandler.js
@@ -11,6 +11,10 @@
 
 import BaseOperationHandler from './baseOperationHandler.js';
 import { resolveEntityId } from '../../utils/entityRefUtils.js';
+import {
+  validateEntityRef as utilValidateEntityRef,
+  validateComponentType as utilValidateComponentType,
+} from '../../utils/operationValidationUtils.js';
 
 /**
  * @typedef {object} EntityRefObject
@@ -39,12 +43,12 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * Validate a component type string.
    *
    * @param {*} type - Raw component type.
+   * @param {ILogger} [log] - Logger used for warnings.
+   * @param {string} [operationName] - Optional operation name prefix for logging.
    * @returns {string|null} Trimmed component type or null if invalid.
    */
-  validateComponentType(type) {
-    if (typeof type !== 'string') return null;
-    const trimmed = type.trim();
-    return trimmed ? trimmed : null;
+  validateComponentType(type, log = this.logger, operationName) {
+    return utilValidateComponentType(type, log, operationName);
   }
 
   /**
@@ -57,19 +61,13 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * @returns {string|null} The resolved ID or null when invalid.
    */
   validateEntityRef(entityRef, log, operationName, executionContext) {
-    const prefix = operationName ? `${operationName}: ` : '';
-    if (!entityRef) {
-      log.warn(`${prefix}"entity_ref" parameter is required.`);
-      return null;
-    }
-    const resolved = this.resolveEntity(entityRef, executionContext);
-    if (!resolved) {
-      log.warn(`${prefix}Could not resolve entity id from entity_ref.`, {
-        entity_ref: entityRef,
-      });
-      return null;
-    }
-    return resolved;
+    return utilValidateEntityRef(
+      entityRef,
+      executionContext,
+      log,
+      undefined,
+      operationName
+    );
   }
 
   /**
@@ -81,15 +79,7 @@ class ComponentOperationHandler extends BaseOperationHandler {
    * @returns {string|null} Trimmed component type or null if invalid.
    */
   requireComponentType(type, log, operationName) {
-    const prefix = operationName ? `${operationName}: ` : '';
-    const trimmed = this.validateComponentType(type);
-    if (!trimmed) {
-      log.warn(
-        `${prefix}Invalid or missing "component_type" parameter (must be non-empty string).`
-      );
-      return null;
-    }
-    return trimmed;
+    return utilValidateComponentType(type, log, operationName);
   }
 
   /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -34,3 +34,4 @@ export { validateNonEmptyString } from './stringValidation.js';
 export { createErrorDetails } from './errorDetails.js';
 export { readComponent, writeComponent } from './componentAccessUtils.js';
 export * from '../turns/strategies/strategyHelpers.js';
+export * from './operationValidationUtils.js';

--- a/src/utils/operationValidationUtils.js
+++ b/src/utils/operationValidationUtils.js
@@ -1,0 +1,92 @@
+/**
+ * @file Utility functions for validating operation parameters.
+ * @module operationValidationUtils
+ */
+
+/** @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher */
+/** @typedef {import('../logic/operationHandlers/modifyComponentHandler.js').EntityRefObject} EntityRefObject */
+
+import { resolveEntityId } from './entityRefUtils.js';
+import { safeDispatchError } from './safeDispatchErrorUtils.js';
+import { ensureValidLogger } from './loggerUtils.js';
+
+/**
+ * Validate and resolve an entity reference. Emits warnings or error events on failure.
+ *
+ * @param {'actor'|'target'|string|EntityRefObject} entityRef - Reference to resolve.
+ * @param {ExecutionContext} executionContext - Execution context used for keyword resolution.
+ * @param {ILogger} logger - Logger used for warnings.
+ * @param {ISafeEventDispatcher} [dispatcher] - Optional dispatcher for error events.
+ * @param {string} [operationName] - Optional prefix for log messages.
+ * @returns {string|null} Resolved entity id or `null` when invalid.
+ */
+export function validateEntityRef(
+  entityRef,
+  executionContext,
+  logger,
+  dispatcher,
+  operationName = ''
+) {
+  const log = ensureValidLogger(logger, 'validateEntityRef');
+  const prefix = operationName ? `${operationName}: ` : '';
+
+  if (!entityRef) {
+    const message = `${prefix}"entity_ref" parameter is required.`;
+    if (dispatcher && typeof dispatcher.dispatch === 'function') {
+      safeDispatchError(dispatcher, message, { entity_ref: entityRef }, log);
+    } else {
+      log.warn(message);
+    }
+    return null;
+  }
+
+  const resolved = resolveEntityId(entityRef, executionContext);
+  if (!resolved) {
+    const message = `${prefix}Could not resolve entity id from entity_ref.`;
+    if (dispatcher && typeof dispatcher.dispatch === 'function') {
+      safeDispatchError(dispatcher, message, { entity_ref: entityRef }, log);
+    } else {
+      log.warn(message, { entity_ref: entityRef });
+    }
+    return null;
+  }
+
+  return resolved;
+}
+
+/**
+ * Validate a component type string.
+ *
+ * @param {*} type - Raw component type value.
+ * @param {ILogger} logger - Logger used for warnings.
+ * @param {string} [operationName] - Optional prefix for log messages.
+ * @returns {string|null} Trimmed component type or `null` when invalid.
+ */
+export function validateComponentType(type, logger, operationName = '') {
+  const log = ensureValidLogger(logger, 'validateComponentType');
+  const prefix = operationName ? `${operationName}: ` : '';
+
+  if (typeof type !== 'string') {
+    log.warn(
+      `${prefix}Invalid or missing "component_type" parameter (must be non-empty string).`
+    );
+    return null;
+  }
+
+  const trimmed = type.trim();
+  if (!trimmed) {
+    log.warn(
+      `${prefix}Invalid or missing "component_type" parameter (must be non-empty string).`
+    );
+    return null;
+  }
+
+  return trimmed;
+}
+
+export default {
+  validateEntityRef,
+  validateComponentType,
+};

--- a/tests/unit/utils/operationValidationUtils.test.js
+++ b/tests/unit/utils/operationValidationUtils.test.js
@@ -1,0 +1,60 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+  validateEntityRef,
+  validateComponentType,
+} from '../../../src/utils/operationValidationUtils.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+
+const logger = {
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+const dispatcher = { dispatch: jest.fn() };
+
+const ctx = {
+  evaluationContext: { actor: { id: 'a1' }, target: { id: 't1' } },
+};
+
+describe('operationValidationUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('validateComponentType trims valid input', () => {
+    const result = validateComponentType('  core:stat  ', logger, 'TEST');
+    expect(result).toBe('core:stat');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('validateComponentType warns on invalid input', () => {
+    const result = validateComponentType('  ', logger, 'TEST');
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'TEST: Invalid or missing "component_type" parameter (must be non-empty string).'
+    );
+  });
+
+  test('validateEntityRef resolves actor keyword', () => {
+    const result = validateEntityRef('actor', ctx, logger, undefined, 'TEST');
+    expect(result).toBe('a1');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('validateEntityRef dispatches when unresolved and dispatcher provided', () => {
+    const result = validateEntityRef(
+      { bad: true },
+      ctx,
+      logger,
+      dispatcher,
+      'TEST'
+    );
+    expect(result).toBeNull();
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Adds shared utilities for validating entity references and component types. ComponentOperationHandler methods now delegate to these helpers. New unit tests cover the validation utilities.

Changes Made:
- new `operationValidationUtils.js` with `validateEntityRef` and `validateComponentType`
- ComponentOperationHandler refactored to use the new utilities
- exported utilities via `src/utils/index.js`
- added corresponding unit tests

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and llm-proxy-server)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_68629c204bfc8331afa2d9232ef43fa6