### PR TITLE
[Agent] rename variable cmdStr

### DIFF
--- a/src/turns/states/workflows/actionDecisionWorkflow.js
+++ b/src/turns/states/workflows/actionDecisionWorkflow.js
@@ -3,8 +3,14 @@
  * @description Workflow logic for AwaitingActorDecisionState handling action decisions.
  */
 
+/**
+ * @class ActionDecisionWorkflow
+ * @description Executes the action decision workflow for an AwaitingActorDecisionState instance.
+ */
 export class ActionDecisionWorkflow {
   /**
+   * Constructs an instance of ActionDecisionWorkflow.
+   *
    * @param {import('../awaitingActorDecisionState.js').AwaitingActorDecisionState} state - Owning state instance.
    * @param {import('../../interfaces/turnStateContextTypes.js').AwaitingActorDecisionStateContext} turnContext - Context for the turn.
    * @param {import('../../../entities/entity.js').default} actor - Actor making the decision.
@@ -45,7 +51,7 @@ export class ActionDecisionWorkflow {
         extractedData
       );
 
-      const cmdStr =
+      const commandToExecute =
         action.commandString && action.commandString.trim().length > 0
           ? action.commandString
           : action.actionDefinitionId;
@@ -54,7 +60,7 @@ export class ActionDecisionWorkflow {
         `${this._state.getStateName()}: Requesting transition to ProcessingCommandState for actor ${this._actor.id}.`
       );
       await this._turnContext.requestProcessingCommandStateTransition(
-        cmdStr,
+        commandToExecute,
         action
       );
     } catch (error) {


### PR DESCRIPTION
Summary: Updated ActionDecisionWorkflow by renaming `cmdStr` to `commandToExecute` and added JSDoc descriptions for clarity.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6862b91460b48331a06944463ce2b371