### PR TITLE
[Agent] add serialization interface

### DIFF
--- a/src/persistence/iSerializer.js
+++ b/src/persistence/iSerializer.js
@@ -1,0 +1,47 @@
+// src/persistence/iSerializer.js
+
+/**
+ * @typedef {import('../interfaces/ISaveLoadService.js').SaveGameStructure} SaveGameStructure
+ * @typedef {import('./persistenceTypes.js').PersistenceResult} PersistenceResult
+ */
+
+/**
+ * @interface ISerializer
+ * @description Defines the contract for a serialization strategy, responsible
+ * for converting a SaveGameStructure object to and from a Uint8Array buffer.
+ */
+export class ISerializer {
+  /**
+   * Serializes the complete game state object into a byte array.
+   * This includes calculating and embedding the final checksum.
+   *
+   * @param {SaveGameStructure} _gameStateObject - The game state object to serialize.
+   * @returns {Promise<PersistenceResult>} A result object containing the serialized data as a Uint8Array.
+   * @async
+   */
+  async serialize(_gameStateObject) {
+    throw new Error('ISerializer.serialize must be implemented');
+  }
+
+  /**
+   * Deserializes a byte array back into a game state object.
+   *
+   * @param {Uint8Array} _data - The byte array to deserialize.
+   * @returns {Promise<PersistenceResult>} A result object containing the deserialized SaveGameStructure.
+   * @async
+   */
+  async deserialize(_data) {
+    throw new Error('ISerializer.deserialize must be implemented');
+  }
+
+  /**
+   * Gets the file extension associated with this serialization format (including the dot).
+   *
+   * @returns {string} File extension including the leading dot.
+   */
+  get fileExtension() {
+    throw new Error('ISerializer.fileExtension getter must be implemented');
+  }
+}
+
+export default ISerializer;

--- a/tests/unit/persistence/iSerializer.test.js
+++ b/tests/unit/persistence/iSerializer.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from '@jest/globals';
+import ISerializer from '../../../src/persistence/iSerializer.js';
+
+describe('ISerializer interface', () => {
+  it('serialize throws if not implemented', async () => {
+    const serializer = new ISerializer();
+    await expect(serializer.serialize({})).rejects.toThrow(
+      'ISerializer.serialize must be implemented'
+    );
+  });
+
+  it('deserialize throws if not implemented', async () => {
+    const serializer = new ISerializer();
+    await expect(serializer.deserialize(new Uint8Array())).rejects.toThrow(
+      'ISerializer.deserialize must be implemented'
+    );
+  });
+
+  it('fileExtension getter throws if not implemented', () => {
+    const serializer = new ISerializer();
+    expect(() => serializer.fileExtension).toThrow(
+      'ISerializer.fileExtension getter must be implemented'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `ISerializer` to define serialization strategy contract
- add unit tests for the new interface

## Testing
- `npm run lint`
- `npm run test`
- `npm run lint --prefix llm-proxy-server`
- `npm run test --prefix llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_6862e8a2d9e48331b9f44abaaa2ccc10