### PR TITLE
[Agent] Parallelize perception and location fetch

### DIFF
--- a/src/turns/services/AIGameStateProvider.js
+++ b/src/turns/services/AIGameStateProvider.js
@@ -72,15 +72,10 @@ export class AIGameStateProvider extends IAIGameStateProvider {
       actorState,
       actor.id
     );
-    const perceptionLog = await this.#perceptionLogProvider.get(
-      actor,
-      logger,
-      this.#safeEventDispatcher
-    );
-    const locationSummary = await this.#locationSummaryProvider.build(
-      actor,
-      logger
-    );
+    const [perceptionLog, locationSummary] = await Promise.all([
+      this.#perceptionLogProvider.get(actor, logger, this.#safeEventDispatcher),
+      this.#locationSummaryProvider.build(actor, logger),
+    ]);
 
     /** @type {AIGameStateDTO} */
     const gameState = {


### PR DESCRIPTION
## Summary
- fetch perception log and location summary concurrently in `AIGameStateProvider`

## Testing Done
- `npm run test -- tests/unit/turns/services/AIGameStateProvider.*.test.js`
- `npm test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_6862bfca1b288331926cb60a539501dc