### PR TITLE
[Agent] add getLlmId utility

### DIFF
--- a/src/llms/LLMStrategyFactory.js
+++ b/src/llms/LLMStrategyFactory.js
@@ -7,6 +7,7 @@ import { ILLMStrategy } from './interfaces/ILLMStrategy.js'; // Assuming ILLMStr
 import { ConfigurationError } from '../errors/configurationError';
 import { LLMStrategyFactoryError } from './errors/LLMStrategyFactoryError.js';
 import { initLogger } from '../utils/index.js';
+import { getLlmId } from './utils/llmUtils.js';
 
 // Import concrete strategy implementations
 import strategyRegistry from './strategies/strategyRegistry.js';
@@ -175,7 +176,7 @@ export class LLMStrategyFactory {
       });
     }
 
-    const llmId = llmConfig.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
     const apiType = llmConfig.apiType.trim().toLowerCase();
     const configuredMethod = llmConfig.jsonOutputStrategy?.method
       ?.trim()

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -7,6 +7,7 @@ import { validateDependency } from '../utils/dependencyUtils.js';
 import { initLogger } from '../utils/index.js';
 import { CLOUD_API_TYPES } from './constants/llmConstants.js';
 import { isValidEnvironmentContext } from './environmentContext.js';
+import { getLlmId } from './utils/llmUtils.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -73,7 +74,7 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
    * @returns {Promise<string | null>} A Promise that always resolves to null.
    */
   async getKey(llmConfig, environmentContext) {
-    const llmId = llmConfig?.configId || 'UnknownLLM'; // For logging context
+    const llmId = getLlmId(llmConfig); // For logging context
 
     if (!isValidEnvironmentContext(environmentContext)) {
       safeDispatchError(

--- a/src/llms/strategies/base/baseOpenRouterStrategy.js
+++ b/src/llms/strategies/base/baseOpenRouterStrategy.js
@@ -4,6 +4,7 @@ import { BaseChatLLMStrategy } from './baseChatLLMStrategy.js';
 import { ConfigurationError } from '../../../errors/configurationError';
 import { LLMStrategyError } from '../../errors/LLMStrategyError.js';
 import { logPreview } from '../../../utils/index.js';
+import { getLlmId } from '../../utils/llmUtils.js';
 // Assuming HttpClientError might be a specific type, if not, general Error is caught.
 // For actual HttpClientError type, it would be imported from its definition:
 // import { HttpClientError } from '../../retryHttpClient.js'; // Example path
@@ -69,7 +70,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
    */
   _buildProviderRequestPayloadAdditions(baseMessagesPayload, llmConfig) {
     const errorMessage = `${this.constructor.name}._buildProviderRequestPayloadAdditions: Method not implemented. Subclasses must override this method.`;
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
     this.logger.error(errorMessage, { llmId });
     throw new Error(errorMessage); // Or potentially an LLMStrategyError
   }
@@ -90,7 +91,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
    */
   async _extractJsonOutput(responseData, llmConfig, _providerRequestPayload) {
     const errorMessage = `${this.constructor.name}._extractJsonOutput: Method not implemented. Subclasses must override this method.`;
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
     this.logger.error(errorMessage, { llmId });
     throw new Error(errorMessage); // Or potentially an LLMStrategyError
   }
@@ -112,7 +113,7 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
       });
     }
 
