### PR TITLE
[Agent] freeze loaded manifests

### DIFF
--- a/src/modding/modManifestLoader.js
+++ b/src/modding/modManifestLoader.js
@@ -14,6 +14,8 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 /** @typedef {import('../interfaces/coreServices.js').ValidationResult} ValidationResult */
 
+import { freezeMap } from '../utils/cloneUtils.js';
+
 // --- MODLOADER-005 E: Error Code Constants ---
 /**
  * Standardized error codes for ModManifestLoader logging.
@@ -42,6 +44,7 @@ class ModManifestLoader {
   #schemaValidator;
   #dataRegistry;
   #logger;
+  /** @type {ReadonlyMap<string, object> | null} */
   #lastLoadedManifests = null;
 
   constructor(
@@ -303,9 +306,10 @@ class ModManifestLoader {
 
     /* ── 5. store each validated manifest ─────────────────────────── */
     const stored = this._storeValidatedManifests(validated);
+    const frozenStored = freezeMap(stored);
 
     /* ── 6. summary ───────────────────────────────────────────────── */
-    this.#lastLoadedManifests = stored;
+    this.#lastLoadedManifests = frozenStored;
     this.#logger.debug(
       `${fn}: finished – fetched ${
         settled.filter((s) => s.status === 'fulfilled').length
@@ -313,7 +317,7 @@ class ModManifestLoader {
         trimmedIds.length
       }, validated ${validated.length}, stored ${stored.size}.`
     );
-    return stored;
+    return frozenStored;
   }
 
   /* ---------------- placeholders / future work (unchanged) ------------ */

--- a/tests/unit/modding/modManifestLoader.immutability.test.js
+++ b/tests/unit/modding/modManifestLoader.immutability.test.js
@@ -1,0 +1,70 @@
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import ModManifestLoader from '../../../src/modding/modManifestLoader.js';
+
+/**
+ * Helper to build loader with basic mocks.
+ *
+ * @returns {{loader: ModManifestLoader, deps: object}} Loader and dependencies.
+ */
+const buildLoader = () => {
+  const deps = {
+    configuration: { getContentTypeSchemaId: jest.fn(() => 'schema') },
+    pathResolver: { resolveModManifestPath: jest.fn() },
+    dataFetcher: { fetch: jest.fn() },
+    schemaValidator: {
+      getValidator: jest.fn(() => jest.fn(() => ({ isValid: true }))),
+    },
+    dataRegistry: { store: jest.fn() },
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+
+  return {
+    loader: new ModManifestLoader(
+      deps.configuration,
+      deps.pathResolver,
+      deps.dataFetcher,
+      deps.schemaValidator,
+      deps.dataRegistry,
+      deps.logger
+    ),
+    deps,
+  };
+};
+
+describe('ModManifestLoader immutability', () => {
+  let loader;
+  let deps;
+
+  beforeEach(() => {
+    const built = buildLoader();
+    loader = built.loader;
+    deps = built.deps;
+    deps.pathResolver.resolveModManifestPath.mockImplementation(
+      (id) => `mods/${id}/mod-manifest.json`
+    );
+    deps.dataFetcher.fetch.mockResolvedValue({
+      id: 'modA',
+      name: 'A',
+      version: '1.0.0',
+    });
+  });
+
+  test('getLoadedManifests returns a frozen map', async () => {
+    const result = await loader.loadRequestedManifests(['modA']);
+
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.get('modA'))).toBe(true);
+
+    expect(() => result.set('other', {})).toThrow(TypeError);
+    expect(() => {
+      const manifest = result.get('modA');
+      // @ts-ignore intentional mutation attempt for test
+      manifest.name = 'B';
+    }).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Summary:
- freeze manifests via new `freezeMap` and store immutable results
- expose immutable manifests from `loadRequestedManifests`
- add immutability test for `ModManifestLoader`

Testing Done:
- `npm run format`
- `npm run lint` *(fails: 729 errors, 2951 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm install`
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862af5a90e88331897fbba3a0ea5838