### PR TITLE
[Agent] expand helper tests in AIPromptContentProvider

### DIFF
--- a/tests/unit/prompting/AIPromptContentProvider.helpers.test.js
+++ b/tests/unit/prompting/AIPromptContentProvider.helpers.test.js
@@ -131,4 +131,31 @@ describe('AIPromptContentProvider helper methods', () => {
     }));
     expect(() => provider._validateOrThrow({}, logger)).toThrow('bad');
   });
+
+  test('_formatOptionalAttribute returns formatted string or null', () => {
+    expect(provider._formatOptionalAttribute('Label', ' value ')).toBe(
+      'Label: value'
+    );
+    expect(provider._formatOptionalAttribute('Label', '   ')).toBeNull();
+    expect(provider._formatOptionalAttribute('Label', null)).toBeNull();
+  });
+
+  test('_formatListSegment handles arrays and empty cases', () => {
+    const items = ['a', 'b'];
+    const result = provider._formatListSegment(
+      'Things',
+      items,
+      (i) => `- ${i}`,
+      'none'
+    );
+    expect(result).toBe('Things:\n- a\n- b');
+
+    const emptyResult = provider._formatListSegment(
+      'Empty',
+      [],
+      (i) => `- ${i}`,
+      'none'
+    );
+    expect(emptyResult).toBe('Empty:\nnone');
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for `_formatOptionalAttribute` and `_formatListSegment`
- keep root and proxy test suites passing

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862f2fee8e48331a782e82105c204c6