### PR TITLE
[Agent] Consistent environment context validation

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -15,3 +15,4 @@ export * from './missingEntityInstanceError.js';
 export * from './missingInstanceIdError.js';
 export * from './validationError.js';
 export * from './fetchError.js';
+export * from './invalidEnvironmentContextError.js';

--- a/src/errors/invalidEnvironmentContextError.js
+++ b/src/errors/invalidEnvironmentContextError.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when an invalid EnvironmentContext is provided.
+ *
+ * @class InvalidEnvironmentContextError
+ * @augments {Error}
+ * @param {string} message - Error message describing the failure.
+ * @param {object} [details] - Optional details about the invalid context.
+ */
+export class InvalidEnvironmentContextError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'InvalidEnvironmentContextError';
+    this.details = details;
+  }
+}
+
+// --- FILE END ---

--- a/src/llms/clientApiKeyProvider.js
+++ b/src/llms/clientApiKeyProvider.js
@@ -75,15 +75,12 @@ export class ClientApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = getLlmId(llmConfig); // For logging context
 
-    if (
-      !validateEnvironmentContext(
-        environmentContext,
-        `ClientApiKeyProvider.getKey (${llmId})`,
-        this.#dispatcher
-      )
-    ) {
-      return null;
-    }
+    validateEnvironmentContext(
+      environmentContext,
+      `ClientApiKeyProvider.getKey (${llmId})`,
+      this.#dispatcher,
+      this.#logger
+    );
 
     if (!environmentContext.isClient()) {
       this.#logger.warn(

--- a/src/llms/serverApiKeyProvider.js
+++ b/src/llms/serverApiKeyProvider.js
@@ -173,15 +173,12 @@ export class ServerApiKeyProvider extends IApiKeyProvider {
   async getKey(llmConfig, environmentContext) {
     const llmId = llmConfig?.id || 'UnknownLLM';
 
-    if (
-      !validateEnvironmentContext(
-        environmentContext,
-        `ServerApiKeyProvider.getKey (${llmId})`,
-        this.#dispatcher
-      )
-    ) {
-      return null;
-    }
+    validateEnvironmentContext(
+      environmentContext,
+      `ServerApiKeyProvider.getKey (${llmId})`,
+      this.#dispatcher,
+      this.#logger
+    );
 
     if (!environmentContext.isServer()) {
       this.#logger.warn(

--- a/src/llms/strategies/base/baseOpenRouterStrategy.js
+++ b/src/llms/strategies/base/baseOpenRouterStrategy.js
@@ -4,7 +4,7 @@ import { BaseChatLLMStrategy } from './baseChatLLMStrategy.js';
 import { ConfigurationError } from '../../../errors/configurationError';
 import { LLMStrategyError } from '../../errors/LLMStrategyError.js';
 import { logPreview } from '../../../utils/index.js';
-import { getLlmId } from '../../utils/llmUtils.js';
+import { getLlmId, validateEnvironmentContext } from '../../utils/llmUtils.js';
 // Assuming HttpClientError might be a specific type, if not, general Error is caught.
 // For actual HttpClientError type, it would be imported from its definition:
 // import { HttpClientError } from '../../retryHttpClient.js'; // Example path
@@ -120,6 +120,13 @@ export class BaseOpenRouterStrategy extends BaseChatLLMStrategy {
       this.logger.error(errorMsg, { llmId });
       throw new ConfigurationError(errorMsg, { llmId });
     }
+
+    validateEnvironmentContext(
+      environmentContext,
+      `${this.constructor.name} (${llmId})`,
+      null,
+      this.logger
+    );
 
     this.logger.debug(
       `${this.constructor.name}.execute called for LLM ID: ${llmId}.`

--- a/src/llms/utils/llmUtils.js
+++ b/src/llms/utils/llmUtils.js
@@ -6,6 +6,7 @@
 
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { isValidEnvironmentContext } from '../environmentContext.js';
+import { InvalidEnvironmentContextError } from '../../errors/invalidEnvironmentContextError.js';
 
 /** @typedef {import('../environmentContext.js').EnvironmentContext} EnvironmentContext */
 
@@ -20,21 +21,33 @@ export function getLlmId(config) {
 }
 
 /**
- * Validates an {@link EnvironmentContext} instance and dispatches an error when invalid.
+ * Validates an {@link EnvironmentContext} instance.
+ *
+ * When the context is invalid, an {@link InvalidEnvironmentContextError}
+ * is thrown. If a dispatcher is provided, a system error event is also
+ * emitted via {@link safeDispatchError} before throwing.
  *
  * @param {EnvironmentContext|any} ctx - The context object to validate.
  * @param {string} contextMsg - Prefix for the error message.
- * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} dispatcher - Dispatcher for error events.
- * @returns {boolean} True if the context is valid; otherwise false.
+ * @param {import('../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} [dispatcher] - Dispatcher for error events.
+ * @param {import('../../interfaces/coreServices.js').ILogger} [logger=console] - Logger used when dispatcher is absent.
+ * @returns {boolean} True if the context is valid.
+ * @throws {InvalidEnvironmentContextError} When the context is invalid.
  */
-export function validateEnvironmentContext(ctx, contextMsg, dispatcher) {
+export function validateEnvironmentContext(
+  ctx,
+  contextMsg,
+  dispatcher,
+  logger = console
+) {
   if (!isValidEnvironmentContext(ctx)) {
-    safeDispatchError(
-      dispatcher,
-      `${contextMsg}: Invalid environmentContext provided.`,
-      { providedValue: ctx }
-    );
-    return false;
+    const message = `${contextMsg}: Invalid environmentContext provided.`;
+    if (dispatcher && typeof dispatcher.dispatch === 'function') {
+      safeDispatchError(dispatcher, message, { providedValue: ctx }, logger);
+    } else if (logger && typeof logger.error === 'function') {
+      logger.error(message, { providedValue: ctx });
+    }
+    throw new InvalidEnvironmentContextError(message, { providedValue: ctx });
   }
   return true;
 }

--- a/tests/unit/llms/clientApiKeyProvider.test.js
+++ b/tests/unit/llms/clientApiKeyProvider.test.js
@@ -6,6 +6,7 @@ import { ClientApiKeyProvider } from '../../../src/llms/clientApiKeyProvider.js'
 import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
 import * as LlmUtils from '../../../src/llms/utils/llmUtils.js';
 const { EnvironmentContext } = EnvironmentModule;
+import { InvalidEnvironmentContextError } from '../../../src/errors/invalidEnvironmentContextError.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import { LOGGER_INFO_METHOD_ERROR } from '../../common/constants.js';
 import { expectNoDispatch } from '../../common/engine/dispatchTestUtils.js';
@@ -121,47 +122,34 @@ describe('ClientApiKeyProvider', () => {
       );
     });
 
-    test('should return null and log error if environmentContext is invalid', async () => {
+    test('should throw InvalidEnvironmentContextError if environmentContext is invalid', async () => {
       const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
-      const key = await provider.getKey(llmConfig, null);
-      expect(key).toBeNull();
-      expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({
-          message:
-            'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
-        })
+      await expect(provider.getKey(llmConfig, null)).rejects.toThrow(
+        InvalidEnvironmentContextError
       );
       expect(spy).toHaveBeenCalledWith(
         null,
         'ClientApiKeyProvider.getKey (test-llm)',
-        dispatcher
+        dispatcher,
+        logger
       );
       spy.mockRestore();
     });
 
-    test('should return null and log error if environmentContext.isClient is not a function', async () => {
+    test('should throw InvalidEnvironmentContextError if environmentContext.isClient is not a function', async () => {
       const invalidEc = {
         // isClient: 'not-a-function' // or missing
         getExecutionEnvironment: jest.fn().mockReturnValue('client'),
       };
       const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
-      const key = await provider.getKey(
-        llmConfig,
-        /** @type {any} */ (invalidEc)
-      );
-      expect(key).toBeNull();
-      expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({
-          message:
-            'ClientApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
-        })
-      );
+      await expect(
+        provider.getKey(llmConfig, /** @type {any} */ (invalidEc))
+      ).rejects.toThrow(InvalidEnvironmentContextError);
       expect(spy).toHaveBeenCalledWith(
         invalidEc,
         'ClientApiKeyProvider.getKey (test-llm)',
-        dispatcher
+        dispatcher,
+        logger
       );
       spy.mockRestore();
     });

--- a/tests/unit/llms/serverApiKeyProvider.test.js
+++ b/tests/unit/llms/serverApiKeyProvider.test.js
@@ -6,6 +6,7 @@ import { ServerApiKeyProvider } from '../../../src/llms/serverApiKeyProvider.js'
 import * as EnvironmentModule from '../../../src/llms/environmentContext.js';
 import * as LlmUtils from '../../../src/llms/utils/llmUtils.js';
 const { EnvironmentContext } = EnvironmentModule;
+import { InvalidEnvironmentContextError } from '../../../src/errors/invalidEnvironmentContextError.js';
 import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 // Import the actual interfaces to ensure mocks align if needed, though not strictly used for type in JS tests
 // import { IFileSystemReader, IEnvironmentVariableReader } from '../../src/llms/interfaces/IServerUtils.js';
@@ -191,21 +192,16 @@ describe('ServerApiKeyProvider', () => {
       expect(fileSystemReader.readFile).not.toHaveBeenCalled();
     });
 
-    test('should return null and log if environmentContext is invalid', async () => {
+    test('should throw InvalidEnvironmentContextError if environmentContext is invalid', async () => {
       const spy = jest.spyOn(LlmUtils, 'validateEnvironmentContext');
-      const key = await provider.getKey(llmConfig, null);
-      expect(key).toBeNull();
-      expect(dispatcher.dispatch).toHaveBeenCalledWith(
-        SYSTEM_ERROR_OCCURRED_ID,
-        expect.objectContaining({
-          message:
-            'ServerApiKeyProvider.getKey (test-llm): Invalid environmentContext provided.',
-        })
+      await expect(provider.getKey(llmConfig, null)).rejects.toThrow(
+        InvalidEnvironmentContextError
       );
       expect(spy).toHaveBeenCalledWith(
         null,
         'ServerApiKeyProvider.getKey (test-llm)',
-        dispatcher
+        dispatcher,
+        logger
       );
       spy.mockRestore();
     });

--- a/tests/unit/llms/strategies/openRouterJsonSchemaStrategy.test.js
+++ b/tests/unit/llms/strategies/openRouterJsonSchemaStrategy.test.js
@@ -4,6 +4,7 @@
 import { OpenRouterJsonSchemaStrategy } from '../../../../src/llms/strategies/openRouterJsonSchemaStrategy.js';
 import { LLMStrategyError } from '../../../../src/llms/errors/LLMStrategyError.js';
 import { ConfigurationError } from '../../../../src/errors/configurationError';
+import { InvalidEnvironmentContextError } from '../../../../src/errors/invalidEnvironmentContextError.js';
 import { OPENROUTER_GAME_AI_ACTION_SPEECH_SCHEMA } from '../../../../src/llms/constants/llmConstants.js';
 import { BaseChatLLMStrategy } from '../../../../src/llms/strategies/base/baseChatLLMStrategy.js';
 import {
@@ -73,6 +74,9 @@ describe('OpenRouterJsonSchemaStrategy', () => {
     };
     mockEnvironmentContext = {
       isClient: jest.fn().mockReturnValue(false),
+      isServer: jest.fn().mockReturnValue(true),
+      getExecutionEnvironment: jest.fn().mockReturnValue('server'),
+      getProjectRootPath: jest.fn().mockReturnValue('/project/root'),
       getProxyServerUrl: jest
         .fn()
         .mockReturnValue('http://localhost:3001/proxy'),
@@ -143,6 +147,19 @@ describe('OpenRouterJsonSchemaStrategy', () => {
             `OpenRouterJsonSchemaStrategy (${baseLlmConfig.configId}): Missing environmentContext. Cannot proceed.`,
             { llmId: baseLlmConfig.configId }
           )
+        );
+      });
+
+      it('should throw InvalidEnvironmentContextError if environmentContext is invalid', async () => {
+        const params = {
+          gameSummary: mockGameSummary,
+          llmConfig: { ...baseLlmConfig },
+          apiKey: mockApiKey,
+          environmentContext: { isClient: jest.fn() },
+        };
+
+        await expect(strategy.execute(params)).rejects.toThrow(
+          InvalidEnvironmentContextError
         );
       });
 

--- a/tests/unit/llms/strategies/openRouterToolCallingStrategy.test.js
+++ b/tests/unit/llms/strategies/openRouterToolCallingStrategy.test.js
@@ -132,7 +132,13 @@ describe('OpenRouterToolCallingStrategy', () => {
       gameSummary: 'summary',
       llmConfig: execConfig,
       apiKey: 'key',
-      environmentContext: { isClient: jest.fn().mockReturnValue(false) },
+      environmentContext: {
+        isClient: jest.fn().mockReturnValue(false),
+        isServer: jest.fn().mockReturnValue(true),
+        getExecutionEnvironment: jest.fn().mockReturnValue('server'),
+        getProjectRootPath: jest.fn().mockReturnValue('/root'),
+        getProxyServerUrl: jest.fn(),
+      },
     };
     const result = await strategy.execute(params);
     expect(result).toBe('{}');


### PR DESCRIPTION
## Summary
- raise InvalidEnvironmentContextError when `EnvironmentContext` objects are invalid
- use new validation in server/client API key providers
- validate environment context in BaseOpenRouterStrategy
- update tests for new error-handling semantics

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3726 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6862e85b0a048331a57a79a1f5acaa5e