### PR TITLE
[Agent] improve error handling in loaders

### DIFF
--- a/src/errors/fetchError.js
+++ b/src/errors/fetchError.js
@@ -1,0 +1,23 @@
+/**
+ * @file Error type for fetch operation failures.
+ */
+
+/**
+ * Error thrown when a file or resource cannot be fetched.
+ *
+ * @class
+ * @augments {Error}
+ */
+export class FetchError extends Error {
+  /**
+   * @param {string} message - Description of the fetch failure.
+   * @param {string} [path] - Path or URL that failed to fetch.
+   */
+  constructor(message, path = null) {
+    super(message);
+    this.name = 'FetchError';
+    this.path = path;
+  }
+}
+
+export default FetchError;

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -13,3 +13,5 @@ export * from './componentOverrideNotFoundError.js';
 export * from './locationNotFoundError.js';
 export * from './missingEntityInstanceError.js';
 export * from './missingInstanceIdError.js';
+export * from './validationError.js';
+export * from './fetchError.js';

--- a/src/loaders/anatomyFormattingLoader.js
+++ b/src/loaders/anatomyFormattingLoader.js
@@ -2,6 +2,7 @@
 
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
+import { ValidationError } from '../errors/validationError.js';
 
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
 /** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
@@ -76,7 +77,7 @@ class AnatomyFormattingLoader extends BaseManifestItemLoader {
 
     for (const field of arrayFields) {
       if (data[field] !== undefined && !Array.isArray(data[field])) {
-        throw new Error(
+        throw new ValidationError(
           `Invalid '${field}' for anatomy formatting '${baseId}' in '${filename}'. Expected array, received ${typeof data[
             field
           ]}.`
@@ -91,7 +92,7 @@ class AnatomyFormattingLoader extends BaseManifestItemLoader {
         data.irregularPlurals === null ||
         Array.isArray(data.irregularPlurals))
     ) {
-      throw new Error(
+      throw new ValidationError(
         `Invalid 'irregularPlurals' for anatomy formatting '${baseId}' in '${filename}'. Expected object, received ${
           data.irregularPlurals === null ? 'null' : typeof data.irregularPlurals
         }.`

--- a/src/loaders/anatomyRecipeLoader.js
+++ b/src/loaders/anatomyRecipeLoader.js
@@ -3,6 +3,7 @@
 import { SimpleItemLoader } from './simpleItemLoader.js';
 import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
+import { ValidationError } from '../errors/validationError.js';
 
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
 /** @typedef {import('../interfaces/coreServices.js').IPathResolver} IPathResolver */
