### PR TITLE
[Agent] rename reqIndex for clarity

### DIFF
--- a/src/modding/modLoadOrderResolver.js
+++ b/src/modding/modLoadOrderResolver.js
@@ -207,15 +207,15 @@ export default class ModLoadOrderResolver {
     const { nodes, edges } = buildDependencyGraph(requestedIds, manifestsMap);
 
     /* 2 – Tie-breaker priorities derived from original request */
-    const reqIndex = new Map();
+    const requestOrderIndex = new Map();
     requestedIds.forEach((id, i) => {
       const lc = String(id).toLowerCase();
-      if (!reqIndex.has(lc)) reqIndex.set(lc, i);
+      if (!requestOrderIndex.has(lc)) requestOrderIndex.set(lc, i);
     });
     const priorityOf = (id) =>
       id.toLowerCase() === CORE_MOD_ID
         ? -1
-        : (reqIndex.get(id.toLowerCase()) ?? Number.MAX_SAFE_INTEGER);
+        : (requestOrderIndex.get(id.toLowerCase()) ?? Number.MAX_SAFE_INTEGER);
 
     /* 3 – Compute in-degrees */
     const inDeg = new Map();


### PR DESCRIPTION
Summary: Renamed an internal variable in `ModLoadOrderResolver` to improve readability and reflect its purpose.

Testing Done:
- [x] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68629c6c5f1c8331ab2eed50526a72ae