### PR TITLE
[Agent] Rename LLMConfigService to LlmConfigManager

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -33,7 +33,7 @@
 /** @typedef {import('../../interfaces/IPerceptionLogFormatter.js').IPerceptionLogFormatter} IPerceptionLogFormatter */
 /** @typedef {import('../../interfaces/IGameStateValidationServiceForPrompting.js').IGameStateValidationServiceForPrompting} IGameStateValidationServiceForPrompting */
 /** @typedef {import('../../interfaces/IConfigurationProvider.js').IConfigurationProvider} IConfigurationProvider */
-/** @typedef {import('../../llms/llmConfigService.js').LLMConfigService} LLMConfigService_Concrete */
+/** @typedef {import('../../llms/llmConfigManager.js').LlmConfigManager} LlmConfigManager_Concrete */
 /** @typedef {import('../../utils/placeholderResolverUtils.js').PlaceholderResolver} PlaceholderResolver_Concrete */
 /** @typedef {import('../../utils/executionPlaceholderResolver.js').ExecutionPlaceholderResolver} ExecutionPlaceholderResolver_Concrete */
 /** @typedef {import('../../prompting/assembling/standardElementAssembler.js').StandardElementAssembler} StandardElementAssembler_Concrete */
@@ -63,7 +63,7 @@ import { PromptStaticContentService } from '../../prompting/promptStaticContentS
 import { PerceptionLogFormatter } from '../../formatting/perceptionLogFormatter.js';
 import { GameStateValidationServiceForPrompting } from '../../validation/gameStateValidationServiceForPrompting.js';
 import { HttpConfigurationProvider } from '../../configuration/httpConfigurationProvider.js';
-import { LLMConfigService } from '../../llms/llmConfigService.js';
+import { LlmConfigManager } from '../../llms/llmConfigManager.js';
 import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
 import { PlaceholderResolver } from '../../utils/placeholderResolverUtils.js';
 import { ExecutionPlaceholderResolver } from '../../utils/executionPlaceholderResolver.js';
@@ -211,8 +211,8 @@ export function registerPromptingEngine(registrar, logger) {
       })
   );
 