@@ -102,13 +103,13 @@ class AnatomyRecipeLoader extends SimpleItemLoader {
    */
   _validateConstraints(constraints, modId, filename) {
     if (constraints.requires && !Array.isArray(constraints.requires)) {
-      throw new Error(
+      throw new ValidationError(
         `Invalid 'requires' constraint in recipe '${filename}' from mod '${modId}'. Expected array.`
       );
     }
 
     if (constraints.excludes && !Array.isArray(constraints.excludes)) {
-      throw new Error(
+      throw new ValidationError(
         `Invalid 'excludes' constraint in recipe '${filename}' from mod '${modId}'. Expected array.`
       );
     }
@@ -117,7 +118,7 @@ class AnatomyRecipeLoader extends SimpleItemLoader {
     if (constraints.requires) {
       for (const group of constraints.requires) {
         if (!Array.isArray(group) || group.length < 2) {
-          throw new Error(
+          throw new ValidationError(
             `Invalid 'requires' group in recipe '${filename}' from mod '${modId}'. Each group must have at least 2 items.`
           );
         }
@@ -127,7 +128,7 @@ class AnatomyRecipeLoader extends SimpleItemLoader {
     if (constraints.excludes) {
       for (const group of constraints.excludes) {
         if (!Array.isArray(group) || group.length < 2) {
-          throw new Error(
+          throw new ValidationError(
             `Invalid 'excludes' group in recipe '${filename}' from mod '${modId}'. Each group must have at least 2 items.`
           );
         }

--- a/src/loaders/entityDefinitionLoader.js
+++ b/src/loaders/entityDefinitionLoader.js
@@ -10,6 +10,7 @@ import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
 import { processAndStoreItem } from './helpers/processAndStoreItem.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 import EntityDefinition from '../entities/entityDefinition.js';
+import { ValidationError } from '../errors/validationError.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -142,7 +143,7 @@ class EntityDefinitionLoader extends BaseManifestItemLoader {
         entityId,
         failedComponentIds,
       });
-      throw new Error(comprehensiveMessage);
+      throw new ValidationError(comprehensiveMessage);
     }
     this._logger.debug(
       `EntityLoader [${modId}]: All runtime component validations passed for entity '${entityId}' from ${filename}.`

--- a/src/loaders/entityInstanceLoader.js
+++ b/src/loaders/entityInstanceLoader.js
@@ -7,6 +7,7 @@
 import { BaseManifestItemLoader } from './baseManifestItemLoader.js';
 import { parseAndValidateId } from '../utils/idUtils.js';
 import { formatAjvErrors } from '../utils/ajvUtils.js';
+import { ValidationError } from '../errors/validationError.js';
 
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../interfaces/coreServices.js').IConfiguration} IConfiguration */
@@ -115,7 +116,7 @@ export class EntityInstanceLoader extends BaseManifestItemLoader {
         .map((failure) => failure.componentId)
         .join(', ');
       const comprehensiveMessage = `Component override validation failed for instance '${instanceId}' in file '${filename}' (mod: ${modId}). Invalid components: [${failedComponentIds}]. See previous error logs for details.`;
-      throw new Error(comprehensiveMessage);
+      throw new ValidationError(comprehensiveMessage);
     }
   }
 

--- a/src/loaders/gameConfigLoader.js
+++ b/src/loaders/gameConfigLoader.js
@@ -15,6 +15,8 @@ import { CORE_MOD_ID } from '../constants/core';
 import AbstractLoader from './abstractLoader.js';
 import { formatAjvErrors } from '../utils/ajvUtils.js';
 import { validateAgainstSchema } from '../utils/schemaValidationUtils.js';
+import { ValidationError } from '../errors/validationError.js';
+import { FetchError } from '../errors/fetchError.js';
 
 /**
  * Service responsible for locating, fetching, validating, and parsing the game configuration file (e.g., game.json).
@@ -98,8 +100,9 @@ class GameConfigLoader extends AbstractLoader {
         `FATAL: Game configuration file '${filename}' not found or could not be fetched at ${path}. Details: ${fetchError.message}`,
         fetchError
       );
-      throw new Error(
-        `Failed to fetch game configuration '${filename}' from ${path}: ${fetchError.message}`
+      throw new FetchError(
+        `Failed to fetch game configuration '${filename}' from ${path}: ${fetchError.message}`,
+        path
       );
     }
   }
@@ -119,7 +122,7 @@ class GameConfigLoader extends AbstractLoader {
       this.#logger.error(
         "FATAL: Schema ID for 'game' configuration type not found in IConfiguration."
       );
-      throw new Error(
+      throw new ValidationError(
         'Schema ID for \u2018game\u2019 configuration type not configured.'
       );
     }
@@ -155,7 +158,7 @@ class GameConfigLoader extends AbstractLoader {
       this.#logger.error(
         `FATAL: Validated game config '${filename}' is missing the required 'mods' array property or has incorrect type. Path: ${path}.`
       );
-      throw new Error(
+      throw new ValidationError(
         `Validated game config '${filename}' is missing the required 'mods' array.`
       );
     }
@@ -163,7 +166,7 @@ class GameConfigLoader extends AbstractLoader {
       this.#logger.error(
         `FATAL: Validated game config '${filename}' 'mods' array contains non-string elements. Path: ${path}.`
       );
-      throw new Error(
+      throw new ValidationError(
         `Validated game config '${filename}' 'mods' array contains non-string elements.`
       );
     }

--- a/src/loaders/promptTextLoader.js
+++ b/src/loaders/promptTextLoader.js
@@ -10,6 +10,7 @@
 /** @typedef {import('../interfaces/coreServices.js').ISchemaValidator} ISchemaValidator */
 /** @typedef {import('../interfaces/coreServices.js').IDataRegistry} IDataRegistry */
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
+import { ValidationError } from '../errors/validationError.js';
 
 import AbstractLoader from './abstractLoader.js';
 
@@ -97,7 +98,7 @@ class PromptTextLoader extends AbstractLoader {
         `PromptTextLoader: Validation failed for ${filePath} using schema '${schemaId}'.`,
         { errors: validationResult.errors }
       );
-      throw new Error('Prompt text validation failed.');
+      throw new ValidationError('Prompt text validation failed.');
     }
 
     this.#dataRegistry.store('prompt_text', 'core', data);

--- a/src/loaders/uiAssetsLoader.js
+++ b/src/loaders/uiAssetsLoader.js
@@ -236,6 +236,11 @@ class UiAssetsLoader extends AbstractLoader {
         overrides += loaderResult.overrides;
         errors += loaderResult.errors;
         if (Array.isArray(loaderResult.failures)) {
+          for (const failure of loaderResult.failures) {
+            this._logger.warn(
+              `UiAssetsLoader [${modId}]: ${failure.file} failed due to ${failure.reason}`
+            );
+          }
           failures.push(...loaderResult.failures);
         }
       } catch (e) {

--- a/tests/unit/loaders/entityInstanceLoader.test.js
+++ b/tests/unit/loaders/entityInstanceLoader.test.js
@@ -15,8 +15,9 @@ describe('EntityInstanceLoader', () => {
   let mockSchemaValidator;
   let dataRegistry;
   let mockLogger;
-  
-  const PRIMARY_SCHEMA_ID = 'http://example.com/schemas/entity-instance.schema.json';
+
+  const PRIMARY_SCHEMA_ID =
+    'http://example.com/schemas/entity-instance.schema.json';
 
   beforeEach(() => {
     // Create a real data registry for testing
@@ -37,8 +38,8 @@ describe('EntityInstanceLoader', () => {
     // Configure mocks
     mockConfig.getContentTypeSchemaId
       .calledWith('entityInstances')
-      .mockReturnValue(PRIMARY_SCHEMA_ID);  // Return full schema ID
-    
+      .mockReturnValue(PRIMARY_SCHEMA_ID); // Return full schema ID
+
     mockConfig.get.mockImplementation((key) => {
       if (key === 'schemas.entityInstances.primaryId') {
         return PRIMARY_SCHEMA_ID;
@@ -47,15 +48,16 @@ describe('EntityInstanceLoader', () => {
         return false;
       }
       if (key === 'validation.skipIfSchemaNotLoaded') {
-        return false;  // Don't skip validation
+        return false; // Don't skip validation
       }
       return null;
     });
 
     mockConfig.getModsBasePath.mockReturnValue('./data/mods');
 
-    mockPathResolver.resolveModContentPath.mockImplementation((modId, diskFolder, filename) => 
-      `./data/mods/${modId}/${diskFolder}/${filename}`
+    mockPathResolver.resolveModContentPath.mockImplementation(
+      (modId, diskFolder, filename) =>
+        `./data/mods/${modId}/${diskFolder}/${filename}`
     );
 
     // Create the loader instance
@@ -80,12 +82,12 @@ describe('EntityInstanceLoader', () => {
       };
 
       mockDataFetcher.fetch.mockResolvedValue(invalidInstance);
-      
+
       // Mock schema validation
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, invalidInstance)
         .mockReturnValue({
@@ -111,9 +113,9 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
@@ -122,14 +124,18 @@ describe('EntityInstanceLoader', () => {
       expect(result.failures).toHaveLength(1);
       expect(result.failures[0]).toHaveProperty('error');
       // The error comes from schema validation, not parseAndValidateId
-      expect(result.failures[0].error.message).toContain("must have required property 'instanceId'");
-      expect(dataRegistry.get('entityInstances', 'test:invalid_instance')).toBeUndefined();
+      expect(result.failures[0].error.message).toContain(
+        "must have required property 'instanceId'"
+      );
+      expect(
+        dataRegistry.get('entityInstances', 'test:invalid_instance')
+      ).toBeUndefined();
     });
 
     it('should reject entity instance with missing definitionId', async () => {
       const invalidInstance = {
         $schema: 'http://example.com/schemas/entity-instance.schema.json',
-        instanceId: 'test-mod:my_instance',  // Properly namespaced
+        instanceId: 'test-mod:my_instance', // Properly namespaced
         // Missing definitionId
         componentOverrides: {
           'core:name': { text: 'Test Instance' },
@@ -137,12 +143,12 @@ describe('EntityInstanceLoader', () => {
       };
 
       mockDataFetcher.fetch.mockResolvedValue(invalidInstance);
-      
+
       // Mock schema validation to fail for missing definitionId
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       // When validation fails, it returns false and errors
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, invalidInstance)
@@ -169,9 +175,9 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
@@ -180,7 +186,9 @@ describe('EntityInstanceLoader', () => {
       expect(result.failures).toHaveLength(1);
       expect(result.failures[0]).toHaveProperty('error');
       // The actual error message contains the full validation error details
-      expect(result.failures[0].error.message).toContain("must have required property 'definitionId'");
+      expect(result.failures[0].error.message).toContain(
+        "must have required property 'definitionId'"
+      );
     });
 
     it('should reject entity instance with invalid additional properties', async () => {
@@ -189,18 +197,19 @@ describe('EntityInstanceLoader', () => {
         instanceId: 'test:my_instance',
         definitionId: 'test:some_entity',
         id: 'should-not-be-here', // This is not allowed in instances
-        components: { // Should be componentOverrides
+        components: {
+          // Should be componentOverrides
           'core:name': { text: 'Test' },
         },
       };
 
       mockDataFetcher.fetch.mockResolvedValue(invalidInstance);
-      
+
       // Mock schema validation
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       // When validation fails, it returns false and errors
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, invalidInstance)
@@ -234,9 +243,9 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
@@ -245,13 +254,15 @@ describe('EntityInstanceLoader', () => {
       expect(result.failures).toHaveLength(1);
       expect(result.failures[0]).toHaveProperty('error');
       // The actual error message contains validation details
-      expect(result.failures[0].error.message).toContain('must NOT have additional properties');
+      expect(result.failures[0].error.message).toContain(
+        'must NOT have additional properties'
+      );
     });
 
     it('should accept valid entity instance', async () => {
       const validInstance = {
         $schema: 'http://example.com/schemas/entity-instance.schema.json',
-        instanceId: 'test-mod:my_character',  // Properly namespaced
+        instanceId: 'test-mod:my_character', // Properly namespaced
         definitionId: 'test:character_template',
         componentOverrides: {
           'core:name': { text: 'My Character' },
@@ -260,12 +271,12 @@ describe('EntityInstanceLoader', () => {
       };
 
       mockDataFetcher.fetch.mockResolvedValue(validInstance);
-      
+
       // Mock schema validation
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, validInstance)
         .mockReturnValue({ isValid: true, errors: null });
@@ -280,16 +291,18 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
 
       expect(result.errors).toBe(0);
       expect(result.count).toBe(1);
-      expect(dataRegistry.get('entityInstances', 'test-mod:my_character')).toBeDefined();
+      expect(
+        dataRegistry.get('entityInstances', 'test-mod:my_character')
+      ).toBeDefined();
     });
   });
 
@@ -307,12 +320,12 @@ describe('EntityInstanceLoader', () => {
       };
 
       mockDataFetcher.fetch.mockResolvedValue(entityDefinition);
-      
+
       // Mock schema validation
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, entityDefinition)
         .mockReturnValue({
@@ -359,9 +372,9 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
@@ -371,8 +384,10 @@ describe('EntityInstanceLoader', () => {
       expect(result.failures[0]).toHaveProperty('error');
       const errorMessage = result.failures[0].error.message;
       // The error message should mention the missing required fields and additional properties
-      expect(errorMessage).toMatch(/instanceId|definitionId|additional properties/);
-      
+      expect(errorMessage).toMatch(
+        /instanceId|definitionId|additional properties/
+      );
+
       // Verify it logs helpful information
       expect(mockLogger.error).toHaveBeenCalled();
     });
@@ -390,9 +405,9 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
@@ -405,7 +420,7 @@ describe('EntityInstanceLoader', () => {
     it('should continue processing other files when one fails', async () => {
       const validInstance = {
         $schema: 'http://example.com/schemas/entity-instance.schema.json',
-        instanceId: 'test-mod:valid_instance',  // Properly namespaced
+        instanceId: 'test-mod:valid_instance', // Properly namespaced
         definitionId: 'test:some_entity',
       };
 
@@ -423,22 +438,24 @@ describe('EntityInstanceLoader', () => {
       mockSchemaValidator.isSchemaLoaded
         .calledWith(PRIMARY_SCHEMA_ID)
         .mockReturnValue(true);
-      
+
       // First call for invalid instance - validation passes (schema check)
       // but parseAndValidateId will fail due to missing instanceId
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, invalidInstance)
         .mockReturnValue({
           isValid: false,
-          errors: [{ 
-            message: "must have required property 'instanceId'",
-            instancePath: '',
-            schemaPath: '#/required',
-            keyword: 'required',
-            params: { missingProperty: 'instanceId' }
-          }],
+          errors: [
+            {
+              message: "must have required property 'instanceId'",
+              instancePath: '',
+              schemaPath: '#/required',
+              keyword: 'required',
+              params: { missingProperty: 'instanceId' },
+            },
+          ],
         });
-      
+
       // Second call for valid instance
       mockSchemaValidator.validate
         .calledWith(PRIMARY_SCHEMA_ID, validInstance)
@@ -454,16 +471,18 @@ describe('EntityInstanceLoader', () => {
       };
 
       const result = await loader.loadItemsForMod(
-        manifest.id, 
-        manifest, 
-        'entities.instances', 
+        manifest.id,
+        manifest,
+        'entities.instances',
         'entities/instances',
         'entityInstances'
       );
 
       expect(result.errors).toBe(1);
       expect(result.count).toBe(1);
-      expect(dataRegistry.get('entityInstances', 'test-mod:valid_instance')).toBeDefined();
+      expect(
+        dataRegistry.get('entityInstances', 'test-mod:valid_instance')
+      ).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated `FetchError` class
- export new errors
- use `ValidationError` for component validation failures
- report per-file errors when loading UI assets

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6862d1a0cf448331b787edbb268a1bb0