### PR TITLE
[Fix] Validate mod dependency version ranges

### DIFF
--- a/src/modding/modDependencyValidator.js
+++ b/src/modding/modDependencyValidator.js
@@ -12,7 +12,7 @@ import { assertIsMap, assertIsLogger } from '../utils/argValidation.js';
  * @param {boolean} required - Whether the dependency is required.
  * @param {ILogger} logger - Logger instance for warnings.
  * @param {string[]} fatals - Array collecting fatal error messages.
- * @param {{valid: Function, satisfies: Function}} semverLib - Semver library for version checks.
+ * @param {{valid: Function, satisfies: Function, validRange: Function}} semverLib - Semver library for version checks.
  * @returns {void}
  */
 function _checkVersionCompatibility(
@@ -35,6 +35,16 @@ function _checkVersionCompatibility(
       logger.warn(`${msg} Cannot check optional version requirement.`);
     }
     return; // Invalid version, skip further checks
+  }
+
+  if (!semverLib.validRange(requiredVersionRange)) {
+    const msg = `Mod '${hostId}' dependency '${dep.id}' has an invalid version range: '${requiredVersionRange}'.`;
+    if (required) {
+      fatals.push(msg);
+    } else {
+      logger.warn(`${msg} Cannot check optional version requirement.`);
+    }
+    return; // Invalid range, skip further checks
   }
 
   if (!semverLib.satisfies(targetVersion, requiredVersionRange)) {
@@ -72,7 +82,7 @@ class ModDependencyValidator {
    * @param {Map<string, ModManifest>} manifests - Map of mod manifests, keyed by **lower-cased** mod ID.
    * @param {ILogger} logger - Logger instance for warnings.
    * @param {object} [options] - Optional validation options.
-   * @param {{valid: Function, satisfies: Function}} [options.semverLib] - Library used for semver checks.
+   * @param {{valid: Function, satisfies: Function, validRange: Function}} [options.semverLib] - Library used for semver checks.
    * @returns {void} - Returns nothing, but throws ModDependencyError on fatal issues.
    * @throws {ModDependencyError} If fatal validation errors occur (missing required, version mismatch, conflict).
    */

--- a/tests/unit/modding/modDependencyValidator.invalidRange.test.js
+++ b/tests/unit/modding/modDependencyValidator.invalidRange.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import ModDependencyValidator from '../../../src/modding/modDependencyValidator.js';
+import ModDependencyError from '../../../src/errors/modDependencyError.js';
+
+const createMockLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+const createManifestMap = (arr) => {
+  const map = new Map();
+  for (const m of arr) {
+    map.set(m.id.toLowerCase(), m);
+  }
+  return map;
+};
+
+describe('ModDependencyValidator invalid range handling', () => {
+  let logger;
+  beforeEach(() => {
+    logger = createMockLogger();
+    jest.clearAllMocks();
+  });
+
+  it('throws when required dependency has invalid version range', () => {
+    const modB = { id: 'ModB', version: '1.0.0' };
+    const modA = {
+      id: 'ModA',
+      version: '1.0.0',
+      dependencies: [{ id: 'ModB', version: '>=foo', required: true }],
+    };
+    const manifests = createManifestMap([modA, modB]);
+    expect(() => ModDependencyValidator.validate(manifests, logger)).toThrow(
+      ModDependencyError
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when optional dependency has invalid version range', () => {
+    const modB = { id: 'ModB', version: '1.0.0' };
+    const modA = {
+      id: 'ModA',
+      version: '1.0.0',
+      dependencies: [{ id: 'ModB', version: '~invalid', required: false }],
+    };
+    const manifests = createManifestMap([modA, modB]);
+    expect(() =>
+      ModDependencyValidator.validate(manifests, logger)
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/invalid version range/)
+    );
+  });
+});

--- a/tests/unit/services/modDependencyValidator.test.js
+++ b/tests/unit/services/modDependencyValidator.test.js
@@ -244,6 +244,7 @@ describe('ModDependencyValidator', () => {
 
     const fakeSemver = {
       valid: jest.fn(() => true),
+      validRange: jest.fn(() => true),
       satisfies: jest.fn(() => false),
     };
 
@@ -253,6 +254,7 @@ describe('ModDependencyValidator', () => {
       })
     ).toThrow(/requires dependency 'ModB' version '\^1.0.0'/);
     expect(fakeSemver.valid).toHaveBeenCalledWith('1.0.0');
+    expect(fakeSemver.validRange).toHaveBeenCalledWith('^1.0.0');
     expect(fakeSemver.satisfies).toHaveBeenCalledWith('1.0.0', '^1.0.0');
   });
 


### PR DESCRIPTION
Summary: Ensure invalid version ranges in mod dependencies are detected. Optional dependencies log warnings, required ones throw errors.

Changes Made:
- Added `semver.validRange` check in `modDependencyValidator`
- Updated injected semver usage in tests
- Added new test covering invalid version ranges

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6862bf65c0148331b428fd00a901552a