### PR TITLE
[Agent] add LLM JSON parsing service

### DIFF
--- a/src/dependencyInjection/registrations/aiRegistrations.js
+++ b/src/dependencyInjection/registrations/aiRegistrations.js
@@ -65,6 +65,7 @@ import { GameStateValidationServiceForPrompting } from '../../validation/gameSta
 import { HttpConfigurationProvider } from '../../configuration/httpConfigurationProvider.js';
 import { LlmConfigManager } from '../../llms/llmConfigManager.js';
 import { LlmConfigLoader } from '../../llms/services/llmConfigLoader.js';
+import { LlmJsonService } from '../../llms/llmJsonService.js';
 import { PlaceholderResolver } from '../../utils/placeholderResolverUtils.js';
 import { ExecutionPlaceholderResolver } from '../../utils/executionPlaceholderResolver.js';
 import { StandardElementAssembler } from '../../prompting/assembling/standardElementAssembler.js';
@@ -390,6 +391,7 @@ export function registerAITurnPipeline(registrar, logger) {
       ),
     });
   });
+  registrar.singletonFactory(tokens.LlmJsonService, () => new LlmJsonService());
   registrar.singletonFactory(
     tokens.ILLMResponseProcessor,
     (c) =>
@@ -397,6 +399,7 @@ export function registerAITurnPipeline(registrar, logger) {
         schemaValidator: c.resolve(tokens.ISchemaValidator),
         logger: c.resolve(tokens.ILogger),
         safeEventDispatcher: c.resolve(tokens.ISafeEventDispatcher),
+        llmJsonService: c.resolve(tokens.LlmJsonService),
       })
   );
   registrar.singletonFactory(

--- a/src/dependencyInjection/tokens/tokens-ai.js
+++ b/src/dependencyInjection/tokens/tokens-ai.js
@@ -54,4 +54,5 @@ export const aiTokens = freeze({
   ILocationSummaryProvider: 'ILocationSummaryProvider',
   IActorDataExtractor: 'IActorDataExtractor',
   ILLMDecisionProvider: 'ILLMDecisionProvider',
+  LlmJsonService: 'LlmJsonService',
 });

--- a/src/llms/llmJsonService.js
+++ b/src/llms/llmJsonService.js
@@ -1,0 +1,107 @@
+// src/llms/llmJsonService.js
+// --- FILE START ---
+/**
+ * @file Service for cleaning and parsing JSON produced by Large Language Models.
+ */
+
+import { cleanLLMJsonOutput } from '../utils/jsonCleaning.js';
+import {
+  JsonProcessingError,
+  initialParse,
+  repairAndParse,
+} from '../utils/jsonRepair.js';
+import { ensureValidLogger } from '../utils/loggerUtils.js';
+import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
+
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} ILogger
+ */
+
+/**
+ * @typedef {import('../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher
+ */
+
+/**
+ * Service providing utilities to sanitize and parse JSON output from LLMs.
+ */
+export class LlmJsonService {
+  /**
+   * Remove conversational prefixes and markdown wrappers from raw LLM output.
+   *
+   * @param {any} rawOutput - The raw string or value from the LLM.
+   * @returns {any} Cleaned string if `rawOutput` is a string, otherwise the value as provided.
+   */
+  clean(rawOutput) {
+    return cleanLLMJsonOutput(rawOutput);
+  }
+
+  /**
+   * Parse a JSON string, attempting a repair on failure.
+   *
+   * @param {string} jsonString - The raw JSON string to parse.
+   * @param {{logger?: ILogger, dispatcher?: ISafeEventDispatcher}} [options] - Optional logger and dispatcher to use during parsing.
+   * @returns {Promise<object>} Parsed JSON object.
+   * @throws {JsonProcessingError|TypeError} When parsing fails.
+   */
+  async parseAndRepair(jsonString, { logger, dispatcher } = {}) {
+    const log = ensureValidLogger(logger, 'LlmJsonService');
+
+    if (typeof jsonString !== 'string') {
+      const message = "Input 'jsonString' must be a string.";
+      if (dispatcher) {
+        safeDispatchError(
+          dispatcher,
+          `parseAndRepair: ${message} Received type: ${typeof jsonString}`
+        );
+      } else {
+        log.error(
+          `parseAndRepair: ${message} Received type: ${typeof jsonString}`
+        );
+      }
+      throw new TypeError(message);
+    }
+
+    const cleaned = cleanLLMJsonOutput(jsonString);
+
+    if (cleaned === null || cleaned.trim() === '') {
+      const msg = 'Cleaned JSON string is null or empty, cannot parse.';
+      if (dispatcher) {
+        safeDispatchError(dispatcher, `parseAndRepair: ${msg}`, {
+          originalInput: jsonString,
+        });
+      } else {
+        log.error(`parseAndRepair: ${msg}`, { originalInput: jsonString });
+      }
+      throw new JsonProcessingError(msg, {
+        stage: 'initial_clean',
+        attemptedJsonString: jsonString,
+      });
+    }
+
+    try {
+      const parsed = initialParse(cleaned, log);
+      log.debug(
+        'parseAndRepair: Successfully parsed JSON on first attempt after cleaning.',
+        {
+          inputLength: jsonString.length,
+          cleanedLength: cleaned.length,
+        }
+      );
+      return parsed;
+    } catch (initialError) {
+      log.warn(
+        `parseAndRepair: Initial JSON.parse failed after cleaning. Attempting repair. Error: ${initialError.message}`,
+        {
+          originalInputLength: jsonString.length,
+          cleanedJsonStringLength: cleaned.length,
+          cleanedJsonPreview:
+            cleaned.substring(0, 100) + (cleaned.length > 100 ? '...' : ''),
+          error: { message: initialError.message, name: initialError.name },
+        }
+      );
+      return repairAndParse(cleaned, log, dispatcher, initialError);
+    }
+  }
+}
+
+// --- FILE END ---

