### PR TITLE
[Agent] clarify loader errors

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -11,3 +11,5 @@ export * from './unknownAstNodeError.js';
 export * from './repositoryConsistencyError.js';
 export * from './componentOverrideNotFoundError.js';
 export * from './locationNotFoundError.js';
+export * from './missingEntityInstanceError.js';
+export * from './missingInstanceIdError.js';

--- a/src/errors/missingEntityInstanceError.js
+++ b/src/errors/missingEntityInstanceError.js
@@ -1,0 +1,29 @@
+/**
+ * @file Error thrown when a world references an entity instance that does not exist.
+ */
+
+/**
+ * Error thrown when a world references a non-existent entity instance.
+ *
+ * @class MissingEntityInstanceError
+ * @augments {Error}
+ */
+export class MissingEntityInstanceError extends Error {
+  /**
+   * @param {string} instanceId - The missing entity instance ID.
+   * @param {string} worldFile - The world filename where the reference occurs.
+   */
+  constructor(instanceId, worldFile) {
+    super(
+      `Unknown entity instanceId '${instanceId}' referenced in world '${worldFile}'.`
+    );
+    this.name = 'MissingEntityInstanceError';
+    this.instanceId = instanceId;
+    this.worldFile = worldFile;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MissingEntityInstanceError);
+    }
+  }
+}
+
+export default MissingEntityInstanceError;

--- a/src/errors/missingInstanceIdError.js
+++ b/src/errors/missingInstanceIdError.js
@@ -1,0 +1,25 @@
+/**
+ * @file Error thrown when an entity instance within a world file is missing an instanceId.
+ */
+
+/**
+ * Error thrown when an instance lacks the required instanceId.
+ *
+ * @class MissingInstanceIdError
+ * @augments {Error}
+ */
+export class MissingInstanceIdError extends Error {
+  /**
+   * @param {string} worldFile - World file where the instance resides.
+   */
+  constructor(worldFile) {
+    super(`Instance in world file '${worldFile}' is missing an 'instanceId'.`);
+    this.name = 'MissingInstanceIdError';
+    this.worldFile = worldFile;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MissingInstanceIdError);
+    }
+  }
+}
+
+export default MissingInstanceIdError;

--- a/src/loaders/uiAssetsLoader.js
+++ b/src/loaders/uiAssetsLoader.js
@@ -98,9 +98,9 @@ class UiAssetsLoader extends AbstractLoader {
     for (const filename of targetFiles) {
       const path = this.#resolver.resolveModContentPath(modId, 'ui', filename);
 
-      let data;
+      let fileData;
       try {
-        data = await this.#fetcher.fetch(path);
+        fileData = await this.#fetcher.fetch(path);
       } catch (e) {
         errors++;
         failures.push({ file: filename, reason: 'fetch' });
@@ -111,9 +111,9 @@ class UiAssetsLoader extends AbstractLoader {
       }
 
       const schemaId = this.#config.getContentTypeSchemaId(schemaKey);
-      let res;
+      let validationResult;
       try {
-        res = this.#validator.validate(schemaId, data);
+        validationResult = this.#validator.validate(schemaId, fileData);
       } catch (e) {
         errors++;
         failures.push({ file: filename, reason: 'validation' });
@@ -123,7 +123,7 @@ class UiAssetsLoader extends AbstractLoader {
         continue;
       }
 
-      if (!res.isValid) {
+      if (!validationResult.isValid) {
         errors++;
         failures.push({ file: filename, reason: 'validation' });
         this._logger.error(
@@ -132,7 +132,7 @@ class UiAssetsLoader extends AbstractLoader {
         continue;
       }
 
-      for (const [name, value] of Object.entries(data)) {
+      for (const [name, value] of Object.entries(fileData)) {
         if (this.#registry.get(registryCat, name) !== undefined) {
           overrides++;
         }
@@ -229,12 +229,14 @@ class UiAssetsLoader extends AbstractLoader {
 
     for (const filename of files) {
       try {
-        const res = await loader(modId, { content: { ui: [filename] } });
-        count += res.count;
-        overrides += res.overrides;
-        errors += res.errors;
-        if (Array.isArray(res.failures)) {
-          failures.push(...res.failures);
+        const loaderResult = await loader(modId, {
+          content: { ui: [filename] },
+        });
+        count += loaderResult.count;
+        overrides += loaderResult.overrides;
+        errors += loaderResult.errors;
+        if (Array.isArray(loaderResult.failures)) {
+          failures.push(...loaderResult.failures);
         }
       } catch (e) {
         errors++;

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -17,6 +17,8 @@
 import AbstractLoader from './abstractLoader.js';
 import { validateAgainstSchema } from '../utils/schemaValidationUtils.js';
 import ModsLoaderError from '../errors/modsLoaderError.js';
+import MissingEntityInstanceError from '../errors/missingEntityInstanceError.js';
+import MissingInstanceIdError from '../errors/missingInstanceIdError.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 
 const WORLDS_REGISTRY_KEY = 'worlds';
@@ -373,7 +375,7 @@ export class WorldLoader extends AbstractLoader {
    * @param {string} modId - The ID of the mod owning the world file.
    * @param {string} filename - The filename for logging context.
    * @returns {{resolved: number, unresolved: number, instanceCount: number}} Counts of definitions and instances.
-   * @throws {ModsLoaderError} If any instance has a missing or unresolvable definitionId.
+   * @throws {MissingInstanceIdError|MissingEntityInstanceError} If any instance data is invalid.
    */
   #validateWorldInstances(worldData, modId, filename) {
     let resolved = 0;
@@ -383,11 +385,7 @@ export class WorldLoader extends AbstractLoader {
       const { instanceId } = instance;
       if (!instanceId) {
         unresolved++;
-        throw new ModsLoaderError(
-          `Instance in world file '${filename}' is missing an 'instanceId'.`,
-          'missing_instance_id_in_world',
-          { modId, filename, instance }
-        );
+        throw new MissingInstanceIdError(filename);
       }
 
       const entityInstanceDef = this._dataRegistry.get(
@@ -397,11 +395,7 @@ export class WorldLoader extends AbstractLoader {
 
       if (!entityInstanceDef) {
         unresolved++;
-        throw new ModsLoaderError(
-          `Unknown entity instanceId '${instanceId}' referenced in world '${filename}'.`,
-          'missing_entity_instance',
-          { modId, filename, instanceId }
-        );
+        throw new MissingEntityInstanceError(instanceId, filename);
       }
       resolved++;
     }


### PR DESCRIPTION
Summary: Improve naming clarity and error handling for loader utilities.

Changes Made:
- Added `MissingInstanceIdError` and `MissingEntityInstanceError` for world validation.
- Renamed temporary variables in `uiAssetsLoader` for clarity.
- Updated `WorldLoader` to use new error classes and adjusted tests.
- Updated unit tests to verify error logging behavior.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root & `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6862af2a505083318f914bc212466218