### PR TITLE
[Agent] Extract flow control handlers

### DIFF
--- a/src/logic/flowHandlers/forEachHandler.js
+++ b/src/logic/flowHandlers/forEachHandler.js
@@ -1,0 +1,77 @@
+// src/logic/flowHandlers/forEachHandler.js
+
+/**
+ * @module flowHandlers/forEachHandler
+ * @description Flow-control handler that iterates over a collection and
+ * executes an action sequence for each item.
+ */
+
+/** @typedef {import('../../../data/schemas/operation.schema.json').Operation} Operation */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../operationInterpreter.js').default} OperationInterpreter */
+/**
+ * @typedef {ExecutionContext & {
+ *   scopeLabel?: string,
+ *   jsonLogic: import('../jsonLogicEvaluationService.js').default,
+ * }} ActionExecutionContext
+ */
+
+import { resolvePath } from '../../utils/objectUtils.js';
+import { executeActionSequence } from '../actionSequence.js';
+
+/**
+ * Execute FOR_EACH logic.
+ *
+ * @param {Operation} node - Operation describing the FOR_EACH loop.
+ * @param {ActionExecutionContext} nestedCtx - Execution context for the loop.
+ * @param {ILogger} logger - Logger instance for diagnostics.
+ * @param {OperationInterpreter} operationInterpreter - Interpreter for executing the loop body.
+ * @returns {void}
+ */
+export function handleForEach(node, nestedCtx, logger, operationInterpreter) {
+  const {
+    collection: path,
+    item_variable: varName,
+    actions,
+  } = node.parameters || {};
+
+  const { scopeLabel, jsonLogic, ...baseCtx } = nestedCtx;
+
+  if (
+    !path?.trim() ||
+    !varName?.trim() ||
+    !Array.isArray(actions) ||
+    actions.length === 0
+  ) {
+    logger.warn(`${scopeLabel}: invalid parameters.`);
+    return;
+  }
+  const collection = resolvePath(baseCtx.evaluationContext, path.trim());
+  if (!Array.isArray(collection)) {
+    logger.warn(`${scopeLabel}: '${path}' did not resolve to an array.`);
+    return;
+  }
+
+  const store = baseCtx.evaluationContext.context;
+  const hadPrior = Object.prototype.hasOwnProperty.call(store, varName);
+  const saved = store[varName];
+
+  try {
+    for (let i = 0; i < collection.length; i++) {
+      store[varName] = collection[i];
+      executeActionSequence(
+        actions,
+        {
+          ...baseCtx,
+          scopeLabel: `${scopeLabel} > Item ${i + 1}/${collection.length}`,
+          jsonLogic,
+        },
+        logger,
+        operationInterpreter
+      );
+    }
+  } finally {
+    hadPrior ? (store[varName] = saved) : delete store[varName];
+  }
+}

--- a/src/logic/flowHandlers/ifHandler.js
+++ b/src/logic/flowHandlers/ifHandler.js
@@ -1,0 +1,70 @@
+// src/logic/flowHandlers/ifHandler.js
+
+/**
+ * @module flowHandlers/ifHandler
+ * @description Flow-control handler that executes THEN or ELSE action sequences
+ * based on a JSON Logic condition.
+ */
+
+/** @typedef {import('../../../data/schemas/operation.schema.json').Operation} Operation */
+/** @typedef {import('../defs.js').ExecutionContext} ExecutionContext */
+/** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+/** @typedef {import('../operationInterpreter.js').default} OperationInterpreter */
+/**
+ * @typedef {ExecutionContext & {
+ *   scopeLabel?: string,
+ *   jsonLogic: import('../jsonLogicEvaluationService.js').default,
+ * }} ActionExecutionContext
+ */
+
+import { evaluateConditionWithLogging } from '../jsonLogicEvaluationService.js';
+import { executeActionSequence } from '../actionSequence.js';
+
+/**
+ * Execute IF logic.
+ *
+ * @param {Operation} node - Operation describing the IF logic.
+ * @param {ActionExecutionContext} nestedCtx - Execution context for nested actions.
+ * @param {ILogger} logger - Logger instance for diagnostics.
+ * @param {OperationInterpreter} operationInterpreter - Interpreter used to execute nested operations.
+ * @returns {void}
+ */
+export function handleIf(node, nestedCtx, logger, operationInterpreter) {
+  const {
+    condition,
+    then_actions: thenActs = [],
+    else_actions: elseActs = [],
+  } = node.parameters || {};
+
+  const { scopeLabel = 'IF', jsonLogic, ...baseCtx } = nestedCtx;
+  const { result, errored } = evaluateConditionWithLogging(
+    jsonLogic,
+    condition,
+    baseCtx.evaluationContext,
+    logger,
+    scopeLabel
+  );
+
+  if (errored) {
+    return;
+  }
+
+  if (result) {
+    logger.debug(`[handleIf] then_actions length: ${thenActs.length}`);
+    logger.debug(
+      `[handleIf] then_actions: ${JSON.stringify(thenActs, null, 2)}`
+    );
+  } else {
+    logger.debug(`[handleIf] else_actions length: ${elseActs.length}`);
+    logger.debug(
+      `[handleIf] else_actions: ${JSON.stringify(elseActs, null, 2)}`
+    );
+  }
+
+  executeActionSequence(
+    result ? thenActs : elseActs,
+    { ...baseCtx, scopeLabel, jsonLogic },
+    logger,
+    operationInterpreter
+  );
+}

