### PR TITLE
[Agent] expose loader helpers and add unit tests

### DIFF
--- a/src/loaders/ContentLoadManager.js
+++ b/src/loaders/ContentLoadManager.js
@@ -8,6 +8,7 @@
 import ModProcessor from './ModProcessor.js';
 import { deepClone } from '../utils/cloneUtils.js';
 import { ContentLoadStatus } from './types.js';
+import { mergeTotals } from './helpers/mergeTotals.js';
 
 /** @typedef {import('./LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
 /** @typedef {import('./LoadResultAggregator.js').default} LoadResultAggregator */
@@ -177,7 +178,7 @@ export class ContentLoadManager {
         results[modId] = result.status;
 
         // Merge the updated totals back into the main totals object
-        totalCounts = this.#mergeTotals(totalCounts, result.updatedTotals);
+        totalCounts = mergeTotals(totalCounts, result.updatedTotals);
       } catch (error) {
         this.#logger.error(
           `ContentLoadManager: Error during processMod for ${modId}, phase ${phase}. Marking as failed and continuing with other mods in this phase.`,
@@ -193,26 +194,6 @@ export class ContentLoadManager {
       `ModsLoader: Completed content loading loop for phase: ${phase}.`
     );
     return { results, updatedTotals: totalCounts };
-  }
-
-  /**
-   * Merges updated totals from an aggregator back into the main totals object.
-   *
-   * @private
-   * @param {TotalResultsSummary} mainTotals - The existing totals object.
-   * @param {TotalResultsSummary} updatedTotals - Totals returned from a processor.
-   * @returns {TotalResultsSummary} New totals object combining the two inputs.
-   */
-  #mergeTotals(mainTotals, updatedTotals) {
-    const merged = { ...mainTotals };
-    for (const [registryKey, counts] of Object.entries(updatedTotals)) {
-      merged[registryKey] = {
-        count: counts.count ?? 0,
-        overrides: counts.overrides ?? 0,
-        errors: counts.errors ?? 0,
-      };
-    }
-    return merged;
   }
 
   async processMod(modId, manifest, totalCounts, phaseLoaders, phase) {

--- a/src/loaders/helpers/mergeTotals.js
+++ b/src/loaders/helpers/mergeTotals.js
@@ -1,0 +1,26 @@
+/**
+ * @file Helper to merge totals summaries from different loaders.
+ */
+
+/** @typedef {import('../ContentLoadManager.js').default} ContentLoadManager */
+/** @typedef {import('../LoadResultAggregator.js').TotalResultsSummary} TotalResultsSummary */
+
+/**
+ * @description Merges updated totals from an aggregator back into the main totals object.
+ * @param {TotalResultsSummary} mainTotals - The existing totals object.
+ * @param {TotalResultsSummary} updatedTotals - Totals returned from a processor.
+ * @returns {TotalResultsSummary} New totals object combining the two inputs.
+ */
+export function mergeTotals(mainTotals, updatedTotals) {
+  const merged = { ...mainTotals };
+  for (const [registryKey, counts] of Object.entries(updatedTotals)) {
+    merged[registryKey] = {
+      count: counts.count ?? 0,
+      overrides: counts.overrides ?? 0,
+      errors: counts.errors ?? 0,
+    };
+  }
+  return merged;
+}
+
+export default mergeTotals;

--- a/src/loaders/worldLoader.js
+++ b/src/loaders/worldLoader.js
@@ -415,6 +415,20 @@ export class WorldLoader extends AbstractLoader {
 
     return { resolved, unresolved, instanceCount: worldData.instances.length };
   }
+
+  /**
+   * Exposes {@link WorldLoader.#validateWorldInstances} for tests.
+   *
+   * @public
+   * @param {object} worldData - Parsed world data.
+   * @param {string} modId - Mod ID for context.
+   * @param {string} filename - Source filename.
+   * @returns {{resolved:number,unresolved:number,instanceCount:number}}
+   *   Result of internal validation.
+   */
+  forTest_validateWorldInstances(worldData, modId, filename) {
+    return this.#validateWorldInstances(worldData, modId, filename);
+  }
 }
 
 export default WorldLoader;

