### PR TITLE
[Agent] introduce ActionIndexingError

### DIFF
--- a/src/turns/services/actionIndexingService.js
+++ b/src/turns/services/actionIndexingService.js
@@ -1,4 +1,5 @@
 import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../constants/core.js';
+import { ActionIndexingError } from './errors/actionIndexingError.js';
 
 /**
  * Remove duplicate actions by id and params.
@@ -165,7 +166,11 @@ export class ActionIndexingService {
    */
   getIndexedList(actorId) {
     const list = this.#actorCache.get(actorId);
-    if (!list) throw new Error(`No indexed action list for actor "${actorId}"`);
+    if (!list)
+      throw new ActionIndexingError(
+        `No indexed action list for actor "${actorId}"`,
+        actorId
+      );
     return list.slice(); // shallow copy to protect internal state
   }
 
@@ -177,11 +182,17 @@ export class ActionIndexingService {
    */
   resolve(actorId, chosenIndex) {
     const list = this.#actorCache.get(actorId);
-    if (!list) throw new Error(`No actions indexed for actor "${actorId}"`);
+    if (!list)
+      throw new ActionIndexingError(
+        `No actions indexed for actor "${actorId}"`,
+        actorId
+      );
     const composite = list.find((c) => c.index === chosenIndex);
     if (!composite) {
-      throw new Error(
-        `No action found at index ${chosenIndex} for actor "${actorId}"`
+      throw new ActionIndexingError(
+        `No action found at index ${chosenIndex} for actor "${actorId}"`,
+        actorId,
+        chosenIndex
       );
     }
     return composite;

--- a/src/turns/services/errors/actionIndexingError.js
+++ b/src/turns/services/errors/actionIndexingError.js
@@ -1,0 +1,34 @@
+/**
+ * @module turns/services/errors/actionIndexingError
+ * @description Error thrown by ActionIndexingService when resolving or retrieving
+ * indexed actions fails.
+ */
+
+/**
+ * Custom error for ActionIndexingService failures, providing actor and index context.
+ *
+ * @class ActionIndexingError
+ * @augments {Error}
+ */
+export class ActionIndexingError extends Error {
+  /**
+   * Creates a new ActionIndexingError instance.
+   *
+   * @param {string} message - Description of the failure.
+   * @param {string} actorId - The actor associated with the failure.
+   * @param {number} [index] - The index involved in the error if applicable.
+   */
+  constructor(message, actorId, index = null) {
+    super(message);
+    this.name = 'ActionIndexingError';
+    /** @type {string} */
+    this.actorId = actorId;
+    /** @type {number|null} */
+    this.index = index;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ActionIndexingError);
+    }
+  }
+}
+
+export default ActionIndexingError;

--- a/tests/unit/turns/services/actionIndexingService.test.js
+++ b/tests/unit/turns/services/actionIndexingService.test.js
@@ -1,4 +1,5 @@
 import { ActionIndexingService } from '../../../../src/turns/services/actionIndexingService.js';
+import { ActionIndexingError } from '../../../../src/turns/services/errors/actionIndexingError.js';
 import { MAX_AVAILABLE_ACTIONS_PER_TURN } from '../../../../src/constants/core.js';
 import { describe, beforeEach, it, expect, jest } from '@jest/globals';
 
@@ -166,9 +167,7 @@ describe('ActionIndexingService', () => {
   });
 
   it('throws if getIndexedList called before indexActions', () => {
-    expect(() => service.getIndexedList('actorX')).toThrow(
-      'No indexed action list for actor "actorX"'
-    );
+    expect(() => service.getIndexedList('actorX')).toThrow(ActionIndexingError);
   });
 
   it('getIndexedList returns a copy and protects internal state', () => {
@@ -184,17 +183,13 @@ describe('ActionIndexingService', () => {
   });
 
   it('resolve throws if called before indexActions', () => {
-    expect(() => service.resolve('actorZ', 1)).toThrow(
-      'No actions indexed for actor "actorZ"'
-    );
+    expect(() => service.resolve('actorZ', 1)).toThrow(ActionIndexingError);
   });
 
   it('resolve throws if index out of range', () => {
     service.indexActions('actorZ', [
       { id: 'x', params: {}, command: 'cmd', description: 'desc' },
     ]);
-    expect(() => service.resolve('actorZ', 2)).toThrow(
-      'No action found at index 2 for actor "actorZ"'
-    );
+    expect(() => service.resolve('actorZ', 2)).toThrow(ActionIndexingError);
   });
 });


### PR DESCRIPTION
## Summary
- add custom `ActionIndexingError`
- use `ActionIndexingError` when resolving or retrieving actions
- update unit tests for new error class

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3732 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862d21e4bbc8331b1889c0bceb3d1c0