### PR TITLE
[Agent] switch totals to immutable returns

### DIFF
--- a/src/loaders/phases/contentPhase.js
+++ b/src/loaders/phases/contentPhase.js
@@ -48,11 +48,12 @@ export default class ContentPhase extends LoaderPhase {
       const nextTotals = deepClone(ctx.totals);
       const next = { ...ctx, totals: nextTotals };
 
-      await this.manager.loadContent(
+      const { updatedTotals } = await this.manager.loadContent(
         next.finalModOrder,
         next.manifests,
         next.totals
       );
+      next.totals = updatedTotals;
 
       return Object.freeze(next);
     } catch (e) {

--- a/src/loaders/phases/worldPhase.js
+++ b/src/loaders/phases/worldPhase.js
@@ -56,11 +56,12 @@ export default class WorldPhase extends LoaderPhase {
       const nextTotals = deepClone(ctx.totals);
       const next = { ...ctx, totals: nextTotals };
 
-      await this.worldLoader.loadWorlds(
+      const updatedTotals = await this.worldLoader.loadWorlds(
         next.finalModOrder,
         next.manifests,
         next.totals
       );
+      next.totals = updatedTotals;
 
       // Return frozen context (no modifications except totals)
       return Object.freeze(next);

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -99,14 +99,14 @@ export class WorldLoader extends AbstractLoader {
    *
    * @param {string[]} finalModOrder - The resolved load order of mods.
    * @param {Map<string, ModManifest>} manifests - A map of all loaded mod manifests.
-   * @param {TotalResultsSummary} totalCounts - The aggregator for load results to be updated.
-   * @returns {Promise<void>} A promise that resolves when all world files have been processed.
+   * @param {TotalResultsSummary} totalCounts - Previous totals object. This object is not mutated.
+   * @returns {Promise<TotalResultsSummary>} Updated totals after processing worlds.
    * @throws {ModsLoaderError} If an instance references an unknown entity definition that is configured to halt the process.
    */
   async loadWorlds(finalModOrder, manifests, totalCounts) {
     this._logger.info('--- Starting World File Loading Phase ---');
 
-    const totals = {
+    let totals = {
       filesProcessed: 0,
       filesFailed: 0,
       instances: 0,
@@ -121,15 +121,17 @@ export class WorldLoader extends AbstractLoader {
       this._logger.error(
         "WorldLoader: Schema ID for content type 'world' not found in configuration. Cannot process world files."
       );
-      totalCounts.worlds = {
-        count: 0,
-        overrides: 0,
-        errors: finalModOrder.length,
-        instances: 0,
-        resolvedDefinitions: 0,
-        unresolvedDefinitions: 0,
+      return {
+        ...totalCounts,
+        worlds: {
+          count: 0,
+          overrides: 0,
+          errors: finalModOrder.length,
+          instances: 0,
+          resolvedDefinitions: 0,
+          unresolvedDefinitions: 0,
+        },
       };
-      return;
     }
 
     for (const modId of finalModOrder) {
@@ -149,19 +151,26 @@ export class WorldLoader extends AbstractLoader {
         continue;
       }
 
-      const filePromises = worldFiles.map((filename) =>
-        this._processWorldFile(modId, filename, worldSchemaId, totals)
-      );
-      await Promise.all(filePromises);
+      for (const filename of worldFiles) {
+        totals = await this._processWorldFile(
+          modId,
+          filename,
+          worldSchemaId,
+          totals
+        );
+      }
     }
 
-    totalCounts.worlds = {
-      count: totals.filesProcessed,
-      overrides: totals.overrides,
-      errors: totals.filesFailed,
-      instances: totals.instances,
-      resolvedDefinitions: totals.resolvedDefinitions,
-      unresolvedDefinitions: totals.unresolvedDefinitions,
+    const updatedTotals = {
+      ...totalCounts,
+      worlds: {
+        count: totals.filesProcessed,
+        overrides: totals.overrides,
+        errors: totals.filesFailed,
+        instances: totals.instances,
+        resolvedDefinitions: totals.resolvedDefinitions,
+        unresolvedDefinitions: totals.unresolvedDefinitions,
+      },
     };
 
     this._logger.info('--- World File Loading Phase Complete ---');
@@ -174,6 +183,7 @@ export class WorldLoader extends AbstractLoader {
         `WorldLoader: Successfully processed and registered ${totals.filesProcessed} worlds, containing ${totals.instances} entity instances. All ${totals.resolvedDefinitions} definition references were resolved.`
       );
     }
+    return updatedTotals;
   }
 
   /**
@@ -184,8 +194,8 @@ export class WorldLoader extends AbstractLoader {
    * @param {string} modId - The owning mod ID.
    * @param {string} filename - World filename.
    * @param {string} worldSchemaId - Schema ID to validate against.
-   * @param {object} totals - Totals object to update.
-   * @returns {Promise<void>} Resolves when processing completes.
+   * @param {object} totals - Running totals object.
+   * @returns {Promise<object>} Updated totals object.
    */
   async _processWorldFile(modId, filename, worldSchemaId, totals) {
     let resolvedPath = '';
@@ -215,7 +225,7 @@ export class WorldLoader extends AbstractLoader {
         worldData
       );
 
-      this.#updateTotals(totals, {
+      totals = this.#updateTotals(totals, {
         success: true,
         override: didOverride,
         instanceCount: Array.isArray(worldData.instances)
@@ -225,7 +235,7 @@ export class WorldLoader extends AbstractLoader {
         unresolved: validation.unresolved,
       });
     } catch (error) {
-      this.#updateTotals(totals, { success: false });
+      totals = this.#updateTotals(totals, { success: false });
       this._logger.error(
         `WorldLoader [${modId}]: Failed to process world file '${filename}'. Path: '${resolvedPath || 'unresolved'}'. Error: ${error.message}`,
         { modId, filename, error }
@@ -239,6 +249,7 @@ export class WorldLoader extends AbstractLoader {
         throw error;
       }
     }
+    return totals;
   }
 
   /**
@@ -339,9 +350,9 @@ export class WorldLoader extends AbstractLoader {
    * Updates running totals during world loading.
    *
    * @private
-   * @param {object} totals - Totals object to mutate.
+   * @param {object} totals - Current totals object.
    * @param {{success:boolean, override?:boolean, instanceCount?:number, resolved?:number, unresolved?:number}} info - Update info.
-   * @returns {void}
+   * @returns {object} New totals object.
    */
   #updateTotals(
     totals,
@@ -353,17 +364,19 @@ export class WorldLoader extends AbstractLoader {
       unresolved = 0,
     }
   ) {
+    const next = { ...totals };
     if (success) {
-      totals.filesProcessed += 1;
-      totals.instances += instanceCount;
+      next.filesProcessed += 1;
+      next.instances += instanceCount;
       if (override) {
-        totals.overrides += 1;
+        next.overrides += 1;
       }
     } else {
-      totals.filesFailed += 1;
+      next.filesFailed += 1;
     }
-    totals.resolvedDefinitions += resolved;
-    totals.unresolvedDefinitions += unresolved;
+    next.resolvedDefinitions += resolved;
+    next.unresolvedDefinitions += unresolved;
+    return next;
   }
 
   /**

--- a/tests/integration/loaders/multiModsWorldLoader.integration.test.js
+++ b/tests/integration/loaders/multiModsWorldLoader.integration.test.js
@@ -141,8 +141,16 @@ describe('Multi-mod content loading and world validation', () => {
 
   it('aggregates definitions, instances, and worlds from all mods', async () => {
     const totals = {};
-    await env.manager.loadContent(finalOrder, manifests, totals);
-    await env.worldLoader.loadWorlds(finalOrder, manifests, totals);
+    const { updatedTotals: afterContent } = await env.manager.loadContent(
+      finalOrder,
+      manifests,
+      totals
+    );
+    const updatedTotals = await env.worldLoader.loadWorlds(
+      finalOrder,
+      manifests,
+      afterContent
+    );
 
     expect(env.registry.getAll('entityDefinitions').length).toBe(2);
     expect(env.registry.getAll('entityInstances').length).toBe(2);
@@ -179,13 +187,21 @@ describe('Multi-mod content loading and world validation', () => {
     ]);
 
     const totals = {};
-    await env.manager.loadContent(finalOrder, manifests, totals);
+    const { updatedTotals: afterContent } = await env.manager.loadContent(
+      finalOrder,
+      manifests,
+      totals
+    );
 
     // The duplicate instance should cause an error (not a warning)
-    expect(totals.entityInstances?.errors).toBe(1);
+    expect(afterContent.entityInstances?.errors).toBe(1);
 
-    await env.worldLoader.loadWorlds(finalOrder, manifests, totals);
-    expect(totals.worlds.errors).toBe(1);
+    const updatedTotals = await env.worldLoader.loadWorlds(
+      finalOrder,
+      manifests,
+      afterContent
+    );
+    expect(updatedTotals.worlds.errors).toBe(1);
   });
 
   it('handles large numbers of files', async () => {

--- a/tests/unit/loaders/contentLoadManager.test.js
+++ b/tests/unit/loaders/contentLoadManager.test.js
@@ -101,11 +101,16 @@ describe('ContentLoadManager.loadContent', () => {
     ]);
     /** @type {TotalResultsSummary} */ const totals = {};
 
-    const results = await manager.loadContent(finalModOrder, manifests, totals);
+    const { results, updatedTotals } = await manager.loadContent(
+      finalModOrder,
+      manifests,
+      totals
+    );
 
     expect(results).toEqual({ modA: 'success', modB: 'failed' });
-    expect(totals.items.count).toBe(1); // Only loaderA succeeded
-    expect(totals.items.errors).toBe(1); // Only loaderB failed
+    expect(updatedTotals.items.count).toBe(1); // Only loaderA succeeded
+    expect(updatedTotals.items.errors).toBe(1); // Only loaderB failed
+    expect(totals).toEqual({});
 
     // Check that dispatcher was called for loaderB's failure
     expect(dispatcher.dispatch).toHaveBeenCalledWith(

--- a/tests/unit/loaders/phases/contentPhase.test.js
+++ b/tests/unit/loaders/phases/contentPhase.test.js
@@ -18,9 +18,11 @@ describe('ContentPhase', () => {
       loadContent: jest
         .fn()
         .mockImplementation((_order, _manifests, totals) => {
-          // Simulate the manager mutating the totals object
-          totals.components = { count: 10, overrides: 1, errors: 0 };
-          return Promise.resolve();
+          const updated = {
+            ...totals,
+            components: { count: 10, overrides: 1, errors: 0 },
+          };
+          return Promise.resolve({ results: {}, updatedTotals: updated });
         }),
     };
     mockLogger = {

--- a/tests/unit/loaders/phases/worldPhase.test.js
+++ b/tests/unit/loaders/phases/worldPhase.test.js
@@ -42,7 +42,7 @@ describe('WorldPhase', () => {
       ctx.manifests = manifests;
       Object.freeze(ctx);
       Object.freeze(ctx.totals);
-      worldLoader.loadWorlds.mockResolvedValue(undefined);
+      worldLoader.loadWorlds.mockResolvedValue({});
 
       // Act
       const result = await worldPhase.execute(ctx);

--- a/tests/unit/loaders/worldLoader.processWorldFile.test.js
+++ b/tests/unit/loaders/worldLoader.processWorldFile.test.js
@@ -77,7 +77,12 @@ describe('WorldLoader._processWorldFile', () => {
     fetcher.fetch.mockResolvedValue(mockWorldData);
     registry.get.mockReturnValue({ id: 'def' });
 
-    await loader._processWorldFile('modA', 'world1.json', 'schemaId', totals);
+    const updated = await loader._processWorldFile(
+      'modA',
+      'world1.json',
+      'schemaId',
+      totals
+    );
 
     expect(resolver.resolveModContentPath).toHaveBeenCalledWith(
       'modA',
@@ -90,7 +95,7 @@ describe('WorldLoader._processWorldFile', () => {
       'test:world',
       mockWorldData
     );
-    expect(totals).toEqual({
+    expect(updated).toEqual({
       filesProcessed: 1,
       filesFailed: 0,
       instances: 2,
@@ -112,13 +117,18 @@ describe('WorldLoader._processWorldFile', () => {
     const fetchError = new Error('fail');
     fetcher.fetch.mockRejectedValue(fetchError);
 
-    await loader._processWorldFile('modA', 'bad.json', 'schemaId', totals);
+    const updated = await loader._processWorldFile(
+      'modA',
+      'bad.json',
+      'schemaId',
+      totals
+    );
 
     expect(logger.error).toHaveBeenCalledWith(
       "WorldLoader [modA]: Failed to process world file 'bad.json'. Path: '/mods/modA/worlds/bad.json'. Error: fail",
       { modId: 'modA', filename: 'bad.json', error: fetchError }
     );
-    expect(totals).toEqual({
+    expect(updated).toEqual({
       filesProcessed: 0,
       filesFailed: 1,
       instances: 0,
@@ -139,7 +149,12 @@ describe('WorldLoader._processWorldFile', () => {
     };
     const worldData = { id: 'w:1', instances: [{}] };
     fetcher.fetch.mockResolvedValue(worldData);
-    await loader._processWorldFile('modA', 'world.json', 'schemaId', totals);
+    const updated = await loader._processWorldFile(
+      'modA',
+      'world.json',
+      'schemaId',
+      totals
+    );
     expect(logger.error).toHaveBeenCalledWith(
       "WorldLoader [modA]: Failed to process world file 'world.json'. Path: '/mods/modA/worlds/world.json'. Error: Instance in world file 'world.json' is missing an 'instanceId'.",
       {
@@ -148,7 +163,7 @@ describe('WorldLoader._processWorldFile', () => {
         error: expect.any(MissingInstanceIdError),
       }
     );
-    expect(totals.filesFailed).toBe(1);
+    expect(updated.filesFailed).toBe(1);
   });
 
   it('logs error for unknown instance', async () => {
@@ -163,7 +178,12 @@ describe('WorldLoader._processWorldFile', () => {
     const worldData = { id: 'w:1', instances: [{ instanceId: 'x:y' }] };
     fetcher.fetch.mockResolvedValue(worldData);
     registry.get.mockReturnValue(undefined);
-    await loader._processWorldFile('modA', 'world.json', 'schemaId', totals);
+    const updated = await loader._processWorldFile(
+      'modA',
+      'world.json',
+      'schemaId',
+      totals
+    );
     expect(logger.error).toHaveBeenCalledWith(
       "WorldLoader [modA]: Failed to process world file 'world.json'. Path: '/mods/modA/worlds/world.json'. Error: Unknown entity instanceId 'x:y' referenced in world 'world.json'.",
       {
@@ -172,6 +192,6 @@ describe('WorldLoader._processWorldFile', () => {
         error: expect.any(MissingEntityInstanceError),
       }
     );
-    expect(totals.filesFailed).toBe(1);
+    expect(updated.filesFailed).toBe(1);
   });
 });

--- a/tests/unit/loaders/worldLoader.schema.test.js
+++ b/tests/unit/loaders/worldLoader.schema.test.js
@@ -119,7 +119,11 @@ describe('WorldLoader Schema Validation', () => {
       );
 
       // Assert
-      return expect(loadPromise).resolves.toBeUndefined();
+      return expect(loadPromise).resolves.toEqual(
+        expect.objectContaining({
+          worlds: expect.objectContaining({ errors: 1 }),
+        })
+      );
     });
   });
 
@@ -159,7 +163,11 @@ describe('WorldLoader Schema Validation', () => {
       mockDataRegistry.get.mockReturnValue({ id: 'test:definition' });
 
       // Act
-      await worldLoader.loadWorlds(finalModOrder, manifests, totalCounts);
+      const updated = await worldLoader.loadWorlds(
+        finalModOrder,
+        manifests,
+        totalCounts
+      );
 
       // Assert
       expect(mockDataFetcher.fetch).toHaveBeenCalledWith(
@@ -174,6 +182,7 @@ describe('WorldLoader Schema Validation', () => {
         'test:world',
         mockWorldData
       );
+      expect(updated.worlds.count).toBe(1);
     });
 
     it('should validate world file against correct schema ID', async () => {
@@ -201,7 +210,11 @@ describe('WorldLoader Schema Validation', () => {
       mockSchemaValidator.validate.mockReturnValue({ valid: true });
 
       // Act
-      await worldLoader.loadWorlds(finalModOrder, manifests, totalCounts);
+      const updated = await worldLoader.loadWorlds(
+        finalModOrder,
+        manifests,
+        totalCounts
+      );
 
       // Assert
       expect(mockSchemaValidator.validate).toHaveBeenCalledWith(
@@ -239,7 +252,11 @@ describe('WorldLoader Schema Validation', () => {
       });
 
       // Act
-      await worldLoader.loadWorlds(finalModOrder, manifests, totalCounts);
+      const updated = await worldLoader.loadWorlds(
+        finalModOrder,
+        manifests,
+        totalCounts
+      );
 
       // Assert
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -285,10 +302,14 @@ describe('WorldLoader Schema Validation', () => {
       mockDataRegistry.get.mockReturnValue({ id: 'test:definition' });
 
       // Act
-      await worldLoader.loadWorlds(finalModOrder, manifests, totalCounts);
+      const updated = await worldLoader.loadWorlds(
+        finalModOrder,
+        manifests,
+        totalCounts
+      );
 
       // Assert
-      expect(totalCounts.worlds).toEqual({
+      expect(updated.worlds).toEqual({
         count: 1,
         overrides: 0,
         errors: 0,
@@ -296,6 +317,7 @@ describe('WorldLoader Schema Validation', () => {
         resolvedDefinitions: 1,
         unresolvedDefinitions: 0,
       });
+      expect(totalCounts).toEqual({});
     });
   });
 });

--- a/tests/unit/schemas/descriptors.components.validation.test.js
+++ b/tests/unit/schemas/descriptors.components.validation.test.js
@@ -1,6 +1,6 @@
 /**
  * @file Test suite to validate that descriptor component definition files adhere to the component schema.
- * 
+ *
  * This test suite was created to ensure all descriptor components follow the correct schema
  * after fixing validation errors where components were missing 'id' and using 'data' instead of 'dataSchema'.
  */
@@ -37,7 +37,7 @@ const descriptorComponentFiles = fs
  *
  * This suite validates that all descriptor component definition files
  * conform to the primary component schema (`component.schema.json`).
- * 
+ *
  * It specifically tests:
  * 1. All required properties are present (id, description, dataSchema)
  * 2. The id follows the correct format (descriptors:{component_name})
@@ -97,7 +97,7 @@ describe('Descriptor Components - Schema Validation', () => {
         expect(componentDefinition).toHaveProperty('id');
         expect(componentDefinition).toHaveProperty('description');
         expect(componentDefinition).toHaveProperty('dataSchema');
-        
+
         // Ensure 'data' property is NOT present (was the old incorrect property name)
         expect(componentDefinition).not.toHaveProperty('data');
       }
@@ -109,11 +109,11 @@ describe('Descriptor Components - Schema Validation', () => {
       '✓ %s – should have valid dataSchema structure',
       (filename, componentDefinition) => {
         const { dataSchema } = componentDefinition;
-        
+
         // dataSchema should be an object
         expect(typeof dataSchema).toBe('object');
         expect(dataSchema).not.toBeNull();
-        
+
         // For descriptor components, dataSchema typically defines a type and properties
         // Check if type is present and valid when defined
         expect(
@@ -133,7 +133,7 @@ describe('Descriptor Components - Schema Validation', () => {
         description: 'Test component',
         dataSchema: { type: 'object' },
       };
-      
+
       expect(validate(invalidComponent)).toBe(false);
       expect(validate.errors).toEqual(
         expect.arrayContaining([
@@ -151,7 +151,7 @@ describe('Descriptor Components - Schema Validation', () => {
         description: 'Test component',
         data: { type: 'object' }, // Wrong property name
       };
-      
+
       expect(validate(invalidComponent)).toBe(false);
       expect(validate.errors).toEqual(
         expect.arrayContaining([
@@ -170,7 +170,7 @@ describe('Descriptor Components - Schema Validation', () => {
         dataSchema: { type: 'object' },
         data: { type: 'object' }, // Additional property not allowed
       };
-      
+
       expect(validate(invalidComponent)).toBe(false);
       expect(validate.errors).toEqual(
         expect.arrayContaining([

--- a/tests/unit/validation/schemaReferenceValidation.test.js
+++ b/tests/unit/validation/schemaReferenceValidation.test.js
@@ -2,7 +2,8 @@
  * @file Tests for schema reference validation, specifically for anatomy schemas
  */
 
-const AjvSchemaValidator = require('../../../src/validation/ajvSchemaValidator.js').default;
+const AjvSchemaValidator =
+  require('../../../src/validation/ajvSchemaValidator.js').default;
 const fs = require('fs');
 const path = require('path');
 
@@ -30,17 +31,23 @@ describe('Schema Reference Validation', () => {
   beforeAll(() => {
     // Load the schemas from the data directory
     const schemaDir = path.join(__dirname, '../../../data/schemas');
-    
+
     commonSchema = JSON.parse(
       fs.readFileSync(path.join(schemaDir, 'common.schema.json'), 'utf8')
     );
-    
+
     anatomyBlueprintSchema = JSON.parse(
-      fs.readFileSync(path.join(schemaDir, 'anatomy.blueprint.schema.json'), 'utf8')
+      fs.readFileSync(
+        path.join(schemaDir, 'anatomy.blueprint.schema.json'),
+        'utf8'
+      )
     );
-    
+
     anatomyRecipeSchema = JSON.parse(
-      fs.readFileSync(path.join(schemaDir, 'anatomy.recipe.schema.json'), 'utf8')
+      fs.readFileSync(
+        path.join(schemaDir, 'anatomy.recipe.schema.json'),
+        'utf8'
+      )
     );
   });
 
@@ -60,9 +67,11 @@ describe('Schema Reference Validation', () => {
       // Add common schema first since anatomy schemas reference it
       await validator.addSchema(commonSchema, commonSchema.$id);
       await validator.addSchema(anatomyRecipeSchema, anatomyRecipeSchema.$id);
-      
+
       const schemaIds = validator.getLoadedSchemaIds();
-      expect(schemaIds).toContain('http://example.com/schemas/anatomy.recipe.schema.json');
+      expect(schemaIds).toContain(
+        'http://example.com/schemas/anatomy.recipe.schema.json'
+      );
     });
 
     it('should load anatomy.blueprint.schema.json with references to anatomy.recipe.schema.json', async () => {
@@ -70,32 +79,46 @@ describe('Schema Reference Validation', () => {
       await validator.addSchema(commonSchema, commonSchema.$id);
       // Then add the recipe schema which is referenced
       await validator.addSchema(anatomyRecipeSchema, anatomyRecipeSchema.$id);
-      
+
       // Then add the blueprint schema
-      await validator.addSchema(anatomyBlueprintSchema, anatomyBlueprintSchema.$id);
-      
+      await validator.addSchema(
+        anatomyBlueprintSchema,
+        anatomyBlueprintSchema.$id
+      );
+
       const schemaIds = validator.getLoadedSchemaIds();
-      expect(schemaIds).toContain('http://example.com/schemas/anatomy.blueprint.schema.json');
+      expect(schemaIds).toContain(
+        'http://example.com/schemas/anatomy.blueprint.schema.json'
+      );
     });
 
     it('should validate that anatomy.blueprint.schema.json references use correct relative paths', () => {
       const schemaContent = JSON.stringify(anatomyBlueprintSchema);
-      
+
       // Check that we're using ./ instead of ../
-      expect(schemaContent).toContain('"./anatomy.recipe.schema.json#/definitions/slotDefinition"');
-      expect(schemaContent).not.toContain('"../anatomy.recipe.schema.json#/definitions/slotDefinition"');
+      expect(schemaContent).toContain(
+        '"./anatomy.recipe.schema.json#/definitions/slotDefinition"'
+      );
+      expect(schemaContent).not.toContain(
+        '"../anatomy.recipe.schema.json#/definitions/slotDefinition"'
+      );
     });
 
     it('should successfully validate schema references after loading both schemas', async () => {
       // Add all required schemas
       await validator.addSchema(commonSchema, commonSchema.$id);
       await validator.addSchema(anatomyRecipeSchema, anatomyRecipeSchema.$id);
-      await validator.addSchema(anatomyBlueprintSchema, anatomyBlueprintSchema.$id);
-      
+      await validator.addSchema(
+        anatomyBlueprintSchema,
+        anatomyBlueprintSchema.$id
+      );
+
       // Validate references
-      const refsValid = validator.validateSchemaRefs(anatomyBlueprintSchema.$id);
+      const refsValid = validator.validateSchemaRefs(
+        anatomyBlueprintSchema.$id
+      );
       expect(refsValid).toBe(true);
-      
+
       // Check that no errors were logged
       expect(logger.error).not.toHaveBeenCalledWith(
         expect.stringContaining("can't resolve reference")
@@ -106,8 +129,11 @@ describe('Schema Reference Validation', () => {
       // Add all required schemas
       await validator.addSchema(commonSchema, commonSchema.$id);
       await validator.addSchema(anatomyRecipeSchema, anatomyRecipeSchema.$id);
-      await validator.addSchema(anatomyBlueprintSchema, anatomyBlueprintSchema.$id);
-      
+      await validator.addSchema(
+        anatomyBlueprintSchema,
+        anatomyBlueprintSchema.$id
+      );
+
       // Sample blueprint data
       const sampleBlueprint = {
         id: 'anatomy:test_blueprint',
@@ -116,21 +142,21 @@ describe('Schema Reference Validation', () => {
           {
             parent: 'anatomy:torso',
             socket: 'head_socket',
-            child: 'anatomy:head'
-          }
+            child: 'anatomy:head',
+          },
         ],
         defaultSlots: {
-          'arm_slots': {
+          arm_slots: {
             partType: 'arm',
-            count: { min: 1, max: 2 }
-          }
-        }
+            count: { min: 1, max: 2 },
+          },
+        },
       };
-      
+
       // Get the validator function for the schema
       const validateFn = validator.getValidator(anatomyBlueprintSchema.$id);
       expect(validateFn).toBeDefined();
-      
+
       // Validate the sample data
       const result = validateFn(sampleBlueprint);
       expect(result.isValid).toBe(true);
@@ -140,15 +166,22 @@ describe('Schema Reference Validation', () => {
 
   describe('Dist Folder Consistency', () => {
     it('should ensure dist folder schemas match source schemas', async () => {
-      const distSchemaPath = path.join(__dirname, '../../../dist/data/schemas/anatomy.blueprint.schema.json');
-      
+      const distSchemaPath = path.join(
+        __dirname,
+        '../../../dist/data/schemas/anatomy.blueprint.schema.json'
+      );
+
       try {
         const distSchema = JSON.parse(fs.readFileSync(distSchemaPath, 'utf8'));
         const distContent = JSON.stringify(distSchema);
-        
+
         // Check that dist version also uses correct relative paths
-        expect(distContent).toContain('"./anatomy.recipe.schema.json#/definitions/slotDefinition"');
-        expect(distContent).not.toContain('"../anatomy.recipe.schema.json#/definitions/slotDefinition"');
+        expect(distContent).toContain(
+          '"./anatomy.recipe.schema.json#/definitions/slotDefinition"'
+        );
+        expect(distContent).not.toContain(
+          '"../anatomy.recipe.schema.json#/definitions/slotDefinition"'
+        );
       } catch (error) {
         // If dist doesn't exist yet, that's okay - this test will help catch issues after build
         if (error.code !== 'ENOENT') {
@@ -166,11 +199,11 @@ describe('Schema Reference Validation', () => {
         type: 'object',
         properties: {
           slot: {
-            $ref: '../nonexistent.schema.json#/definitions/something'
-          }
-        }
+            $ref: '../nonexistent.schema.json#/definitions/something',
+          },
+        },
       };
-      
+
       // Adding a schema with bad references will fail during addSchema
       let addError = null;
       try {
@@ -178,11 +211,11 @@ describe('Schema Reference Validation', () => {
       } catch (error) {
         addError = error;
       }
-      
+
       // The schema with bad references should fail to add
       expect(addError).toBeTruthy();
       expect(addError.message).toContain("can't resolve reference");
-      
+
       // Since the schema failed to add, getValidator should return undefined
       const validateFn = validator.getValidator(schemaWithBadRef.$id);
       expect(validateFn).toBeUndefined();


### PR DESCRIPTION
Summary:
- refactor loadContent manager to return new totals objects
- refactor world loader to avoid mutating input totals
- update phases and tests for new immutable behaviour

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 734 errors)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start` *(not executed)*

------
https://chatgpt.com/codex/tasks/task_e_6862c944a1d4833198c78c32d7c09e9d