### PR TITLE
[Agent] centralize state reset logic

### DIFF
--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -136,11 +136,13 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
   //─────────────────────────────────────────────────────────────────────────────
   async exitState(handler, next) {
     this.#clearGuards(this._getTurnContext());
+    this.#resetInternalState();
     await super.exitState(handler, next);
   }
 
   async destroy(handler) {
     this.#clearGuards(this._getTurnContext());
+    this.#resetInternalState();
     await super.destroy(handler);
   }
 
@@ -166,6 +168,33 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
         );
       }
     }
+    this.#resetInternalState();
+  }
+
+  /**
+   * Resets mutable internal fields to a neutral state.
+   *
+   * @private
+   * @returns {void}
+   */
+  #resetInternalState() {
+    this.#timeoutId = null;
+    this.#unsubscribeFn = undefined;
+    this.#awaitingActionId = 'unknown-action';
+  }
+
+  /**
+   * Returns key internal values for unit tests.
+   *
+   * @public
+   * @returns {{timeoutId: any, unsubscribeFn: Function|undefined, awaitingActionId: string}}
+   */
+  getInternalStateForTest() {
+    return {
+      timeoutId: this.#timeoutId,
+      unsubscribeFn: this.#unsubscribeFn,
+      awaitingActionId: this.#awaitingActionId,
+    };
   }
 
   async #onTimeout() {

--- a/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -440,6 +440,31 @@ describe('AwaitingExternalTurnEndState', () => {
     });
   });
 
+  // --- Internal State Reset ---
+  describe('Internal State Reset', () => {
+    beforeEach(async () => {
+      await state.enterState(mockHandler, null);
+    });
+
+    test('exitState resets internal fields', async () => {
+      await state.exitState(mockHandler, null);
+      expect(state.getInternalStateForTest()).toEqual({
+        timeoutId: null,
+        unsubscribeFn: undefined,
+        awaitingActionId: 'unknown-action',
+      });
+    });
+
+    test('destroy resets internal fields', async () => {
+      await state.destroy(mockHandler);
+      expect(state.getInternalStateForTest()).toEqual({
+        timeoutId: null,
+        unsubscribeFn: undefined,
+        awaitingActionId: 'unknown-action',
+      });
+    });
+  });
+
   // --- Ignored Actions ---
   describe('Ignored Actions', () => {
     test('handleSubmittedCommand should be a no-op', async () => {


### PR DESCRIPTION
## Summary
- add `#resetInternalState` and expose `getInternalStateForTest`
- call `#resetInternalState` from `#clearGuards`, `exitState`, and `destroy`
- test that internal fields reset after exit or destroy

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 729 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6862bff1263c8331943e6df96ec05be0