-    const llmId = llmConfig.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
 
     if (!environmentContext) {
       const errorMsg = `${this.constructor.name} (${llmId}): Missing environmentContext. Cannot proceed.`;

--- a/src/llms/strategies/openRouterJsonSchemaStrategy.js
+++ b/src/llms/strategies/openRouterJsonSchemaStrategy.js
@@ -4,6 +4,7 @@ import { BaseOpenRouterStrategy } from './base/baseOpenRouterStrategy.js';
 import { LLMStrategyError } from '../errors/LLMStrategyError.js';
 import { OPENROUTER_GAME_AI_ACTION_SPEECH_SCHEMA } from '../constants/llmConstants.js'; // Still potentially used for tool_calls fallback logic's expected name
 import { isNonBlankString } from '../../utils/textUtils.js';
+import { getLlmId } from '../utils/llmUtils.js';
 
 /**
  * @typedef {import('../services/llmConfigLoader.js').LLMModelConfig} LLMModelConfig
@@ -47,7 +48,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
    * @throws {LLMStrategyError} if jsonSchema is missing or invalid in llmConfig.
    */
   _buildProviderRequestPayloadAdditions(baseMessagesPayload, llmConfig) {
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
 
     const configuredJsonSchema = llmConfig.jsonOutputStrategy?.jsonSchema;
 
@@ -103,7 +104,7 @@ export class OpenRouterJsonSchemaStrategy extends BaseOpenRouterStrategy {
    * @throws {LLMStrategyError} If JSON content cannot be extracted.
    */
   async _extractJsonOutput(responseData, llmConfig, providerRequestPayload) {
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
     let extractedJsonString = null;
     const message = responseData?.choices?.[0]?.message;
 

--- a/src/llms/strategies/openRouterToolCallingStrategy.js
+++ b/src/llms/strategies/openRouterToolCallingStrategy.js
@@ -6,6 +6,7 @@ import {
   OPENROUTER_GAME_AI_ACTION_SPEECH_SCHEMA, // Still needed for the parameters schema
   OPENROUTER_DEFAULT_TOOL_DESCRIPTION, // Can still be used for description
 } from '../constants/llmConstants.js';
+import { getLlmId } from '../utils/llmUtils.js';
 
 /**
  * @typedef {import('../interfaces/IHttpClient.js').IHttpClient} IHttpClient
@@ -44,7 +45,7 @@ export class OpenRouterToolCallingStrategy extends BaseOpenRouterStrategy {
    * @throws {LLMStrategyError} If tool schema configuration is invalid.
    */
   _buildProviderRequestPayloadAdditions(baseMessagesPayload, llmConfig) {
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
 
     const configuredToolName = llmConfig.jsonOutputStrategy?.toolName;
 
@@ -122,7 +123,7 @@ export class OpenRouterToolCallingStrategy extends BaseOpenRouterStrategy {
    * @throws {LLMStrategyError} If JSON content cannot be extracted or validated.
    */
   async _extractJsonOutput(responseData, llmConfig, _providerRequestPayload) {
-    const llmId = llmConfig?.configId || 'UnknownLLM';
+    const llmId = getLlmId(llmConfig);
     const message = responseData?.choices?.[0]?.message;
 
     const expectedToolName = llmConfig.jsonOutputStrategy?.toolName;

--- a/src/llms/utils/llmUtils.js
+++ b/src/llms/utils/llmUtils.js
@@ -1,0 +1,15 @@
+/**
+ * Utility functions for LLM-related helpers.
+ *
+ * @module llmUtils
+ */
+
+/**
+ * Retrieves the LLM identifier from configuration with a fallback to 'UnknownLLM'.
+ *
+ * @param {object} [config] - The LLM configuration object.
+ * @returns {string} The configuration's configId or 'UnknownLLM' if unavailable.
+ */
+export function getLlmId(config) {
+  return config?.configId || 'UnknownLLM';
+}

--- a/tests/unit/llms/utils/llmUtils.test.js
+++ b/tests/unit/llms/utils/llmUtils.test.js
@@ -1,0 +1,15 @@
+import { describe, test, expect } from '@jest/globals';
+import { getLlmId } from '../../../../src/llms/utils/llmUtils.js';
+
+describe('getLlmId', () => {
+  test('returns configId when present', () => {
+    const config = { configId: 'llm-123' };
+    expect(getLlmId(config)).toBe('llm-123');
+  });
+
+  test('returns fallback when configId missing', () => {
+    expect(getLlmId({})).toBe('UnknownLLM');
+    expect(getLlmId(null)).toBe('UnknownLLM');
+    expect(getLlmId(undefined)).toBe('UnknownLLM');
+  });
+});


### PR DESCRIPTION
## Summary
- add `getLlmId` helper for consistent llmId extraction
- use `getLlmId` across LLM strategies and providers
- cover new helper with unit tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862af0db01c8331a0377ad3fc959923