### PR TITLE
[Agent] handle circular ASTs in cache

### DIFF
--- a/src/scopeDsl/cache.js
+++ b/src/scopeDsl/cache.js
@@ -5,6 +5,7 @@
 
 import { TURN_STARTED_ID } from '../constants/eventIds.js';
 import { IScopeEngine } from '../interfaces/IScopeEngine.js';
+import { safeStringify } from '../utils/index.js';
 
 /** @typedef {import('../types/runtimeContext.js').RuntimeContext} RuntimeContext */
 
@@ -87,7 +88,7 @@ class ScopeCache extends IScopeEngine {
    */
   _generateKey(actorId, ast, runtimeCtx) {
     // Create a stable key from the AST structure
-    const astKey = JSON.stringify(ast);
+    const astKey = safeStringify(ast);
 
     // Extract location ID from runtime context if available
     const locationId = runtimeCtx?.location?.id || 'no-location';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,3 +35,4 @@ export { createErrorDetails } from './errorDetails.js';
 export { readComponent, writeComponent } from './componentAccessUtils.js';
 export * from '../turns/strategies/strategyHelpers.js';
 export * from './operationValidationUtils.js';
+export { safeStringify } from './safeStringify.js';

--- a/src/utils/safeStringify.js
+++ b/src/utils/safeStringify.js
@@ -1,0 +1,25 @@
+// src/utils/safeStringify.js
+
+/**
+ * Safely stringifies a value that may contain circular references.
+ *
+ * @description
+ * Uses a WeakSet to track visited objects and replaces circular
+ * references with the string "[Circular]".
+ * This mirrors JSON.stringify behavior for non-cyclic structures
+ * but avoids throwing errors when cycles are present.
+ * @param {any} value - The value to stringify.
+ * @returns {string} The JSON string representation.
+ */
+export function safeStringify(value) {
+  const seen = new WeakSet();
+  return JSON.stringify(value, (key, val) => {
+    if (val && typeof val === 'object') {
+      if (seen.has(val)) {
+        return '[Circular]';
+      }
+      seen.add(val);
+    }
+    return val;
+  });
+}

--- a/tests/unit/scopeDsl/cache.additional.test.js
+++ b/tests/unit/scopeDsl/cache.additional.test.js
@@ -295,18 +295,21 @@ describe('Scope-DSL Cache - Additional Coverage Tests', () => {
       );
     });
 
-    test('should handle AST with circular references in JSON.stringify', () => {
+    test('should handle AST with circular references', () => {
       const ast = { type: 'Source', kind: 'actor' };
-      // Create circular reference
       ast.self = ast;
 
       mockCache.get.mockReturnValue(undefined);
       mockScopeEngine.resolve.mockReturnValue(new Set(['result']));
 
-      // JSON.stringify with circular reference throws an error, which is expected behavior
       expect(() => {
         cache.resolve(ast, mockActorEntity, mockRuntimeCtx);
-      }).toThrow('Converting circular structure to JSON');
+      }).not.toThrow();
+
+      expect(mockCache.set).toHaveBeenCalledWith(
+        expect.stringContaining('actor123:'),
+        new Set(['result'])
+      );
     });
 
     test('should handle cache hit returning null/undefined values', () => {


### PR DESCRIPTION
Summary: Fix scope cache key generation to handle cyclic ASTs without crashing. Added safe stringifier and updated tests.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6862d23c8778833180358b6a634a8ebb