### PR TITLE
[Agent] remove unused logger args and rename vars

### DIFF
--- a/src/prompting/AIPromptContentProvider.js
+++ b/src/prompting/AIPromptContentProvider.js
@@ -107,10 +107,9 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
    * @param {Array<*>} items - Array of items to format.
    * @param {function(*): string} itemFormatter - Function to convert each item to a string.
    * @param {string} emptyMessage - Message to show if items is empty.
-   * @param {ILogger} logger - Logger instance for debugging.
    * @returns {string} Formatted section string.
    */
-  _formatListSegment(title, items, itemFormatter, emptyMessage, logger) {
+  _formatListSegment(title, items, itemFormatter, emptyMessage) {
     const cleanedTitle = title.replace(/[:\n]*$/, '');
     const lines = [cleanedTitle + ':'];
 
@@ -118,12 +117,12 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
       items.forEach((item) => {
         lines.push(itemFormatter(item));
       });
-      logger.debug(
+      this.#logger.debug(
         `AIPromptContentProvider: Formatted ${items.length} items for section "${cleanedTitle}".`
       );
     } else {
       lines.push(emptyMessage);
-      logger.debug(
+      this.#logger.debug(
         `AIPromptContentProvider: Section "${cleanedTitle}" is empty, using empty message.`
       );
     }
@@ -155,8 +154,8 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
    * @returns {Array<{text:string,timestamp:string}>} Sanitized array of entries.
    */
   _extractTimestampedEntries(component, key) {
-    const arr = Array.isArray(component?.[key]) ? component[key] : [];
-    return arr
+    const entries = Array.isArray(component?.[key]) ? component[key] : [];
+    return entries
       .filter(
         (e) =>
           typeof e.text === 'string' &&
@@ -328,21 +327,13 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
     try {
       const baseValues = {
         taskDefinitionContent: this.getTaskDefinitionContent(),
-        characterPersonaContent: this.getCharacterPersonaContent(
-          gameStateDto,
-          this.#logger
-        ),
+        characterPersonaContent: this.getCharacterPersonaContent(gameStateDto),
         portrayalGuidelinesContent:
           this.getCharacterPortrayalGuidelinesContent(characterName),
         contentPolicyContent: this.getContentPolicyContent(),
-        worldContextContent: this.getWorldContextContent(
-          gameStateDto,
-          this.#logger
-        ),
-        availableActionsInfoContent: this.getAvailableActionsInfoContent(
-          gameStateDto,
-          this.#logger
-        ),
+        worldContextContent: this.getWorldContextContent(gameStateDto),
+        availableActionsInfoContent:
+          this.getAvailableActionsInfoContent(gameStateDto),
         userInputContent: currentUserInput,
         finalInstructionsContent: this.getFinalInstructionsContent(),
         perceptionLogArray: perceptionLogArray,
@@ -374,10 +365,9 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
 
   /**
    * @param {AIGameStateDTO} gameState - The game state DTO.
-   * @param {ILogger} [_logger] - Optional logger instance.
    * @returns {string} Formatted character persona content.
    */
-  getCharacterPersonaContent(gameState, _logger) {
+  getCharacterPersonaContent(gameState) {
     this.#logger.debug(
       'AIPromptContentProvider: Formatting character persona content.'
     );
@@ -444,10 +434,9 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
 
   /**
    * @param {AIGameStateDTO} gameState - The game state DTO.
-   * @param {ILogger} [_logger] - Optional logger instance.
    * @returns {string} Formatted world context content.
    */
-  getWorldContextContent(gameState, _logger) {
+  getWorldContextContent(gameState) {
     this.#logger.debug(
       'AIPromptContentProvider: Formatting world context content.'
     );
@@ -480,8 +469,7 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
             exit.targetLocationId ||
             DEFAULT_FALLBACK_LOCATION_NAME
           }.`,
-        PROMPT_FALLBACK_NO_EXITS,
-        this.#logger
+        PROMPT_FALLBACK_NO_EXITS
       )
     );
     segments.push(
@@ -495,8 +483,7 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
           descriptionText = ensureTerminalPunctuation(descriptionText);
           return `- ${namePart} - Description: ${descriptionText}`;
         },
-        PROMPT_FALLBACK_ALONE_IN_LOCATION,
-        this.#logger
+        PROMPT_FALLBACK_ALONE_IN_LOCATION
       )
     );
     return segments.join('\n\n');
@@ -504,10 +491,9 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
 
   /**
    * @param {AIGameStateDTO} gameState - The game state DTO.
-   * @param {ILogger} [_logger] - Optional logger instance.
    * @returns {string} Formatted available actions content.
    */
-  getAvailableActionsInfoContent(gameState, _logger) {
+  getAvailableActionsInfoContent(gameState) {
     this.#logger.debug(
       'AIPromptContentProvider: Formatting available actions info content.'
     );
@@ -537,8 +523,7 @@ export class AIPromptContentProvider extends IAIPromptContentProvider {
         // The critical change: Add the index clearly at the start of the line.
         return `[Index: ${action.index}] Command: "${commandStr}". Description: ${description}`;
       },
-      noActionsMessage,
-      this.#logger
+      noActionsMessage
     );
   }
 

--- a/src/prompting/assembling/goalsSectionAssembler.js
+++ b/src/prompting/assembling/goalsSectionAssembler.js
@@ -27,8 +27,8 @@ export class GoalsSectionAssembler extends IPromptElementAssembler {
       return '';
     }
 
-    const arr = promptData?.goalsArray;
-    if (!Array.isArray(arr) || arr.length === 0) {
+    const goals = promptData?.goalsArray;
+    if (!Array.isArray(goals) || goals.length === 0) {
       return '';
     }
 
@@ -42,13 +42,13 @@ export class GoalsSectionAssembler extends IPromptElementAssembler {
       const ms = new Date(ts).getTime();
       return Number.isFinite(ms) ? ms : Number.POSITIVE_INFINITY;
     };
-    const sorted = arr
+    const sortedGoals = goals
       .slice()
       .sort((a, b) => safeMs(a.timestamp) - safeMs(b.timestamp));
 
-    const goalLines = sorted
-      .filter((g) => g?.text)
-      .map((g) => `- ${String(g.text)}`)
+    const goalLines = sortedGoals
+      .filter((goal) => goal?.text)
+      .map((goal) => `- ${String(goal.text)}`)
       .join('\n');
 
     if (!goalLines) {

--- a/src/prompting/assembling/notesSectionAssembler.js
+++ b/src/prompting/assembling/notesSectionAssembler.js
@@ -39,7 +39,7 @@ export class NotesSectionAssembler extends IPromptElementAssembler {
         (a, b) =>
           new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
       )
-      .map((n) => `- ${n.text}`)
+      .map((note) => `- ${note.text}`)
       .join('\n');
 
     return `${resolvedPrefix}\n${bodyLines}\n${resolvedSuffix}`;

--- a/src/prompting/assembling/perceptionLogAssembler.js
+++ b/src/prompting/assembling/perceptionLogAssembler.js
@@ -58,8 +58,8 @@ export class PerceptionLogAssembler extends IPromptElementAssembler {
     );
 
     // Check for empty or missing log array
-    const arr = promptData.perceptionLogArray;
-    if (!Array.isArray(arr) || arr.length === 0) {
+    const logEntries = promptData.perceptionLogArray;
+    if (!Array.isArray(logEntries) || logEntries.length === 0) {
       this.#logger.debug(
         `Perception log array for '${elementConfig.key}' missing or empty`
       );
@@ -80,7 +80,7 @@ export class PerceptionLogAssembler extends IPromptElementAssembler {
 
     // Assemble each entry
     let assembledEntries = '';
-    for (const entry of arr) {
+    for (const entry of logEntries) {
       if (!entry || typeof entry !== 'object') {
         this.#logger.warn('Invalid perception log entry encountered', {
           entry,

--- a/src/prompting/assembling/thoughtsSectionAssembler.js
+++ b/src/prompting/assembling/thoughtsSectionAssembler.js
@@ -27,8 +27,8 @@ export class ThoughtsSectionAssembler extends IPromptElementAssembler {
       return '';
     }
 
-    const arr = promptData?.thoughtsArray;
-    if (!Array.isArray(arr) || arr.length === 0) {
+    const thoughts = promptData?.thoughtsArray;
+    if (!Array.isArray(thoughts) || thoughts.length === 0) {
       return '';
     }
 
@@ -38,9 +38,11 @@ export class ThoughtsSectionAssembler extends IPromptElementAssembler {
       promptData
     );
 
-    const thoughtLines = arr
-      .filter((t) => t !== null && t !== undefined && t !== '')
-      .map((t) => `- ${String(t)}`)
+    const thoughtLines = thoughts
+      .filter(
+        (thought) => thought !== null && thought !== undefined && thought !== ''
+      )
+      .map((thought) => `- ${String(thought)}`)
       .join('\n');
 
     if (!thoughtLines) {

--- a/src/turns/interfaces/IAIPromptContentProvider.js
+++ b/src/turns/interfaces/IAIPromptContentProvider.js
@@ -63,11 +63,10 @@ export class IAIPromptContentProvider {
    * Generates the character definition content.
    *
    * @param {AIGameStateDTO} gameStateDto - The game state DTO.
-   * @param {ILogger} [logger] - Optional logger instance.
    * @returns {string} The formatted character segment.
    * @throws {Error} If the method is not implemented.
    */
-  getCharacterPersonaContent(gameStateDto, logger) {
+  getCharacterPersonaContent(gameStateDto) {
     throw new Error(
       "Method 'getCharacterPersonaContent()' must be implemented."
     );
@@ -77,11 +76,10 @@ export class IAIPromptContentProvider {
    * Generates the world context content (location, exits, other characters).
    *
    * @param {AIGameStateDTO} gameStateDto - The game state DTO.
-   * @param {ILogger} [logger] - Optional logger instance.
    * @returns {string} The formatted world context segment.
    * @throws {Error} If the method is not implemented.
    */
-  getWorldContextContent(gameStateDto, logger) {
+  getWorldContextContent(gameStateDto) {
     throw new Error("Method 'getWorldContextContent()' must be implemented.");
   }
 
@@ -89,11 +87,10 @@ export class IAIPromptContentProvider {
    * Generates the available actions content.
    *
    * @param {AIGameStateDTO} gameStateDto - The game state DTO.
-   * @param {ILogger} [logger] - Optional logger instance.
    * @returns {string} The formatted actions segment.
    * @throws {Error} If the method is not implemented.
    */
-  getAvailableActionsInfoContent(gameStateDto, logger) {
+  getAvailableActionsInfoContent(gameStateDto) {
     throw new Error(
       "Method 'getAvailableActionsInfoContent()' must be implemented."
     );

--- a/tests/unit/prompting/AIPromptContentProvider.test.js
+++ b/tests/unit/prompting/AIPromptContentProvider.test.js
@@ -6,9 +6,7 @@ import {
   DEFAULT_FALLBACK_CHARACTER_NAME,
   DEFAULT_FALLBACK_LOCATION_NAME,
   DEFAULT_FALLBACK_DESCRIPTION_RAW,
-  DEFAULT_FALLBACK_ACTION_ID,
   DEFAULT_FALLBACK_ACTION_COMMAND,
-  DEFAULT_FALLBACK_ACTION_NAME,
   DEFAULT_FALLBACK_ACTION_DESCRIPTION_RAW,
   ERROR_FALLBACK_CRITICAL_GAME_STATE_MISSING,
   PROMPT_FALLBACK_UNKNOWN_CHARACTER_DETAILS,
@@ -451,17 +449,10 @@ describe('AIPromptContentProvider', () => {
       expect(getCharacterPortrayalGuidelinesContentSpy).toHaveBeenCalledWith(
         DEFAULT_FALLBACK_CHARACTER_NAME
       );
-      expect(getCharacterPersonaContentSpy).toHaveBeenCalledWith(
-        minimalDto,
-        mockLoggerInstance
-      ); // uses instance logger
-      expect(getWorldContextContentSpy).toHaveBeenCalledWith(
-        minimalDto,
-        mockLoggerInstance
-      );
+      expect(getCharacterPersonaContentSpy).toHaveBeenCalledWith(minimalDto);
+      expect(getWorldContextContentSpy).toHaveBeenCalledWith(minimalDto);
       expect(getAvailableActionsInfoContentSpy).toHaveBeenCalledWith(
-        minimalDto,
-        mockLoggerInstance
+        minimalDto
       );
 
       expect(mockLoggerInstance.debug).toHaveBeenCalledWith(
@@ -546,22 +537,13 @@ describe('AIPromptContentProvider', () => {
 
       // Verify that the internal (spied) getter methods were called correctly
       expect(getTaskDefinitionContentSpy).toHaveBeenCalled();
-      expect(getCharacterPersonaContentSpy).toHaveBeenCalledWith(
-        fullDto,
-        mockLoggerInstance
-      ); // uses instance logger
+      expect(getCharacterPersonaContentSpy).toHaveBeenCalledWith(fullDto);
       expect(getCharacterPortrayalGuidelinesContentSpy).toHaveBeenCalledWith(
         testCharName
       );
       expect(getContentPolicyContentSpy).toHaveBeenCalled();
-      expect(getWorldContextContentSpy).toHaveBeenCalledWith(
-        fullDto,
-        mockLoggerInstance
-      ); // uses instance logger
-      expect(getAvailableActionsInfoContentSpy).toHaveBeenCalledWith(
-        fullDto,
-        mockLoggerInstance
-      ); // uses instance logger
+      expect(getWorldContextContentSpy).toHaveBeenCalledWith(fullDto);
+      expect(getAvailableActionsInfoContentSpy).toHaveBeenCalledWith(fullDto);
       expect(getFinalInstructionsContentSpy).toHaveBeenCalled();
       expect(mockLoggerInstance.debug).toHaveBeenCalledWith(
         'AIPromptContentProvider.getPromptData: PromptData assembled successfully.'
@@ -649,10 +631,7 @@ describe('AIPromptContentProvider', () => {
             speechPatterns: ['Verily!', 'Forsooth!'],
           },
         };
-        const result = provider.getCharacterPersonaContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getCharacterPersonaContent(dto);
 
         expect(result).toContain('YOU ARE Sir Reginald.');
         expect(result).toContain('Your Description: A brave knight.');
@@ -677,10 +656,7 @@ describe('AIPromptContentProvider', () => {
           actorPromptData: null,
           actorState: { id: 'someActor' },
         };
-        const result = provider.getCharacterPersonaContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getCharacterPersonaContent(dto);
         expect(result).toBe(PROMPT_FALLBACK_ACTOR_PROMPT_DATA_UNAVAILABLE);
         expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
           'AIPromptContentProvider: actorPromptData is missing in getCharacterPersonaContent. Using fallback.'
@@ -693,10 +669,7 @@ describe('AIPromptContentProvider', () => {
           actorPromptData: null,
           actorState: null,
         };
-        const result = provider.getCharacterPersonaContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getCharacterPersonaContent(dto);
         expect(result).toBe(PROMPT_FALLBACK_UNKNOWN_CHARACTER_DETAILS);
         expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
           'AIPromptContentProvider: actorPromptData is missing in getCharacterPersonaContent. Using fallback.'
@@ -708,10 +681,7 @@ describe('AIPromptContentProvider', () => {
           ...minimalGameStateDto,
           actorPromptData: { description: 'A wanderer.' },
         };
-        const result = provider.getCharacterPersonaContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getCharacterPersonaContent(dto);
         expect(result).toContain(`YOU ARE ${DEFAULT_FALLBACK_CHARACTER_NAME}.`);
       });
 
@@ -720,27 +690,18 @@ describe('AIPromptContentProvider', () => {
           ...minimalGameStateDto,
           actorPromptData: { name: DEFAULT_FALLBACK_CHARACTER_NAME },
         };
-        let result = provider.getCharacterPersonaContent(
-          dtoDefaultName,
-          mockLoggerInstance
-        );
+        let result = provider.getCharacterPersonaContent(dtoDefaultName);
         expect(result).toBe(PROMPT_FALLBACK_MINIMAL_CHARACTER_DETAILS);
 
         const dtoNoDetails = { ...minimalGameStateDto, actorPromptData: {} }; // only empty object
-        result = provider.getCharacterPersonaContent(
-          dtoNoDetails,
-          mockLoggerInstance
-        );
+        result = provider.getCharacterPersonaContent(dtoNoDetails);
         expect(result).toBe(PROMPT_FALLBACK_MINIMAL_CHARACTER_DETAILS);
 
         const dtoNullNameAndRest = {
           ...minimalGameStateDto,
           actorPromptData: { name: null, description: null, personality: null },
         };
-        result = provider.getCharacterPersonaContent(
-          dtoNullNameAndRest,
-          mockLoggerInstance
-        );
+        result = provider.getCharacterPersonaContent(dtoNullNameAndRest);
         expect(result).toBe(PROMPT_FALLBACK_MINIMAL_CHARACTER_DETAILS);
       });
 
@@ -756,10 +717,7 @@ describe('AIPromptContentProvider', () => {
             secrets: 'A big one.',
           },
         };
-        const result = provider.getCharacterPersonaContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getCharacterPersonaContent(dto);
         expect(result).toContain('Your Personality: Friendly');
         expect(result).not.toContain('Your Profile / Background:');
         expect(result).not.toContain('Your Likes:');
@@ -784,7 +742,7 @@ describe('AIPromptContentProvider', () => {
             ],
           },
         };
-        const result = provider.getWorldContextContent(dto, mockLoggerInstance);
+        const result = provider.getWorldContextContent(dto);
 
         expect(result).toContain('CURRENT SITUATION');
         expect(result).toContain('Location: The Grand Hall.');
@@ -821,7 +779,7 @@ describe('AIPromptContentProvider', () => {
 
       test('should return PROMPT_FALLBACK_UNKNOWN_LOCATION if currentLocation is null', () => {
         const dto = { ...minimalGameStateDto, currentLocation: null };
-        const result = provider.getWorldContextContent(dto, mockLoggerInstance);
+        const result = provider.getWorldContextContent(dto);
         expect(result).toBe(PROMPT_FALLBACK_UNKNOWN_LOCATION);
         expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
           'AIPromptContentProvider: currentLocation is missing in getWorldContextContent. Using fallback.'
@@ -838,7 +796,7 @@ describe('AIPromptContentProvider', () => {
             characters: null, // Will be treated as empty by _formatListSegment
           },
         };
-        const result = provider.getWorldContextContent(dto, mockLoggerInstance);
+        const result = provider.getWorldContextContent(dto);
 
         expect(result).toContain(
           `Location: ${DEFAULT_FALLBACK_LOCATION_NAME}.`
@@ -881,7 +839,7 @@ describe('AIPromptContentProvider', () => {
             characters: [],
           },
         };
-        const result = provider.getWorldContextContent(dto, mockLoggerInstance);
+        const result = provider.getWorldContextContent(dto);
         expect(result).toContain('- Towards east leads to village_east_gate.');
         expect(result).toContain(
           `- Towards west leads to ${DEFAULT_FALLBACK_LOCATION_NAME}.`
@@ -906,10 +864,7 @@ describe('AIPromptContentProvider', () => {
             },
           ],
         };
-        const result = provider.getAvailableActionsInfoContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getAvailableActionsInfoContent(dto);
 
         expect(result).toContain(
           'Choose one of the following available actions by its index:'
@@ -932,10 +887,7 @@ describe('AIPromptContentProvider', () => {
 
       test('should return PROMPT_FALLBACK_NO_ACTIONS_NARRATIVE if no actions are available', () => {
         const dtoNull = { ...minimalGameStateDto, availableActions: null };
-        let result = provider.getAvailableActionsInfoContent(
-          dtoNull,
-          mockLoggerInstance
-        );
+        let result = provider.getAvailableActionsInfoContent(dtoNull);
         expect(result).toContain(
           'Choose one of the following available actions by its index:'
         );
@@ -952,10 +904,7 @@ describe('AIPromptContentProvider', () => {
         mockLoggerInstance.warn.mockClear();
         mockLoggerInstance.debug.mockClear();
         const dtoEmpty = { ...minimalGameStateDto, availableActions: [] };
-        result = provider.getAvailableActionsInfoContent(
-          dtoEmpty,
-          mockLoggerInstance
-        );
+        result = provider.getAvailableActionsInfoContent(dtoEmpty);
         expect(result).toContain(
           'Choose one of the following available actions by its index:'
         );
@@ -978,10 +927,7 @@ describe('AIPromptContentProvider', () => {
             { index: 2, commandString: 'cmd2' }, // missing description
           ],
         };
-        const result = provider.getAvailableActionsInfoContent(
-          dto,
-          mockLoggerInstance
-        );
+        const result = provider.getAvailableActionsInfoContent(dto);
 
         const expectedAction1 = `[Index: 1] Command: "${DEFAULT_FALLBACK_ACTION_COMMAND}". Description: ${ensureTerminalPunctuation(DEFAULT_FALLBACK_ACTION_DESCRIPTION_RAW)}`;
         const expectedAction2 = `[Index: 2] Command: "cmd2". Description: ${ensureTerminalPunctuation(DEFAULT_FALLBACK_ACTION_DESCRIPTION_RAW)}`;


### PR DESCRIPTION
Summary:
- drop unused logger arguments from AIPromptContentProvider methods and update interface
- access logger inside _formatListSegment
- use descriptive variable names in assembler classes
- update associated unit tests

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` (warnings only)
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6862d1aa87ec83319e15c449051921e0