-  registrar.singletonFactory(tokens.LLMConfigService, (c) => {
-    return new LLMConfigService({
+  registrar.singletonFactory(tokens.LlmConfigManager, (c) => {
+    return new LlmConfigManager({
       logger: c.resolve(tokens.ILogger),
       configurationProvider: c.resolve(tokens.IConfigurationProvider),
       configSourceIdentifier: './config/llm-configs.json',
@@ -311,7 +311,7 @@ export function registerPromptingEngine(registrar, logger) {
   registrar.singletonFactory(tokens.IPromptBuilder, (c) => {
     return new PromptBuilder({
       logger: c.resolve(tokens.ILogger),
-      llmConfigService: c.resolve(tokens.LLMConfigService),
+      llmConfigService: c.resolve(tokens.LlmConfigManager),
       placeholderResolver: c.resolve(tokens.PlaceholderResolver),
       assemblerRegistry: c.resolve(tokens.AssemblerRegistry),
       conditionEvaluator: ConditionEvaluator,

--- a/src/dependencyInjection/tokens/tokens-ai.js
+++ b/src/dependencyInjection/tokens/tokens-ai.js
@@ -33,7 +33,7 @@ export const aiTokens = freeze({
   LLMResponseProcessor: 'LLMResponseProcessor',
   ActionIndexingService: 'ActionIndexingService',
   IConfigurationProvider: 'IConfigurationProvider',
-  LLMConfigService: 'LLMConfigService',
+  LlmConfigManager: 'LlmConfigManager',
   PlaceholderResolver: 'PlaceholderResolver',
   ExecutionPlaceholderResolver: 'ExecutionPlaceholderResolver',
   StandardElementAssembler: 'StandardElementAssembler',

--- a/src/prompting/promptBuilder.js
+++ b/src/prompting/promptBuilder.js
@@ -12,7 +12,7 @@
 /* eslint-env es2022 */
 
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../llms/llmConfigService.js').LLMConfigService} LLMConfigService */
+/** @typedef {import('../llms/llmConfigManager.js').LlmConfigManager} LlmConfigManager */
 /** @typedef {import('../utils/placeholderResolverUtils.js').PlaceholderResolver} PlaceholderResolver */
 /** @typedef {import('../interfaces/IPromptBuilder.js').IPromptBuilder} IPromptBuilder */
 /** @typedef {import('../prompting/assemblerRegistry.js').AssemblerRegistry} AssemblerRegistry */
@@ -24,7 +24,7 @@ import { validateDependency } from '../utils/dependencyUtils.js';
 import { PromptAssembler } from './promptAssembler.js';
 
 const INIT_MSG =
-  'PromptBuilder (orchestrator‑only) initialised with LLMConfigService, PlaceholderResolver, AssemblerRegistry and ConditionEvaluator.';
+  'PromptBuilder (orchestrator‑only) initialised with LlmConfigManager, PlaceholderResolver, AssemblerRegistry and ConditionEvaluator.';
 
 /**
  * @class PromptBuilder
@@ -32,7 +32,7 @@ const INIT_MSG =
  */
 export class PromptBuilder extends IPromptBuilder {
   /** @type {ILogger} */ #logger;
-  /** @type {LLMConfigService} */ #llmConfigService;
+  /** @type {LlmConfigManager} */ #llmConfigService;
   /** @type {PlaceholderResolver} */ #placeholderResolver;
   /** @type {AssemblerRegistry} */ #assemblerRegistry;
   /** @type {{ isElementConditionMet: Function }} */ #conditionEvaluator;
@@ -42,7 +42,7 @@ export class PromptBuilder extends IPromptBuilder {
    *
    * @param {object} dependencies
    * @param {ILogger} [dependencies.logger]
-   * @param {LLMConfigService} dependencies.llmConfigService
+   * @param {LlmConfigManager} dependencies.llmConfigService
    * @param {PlaceholderResolver} dependencies.placeholderResolver
    * @param {AssemblerRegistry} dependencies.assemblerRegistry
    * @param {{ isElementConditionMet: Function }} dependencies.conditionEvaluator
@@ -61,7 +61,7 @@ export class PromptBuilder extends IPromptBuilder {
     // ──────────────────────────────────────────────────────────────────────────
     // Dependency validation – fail fast & loud
     // ──────────────────────────────────────────────────────────────────────────
-    validateDependency(llmConfigService, 'LLMConfigService', this.#logger, {
+    validateDependency(llmConfigService, 'LlmConfigManager', this.#logger, {
       requiredMethods: ['getConfig'],
     });
     this.#llmConfigService = llmConfigService;

--- a/tests/unit/config/registrations/promptBuilderRegistration.test.js
+++ b/tests/unit/config/registrations/promptBuilderRegistration.test.js
@@ -1,7 +1,7 @@
 // src/tests/dependencyInjection/registrations/promptBuilderRegistration.test.js
 // --- JSDoc Imports for Type Hinting ---
 /** @typedef {import('../../../../interfaces/coreServices.js').ILogger} ILogger */
-/** @typedef {import('../../../../services/llmConfigService.js').LLMConfigService} LLMConfigService_Concrete */
+/** @typedef {import('../../../../services/llmConfigManager.js').LlmConfigManager} LlmConfigManager_Concrete */
 /** @typedef {import('../../../../utils/placeholderResolverUtils.js').PlaceholderResolver} PlaceholderResolver_Concrete */
 /** @typedef {import('../../../../services/promptElementAssemblers/standardElementAssembler.js').StandardElementAssembler} StandardElementAssembler_Concrete */
 /** @typedef {import('../../../../services/promptElementAssemblers/perceptionLogAssembler.js').PerceptionLogAssembler} PerceptionLogAssembler_Concrete */
@@ -19,7 +19,7 @@ import { MockContainer } from '../../../common/mockFactories/index.js';
 
 // --- Classes to be Mocked ---
 // Mock concrete implementations that will be instantiated by factories or resolved.
-const mockLLMConfigServiceInstance = { getConfig: jest.fn() };
+const mockLlmConfigManagerInstance = { getConfig: jest.fn() };
 const mockPlaceholderResolverInstance = { resolve: jest.fn() };
 const mockStandardElementAssemblerInstance = { assemble: jest.fn() };
 const mockPerceptionLogAssemblerInstance = { assemble: jest.fn() };
@@ -28,10 +28,10 @@ const mockNotesSectionAssemblerInstance = { assemble: jest.fn() };
 const mockPromptBuilderInstance = { build: jest.fn() };
 
 // Mock the modules themselves
-jest.mock('../../../../src/llms/llmConfigService.js', () => ({
-  LLMConfigService: jest
+jest.mock('../../../../src/llms/llmConfigManager.js', () => ({
+  LlmConfigManager: jest
     .fn()
-    .mockImplementation(() => mockLLMConfigServiceInstance),
+    .mockImplementation(() => mockLlmConfigManagerInstance),
 }));
 jest.mock('../../../../src/utils/placeholderResolverUtils.js', () => ({
   PlaceholderResolver: jest
@@ -77,7 +77,7 @@ jest.mock('../../../../src/prompting/promptBuilder.js', () => ({
 }));
 
 // --- Import classes after mocking ---
-import { LLMConfigService } from '../../../../src/llms/llmConfigService.js';
+import { LlmConfigManager } from '../../../../src/llms/llmConfigManager.js';
 import { PlaceholderResolver } from '../../../../src/utils/placeholderResolverUtils.js';
 import { StandardElementAssembler } from '../../../../src/prompting/assembling/standardElementAssembler.js';
 import { PerceptionLogAssembler } from '../../../../src/prompting/assembling/perceptionLogAssembler.js';
@@ -102,8 +102,8 @@ describe('IPromptBuilder Registration and Resolution', () => {
   // We use the actual 'log' from the file (which is mockLogger here)
   const promptBuilderFactory = (c) => {
     const logger = /** @type {ILogger} */ (c.resolve(tokens.ILogger));
-    const llmConfigService = /** @type {LLMConfigService_Concrete} */ (
-      c.resolve(tokens.LLMConfigService)
+    const llmConfigService = /** @type {LlmConfigManager_Concrete} */ (
+      c.resolve(tokens.LlmConfigManager)
     );
     const placeholderResolver = /** @type {PlaceholderResolver_Concrete} */ (
       c.resolve(tokens.PlaceholderResolver)
@@ -150,8 +150,8 @@ describe('IPromptBuilder Registration and Resolution', () => {
     // The factory functions for these will return the mocked instances directly.
     mockContainer.register(tokens.ILogger, mockLogger); // Direct registration of mock
     mockContainer.register(
-      tokens.LLMConfigService,
-      () => mockLLMConfigServiceInstance
+      tokens.LlmConfigManager,
+      () => mockLlmConfigManagerInstance
     );
     mockContainer.register(
       tokens.PlaceholderResolver,
@@ -188,7 +188,7 @@ describe('IPromptBuilder Registration and Resolution', () => {
     // Verify that the PromptBuilder constructor was called with the correct (mocked) dependencies
     expect(PromptBuilder).toHaveBeenCalledWith({
       logger: mockLogger,
-      llmConfigService: mockLLMConfigServiceInstance,
+      llmConfigService: mockLlmConfigManagerInstance,
       placeholderResolver: mockPlaceholderResolverInstance,
       standardElementAssembler: mockStandardElementAssemblerInstance,
       perceptionLogAssembler: mockPerceptionLogAssemblerInstance,

--- a/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
+++ b/tests/unit/dependencyInjection/registrations/aiRegistrations.test.js
@@ -28,7 +28,7 @@ import { PromptStaticContentService } from '../../../../src/prompting/promptStat
 import { PerceptionLogFormatter } from '../../../../src/formatting/perceptionLogFormatter.js';
 import { GameStateValidationServiceForPrompting } from '../../../../src/validation/gameStateValidationServiceForPrompting.js';
 import { HttpConfigurationProvider } from '../../../../src/configuration/httpConfigurationProvider.js';
-import { LLMConfigService } from '../../../../src/llms/llmConfigService.js';
+import { LlmConfigManager } from '../../../../src/llms/llmConfigManager.js';
 import { PlaceholderResolver } from '../../../../src/utils/placeholderResolverUtils.js';
 import { StandardElementAssembler } from '../../../../src/prompting/assembling/standardElementAssembler.js';
 import { PerceptionLogAssembler } from '../../../../src/prompting/assembling/perceptionLogAssembler.js';
@@ -193,7 +193,7 @@ describe('AI registration helpers', () => {
         token: tokens.IConfigurationProvider,
         Class: HttpConfigurationProvider,
       },
-      { token: tokens.LLMConfigService, Class: LLMConfigService },
+      { token: tokens.LlmConfigManager, Class: LlmConfigManager },
       { token: tokens.PlaceholderResolver, Class: PlaceholderResolver },
       {
         token: tokens.StandardElementAssembler,

--- a/tests/unit/prompting/promptBuilder.test.js
+++ b/tests/unit/prompting/promptBuilder.test.js
@@ -223,6 +223,6 @@ describe('PromptBuilder (orchestrator-only)', () => {
           assemblerRegistry,
           conditionEvaluator,
         })
-    ).toThrow(/LLMConfigService/);
+    ).toThrow(/LlmConfigManager/);
   });
 });

--- a/tests/unit/services/llmConfigManager.test.js
+++ b/tests/unit/services/llmConfigManager.test.js
@@ -1,4 +1,4 @@
-// src/services/LLMConfigService.test.js
+// src/services/LlmConfigManager.test.js
 // --- FILE START ---
 import {
   describe,
@@ -8,7 +8,7 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
-import { LLMConfigService } from '../../../src/llms/llmConfigService.js'; // Adjust path as needed
+import { LlmConfigManager } from '../../../src/llms/llmConfigManager.js'; // Adjust path as needed
 import { LlmConfigCache } from '../../../src/llms/services/LlmConfigCache.js';
 import { createMockLogger } from '../testUtils.js'; // Adjust path as needed
 
@@ -44,7 +44,7 @@ const sampleLongerWildcardConfig = {
   promptAssemblyOrder: ['context_ext'],
 };
 
-describe('LLMConfigService', () => {
+describe('LlmConfigManager', () => {
   let mockLogger;
   let service;
 
@@ -62,38 +62,38 @@ describe('LLMConfigService', () => {
     it('should throw an error if configurationProvider is missing', () => {
       expect(
         () =>
-          new LLMConfigService({
+          new LlmConfigManager({
             llmConfigCache: new LlmConfigCache(),
             logger: mockLogger,
             configurationProvider: undefined,
           })
       ).toThrow(
-        'LLMConfigService: configurationProvider and logger are required options.'
+        'LlmConfigManager: configurationProvider and logger are required options.'
       );
     });
 
     it('should throw an error if logger is missing', () => {
       expect(
         () =>
-          new LLMConfigService({
+          new LlmConfigManager({
             llmConfigCache: new LlmConfigCache(),
             configurationProvider: mockConfigurationProvider,
             logger: undefined,
           })
       ).toThrow(
-        'LLMConfigService: configurationProvider and logger are required options.'
+        'LlmConfigManager: configurationProvider and logger are required options.'
       );
     });
 
     it('should initialize with a configSourceIdentifier', () => {
       const sourceId = 'path/to/configs.json';
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
         configSourceIdentifier: sourceId,
       });
-      expect(service).toBeInstanceOf(LLMConfigService);
+      expect(service).toBeInstanceOf(LlmConfigManager);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
           `Configuration source identifier set to: ${sourceId}`
@@ -103,7 +103,7 @@ describe('LLMConfigService', () => {
 
     it('should initialize with valid initialConfigs and mark configsLoadedOrAttempted as true', () => {
       const initialConfigs = [{ ...sampleConfig1 }];
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -122,7 +122,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should handle empty initialConfigs array', () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -131,12 +131,12 @@ describe('LLMConfigService', () => {
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(false); // No valid configs loaded, so flag remains false until source load or programmatic add
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService: Empty array provided for initialConfigs. No initial configurations loaded.'
+        'LlmConfigManager: Empty array provided for initialConfigs. No initial configurations loaded.'
       );
     });
 
     it('should warn if initialConfigs is not an array', () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -145,14 +145,14 @@ describe('LLMConfigService', () => {
       });
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'LLMConfigService: initialConfigs was provided but is not an array. Ignoring.'
+        'LlmConfigManager: initialConfigs was provided but is not an array. Ignoring.'
       );
     });
 
     it('should filter out invalid initialConfigs and log warnings', () => {
       const invalidConfig = { modelIdentifier: 'bad' }; // missing configId, promptElements, etc.
       const initialConfigs = [{ ...sampleConfig1 }, invalidConfig];
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -170,7 +170,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should log if no source identifier and no initial configs loaded', () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -185,7 +185,7 @@ describe('LLMConfigService', () => {
 
   describe('#isValidConfig (indirectly tested via addOrUpdateConfigs and loading)', () => {
     beforeEach(() => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -209,7 +209,7 @@ describe('LLMConfigService', () => {
       service.addOrUpdateConfigs([rest]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: Missing or empty configId.',
+        'LlmConfigManager.#isValidConfig: Missing or empty configId.',
         expect.any(Object)
       );
     });
@@ -218,7 +218,7 @@ describe('LLMConfigService', () => {
       service.addOrUpdateConfigs([{ ...baseValidConfig, modelIdentifier: '' }]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: Missing or empty modelIdentifier.',
+        'LlmConfigManager.#isValidConfig: Missing or empty modelIdentifier.',
         expect.any(Object)
       );
     });
@@ -230,7 +230,7 @@ describe('LLMConfigService', () => {
       ]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: promptElements is not an array.',
+        'LlmConfigManager.#isValidConfig: promptElements is not an array.',
         expect.any(Object)
       );
     });
@@ -240,7 +240,7 @@ describe('LLMConfigService', () => {
       ]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: One or more promptElements are invalid (not an object or missing key).',
+        'LlmConfigManager.#isValidConfig: One or more promptElements are invalid (not an object or missing key).',
         expect.any(Object)
       );
     });
@@ -252,7 +252,7 @@ describe('LLMConfigService', () => {
       ]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: promptAssemblyOrder is not an array.',
+        'LlmConfigManager.#isValidConfig: promptAssemblyOrder is not an array.',
         expect.any(Object)
       );
     });
@@ -263,7 +263,7 @@ describe('LLMConfigService', () => {
       ]);
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService.#isValidConfig: One or more keys in promptAssemblyOrder are not strings.',
+        'LlmConfigManager.#isValidConfig: One or more keys in promptAssemblyOrder are not strings.',
         expect.any(Object)
       );
     });
@@ -271,7 +271,7 @@ describe('LLMConfigService', () => {
 
   describe('addOrUpdateConfigs', () => {
     beforeEach(() => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -332,7 +332,7 @@ describe('LLMConfigService', () => {
       // @ts-ignore
       service.addOrUpdateConfigs('not-an-array');
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'LLMConfigService.addOrUpdateConfigs: Input must be an array of LLMConfig objects.'
+        'LlmConfigManager.addOrUpdateConfigs: Input must be an array of LLMConfig objects.'
       );
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
     });
@@ -353,7 +353,7 @@ describe('LLMConfigService', () => {
     const sourceId = 'test-source';
 
     it('should load and cache configurations from provider if sourceId is set and cache is empty', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -386,7 +386,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should not load from source if configSourceIdentifier is not set', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -403,7 +403,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should handle errors from configurationProvider.fetchData', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -428,7 +428,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should handle invalid data structure from provider (e.g. missing "configs" map)', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -440,7 +440,7 @@ describe('LLMConfigService', () => {
       await service.getConfig('any_id');
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'LLMConfigService.#loadAndCacheConfigurationsFromSource: Fetched data is not in the expected RootLLMConfigsFile format or "configs" map is missing/invalid.',
+        'LlmConfigManager.#loadAndCacheConfigurationsFromSource: Fetched data is not in the expected RootLLMConfigsFile format or "configs" map is missing/invalid.',
         expect.objectContaining({
           source: sourceId,
           receivedData: invalidFetchedData,
@@ -449,7 +449,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should skip invalid configs within fetched data and log them', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -471,7 +471,7 @@ describe('LLMConfigService', () => {
         service.getLlmConfigsCacheForTest().has(sampleConfig1.configId)
       ).toBe(true);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'LLMConfigService.#loadAndCacheConfigurationsFromSource: Skipping invalid or incomplete configuration object during source load.',
+        'LlmConfigManager.#loadAndCacheConfigurationsFromSource: Skipping invalid or incomplete configuration object during source load.',
         expect.objectContaining({
           source: sourceId,
           configKey: 'invalidKey',
@@ -481,7 +481,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should warn if configId in fetched object does not match its key in the map', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -510,7 +510,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should not reload from source if configs already loaded and cache populated', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -525,7 +525,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should not reload from source if load was attempted from source and failed (cache empty)', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -553,27 +553,27 @@ describe('LLMConfigService', () => {
 
   describe('getConfig', () => {
     it('should return undefined and log error if llmId is not a non-empty string', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
       });
       expect(await service.getConfig('')).toBeUndefined();
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'LLMConfigService.getConfig: llmId must be a non-empty string.',
+        'LlmConfigManager.getConfig: llmId must be a non-empty string.',
         { llmIdAttempted: '' }
       );
       // @ts-ignore
       expect(await service.getConfig(null)).toBeUndefined();
       // @ts-ignore
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'LLMConfigService.getConfig: llmId must be a non-empty string.',
+        'LlmConfigManager.getConfig: llmId must be a non-empty string.',
         { llmIdAttempted: null }
       );
     });
 
     it('should return undefined if cache is empty and no source can provide configs', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -589,7 +589,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should return dependencyInjection by direct configId match', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -605,7 +605,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should return a copy of the dependencyInjection, not the cached instance', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -621,7 +621,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should return dependencyInjection by exact modelIdentifier match if configId fails', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -642,7 +642,7 @@ describe('LLMConfigService', () => {
         { ...sampleLongerWildcardConfig },
         { ...sampleConfig1 },
       ];
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -680,7 +680,7 @@ describe('LLMConfigService', () => {
         promptElements: [{ key: 'k' }],
         promptAssemblyOrder: ['k'],
       };
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -703,7 +703,7 @@ describe('LLMConfigService', () => {
         promptElements: [{ key: 'k' }],
         promptAssemblyOrder: ['k'],
       };
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -720,7 +720,7 @@ describe('LLMConfigService', () => {
     });
 
     it('should return undefined if no match is found after all checks', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -739,7 +739,7 @@ describe('LLMConfigService', () => {
   describe('resetCache', () => {
     const sourceId = 'test-source-for-reset';
     it('should clear the cache and reset configsLoadedOrAttempted flag', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -754,12 +754,12 @@ describe('LLMConfigService', () => {
       expect(service.getLlmConfigsCacheForTest().size).toBe(0);
       expect(service.getConfigsLoadedOrAttemptedFlagForTest()).toBe(false);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        'LLMConfigService: Cache cleared and loaded state reset. Configurations will be reloaded from source on next request if source is configured.'
+        'LlmConfigManager: Cache cleared and loaded state reset. Configurations will be reloaded from source on next request if source is configured.'
       );
     });
 
     it('should force a reload from source on next getConfig call if source is configured', async () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -788,7 +788,7 @@ describe('LLMConfigService', () => {
   describe('Test Utility Methods', () => {
     it('getLlmConfigsCacheForTest should return the internal cache', () => {
       const initialConfigs = [{ ...sampleConfig1 }];
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,
@@ -801,7 +801,7 @@ describe('LLMConfigService', () => {
     });
 
     it('getConfigsLoadedOrAttemptedFlagForTest should return the internal flag state', () => {
-      service = new LLMConfigService({
+      service = new LlmConfigManager({
         llmConfigCache: new LlmConfigCache(),
         logger: mockLogger,
         configurationProvider: mockConfigurationProvider,


### PR DESCRIPTION
## Summary
- rename `LLMConfigService` to `LlmConfigManager`
- update DI tokens and registrations
- adjust dependent modules and tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862ddcde8b083318d15a279ff12da3e