--- a/tests/unit/loaders/helpers/mergeTotals.test.js
+++ b/tests/unit/loaders/helpers/mergeTotals.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+import { mergeTotals } from '../../../../src/loaders/helpers/mergeTotals.js';
+
+describe('mergeTotals', () => {
+  it('merges updated totals without mutating original', () => {
+    const main = { items: { count: 1, overrides: 0, errors: 0 } };
+    const updated = {
+      items: { overrides: 2 },
+      actions: { count: 3 },
+    };
+
+    const result = mergeTotals(main, updated);
+
+    expect(result).toEqual({
+      items: { count: 0, overrides: 2, errors: 0 },
+      actions: { count: 3, overrides: 0, errors: 0 },
+    });
+    expect(main).toEqual({ items: { count: 1, overrides: 0, errors: 0 } });
+  });
+});

--- a/tests/unit/loaders/helpers/validationHelpers.test.js
+++ b/tests/unit/loaders/helpers/validationHelpers.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { validateLoadItemsParams } from '../../../../src/loaders/helpers/validationHelpers.js';
+
+describe('validateLoadItemsParams', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { error: jest.fn() };
+  });
+
+  it('returns trimmed values when all parameters valid', () => {
+    const result = validateLoadItemsParams(
+      logger,
+      'TestLoader',
+      ' mod ',
+      {},
+      ' actions ',
+      ' folder ',
+      ' registry '
+    );
+
+    expect(result).toEqual({
+      modId: 'mod',
+      contentKey: 'actions',
+      diskFolder: 'folder',
+      registryKey: 'registry',
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('throws when modId invalid', () => {
+    expect(() =>
+      validateLoadItemsParams(logger, 'TestLoader', '', {}, 'a', 'b', 'c')
+    ).toThrow(TypeError);
+  });
+});

--- a/tests/unit/loaders/worldLoader.validateWorldInstances.test.js
+++ b/tests/unit/loaders/worldLoader.validateWorldInstances.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import WorldLoader from '../../../src/loaders/worldLoader.js';
+import MissingInstanceIdError from '../../../src/errors/missingInstanceIdError.js';
+import MissingEntityInstanceError from '../../../src/errors/missingEntityInstanceError.js';
+
+describe('forTest_validateWorldInstances', () => {
+  let loader;
+  let dataRegistry;
+
+  beforeEach(() => {
+    dataRegistry = {
+      get: jest.fn(),
+      store: jest.fn(),
+    };
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    loader = new WorldLoader(
+      { getContentTypeSchemaId: jest.fn() },
+      { resolveModContentPath: jest.fn() },
+      { fetch: jest.fn() },
+      { validate: jest.fn() },
+      dataRegistry,
+      logger
+    );
+  });
+
+  it('returns counts when all instances valid', () => {
+    dataRegistry.get.mockReturnValue({});
+    const worldData = { instances: [{ instanceId: 'a' }, { instanceId: 'b' }] };
+    const result = loader.forTest_validateWorldInstances(
+      worldData,
+      'modA',
+      'world.json'
+    );
+    expect(result).toEqual({ resolved: 2, unresolved: 0, instanceCount: 2 });
+  });
+
+  it('throws MissingInstanceIdError when an instance lacks id', () => {
+    const worldData = { instances: [{}, { instanceId: 'b' }] };
+    expect(() =>
+      loader.forTest_validateWorldInstances(worldData, 'modA', 'file.json')
+    ).toThrow(MissingInstanceIdError);
+  });
+
+  it('throws MissingEntityInstanceError when instance not found', () => {
+    dataRegistry.get.mockReturnValue(undefined);
+    const worldData = { instances: [{ instanceId: 'x' }] };
+    expect(() =>
+      loader.forTest_validateWorldInstances(worldData, 'modA', 'file.json')
+    ).toThrow(MissingEntityInstanceError);
+  });
+});


### PR DESCRIPTION
## Summary
- extract `mergeTotals` helper and use it in ContentLoadManager
- expose WorldLoader instance validation via `forTest_validateWorldInstances`
- add unit tests for new helpers

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 726 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862dfc23d1483318b030d550980d753