### PR TITLE
[Agent] bubble operation errors to callers

### DIFF
--- a/src/logic/actionSequence.js
+++ b/src/logic/actionSequence.js
@@ -99,7 +99,7 @@ export function executeActionSequence(
         `${tag} CRITICAL error during execution of Operation ${opType}`,
         err
       );
-      break;
+      throw err;
     }
   }
 }

--- a/src/logic/systemLogicInterpreter.js
+++ b/src/logic/systemLogicInterpreter.js
@@ -261,7 +261,15 @@ class SystemLogicInterpreter extends BaseService {
     }
 
     if (Array.isArray(rule.actions) && rule.actions.length) {
-      this._executeActions(rule.actions, nestedCtx, `Rule '${rule.rule_id}'`);
+      try {
+        this._executeActions(rule.actions, nestedCtx, `Rule '${rule.rule_id}'`);
+      } catch (err) {
+        this.#logger.error(
+          `[Rule ${rule.rule_id}] Error during action sequence:`,
+          err
+        );
+        throw err;
+      }
     }
   }
 

--- a/tests/integration/sequentialActionsExecutionError.test.js
+++ b/tests/integration/sequentialActionsExecutionError.test.js
@@ -141,17 +141,28 @@ describe('Sequential Action Execution – Error Path', () => {
     /* ✔️ Action 2 executed & threw */
     expect(failingHandlerMock).toHaveBeenCalledTimes(1);
 
-    /* ✔️ Error logged with contextual message + error object */
-    expect(logger.error).toHaveBeenCalledTimes(1);
+    /* ✔️ Errors logged with contextual message and propagated */
+    expect(logger.error).toHaveBeenCalledTimes(3);
 
-    // --- FIX: Update the expected string to include the 'Rule' context ---
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenNthCalledWith(
+      1,
       expect.stringContaining(
         "[Rule 'test-sequential-error' - Action 2/3] CRITICAL error during execution of Operation FAILING_ACTION"
-      ), // Adjusted expectation
+      ),
       expect.objectContaining({ message: 'Intentional Test Failure' })
     );
-    // --- END FIX ---
+    expect(logger.error).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(
+        '[Rule test-sequential-error] Error during action sequence:'
+      ),
+      expect.objectContaining({ message: 'Intentional Test Failure' })
+    );
+    expect(logger.error).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining("rule 'test-sequential-error' threw:"),
+      expect.objectContaining({ message: 'Intentional Test Failure' })
+    );
 
     /* ✔️ Action 3 never executed */
     expect(skippedModifyHandlerMock).not.toHaveBeenCalled();

--- a/tests/unit/logic/actionSequence.errorPropagation.test.js
+++ b/tests/unit/logic/actionSequence.errorPropagation.test.js
@@ -1,0 +1,39 @@
+// src/tests/unit/logic/actionSequence.errorPropagation.test.js
+
+/**
+ * @jest-environment node
+ */
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { executeActionSequence } from '../../../src/logic/actionSequence.js';
+import { createMockLogger } from '../../common/mockFactories/index.js';
+
+const logger = createMockLogger();
+
+describe('executeActionSequence error propagation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rethrows errors from operation handlers', () => {
+    const interpreter = {
+      execute: jest.fn(() => {
+        throw new Error('boom');
+      }),
+    };
+
+    const actions = [{ type: 'TEST' }, { type: 'SKIP' }];
+    const ctx = { evaluationContext: {}, scopeLabel: 'T', jsonLogic: {} };
+
+    expect(() =>
+      executeActionSequence(actions, ctx, logger, interpreter)
+    ).toThrow('boom');
+
+    expect(interpreter.execute).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[T - Action 1/2] CRITICAL error during execution of Operation TEST'
+      ),
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- throw error from `executeActionSequence` instead of halting silently
- log and rethrow in `SystemLogicInterpreter` so callers see failures
- extend integration test to expect bubbled errors
- add unit test for error propagation

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862e834bfb48331a43de1c5afe6be45