### PR TITLE
[Agent] clarify method naming

### DIFF
--- a/src/logic/operationHandlers/queryComponentHandler.js
+++ b/src/logic/operationHandlers/queryComponentHandler.js
@@ -108,7 +108,7 @@ class QueryComponentHandler extends ComponentOperationHandler {
       );
       return null;
     }
-    const trimmedResultVariable = result_variable.trim();
+    const sanitizedVariableName = result_variable.trim();
 
     if (
       typeof entity_ref === 'string' &&
@@ -125,7 +125,7 @@ class QueryComponentHandler extends ComponentOperationHandler {
       entityId,
       componentType: trimmedComponentType,
       resultVar: result_variable,
-      trimmedResultVar: trimmedResultVariable,
+      trimmedResultVar: sanitizedVariableName,
       missingValue: missing_value,
     };
   }

--- a/src/logic/operationHandlers/queryComponentsHandler.js
+++ b/src/logic/operationHandlers/queryComponentsHandler.js
@@ -113,7 +113,7 @@ class QueryComponentsHandler extends ComponentOperationHandler {
         );
         continue;
       }
-      const trimmedVar = result_variable.trim();
+      const sanitizedVariableName = result_variable.trim();
       let result;
       try {
         result = this.#entityManager.getComponentData(entityId, trimmedType);
@@ -128,7 +128,7 @@ class QueryComponentsHandler extends ComponentOperationHandler {
 
       const valueToStore = result === undefined ? null : result;
       writeContextVariable(
-        trimmedVar,
+        sanitizedVariableName,
         valueToStore,
         executionContext,
         this.#dispatcher,
@@ -137,11 +137,11 @@ class QueryComponentsHandler extends ComponentOperationHandler {
 
       if (result !== undefined) {
         logger.debug(
-          `QueryComponentsHandler: Stored component "${trimmedType}" value in "${trimmedVar}".`
+          `QueryComponentsHandler: Stored component "${trimmedType}" value in "${sanitizedVariableName}".`
         );
       } else {
         logger.debug(
-          `QueryComponentsHandler: Component "${trimmedType}" not found on entity "${entityId}". Stored null in "${trimmedVar}".`
+          `QueryComponentsHandler: Component "${trimmedType}" not found on entity "${entityId}". Stored null in "${sanitizedVariableName}".`
         );
       }
     }

--- a/src/logic/operationHandlers/systemMoveEntityHandler.js
+++ b/src/logic/operationHandlers/systemMoveEntityHandler.js
@@ -53,7 +53,7 @@ class SystemMoveEntityHandler extends BaseOperationHandler {
    * @param {ILogger} logger - Logger for diagnostic output.
    * @returns {string|null} Previous location ID if moved, otherwise null.
    */
-  #moveEntity(entityId, targetId, logger) {
+  #updatePositionAndReturnPrevious(entityId, targetId, logger) {
     const positionComponent = this.#entityManager.getComponentData(
       entityId,
       'core:position'
@@ -161,7 +161,11 @@ class SystemMoveEntityHandler extends BaseOperationHandler {
 
     let fromLocationId = null;
     try {
-      fromLocationId = this.#moveEntity(entityId, target_location_id, log);
+      fromLocationId = this.#updatePositionAndReturnPrevious(
+        entityId,
+        target_location_id,
+        log
+      );
       if (fromLocationId) {
         await this.#emitMovedEvent(
           entityId,


### PR DESCRIPTION
Summary: 
- rename internal method in `SystemMoveEntityHandler` to `updatePositionAndReturnPrevious`
- rename `trimmedVar`/`trimmedResultVariable` variables to `sanitizedVariableName`

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint` (warnings only)
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862d2b04b4c8331a0c186cfc93c0b23