### PR TITLE
[Refactor] DRY timestamped entry extraction

### DIFF
--- a/src/prompting/AIPromptContentProvider.js
+++ b/src/prompting/AIPromptContentProvider.js
@@ -148,6 +148,26 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
   }
 
   /**
+   * @private
+   * @description Extracts and sanitizes timestamped entries from a component.
+   * @param {object} component - Component containing the entries array.
+   * @param {string} key - Key of the array within the component.
+   * @returns {Array<{text:string,timestamp:string}>} Sanitized array of entries.
+   */
+  _extractTimestampedEntries(component, key) {
+    const arr = Array.isArray(component?.[key]) ? component[key] : [];
+    return arr
+      .filter(
+        (e) =>
+          typeof e.text === 'string' &&
+          e.text.trim().length > 0 &&
+          typeof e.timestamp === 'string' &&
+          e.timestamp.trim().length > 0
+      )
+      .map((e) => ({ text: e.text, timestamp: e.timestamp }));
+  }
+
+  /**
    * Validates if the provided AIGameStateDTO contains the critical information.
    *
    * @param {AIGameStateDTO | null | undefined} gameStateDto - The game state DTO to validate.
@@ -232,30 +252,10 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
       : [];
 
     const notesComp = componentsMap['core:notes'];
-    const notesArray = Array.isArray(notesComp?.notes)
-      ? notesComp.notes
-          .filter(
-            (n) =>
-              typeof n.text === 'string' &&
-              n.text.trim().length > 0 &&
-              typeof n.timestamp === 'string' &&
-              n.timestamp.trim().length > 0
-          )
-          .map((n) => ({ text: n.text, timestamp: n.timestamp }))
-      : [];
+    const notesArray = this._extractTimestampedEntries(notesComp, 'notes');
 
     const goalsComp = componentsMap['core:goals'];
-    const goalsArray = Array.isArray(goalsComp?.goals)
-      ? goalsComp.goals
-          .filter(
-            (g) =>
-              typeof g.text === 'string' &&
-              g.text.trim().length > 0 &&
-              typeof g.timestamp === 'string' &&
-              g.timestamp.trim().length > 0
-          )
-          .map((g) => ({ text: g.text, timestamp: g.timestamp }))
-      : [];
+    const goalsArray = this._extractTimestampedEntries(goalsComp, 'goals');
 
     this.#logger.debug(
       `AIPromptContentProvider.getPromptData: goalsArray contains ${goalsArray.length} entries.`

--- a/tests/unit/prompting/AIPromptContentProvider.helpers.test.js
+++ b/tests/unit/prompting/AIPromptContentProvider.helpers.test.js
@@ -82,6 +82,32 @@ describe('AIPromptContentProvider helper methods', () => {
     expect(res.goalsArray).toEqual([{ text: 'g1', timestamp: 't3' }]);
   });
 
+  test('_extractTimestampedEntries returns [] when property missing or not array', () => {
+    const result = provider._extractTimestampedEntries({}, 'notes');
+    expect(result).toEqual([]);
+    const result2 = provider._extractTimestampedEntries(
+      { notes: 'bad' },
+      'notes'
+    );
+    expect(result2).toEqual([]);
+  });
+
+  test('_extractTimestampedEntries filters malformed entries', () => {
+    const comp = {
+      notes: [
+        { text: 'valid', timestamp: 't1' },
+        { text: '', timestamp: 't2' },
+        { text: 'no timestamp' },
+        { text: 'also valid', timestamp: 't3' },
+      ],
+    };
+    const res = provider._extractTimestampedEntries(comp, 'notes');
+    expect(res).toEqual([
+      { text: 'valid', timestamp: 't1' },
+      { text: 'also valid', timestamp: 't3' },
+    ]);
+  });
+
   test('_buildPromptData merges base values and arrays', () => {
     const base = { a: 1 };
     const pd = provider._buildPromptData(


### PR DESCRIPTION
Summary: Centralized filtering of notes and goals to avoid code duplication.

Changes Made:
- Added `_extractTimestampedEntries` utility to `AIPromptContentProvider` for sanitizing arrays.
- Replaced inline logic in `_extractMemoryComponents` with calls to the new helper.
- Extended helper test suite with cases covering missing arrays and malformed entries.

Testing Done:
- [x] Code formatted (`npx prettier`)
- [x] Lint passes on touched files (`npx eslint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_68629c8ba3388331b9b96a7ee377735b