--- a/tests/integration/EndToEndMemoryFlow.test.js
+++ b/tests/integration/EndToEndMemoryFlow.test.js
@@ -10,6 +10,7 @@ import { PlaceholderResolver } from '../../src/utils/placeholderResolverUtils.js
 import { PromptStaticContentService } from '../../src/prompting/promptStaticContentService.js';
 import AjvSchemaValidator from '../../src/validation/ajvSchemaValidator.js';
 import { LLMResponseProcessor } from '../../src/turns/services/LLMResponseProcessor.js';
+import { LlmJsonService } from '../../src/llms/llmJsonService.js';
 import { SHORT_TERM_MEMORY_COMPONENT_ID } from '../../src/constants/componentIds.js';
 import {
   LLM_TURN_ACTION_RESPONSE_SCHEMA,
@@ -144,6 +145,7 @@ describe('End-to-End Short-Term Memory Flow', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
   });
 

--- a/tests/integration/EndToEndNotesPersistence.test.js
+++ b/tests/integration/EndToEndNotesPersistence.test.js
@@ -10,6 +10,7 @@ import { PlaceholderResolver } from '../../src/utils/placeholderResolverUtils.js
 import { PromptStaticContentService } from '../../src/prompting/promptStaticContentService.js';
 import AjvSchemaValidator from '../../src/validation/ajvSchemaValidator.js';
 import { LLMResponseProcessor } from '../../src/turns/services/LLMResponseProcessor.js';
+import { LlmJsonService } from '../../src/llms/llmJsonService.js';
 import {
   LLM_TURN_ACTION_RESPONSE_SCHEMA,
   LLM_TURN_ACTION_RESPONSE_SCHEMA_ID,
@@ -190,6 +191,7 @@ describe('End-to-End Notes Persistence Flow', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
   });
 

--- a/tests/integration/LLMResponseProcessor.e2e.test.js
+++ b/tests/integration/LLMResponseProcessor.e2e.test.js
@@ -10,6 +10,7 @@ import {
 } from '../../src/turns/services/LLMResponseProcessor.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../src/constants/eventIds.js';
 import { expectNoDispatch } from '../common/engine/dispatchTestUtils.js';
