### PR TITLE
[Fix] use speech dispatch helper in processing command state

### DIFF
--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -22,8 +22,8 @@ import { ProcessingExceptionHandler } from './helpers/processingExceptionHandler
 import { buildSpeechPayload } from './helpers/buildSpeechPayload.js';
 import { ProcessingGuard } from './helpers/processingGuard.js';
 import { finishProcessing } from './helpers/processingErrorUtils.js';
-import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
-import { safeDispatchEvent } from '../../utils/safeDispatchEvent.js';
+import { getLogger } from './helpers/contextUtils.js';
+import { dispatchSpeechEvent } from './helpers/dispatchSpeechEvent.js';
 import TurnDirectiveStrategyResolver, {
   DEFAULT_STRATEGY_MAP,
 } from '../strategies/turnDirectiveStrategyResolver.js';
@@ -307,14 +307,7 @@ export class ProcessingCommandState extends AbstractTurnState {
       logger.debug(
         `${this.getStateName()}: Actor ${actorId} spoke: "${payloadBase.speechContent}". Dispatching ${ENTITY_SPOKE_ID}.`
       );
-
-      const dispatcher = getSafeEventDispatcher(turnCtx, this._handler);
-      await safeDispatchEvent(
-        dispatcher,
-        ENTITY_SPOKE_ID,
-        { entityId: actorId, ...payloadBase },
-        logger
-      );
+      await dispatchSpeechEvent(turnCtx, this._handler, actorId, payloadBase);
     } else if (speechRaw !== null && speechRaw !== undefined) {
       logger.debug(
         `${this.getStateName()}: Actor ${actorId} had a non-string or empty speech field in decisionMeta. No ${ENTITY_SPOKE_ID} event dispatched. (Type: ${typeof speechRaw}, Value: "${String(speechRaw)}")`


### PR DESCRIPTION
Summary: Refactors ProcessingCommandState to delegate speech event dispatching to the shared helper and updates tests accordingly.

Changes Made:
- replaced inline dispatcher logic with `dispatchSpeechEvent` usage
- updated imports and debug logging
- revised unit tests to verify calls to the helper and new rejection behavior

Testing Done:
- [x] Code formatted (`prettier`)
- [x] Lint checked (warnings remain)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_68640e1335c48331969204a7d1bcc287