### PR TITLE
[Agent] add test suite for loaders registrations

### DIFF
--- a/tests/unit/config/registrations/loadersRegistrations.branches.test.js
+++ b/tests/unit/config/registrations/loadersRegistrations.branches.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { MockContainer } from '../../../common/mockFactories/index.js';
+
+// helper function to create a logger mock
+/**
+ *
+ */
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe('registerLoaders uncovered branches', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('throws for invalid container instance', () => {
+    const {
+      registerLoaders,
+    } = require('../../../../src/dependencyInjection/registrations/loadersRegistrations.js');
+    expect(() => registerLoaders({})).toThrow(
+      'Registrar requires a valid AppContainer instance.'
+    );
+  });
+
+  it('throws when a loader token is undefined', () => {
+    const realTokens = jest.requireActual(
+      '../../../../src/dependencyInjection/tokens.js'
+    ).tokens;
+
+    jest.doMock('../../../../src/dependencyInjection/tokens.js', () => {
+      const actual = jest.requireActual(
+        '../../../../src/dependencyInjection/tokens.js'
+      );
+      return { tokens: { ...actual.tokens, RuleLoader: undefined } };
+    });
+
+    jest.resetModules();
+    const {
+      registerLoaders,
+    } = require('../../../../src/dependencyInjection/registrations/loadersRegistrations.js');
+
+    const container = new MockContainer();
+    container.register(realTokens.ILogger, createLogger(), {
+      lifecycle: 'singleton',
+    });
+
+    expect(() => registerLoaders(container)).toThrow(
+      /registerLoader called with undefined token/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add branch coverage tests for `registerLoaders` helper to handle invalid container and token errors

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68640067e2208331b70b14a1b774aec4