### PR TITLE
[Agent] fix ScopeCache LRU miss handling

### DIFF
--- a/src/scopeDsl/cache/lruCache.js
+++ b/src/scopeDsl/cache/lruCache.js
@@ -9,7 +9,7 @@ export default function createLruCache(max = 256) {
    * @param k
    */
   function get(k) {
-    if (!map.has(k)) return null;
+    if (!map.has(k)) return undefined;
     const v = map.get(k);
     map.delete(k);
     map.set(k, v);

--- a/tests/cache/lruCache.test.js
+++ b/tests/cache/lruCache.test.js
@@ -9,7 +9,7 @@ describe('createLruCache', () => {
     cache.set('c', 3);
     cache.set('d', 4); // Should evict 'a'
 
-    expect(cache.get('a')).toBeNull();
+    expect(cache.get('a')).toBeUndefined();
     expect(cache.get('b')).toBe(2);
     expect(cache.get('c')).toBe(3);
     expect(cache.get('d')).toBe(4);
@@ -30,7 +30,7 @@ describe('createLruCache', () => {
     cache.set('d', 4);
 
     expect(cache.get('a')).toBe(1); // Still present
-    expect(cache.get('b')).toBeNull(); // Evicted
+    expect(cache.get('b')).toBeUndefined(); // Evicted
     expect(cache.get('c')).toBe(3);
     expect(cache.get('d')).toBe(4);
   });

--- a/tests/unit/scopeDsl/cache.additional.test.js
+++ b/tests/unit/scopeDsl/cache.additional.test.js
@@ -5,6 +5,7 @@
 
 import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import { LRUCache } from 'lru-cache';
+import createLruCache from '../../../src/scopeDsl/cache/lruCache.js';
 import ScopeCache from '../../../src/scopeDsl/cache.js';
 import { TURN_STARTED_ID } from '../../../src/constants/eventIds.js';
 
@@ -102,6 +103,13 @@ describe('Scope-DSL Cache - Additional Coverage Tests', () => {
 
       const cacheWithMax = new LRUCache({ max: 256 });
       expect(cacheWithMax.max).toBe(256);
+    });
+  });
+
+  describe('custom createLruCache behavior', () => {
+    test('returns undefined on cache miss', () => {
+      const cache = createLruCache(2);
+      expect(cache.get('missing')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure custom LRU cache returns `undefined` on misses
- handle cache miss correctly in ScopeCache tests
- test miss behavior for createLruCache

## Testing Done
- `npm run format` *(fails: global repo not formatted due to instructions - formatted changed files manually)*
- `npm run lint` *(fails: repository has numerous existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862e1719f508331aae843b63a9703a5