### PR TITLE
[Agent] Guard initialization against concurrent calls

### DIFF
--- a/src/prompting/promptStaticContentService.js
+++ b/src/prompting/promptStaticContentService.js
@@ -16,6 +16,7 @@ export class PromptStaticContentService extends IPromptStaticContentService {
   /** @type {PromptTextLoader} */ #promptTextLoader;
   /** @type {object|null} */ #promptData = null;
   /** @type {boolean} */ #initialized = false;
+  /** @type {Promise<void>|null} */ #initializing = null;
 
   /**
    * @param {object} dependencies
@@ -48,9 +49,14 @@ export class PromptStaticContentService extends IPromptStaticContentService {
    */
   async initialize() {
     if (this.#initialized) return;
-
-    this.#promptData = await this.#promptTextLoader.loadPromptText();
-    this.#initialized = true;
+    if (!this.#initializing) {
+      this.#initializing = (async () => {
+        this.#promptData = await this.#promptTextLoader.loadPromptText();
+        this.#initialized = true;
+        this.#initializing = null;
+      })();
+    }
+    await this.#initializing;
   }
 
   /** @private */


### PR DESCRIPTION
## Summary
- prevent duplicate prompt loads by adding concurrent initialization guard
- test concurrent initialization behavior of PromptStaticContentService

## Testing Done
- `npm run format`
- `npm run lint` *(fails: many existing repo lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862e151e468833183757557091b7829