### PR TITLE
[Feat] Update AwaitingExternalTurnEndState API

### DIFF
--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -59,15 +59,18 @@ export class AwaitingExternalTurnEndState extends AbstractTurnState {
    * Creates an instance of AwaitingExternalTurnEndState.
    *
    * @param {BaseTurnHandler} handler - The handler managing the turn state.
-   * @param {number} [timeoutMs] - Timeout duration for waiting.
-   * @param {Function} [setTimeoutFn] - Optional custom setTimeout.
-   * @param {Function} [clearTimeoutFn] - Optional custom clearTimeout.
+   * @param {object} [options] - Optional configuration overrides.
+   * @param {number} [options.timeoutMs=TIMEOUT_MS] - Timeout duration for waiting.
+   * @param {Function} [options.setTimeoutFn=setTimeout] - Optional custom setTimeout.
+   * @param {Function} [options.clearTimeoutFn=clearTimeout] - Optional custom clearTimeout.
    */
   constructor(
     handler,
-    timeoutMs = TIMEOUT_MS,
-    setTimeoutFn = setTimeout,
-    clearTimeoutFn = clearTimeout
+    {
+      timeoutMs = TIMEOUT_MS,
+      setTimeoutFn = setTimeout,
+      clearTimeoutFn = clearTimeout,
+    } = {}
   ) {
     super(handler);
     this.#timeoutMs = timeoutMs;

--- a/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.comprehensive.test.js
@@ -138,12 +138,11 @@ describe('AwaitingExternalTurnEndState', () => {
     mockUnsubscribeFn = jest.fn();
     mockEventDispatcher.subscribe.mockImplementation(() => mockUnsubscribeFn);
 
-    state = new AwaitingExternalTurnEndState(
-      mockHandler,
-      TIMEOUT_MS,
-      global.setTimeout,
-      global.clearTimeout
-    );
+    state = new AwaitingExternalTurnEndState(mockHandler, {
+      timeoutMs: TIMEOUT_MS,
+      setTimeoutFn: global.setTimeout,
+      clearTimeoutFn: global.clearTimeout,
+    });
   });
 
   afterEach(() => {

--- a/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
+++ b/tests/unit/turns/states/awaitingExternalTurnEndState.test.js
@@ -68,12 +68,11 @@ describe('AwaitingExternalTurnEndState – action propagation', () => {
     };
 
     /* ── state under test ──────────────────────────────────────────────── */
-    state = new AwaitingExternalTurnEndState(
-      mockHandler,
-      TIMEOUT_MS,
-      global.setTimeout,
-      global.clearTimeout
-    );
+    state = new AwaitingExternalTurnEndState(mockHandler, {
+      timeoutMs: TIMEOUT_MS,
+      setTimeoutFn: global.setTimeout,
+      clearTimeoutFn: global.clearTimeout,
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
Summary: Simplified the AwaitingExternalTurnEndState constructor to take an options object and documented defaults. Updated related tests.

Changes Made:
- Accept options object with defaults in AwaitingExternalTurnEndState
- Updated usage in comprehensive and action propagation tests
- Documented parameter defaults via JSDoc

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_6862d1f5b0108331ab4f301f4f0f20bb