### PR TITLE
[Test] cover strategy helpers and reset resolver

### DIFF
--- a/tests/common/turns/resolverTestHelpers.js
+++ b/tests/common/turns/resolverTestHelpers.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param resolver
+ */
+export function resetResolver(resolver) {
+  if (resolver && typeof resolver.clearCache === 'function') {
+    resolver.clearCache();
+  }
+}

--- a/tests/unit/turns/strategies/strategyHelpers.test.js
+++ b/tests/unit/turns/strategies/strategyHelpers.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  assertDirective,
+  requireContextActor,
+  resolveTurnEndError,
+} from '../../../../src/turns/strategies/strategyHelpers.js';
+
+describe('strategyHelpers', () => {
+  describe('assertDirective', () => {
+    it('does nothing when directive matches', () => {
+      const logger = { error: jest.fn() };
+      expect(() =>
+        assertDirective({
+          expected: 'SAME',
+          actual: 'SAME',
+          logger,
+          className: 'TestClass',
+        })
+      ).not.toThrow();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('throws and logs when directive mismatches', () => {
+      const logger = { error: jest.fn() };
+      expect(() =>
+        assertDirective({
+          expected: 'EXPECTED',
+          actual: 'ACTUAL',
+          logger,
+          className: 'TestClass',
+        })
+      ).toThrow(
+        'TestClass: Received wrong directive (ACTUAL). Expected EXPECTED.'
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'TestClass: Received wrong directive (ACTUAL). Expected EXPECTED.'
+      );
+    });
+  });
+
+  describe('requireContextActor', () => {
+    it('returns actor when present', () => {
+      const actor = { id: 'a1' };
+      const turnContext = {
+        getActor: jest.fn(() => actor),
+        endTurn: jest.fn(),
+      };
+      const logger = { error: jest.fn() };
+
+      const result = requireContextActor({
+        turnContext,
+        logger,
+        className: 'TestClass',
+        errorMsg: 'missing',
+      });
+
+      expect(result).toBe(actor);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(turnContext.endTurn).not.toHaveBeenCalled();
+    });
+
+    it('logs and ends the turn when actor missing', () => {
+      const turnContext = {
+        getActor: jest.fn(() => null),
+        endTurn: jest.fn(),
+      };
+      const logger = { error: jest.fn() };
+
+      const result = requireContextActor({
+        turnContext,
+        logger,
+        className: 'TestClass',
+        errorMsg: 'missing actor',
+      });
+
+      expect(result).toBeNull();
+      expect(logger.error).toHaveBeenCalledWith('missing actor');
+      expect(turnContext.endTurn).toHaveBeenCalledTimes(1);
+      expect(turnContext.endTurn.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(turnContext.endTurn.mock.calls[0][0].message).toBe(
+        'missing actor'
+      );
+    });
+  });
+
+  describe('resolveTurnEndError', () => {
+    it('returns error from command result when instance of Error', () => {
+      const error = new Error('boom');
+      const result = resolveTurnEndError({ error }, 'a1', 'DIR');
+      expect(result).toBe(error);
+    });
+
+    it('wraps non-error value from command result', () => {
+      const result = resolveTurnEndError({ error: 'oops' }, 'a1', 'DIR');
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('oops');
+    });
+
+    it('creates default message when no error provided', () => {
+      const result = resolveTurnEndError({}, 'actor42', 'END_TURN');
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe(
+        "Turn for actor actor42 ended by directive 'END_TURN' (failure)."
+      );
+    });
+  });
+});

--- a/tests/unit/turns/strategies/turnDirectiveStrategyResolver.test.js
+++ b/tests/unit/turns/strategies/turnDirectiveStrategyResolver.test.js
@@ -11,6 +11,7 @@ import {
 import TurnDirectiveStrategyResolver, {
   DEFAULT_STRATEGY_MAP,
 } from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
+import { resetResolver } from '../../../common/turns/resolverTestHelpers.js';
 import TurnDirective from '../../../../src/turns/constants/turnDirectives.js';
 import RepromptStrategy from '../../../../src/turns/strategies/repromptStrategy.js';
 import EndTurnSuccessStrategy from '../../../../src/turns/strategies/endTurnSuccessStrategy.js';
@@ -34,7 +35,7 @@ describe('TurnDirectiveStrategyResolver', () => {
   afterEach(() => {
     consoleWarnSpy.mockRestore();
     process.env.NODE_ENV = originalNodeEnv;
-    resolver.clearCache();
+    resetResolver(resolver);
   });
 
   test('returns correct singleton strategies for known directives', () => {


### PR DESCRIPTION
Summary: Added unit tests for strategy helper functions and standardized resolver cleanup.

Changes Made:
- Added `strategyHelpers.test.js` with tests for `assertDirective`, `requireContextActor`, and `resolveTurnEndError`.
- Created `resetResolver` helper for clearing resolver cache between tests and applied it in `turnDirectiveStrategyResolver.test.js`.

Testing Done:
- [x] Code formatted (`npm run format`)
- [ ] Lint passes (`npm run lint` in root & proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (skipped)


------
https://chatgpt.com/codex/tasks/task_e_6862a60175b083319dad53066d2342b7