### PR TITLE
[Agent] validate actorState input

### DIFF
--- a/src/turns/services/actorDataExtractor.js
+++ b/src/turns/services/actorDataExtractor.js
@@ -72,6 +72,9 @@ class ActorDataExtractor extends IActorDataExtractor {
    * @returns {ActorPromptDataDTO} The populated DTO.
    */
   extractPromptData(actorState, actorId = null) {
+    if (actorState === null || typeof actorState !== 'object') {
+      throw new TypeError('actorState must be an object');
+    }
     /** @type {Partial<ActorPromptDataDTO>} */
     const promptData = {};
 

--- a/tests/unit/turns/services/actorDataExtractor.test.js
+++ b/tests/unit/turns/services/actorDataExtractor.test.js
@@ -353,6 +353,18 @@ describe('ActorDataExtractor', () => {
       result = extractor.extractPromptData(actorState);
       expect(result.speechPatterns).toBeUndefined();
     });
+
+    test('throws TypeError when actorState is null', () => {
+      expect(() => extractor.extractPromptData(null)).toThrow(
+        new TypeError('actorState must be an object')
+      );
+    });
+
+    test('throws TypeError when actorState is a primitive', () => {
+      expect(() => extractor.extractPromptData(42)).toThrow(
+        new TypeError('actorState must be an object')
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add validation for actorState before building prompt data
- test actorState validation edge cases

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3700 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862c9abd66c8331838c3dd7c5487a40