### PR TITLE
[Feat] expose unsubscribe status from event bus

### DIFF
--- a/src/events/eventBus.js
+++ b/src/events/eventBus.js
@@ -49,12 +49,19 @@ class EventBus extends IEventBus {
     return isValid;
   }
 
+  /**
+   * Subscribes a listener to a specific event.
+   *
+   * @param {string} eventName - The name of the event to subscribe to.
+   * @param {EventListener} listener - Function to invoke when the event is dispatched.
+   * @returns {(() => boolean) | null} An unsubscribe function on success, or `null` on failure.
+   */
   subscribe(eventName, listener) {
     if (
       !this.#validateEventName(eventName) ||
       !this.#validateListener(listener)
     ) {
-      return;
+      return null;
     }
 
     if (!this.#listeners.has(eventName)) {
@@ -62,26 +69,33 @@ class EventBus extends IEventBus {
     }
     this.#listeners.get(eventName).add(listener);
 
-    return () => {
-      this.unsubscribe(eventName, listener);
-    };
+    return () => this.unsubscribe(eventName, listener);
   }
 
+  /**
+   * Unsubscribes a listener from a specific event.
+   *
+   * @param {string} eventName - The event identifier.
+   * @param {EventListener} listener - The previously subscribed listener.
+   * @returns {boolean} `true` if a listener was removed, otherwise `false`.
+   */
   unsubscribe(eventName, listener) {
     if (
       !this.#validateEventName(eventName) ||
       !this.#validateListener(listener)
     ) {
-      return;
+      return false;
     }
 
     if (this.#listeners.has(eventName)) {
       const eventListeners = this.#listeners.get(eventName);
-      eventListeners.delete(listener);
+      const deleted = eventListeners.delete(listener);
       if (eventListeners.size === 0) {
         this.#listeners.delete(eventName);
       }
+      return deleted;
     }
+    return false;
   }
 
   /**

--- a/src/events/safeEventDispatcher.js
+++ b/src/events/safeEventDispatcher.js
@@ -166,7 +166,7 @@ export class SafeEventDispatcher extends ISafeEventDispatcher {
       return unsubscribeFn;
     }
 
-    if (unsubscribeFn === undefined) {
+    if (unsubscribeFn === undefined || unsubscribeFn === null) {
       return null;
     }
 
@@ -196,9 +196,11 @@ export class SafeEventDispatcher extends ISafeEventDispatcher {
       return;
     }
 
-    this.#logger.debug(
-      `SafeEventDispatcher: Successfully unsubscribed from event '${eventName}' (direct call).`
-    );
+    if (result) {
+      this.#logger.debug(
+        `SafeEventDispatcher: Successfully unsubscribed from event '${eventName}' (direct call).`
+      );
+    }
   }
 }
 

--- a/src/events/validatedEventDispatcher.js
+++ b/src/events/validatedEventDispatcher.js
@@ -241,24 +241,14 @@ class ValidatedEventDispatcher extends IValidatedEventDispatcher {
    *
    * @param {string} eventName - The name of the event to subscribe to.
    * @param {EventListener} listener - The function to call when the event is dispatched.
-   * @returns {() => void} A function that, when called, unsubscribes the listener.
+   * @returns {(() => boolean) | null} An unsubscribe function on success, or `null` on failure.
    */
   subscribe(eventName, listener) {
     this.#logger.debug(
       `VED: Delegating subscription for event "${eventName}" to EventBus.`
     );
     // Delegate subscription to the internal EventBus instance
-    this.#eventBus.subscribe(eventName, listener);
-
-    // --- FIX ---
-    // You MUST return a function that calls unsubscribe, fulfilling the interface contract.
-    return () => {
-      this.#logger.debug(
-        `VED: Executing unsubscribe callback for "${eventName}". Delegating to EventBus.`
-      );
-      this.#eventBus.unsubscribe(eventName, listener);
-    };
-    // --- END FIX ---
+    return this.#eventBus.subscribe(eventName, listener);
   }
 
   /**
@@ -267,14 +257,14 @@ class ValidatedEventDispatcher extends IValidatedEventDispatcher {
    *
    * @param {string} eventName - The name of the event to unsubscribe from.
    * @param {EventListener} listener - The listener function to remove.
-   * @returns {void}
+   * @returns {boolean} `true` if a listener was removed, otherwise `false`.
    */
   unsubscribe(eventName, listener) {
     this.#logger.debug(
       `VED: Delegating unsubscription for event "${eventName}" to EventBus.`
     );
     // Delegate directly to the internal EventBus instance
-    this.#eventBus.unsubscribe(eventName, listener);
+    return this.#eventBus.unsubscribe(eventName, listener);
   }
 }
 

