### PR TITLE
[Agent] Add engine state unit test

### DIFF
--- a/tests/unit/engine/engineState.test.js
+++ b/tests/unit/engine/engineState.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import EngineState from '../../../src/engine/engineState.js';
+
+// tests/unit/engine/engineState.test.js
+
+describe('EngineState', () => {
+  it('setStarted should initialize and start the engine', () => {
+    const state = new EngineState();
+
+    state.setStarted('WorldA');
+
+    expect(state.isInitialized).toBe(true);
+    expect(state.isGameLoopRunning).toBe(true);
+    expect(state.activeWorld).toBe('WorldA');
+  });
+
+  it('reset should clear all state flags', () => {
+    const state = new EngineState();
+    state.setStarted('WorldB');
+
+    state.reset();
+
+    expect(state.isInitialized).toBe(false);
+    expect(state.isGameLoopRunning).toBe(false);
+    expect(state.activeWorld).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary: Add regression tests for EngineState's lifecycle helpers.

Changes Made:
- Added `engineState.test.js` verifying `setStarted` and `reset` getters.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_6862bdd424c08331af6bb4a8eca249c5