--- a/tests/unit/logic/flowHandlers/forEachHandler.test.js
+++ b/tests/unit/logic/flowHandlers/forEachHandler.test.js
@@ -1,0 +1,66 @@
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+
+jest.mock('../../../../src/logic/actionSequence.js', () => ({
+  executeActionSequence: jest.fn(),
+}));
+
+import { executeActionSequence } from '../../../../src/logic/actionSequence.js';
+import { handleForEach } from '../../../../src/logic/flowHandlers/forEachHandler.js';
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const interpreter = { execute: jest.fn() };
+const jsonLogic = {};
+const baseCtx = { evaluationContext: { context: {} } };
+
+describe('handleForEach', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('iterates over collection and executes actions for each item', () => {
+    const ctx = { evaluationContext: { items: [1, 2], context: {} } };
+    const node = {
+      parameters: {
+        collection: 'items',
+        item_variable: 'i',
+        actions: [{ type: 'LOG' }],
+      },
+    };
+    const captured = [];
+    executeActionSequence.mockImplementation((a, c) => {
+      captured.push(c.evaluationContext.context.i);
+    });
+    handleForEach(
+      node,
+      { ...ctx, jsonLogic, scopeLabel: 'Loop' },
+      logger,
+      interpreter
+    );
+    expect(executeActionSequence).toHaveBeenCalledTimes(2);
+    expect(captured).toEqual([1, 2]);
+    expect(executeActionSequence.mock.calls[0][1].scopeLabel).toBe(
+      'Loop > Item 1/2'
+    );
+    expect(executeActionSequence.mock.calls[1][1].scopeLabel).toBe(
+      'Loop > Item 2/2'
+    );
+    expect(ctx.evaluationContext.context.i).toBeUndefined();
+  });
+
+  test('logs warning and skips when parameters invalid', () => {
+    const node = { parameters: {} };
+    handleForEach(
+      node,
+      { ...baseCtx, jsonLogic, scopeLabel: 'Loop' },
+      logger,
+      interpreter
+    );
+    expect(logger.warn).toHaveBeenCalled();
+    expect(executeActionSequence).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/logic/flowHandlers/ifHandler.test.js
+++ b/tests/unit/logic/flowHandlers/ifHandler.test.js
@@ -1,0 +1,91 @@
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+
+jest.mock('../../../../src/logic/actionSequence.js', () => ({
+  executeActionSequence: jest.fn(),
+}));
+
+jest.mock('../../../../src/logic/jsonLogicEvaluationService.js', () => ({
+  evaluateConditionWithLogging: jest.fn(),
+}));
+
+import { executeActionSequence } from '../../../../src/logic/actionSequence.js';
+import { evaluateConditionWithLogging } from '../../../../src/logic/jsonLogicEvaluationService.js';
+import { handleIf } from '../../../../src/logic/flowHandlers/ifHandler.js';
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const interpreter = { execute: jest.fn() };
+const jsonLogic = { evaluate: jest.fn() };
+const baseCtx = { evaluationContext: { context: {} } };
+
+describe('handleIf', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('executes then_actions when condition is true', () => {
+    evaluateConditionWithLogging.mockReturnValue({
+      result: true,
+      errored: false,
+    });
+    const node = {
+      parameters: { then_actions: [{ type: 'LOG' }], else_actions: [] },
+    };
+    handleIf(
+      node,
+      { ...baseCtx, jsonLogic, scopeLabel: 'S' },
+      logger,
+      interpreter
+    );
+    expect(executeActionSequence).toHaveBeenCalledTimes(1);
+    expect(executeActionSequence).toHaveBeenCalledWith(
+      node.parameters.then_actions,
+      { ...baseCtx, scopeLabel: 'S', jsonLogic },
+      logger,
+      interpreter
+    );
+  });
+
+  test('executes else_actions when condition is false', () => {
+    evaluateConditionWithLogging.mockReturnValue({
+      result: false,
+      errored: false,
+    });
+    const node = {
+      parameters: { then_actions: [], else_actions: [{ type: 'LOG' }] },
+    };
+    handleIf(
+      node,
+      { ...baseCtx, jsonLogic, scopeLabel: 'S' },
+      logger,
+      interpreter
+    );
+    expect(executeActionSequence).toHaveBeenCalledTimes(1);
+    expect(executeActionSequence).toHaveBeenCalledWith(
+      node.parameters.else_actions,
+      { ...baseCtx, scopeLabel: 'S', jsonLogic },
+      logger,
+      interpreter
+    );
+  });
+
+  test('skips execution on evaluation error', () => {
+    evaluateConditionWithLogging.mockReturnValue({
+      result: false,
+      errored: true,
+      error: new Error('fail'),
+    });
+    const node = { parameters: {} };
+    handleIf(
+      node,
+      { ...baseCtx, jsonLogic, scopeLabel: 'S' },
+      logger,
+      interpreter
+    );
+    expect(executeActionSequence).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- split `handleIf` and `handleForEach` into dedicated flow handler modules
- dispatch flow control operations via a handler map in `executeActionSequence`
- add unit tests for the new handlers

## Testing Done
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862af39e03c8331abc1bba3921b56d8