--- a/src/interfaces/IEventBus.js
+++ b/src/interfaces/IEventBus.js
@@ -28,7 +28,7 @@ export class IEventBus {
    *
    * @param {string} eventName - The name of the event to subscribe to.
    * @param {EventListener} listener - Function invoked when the event is dispatched.
-   * @returns {() => void} Function that unsubscribes the listener when called.
+   * @returns {(() => boolean) | null} Function that unsubscribes the listener when called, or `null` on failure.
    */
   subscribe(eventName, listener) {
     throw new Error('IEventBus.subscribe method not implemented.');
@@ -39,7 +39,7 @@ export class IEventBus {
    *
    * @param {string} eventName - The event identifier.
    * @param {EventListener} listener - The previously subscribed listener.
-   * @returns {void}
+   * @returns {boolean} `true` if a listener was removed, otherwise `false`.
    */
   unsubscribe(eventName, listener) {
     throw new Error('IEventBus.unsubscribe method not implemented.');

--- a/src/interfaces/IValidatedEventDispatcher.js
+++ b/src/interfaces/IValidatedEventDispatcher.js
@@ -36,7 +36,7 @@ export class IValidatedEventDispatcher {
    * @function subscribe
    * @param {string} eventName - The name of the event to subscribe to.
    * @param {EventListener} listener - The function to call when the event is dispatched.
-   * @returns {UnsubscribeFn} A function that, when called, unregisters the provided listener.
+   * @returns {UnsubscribeFn | null} A function that unsubscribes the listener, or `null` on failure.
    */
   subscribe(eventName, listener) {
     throw new Error(
@@ -51,7 +51,7 @@ export class IValidatedEventDispatcher {
    * @function unsubscribe
    * @param {string} eventName - The name of the event to unsubscribe from.
    * @param {EventListener} listener - The listener function to remove.
-   * @returns {void}
+   * @returns {boolean} `true` if a listener was removed, otherwise `false`.
    */
   unsubscribe(eventName, listener) {
     throw new Error(

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -110,8 +110,12 @@ class SystemLogicInterpreter extends BaseService {
   }
 
   shutdown() {
-    if (this.#boundEventHandler)
-      this.#eventBus.unsubscribe('*', this.#boundEventHandler);
+    if (this.#boundEventHandler) {
+      const removed = this.#eventBus.unsubscribe('*', this.#boundEventHandler);
+      this.#logger.debug(
+        `SystemLogicInterpreter: removed '*' subscription: ${removed}.`
+      );
+    }
 
     this.#ruleCache.clear();
     this.#boundEventHandler = null;

--- a/tests/unit/events/eventBus.errors.test.js
+++ b/tests/unit/events/eventBus.errors.test.js
@@ -25,14 +25,18 @@ describe('EventBus error handling', () => {
   });
 
   it('logs for invalid subscribe arguments', () => {
-    bus.subscribe('', () => {});
-    bus.subscribe('test', null);
+    const r1 = bus.subscribe('', () => {});
+    const r2 = bus.subscribe('test', null);
+    expect(r1).toBeNull();
+    expect(r2).toBeNull();
     expect(logger.error).toHaveBeenCalledTimes(2);
   });
 
   it('logs for invalid unsubscribe arguments', () => {
-    bus.unsubscribe('', () => {});
-    bus.unsubscribe('a', null);
+    const u1 = bus.unsubscribe('', () => {});
+    const u2 = bus.unsubscribe('a', null);
+    expect(u1).toBe(false);
+    expect(u2).toBe(false);
     expect(logger.error).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/unit/events/eventBus.test.js
+++ b/tests/unit/events/eventBus.test.js
@@ -16,13 +16,15 @@ describe('EventBus', () => {
 
   it('subscribes and dispatches events to specific listeners', async () => {
     const handler = jest.fn();
-    bus.subscribe('test', handler);
+    const unsub = bus.subscribe('test', handler);
+    expect(typeof unsub).toBe('function');
     await bus.dispatch('test', { foo: 'bar' });
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith({
       type: 'test',
       payload: { foo: 'bar' },
     });
+    expect(unsub()).toBe(true);
   });
 
   it('handles wildcard subscriptions', async () => {
@@ -34,8 +36,9 @@ describe('EventBus', () => {
 
   it('unsubscribes listeners correctly', async () => {
     const handler = jest.fn();
-    bus.subscribe('once', handler);
-    bus.unsubscribe('once', handler);
+    const unsub = bus.subscribe('once', handler);
+    expect(typeof unsub).toBe('function');
+    expect(unsub()).toBe(true);
     await bus.dispatch('once');
     expect(handler).not.toHaveBeenCalled();
     expect(bus.listenerCount('once')).toBe(0);
@@ -47,5 +50,18 @@ describe('EventBus', () => {
     bus.subscribe('count', h1);
     bus.subscribe('count', h2);
     expect(bus.listenerCount('count')).toBe(2);
+  });
+
+  it('returns null on failed subscription and false on failed unsubscribe', () => {
+    const unsub = bus.subscribe('', () => {});
+    expect(unsub).toBeNull();
+    const result = bus.unsubscribe('', () => {});
+    expect(result).toBe(false);
+  });
+
+  it('unsubscribe returns false when listener not found', () => {
+    const handler = jest.fn();
+    const result = bus.unsubscribe('missing', handler);
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
Summary: Exposes success information when using the event bus by returning a boolean from `unsubscribe` and propagating through higher level dispatchers. `subscribe` now yields `null` on failure, allowing callers to react. Tests updated to cover the new behavior.

Changes Made:
- Updated `EventBus.subscribe` to return unsubscribe function or `null`; `unsubscribe` now returns a boolean.
- Updated interfaces and implementations in `ValidatedEventDispatcher` and `SafeEventDispatcher`.
- Added logging of unsubscription result in `SystemLogicInterpreter`.
- Revised unit tests for `EventBus` to assert new return values and updated error tests.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` – errors exist in repository)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_6862bdfee1088331a28b006e3c9d14b2