+import { LlmJsonService } from '../../src/llms/llmJsonService.js';
 
 // Mocked logger for capturing logs
 const makeLogger = () => ({
@@ -44,6 +45,7 @@ describe('LLMResponseProcessor', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
     const llmJsonResponse = JSON.stringify({
       chosenIndex: 4,
@@ -78,6 +80,7 @@ describe('LLMResponseProcessor', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
     const llmJsonResponse = JSON.stringify({
       chosenIndex: 7,
@@ -106,6 +109,7 @@ describe('LLMResponseProcessor', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
     const invalidJson = JSON.stringify({
       speech: 'Invalid structure',
@@ -137,6 +141,7 @@ describe('LLMResponseProcessor', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
     const nonJson = 'Not JSON';
 
@@ -168,6 +173,7 @@ describe('LLMResponseProcessor', () => {
       schemaValidator,
       logger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
     const llmJsonResponse = JSON.stringify({
       chosenIndex: 3,

--- a/tests/unit/turns/services/LLMResponseProcessor.goals.test.js
+++ b/tests/unit/turns/services/LLMResponseProcessor.goals.test.js
@@ -7,6 +7,7 @@ import { LLMResponseProcessor } from '../../../../src/turns/services/LLMResponse
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { LLMProcessingError } from '../../../../src/turns/services/LLMResponseProcessor.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
+import { LlmJsonService } from '../../../../src/llms/llmJsonService.js';
 
 describe('LLMResponseProcessor – Handling of disallowed properties', () => {
   let mockLogger;
@@ -41,6 +42,7 @@ describe('LLMResponseProcessor – Handling of disallowed properties', () => {
       schemaValidator: mockSchemaValidator,
       logger: mockLogger,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
   });
 

--- a/tests/unit/turns/services/LLMResponseProcessor.notesGuards.test.js
+++ b/tests/unit/turns/services/LLMResponseProcessor.notesGuards.test.js
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { LLMProcessingError } from '../../../../src/turns/services/LLMResponseProcessor.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../../src/constants/eventIds.js';
 import { expectNoDispatch } from '../../../common/engine/dispatchTestUtils.js';
+import { LlmJsonService } from '../../../../src/llms/llmJsonService.js';
 
 // --- Mocks & Helpers ---
 
@@ -40,6 +41,7 @@ describe('LLMResponseProcessor - notes data extraction', () => {
       schemaValidator: schemaValidatorMock,
       logger: loggerMock,
       safeEventDispatcher,
+      llmJsonService: new LlmJsonService(),
     });
   });
 

--- a/tests/unit/turns/services/LLMResponseProcessor.test.js
+++ b/tests/unit/turns/services/LLMResponseProcessor.test.js
@@ -5,6 +5,7 @@
 
 import { LLMResponseProcessor } from '../../../../src/turns/services/LLMResponseProcessor.js';
 import { LLM_TURN_ACTION_RESPONSE_SCHEMA_ID } from '../../../../src/turns/schemas/llmOutputSchemas.js';
+import { LlmJsonService } from '../../../../src/llms/llmJsonService.js';
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import { LLMProcessingError } from '../../../../src/turns/services/LLMResponseProcessor.js';
 
@@ -34,10 +35,12 @@ describe('LLMResponseProcessor', () => {
     logger = mockLogger();
     schemaValidatorMock = mockSchemaValidator();
     safeEventDispatcher = { dispatch: jest.fn() };
+    const llmJsonService = new LlmJsonService();
     processor = new LLMResponseProcessor({
       schemaValidator: schemaValidatorMock,
       logger,
       safeEventDispatcher,
+      llmJsonService,
     });
   });
 
@@ -57,6 +60,7 @@ describe('LLMResponseProcessor', () => {
           new LLMResponseProcessor({
             logger: aLogger,
             safeEventDispatcher: dispatcher,
+            llmJsonService: new LlmJsonService(),
           })
       ).toThrow('LLMResponseProcessor needs a valid ISchemaValidator');
 
@@ -67,6 +71,7 @@ describe('LLMResponseProcessor', () => {
             schemaValidator: { validate: () => {} },
             logger: aLogger,
             safeEventDispatcher: dispatcher,
+            llmJsonService: new LlmJsonService(),
           })
       ).toThrow('LLMResponseProcessor needs a valid ISchemaValidator');
 
@@ -76,6 +81,7 @@ describe('LLMResponseProcessor', () => {
           new LLMResponseProcessor({
             schemaValidator: schemaValidatorMock,
             safeEventDispatcher: dispatcher,
+            llmJsonService: new LlmJsonService(),
           })
       ).toThrow('LLMResponseProcessor needs a valid ILogger');
 
@@ -85,8 +91,19 @@ describe('LLMResponseProcessor', () => {
           new LLMResponseProcessor({
             schemaValidator: schemaValidatorMock,
             logger: aLogger,
+            llmJsonService: new LlmJsonService(),
           })
       ).toThrow('LLMResponseProcessor requires a valid ISafeEventDispatcher');
+
+      // Test with missing llmJsonService
+      expect(
+        () =>
+          new LLMResponseProcessor({
+            schemaValidator: schemaValidatorMock,
+            logger: aLogger,
+            safeEventDispatcher: dispatcher,
+          })
+      ).toThrow('LLMResponseProcessor requires a valid LlmJsonService');
     });
   });
 


### PR DESCRIPTION
Summary:
- build new `LlmJsonService` with cleaning and repair logic
- integrate service in `LLMResponseProcessor`
- wire service into DI via `tokens.LlmJsonService`
- update tests to use the new service

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint` *(fails: existing lint errors not related to this change)*
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_6862e74d5bc88331896fd74d38251b0e