### PR TITLE
[Agent] expose updated component from movement lock

### DIFF
--- a/src/utils/movementUtils.js
+++ b/src/utils/movementUtils.js
@@ -8,7 +8,7 @@ import { deepClone } from './cloneUtils.js';
  * @param {import('../../entities/entityManager.js').default} entityManager - Entity manager.
  * @param {string} entityId - ID of the entity to update.
  * @param {boolean} locked - Whether movement should be locked.
- * @returns {void}
+ * @returns {object} Updated movement component.
  */
 export function updateMovementLock(entityManager, entityId, locked) {
   const existing = entityManager.getComponentData(entityId, 'core:movement');
@@ -19,4 +19,5 @@ export function updateMovementLock(entityManager, entityId, locked) {
     : {};
   move.locked = locked;
   entityManager.addComponent(entityId, 'core:movement', move);
+  return move;
 }

--- a/tests/unit/utils/movementUtils.test.js
+++ b/tests/unit/utils/movementUtils.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { updateMovementLock } from '../../../src/utils/movementUtils.js';
+
+/** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
+
+describe('updateMovementLock', () => {
+  it('returns cloned component with updated lock state without mutating original', () => {
+    const original = { locked: false, speed: 10 };
+    /** @type {jest.Mocked<IEntityManager>} */
+    const manager = {
+      getComponentData: jest.fn().mockReturnValue(original),
+      addComponent: jest.fn(),
+    };
+
+    const result = updateMovementLock(manager, 'e1', true);
+
+    expect(result).toEqual({ locked: true, speed: 10 });
+    expect(result).not.toBe(original);
+    expect(original.locked).toBe(false);
+    expect(manager.addComponent).toHaveBeenCalledWith(
+      'e1',
+      'core:movement',
+      result
+    );
+  });
+
+  it('creates new component when none exists', () => {
+    /** @type {jest.Mocked<IEntityManager>} */
+    const manager = {
+      getComponentData: jest.fn().mockReturnValue(undefined),
+      addComponent: jest.fn(),
+    };
+
+    const result = updateMovementLock(manager, 'e2', false);
+
+    expect(result).toEqual({ locked: false });
+    expect(manager.addComponent).toHaveBeenCalledWith(
+      'e2',
+      'core:movement',
+      result
+    );
+  });
+});


### PR DESCRIPTION
Summary: updateMovementLock now returns the mutated component so callers can access the new state. Added unit tests verifying return value and immutability.

Testing Done:
- [x] Code formatted     `npx prettier src/utils/movementUtils.js tests/unit/utils/movementUtils.test.js -w`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6862dfed6ec48331a570730d72e1717a