### PR TITLE
[Agent] add shared environment context validation

### DIFF
--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -6,8 +6,7 @@ import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { validateDependency } from '../utils/dependencyUtils.js';
 import { initLogger } from '../utils/index.js';
 import { CLOUD_API_TYPES } from './constants/llmConstants.js';
-import { isValidEnvironmentContext } from './environmentContext.js';
-import { getLlmId } from './utils/llmUtils.js';
+import { getLlmId, validateEnvironmentContext } from './utils/llmUtils.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -76,12 +75,13 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = getLlmId(llmConfig); // For logging context
 
-    if (!isValidEnvironmentContext(environmentContext)) {
-      safeDispatchError(
-        this.#dispatcher,
-        `ClientApiKeyProvider.getKey (${llmId}): Invalid environmentContext provided.`,
-        { providedValue: environmentContext }
-      );
+    if (
+      !validateEnvironmentContext(
+        environmentContext,
+        `ClientApiKeyProvider.getKey (${llmId})`,
+        this.#dispatcher
+      )
+    ) {
       return null;
     }
 

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -10,7 +10,7 @@ import {
 import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
 import { validateDependency } from '../utils/dependencyUtils.js';
 import { initLogger } from '../utils/index.js';
-import { isValidEnvironmentContext } from './environmentContext.js';
+import { validateEnvironmentContext } from './utils/llmUtils.js';
 
 /**
  * @typedef {import('./environmentContext.js').EnvironmentContext} EnvironmentContext
@@ -173,12 +173,13 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = llmConfig?.id || 'UnknownLLM';
 
-    if (!isValidEnvironmentContext(environmentContext)) {
-      safeDispatchError(
-        this.#dispatcher,
-        `ServerApiKeyProvider.getKey (${llmId}): Invalid environmentContext provided.`,
-        { providedValue: environmentContext }
-      );
+    if (
+      !validateEnvironmentContext(
+        environmentContext,
+        `ServerApiKeyProvider.getKey (${llmId})`,
+        this.#dispatcher
+      )
+    ) {
       return null;
     }
 

--- a/src/llms/utils/llmUtils.js
+++ b/src/llms/utils/llmUtils.js
@@ -4,6 +4,11 @@
  * @module llmUtils
  */
 
+import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { isValidEnvironmentContext } from '../environmentContext.js';
+
+/** @typedef {import('../environmentContext.js').EnvironmentContext} EnvironmentContext */
+
 /**
  * Retrieves the LLM identifier from configuration with a fallback to 'UnknownLLM'.
  *
@@ -12,4 +17,24 @@
  */
 export function getLlmId(config) {
   return config?.configId || 'UnknownLLM';
+}
+
+/**
+ * Validates an {@link EnvironmentContext} instance and dispatches an error when invalid.
+ *
+ * @param {EnvironmentContext|any} ctx - The context object to validate.
+ * @param {string} contextMsg - Prefix for the error message.
+ * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher - Dispatcher for error events.
+ * @returns {boolean} True if the context is valid; otherwise false.
+ */
+export function validateEnvironmentContext(ctx, contextMsg, dispatcher) {
+  if (!isValidEnvironmentContext(ctx)) {
+    safeDispatchError(
+      dispatcher,
+      `${contextMsg}: Invalid environmentContext provided.`,
+      { providedValue: ctx }
+    );
+    return false;
+  }
+  return true;
 }

--- a/tests/unit/llms/clientApiKeyProvider.test.js
+++ b/tests/unit/llms/clientApiKeyProvider.test.js
@@ -4,6 +4,7 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ClientApiKeyProvider } from '../../../src/llms/clientApiKeyProvider.js';
 import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
+import * as LlmUtils from '../../../src/llms/utils/llmUtils.js';
 const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
@@ -121,7 +122,7 @@ describe('ClientApiKeyProvider', () => {
     });
 
     test('should return null and log error if environmentContext is invalid', async () => {
-      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
+      const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
@@ -131,7 +132,11 @@ describe('ClientApiKeyProvider', () => {
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
-      expect(spy).toHaveBeenCalledWith(null);
+      expect(spy).toHaveBeenCalledWith(
+        null,
+        'ClientApiKeyProvider.getKey (test-llm)',
+        dispatcher
+      );
       spy.mockRestore();
     });
 
@@ -140,7 +145,7 @@ describe('ClientApiKeyProvider', () => {
         // isClient: 'not-a-function' // or missing
         getExecutionEnvironment: jest.fn().mockReturnValue('client'),
       };
-      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
+      const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
       const key = await provider.getKey(
         llmConfig,
         /** @type {any} */ (invalidEc)
@@ -153,7 +158,11 @@ describe('ClientApiKeyProvider', () => {
             'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
-      expect(spy).toHaveBeenCalledWith(invalidEc);
+      expect(spy).toHaveBeenCalledWith(
+        invalidEc,
+        'ClientApiKeyProvider.getKey (test-llm)',
+        dispatcher
+      );
       spy.mockRestore();
     });
 

--- a/tests/unit/llms/serverApiKeyProvider.test.js
+++ b/tests/unit/llms/serverApiKeyProvider.test.js
@@ -4,6 +4,7 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { ServerApiKeyProvider } from '../../../src/llms/serverApiKeyProvider.js';
 import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
+import * as LlmUtils from '../../../src/llms/utils/llmUtils.js';
 const { EnvironmentContext } = EnvironmentModule;
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 // Import the actual interfaces to ensure mocks align if needed, though not strictly used for type in JS tests
@@ -191,7 +192,7 @@ describe('ServerApiKeyProvider', () => {
     });
 
     test('should return null and log if environmentContext is invalid', async () => {
-      const spy = jest.spyOn(EnvironmentModule, 'isValidEnvironmentContext');
+      const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
       const key = await provider.getKey(llmConfig, null);
       expect(key).toBeNull();
       expect(dispatcher.dispatch).toHaveBeenCalledWith(
@@ -201,7 +202,11 @@ describe('ServerApiKeyProvider', () => {
             'ServerApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
         })
       );
-      expect(spy).toHaveBeenCalledWith(null);
+      expect(spy).toHaveBeenCalledWith(
+        null,
+        'ServerApiKeyProvider.getKey (test-llm)',
+        dispatcher
+      );
       spy.mockRestore();
     });
 


### PR DESCRIPTION
## Summary
- avoid repeated environmentContext validation checks
- share helper `validateEnvironmentContext`
- adjust client and server API key providers
- update related unit tests

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run lint` *(fails: 3687 problems (729 errors, 2958 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6862be6bf9c4833187b8730125240ecc