### PR TITLE
[Agent] expose component accessor errors

### DIFF
--- a/src/logic/componentAccessor.js
+++ b/src/logic/componentAccessor.js
@@ -4,13 +4,37 @@
 /** @typedef {import('../interfaces/coreServices.js').ILogger} ILogger */
 
 /**
+ * Error returned when component access fails.
+ *
+ * @class
+ * @augments Error
+ * @param {string | number} entityId - Entity whose component was requested.
+ * @param {string} componentId - Identifier of the component being fetched.
+ * @param {Error} originalError - Underlying error from the EntityManager.
+ */
+export class ComponentAccessorError extends Error {
+  constructor(entityId, componentId, originalError) {
+    super(
+      `Failed to fetch component [${componentId}] for entity [${entityId}]`
+    );
+    this.name = 'ComponentAccessorError';
+    this.entityId = entityId;
+    this.componentId = componentId;
+    this.originalError = originalError;
+  }
+}
+
+/**
  * @description Create a simple proxy for accessing an entity's components.
  * Accessing a property returns the component data or `null` if missing.
  * The `in` operator checks component existence via EntityManager.
  * @param {string | number} entityId - Target entity identifier.
  * @param {EntityManager} entityManager - Manager used for lookups.
  * @param {ILogger} logger - Logger for diagnostics.
- * @returns {Object<string, object|null>} Read-only view of components.
+ * @returns {Object<string, object | null | {error: ComponentAccessorError}>}
+ *   Read-only view of components. When a component lookup fails, the returned
+ *   value will be an object with an `error` property containing a
+ *   {@link ComponentAccessorError} instance.
  */
 export function createComponentAccessor(entityId, entityManager, logger) {
   return new Proxy(
@@ -25,7 +49,9 @@ export function createComponentAccessor(entityId, entityManager, logger) {
             `ComponentAccessor: Error fetching component [${String(prop)}] for entity [${entityId}]:`,
             error
           );
-          return null;
+          return {
+            error: new ComponentAccessorError(entityId, String(prop), error),
+          };
         }
       },
       has(_target, prop) {

--- a/src/logic/defs.js
+++ b/src/logic/defs.js
@@ -25,11 +25,13 @@
  * `components` resolve to null if the component is not present on the entity,
  * ensuring predictable behavior with the JSON Logic `var` operator.
  * @property {string | number} id - The unique identifier of the entity, retrieved from the Entity instance.
- * @property {Object<string, object|null>} components - A map-like structure providing access to the entity's
- * component data. Keys are Component Type IDs (e.g., "Health", "Position").
- * Accessing a key (e.g., `actor.components.Health`) dynamically retrieves the
- * raw component data object using `EntityManager.getComponentData(entityId, componentTypeId)`.
- * It yields the data object if the entity has that component, or null otherwise.
+ * @property {Object<string, object | null | {error: import('./componentAccessor.js').ComponentAccessorError}>} components -
+ * A map-like structure providing access to the entity's component data. Keys are
+ * Component Type IDs (e.g., "Health", "Position"). Accessing a key (e.g.,
+ * `actor.components.Health`) dynamically retrieves the raw component data object
+ * using `EntityManager.getComponentData(entityId, componentTypeId)`. If the
+ * lookup throws, the value is an object with an `error` property containing the
+ * {@link ComponentAccessorError}.
  */
 
 /**

--- a/src/logic/jsonLogicEvaluationService.js
+++ b/src/logic/jsonLogicEvaluationService.js
@@ -121,13 +121,21 @@ class JsonLogicEvaluationService extends BaseService {
 
       if (context && typeof context === 'object') {
         if (context.entity) {
+          const comp = context.entity.components?.['core:position'];
+          if (comp && comp.error) {
+            this.#logger.error('Error retrieving entity position', comp.error);
+          }
           this.#logger.debug(
-            `    Entity: ${context.entity.id}, Location: ${context.entity.components?.['core:position']?.locationId || 'unknown'}`
+            `    Entity: ${context.entity.id}, Location: ${comp && !comp.error ? comp.locationId : 'unknown'}`
           );
         }
         if (context.actor) {
+          const comp = context.actor.components?.['core:position'];
+          if (comp && comp.error) {
+            this.#logger.error('Error retrieving actor position', comp.error);
+          }
           this.#logger.debug(
-            `    Actor: ${context.actor.id}, Location: ${context.actor.components?.['core:position']?.locationId || 'unknown'}`
+            `    Actor: ${context.actor.id}, Location: ${comp && !comp.error ? comp.locationId : 'unknown'}`
           );
         }
         if (context.location) {

--- a/tests/unit/logic/componentAccessor.test.js
+++ b/tests/unit/logic/componentAccessor.test.js
@@ -90,4 +90,21 @@ describe('createComponentAccessor', () => {
     expect('health' in accessor).toBe(true);
     expect(mockManager.hasComponent).toHaveBeenCalledWith(ENTITY_ID, 'health');
   });
+
+  test('wraps error when getComponentData throws', () => {
+    const err = new Error('bad');
+    mockManager.getComponentData.mockImplementation(() => {
+      throw err;
+    });
+    const accessor = createComponentAccessor(
+      ENTITY_ID,
+      mockManager,
+      mockLogger
+    );
+
+    const result = accessor.health;
+    expect(result).toEqual({ error: expect.any(Object) });
+    expect(result.error.originalError).toBe(err);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- surface underlying errors when component lookups fail
- document new error wrapper in typedefs
- log and expose position access errors when debugging
- test error wrapping behavior

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862f31260148331958e3f5098dba92c