### PR TITLE
[Test] Add coverage for modding helper functions

### DIFF
--- a/src/modding/modDependencyValidator.js
+++ b/src/modding/modDependencyValidator.js
@@ -161,3 +161,6 @@ class ModDependencyValidator {
 }
 
 export default ModDependencyValidator;
+
+// Named export for testing isolated version checks
+export { _checkVersionCompatibility };

--- a/tests/unit/modding/modDependencyValidator.checkVersion.test.js
+++ b/tests/unit/modding/modDependencyValidator.checkVersion.test.js
@@ -1,0 +1,93 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { _checkVersionCompatibility } from '../../../src/modding/modDependencyValidator.js';
+
+const createLogger = () => ({
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('_checkVersionCompatibility', () => {
+  test('records fatal when required dependency has invalid target version', () => {
+    const logger = createLogger();
+    const fatals = [];
+    const semverLib = {
+      valid: jest.fn(() => false),
+      validRange: jest.fn(),
+      satisfies: jest.fn(),
+    };
+    _checkVersionCompatibility(
+      { id: 'B', version: '^1.0.0', _hostId: 'A' },
+      { id: 'B', version: 'bad' },
+      true,
+      logger,
+      fatals,
+      semverLib
+    );
+    expect(fatals[0]).toMatch(/invalid version format/);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('warns when optional dependency has invalid version range', () => {
+    const logger = createLogger();
+    const fatals = [];
+    const semverLib = {
+      valid: jest.fn(() => true),
+      validRange: jest.fn(() => false),
+      satisfies: jest.fn(),
+    };
+    _checkVersionCompatibility(
+      { id: 'B', version: '>=x', _hostId: 'A' },
+      { id: 'B', version: '1.0.0' },
+      false,
+      logger,
+      fatals,
+      semverLib
+    );
+    expect(fatals).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/invalid version range/)
+    );
+  });
+
+  test('records fatal when versions do not satisfy required range', () => {
+    const logger = createLogger();
+    const fatals = [];
+    const semverLib = {
+      valid: jest.fn(() => true),
+      validRange: jest.fn(() => true),
+      satisfies: jest.fn(() => false),
+    };
+    _checkVersionCompatibility(
+      { id: 'B', version: '^2.0.0', _hostId: 'A' },
+      { id: 'B', version: '1.0.0' },
+      true,
+      logger,
+      fatals,
+      semverLib
+    );
+    expect(fatals[0]).toMatch(/requires dependency/);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('passes silently when versions satisfy', () => {
+    const logger = createLogger();
+    const fatals = [];
+    const semverLib = {
+      valid: jest.fn(() => true),
+      validRange: jest.fn(() => true),
+      satisfies: jest.fn(() => true),
+    };
+    _checkVersionCompatibility(
+      { id: 'B', version: '^1.0.0', _hostId: 'A' },
+      { id: 'B', version: '1.1.0' },
+      true,
+      logger,
+      fatals,
+      semverLib
+    );
+    expect(fatals).toHaveLength(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modding/modManifestLoader.additionalHelpers.test.js
+++ b/tests/unit/modding/modManifestLoader.additionalHelpers.test.js
@@ -1,0 +1,66 @@
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import ModManifestLoader from '../../../src/modding/modManifestLoader.js';
+
+// Helper builder for loader and mocks
+const buildLoader = () => {
+  const deps = {
+    configuration: { getContentTypeSchemaId: jest.fn(() => 'schema') },
+    pathResolver: { resolveModManifestPath: jest.fn() },
+    dataFetcher: { fetch: jest.fn() },
+    schemaValidator: {
+      getValidator: jest.fn(() => jest.fn(() => ({ isValid: true }))),
+    },
+    dataRegistry: { store: jest.fn() },
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+  return {
+    loader: new ModManifestLoader(
+      deps.configuration,
+      deps.pathResolver,
+      deps.dataFetcher,
+      deps.schemaValidator,
+      deps.dataRegistry,
+      deps.logger
+    ),
+    deps,
+  };
+};
+
+describe('ModManifestLoader additional helper methods', () => {
+  let loader;
+  let deps;
+
+  beforeEach(() => {
+    ({ loader, deps } = buildLoader());
+    jest.clearAllMocks();
+  });
+
+  test('_validateAndCheckIds returns validated list on success', () => {
+    const jobs = [{ modId: 'a', path: 'p/a', job: Promise.resolve() }];
+    const manifest = { id: 'a', version: '1.0.0' };
+    const settled = [{ status: 'fulfilled', value: manifest }];
+    const validator = jest.fn(() => ({ isValid: true }));
+    const out = loader._validateAndCheckIds(jobs, settled, validator);
+    expect(out).toEqual([{ modId: 'a', data: manifest, path: 'p/a' }]);
+  });
+
+  test('_storeValidatedManifests throws on registry failure', () => {
+    const validated = [{ modId: 'a', data: { id: 'a' }, path: 'p/a' }];
+    deps.dataRegistry.store.mockImplementation(() => {
+      throw new Error('fail');
+    });
+    expect(() => loader._storeValidatedManifests(validated)).toThrow(
+      "failed to store manifest 'a'"
+    );
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("failed to store manifest 'a'"),
+      expect.objectContaining({ modId: 'a', path: 'p/a' })
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added unit tests covering newly extracted helper functions for modding utilities.

Changes Made:
- Exported `_checkVersionCompatibility` from `modDependencyValidator.js` for isolated testing.
- Created `modDependencyValidator.checkVersion.test.js` exercising version check edge cases with mocked semver.
- Added `modManifestLoader.additionalHelpers.test.js` testing success and failure paths for internal helpers.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_6862d29764c88331a02822bc7edd0f2c