### PR TITLE
[Agent] avoid game state mutation

### DIFF
--- a/src/prompting/AIPromptPipeline.js
+++ b/src/prompting/AIPromptPipeline.js
@@ -100,11 +100,11 @@ export class AIPromptPipeline extends IAIPromptPipeline {
       this.#logger
     );
 
-    // Augment the DTO with the definitive list of actions passed as a parameter
-    gameStateDto.availableActions = availableActions;
+    // Construct a new DTO that includes the definitive list of actions
+    const promptDto = { ...gameStateDto, availableActions };
 
     const promptData = await this.#promptContentProvider.getPromptData(
-      gameStateDto,
+      promptDto,
       this.#logger
     );
     const finalPromptString = await this.#promptBuilder.build(

--- a/tests/unit/prompting/AIPromptPipeline.test.js
+++ b/tests/unit/prompting/AIPromptPipeline.test.js
@@ -1,10 +1,7 @@
 /* eslint-env node */
 import { test, expect } from '@jest/globals';
 import { AIPromptPipeline } from '../../../src/prompting/AIPromptPipeline.js';
-import {
-  createAIPromptPipelineBed,
-  describeAIPromptPipelineSuite,
-} from '../../common/prompting/promptPipelineTestBed.js';
+import { describeAIPromptPipelineSuite } from '../../common/prompting/promptPipelineTestBed.js';
 import {
   AIPromptPipelineDependencySpec,
   expectSuccessfulGeneration,
@@ -54,5 +51,17 @@ describeAIPromptPipelineSuite('AIPromptPipeline', (getBed) => {
     },
   ])('generatePrompt rejects when %s', async ({ mutate, error }) => {
     await expectGenerationFailure(bed, mutate, error);
+  });
+
+  test('generatePrompt does not mutate gameStateDto returned by provider', async () => {
+    const actor = bed.defaultActor;
+    const context = bed.defaultContext;
+    const actions = bed.defaultActions;
+
+    const gameState = { state: true };
+    bed.setupMockSuccess({ gameState });
+    await bed.generate(actor, context, actions);
+
+    expect(gameState).toEqual({ state: true });
   });
 });


### PR DESCRIPTION
## Summary
- prevent mutation of the game state DTO in `AIPromptPipeline.generatePrompt`
- verify `generatePrompt` leaves game state DTO unchanged

## Testing Done
- `npm run format` *(ran manually with paths)*
- `npx eslint src/prompting/AIPromptPipeline.js tests/unit/prompting/AIPromptPipeline.test.js --fix`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6862d28110e48331a3bdd3734adaebb4