### PR TITLE
[Agent] clarify OperationRegistry.register

### DIFF
--- a/src/logic/operationRegistry.js
+++ b/src/logic/operationRegistry.js
@@ -26,10 +26,14 @@ class OperationRegistry extends BaseService {
   // ---------------------------------------------------------------------------
 
   /**
-   * Register or overwrite a handler.
+   * Register a handler for the given operation type.
+   * If a handler already exists, it will be overwritten and a warning logged.
    *
-   * @param {string}               operationType
-   * @param {OperationHandler}     handler
+   * @param {string} operationType - Unique operation identifier.
+   * @param {OperationHandler} handler - Function invoked when executing the
+   * operation.
+   * @returns {boolean} `true` if a new handler was added, `false` if an
+   * existing handler was overwritten.
    */
   register(operationType, handler) {
     // --- validate ------------------------------------------------------------
@@ -51,7 +55,8 @@ class OperationRegistry extends BaseService {
     }
 
     // --- overwrite warning ---------------------------------------------------
-    if (this.#registry.has(trimmed)) {
+    const isOverwrite = this.#registry.has(trimmed);
+    if (isOverwrite) {
       this.#logger.warn(
         `OperationRegistry: Overwriting existing handler for operation type "${trimmed}".`
       );
@@ -62,6 +67,8 @@ class OperationRegistry extends BaseService {
     this.#logger.debug(
       `OperationRegistry: Registered handler for operation type "${trimmed}".`
     );
+
+    return !isOverwrite;
   }
 
   // ---------------------------------------------------------------------------
@@ -69,8 +76,9 @@ class OperationRegistry extends BaseService {
   /**
    * Retrieve a handler (if any) for the given type.
    *
-   * @param {string} operationType
-   * @returns {OperationHandler|undefined}
+   * @param {string} operationType - Operation identifier to retrieve.
+   * @returns {OperationHandler|undefined} The registered handler or `undefined`
+   * if none is found.
    */
   getHandler(operationType) {
     const trimmed = getNormalizedOperationType(

--- a/tests/unit/logic/operationRegistry.test.js
+++ b/tests/unit/logic/operationRegistry.test.js
@@ -40,24 +40,27 @@ describe('OperationRegistry', () => {
   describe('register()', () => {
     test('registers handler and logs debug', () => {
       const registry = new OperationRegistry({ logger: mockLogger });
-      registry.register('TEST', dummyHandler);
+      const result = registry.register('TEST', dummyHandler);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'OperationRegistry: OperationRegistry: Registered handler for operation type "TEST".'
       );
       expect(registry.getHandler('TEST')).toBe(dummyHandler);
+      expect(result).toBe(true);
     });
 
     test('warns when overwriting existing handler', () => {
       const registry = new OperationRegistry({ logger: mockLogger });
-      registry.register('TEST', dummyHandler);
+      const first = registry.register('TEST', dummyHandler);
       mockLogger.debug.mockClear();
-      registry.register('TEST', dummyHandler);
+      const second = registry.register('TEST', dummyHandler);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'OperationRegistry: OperationRegistry: Overwriting existing handler for operation type "TEST".'
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'OperationRegistry: OperationRegistry: Registered handler for operation type "TEST".'
       );
+      expect(first).toBe(true);
+      expect(second).toBe(false);
     });
 
     test('throws and logs error for invalid type', () => {


### PR DESCRIPTION
Summary: Documented overwrite behavior for `OperationRegistry.register` and made it return a boolean. Updated unit tests to assert the new return value.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_6863f8f9bfdc8331b903dadeb516b19d