### PR TITLE
[Agent] Extend ScopeRegistry interface

### DIFF
--- a/src/scopeDsl/scopeRegistry.js
+++ b/src/scopeDsl/scopeRegistry.js
@@ -3,8 +3,11 @@
  * @description Manages scope definitions loaded from mods
  */
 
-class ScopeRegistry {
+import IScopeRegistry from '../interfaces/IScopeRegistry.js';
+
+class ScopeRegistry extends IScopeRegistry {
   constructor() {
+    super();
     this._scopes = new Map();
     this._initialized = false;
   }


### PR DESCRIPTION
Summary: formalizes ScopeRegistry contract by making it extend IScopeRegistry.

Changes Made:
- imported IScopeRegistry into scopeRegistry.js
- extended ScopeRegistry from IScopeRegistry and call super() in constructor

Testing Done:
- [x] Code formatted (`npx prettier src/scopeDsl/scopeRegistry.js --write`)
- [x] Lint passes (`npx eslint src/scopeDsl/scopeRegistry.js --fix`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (not executed)


------
https://chatgpt.com/codex/tasks/task_e_6862e797e9bc833187cef8589476dac7