### PR TITLE
[Agent] Extract timeout helper

### DIFF
--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -13,6 +13,7 @@ import { AbstractTurnState } from './abstractTurnState.js';
 
 import { TURN_ENDED_ID } from '../../constants/eventIds.js';
 import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
+import { createTimeoutError } from '../../utils/timeoutUtils.js';
 import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 
 /** @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler */
@@ -29,22 +30,7 @@ const IS_DEV = (process?.env?.NODE_ENV ?? 'production') !== 'production';
 const TIMEOUT_MS = IS_DEV ? 3_000 : 30_000;
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
-/**
- * Builds the timeout error message and `Error` object.
- *
- * @param {string} actorId - ID of the actor awaiting the turn end.
- * @param {string} actionId - The action definition id.
- * @param {number} timeoutMs - Timeout duration in milliseconds.
- * @returns {{message: string, error: Error}}
- */
-function createTimeoutError(actorId, actionId, timeoutMs = TIMEOUT_MS) {
-  const message =
-    `No rule ended the turn for actor ${actorId} after action ` +
-    `'${actionId}'. The engine timed out after ${timeoutMs} ms.`;
-  const error = new Error(message);
-  error.code = 'TURN_END_TIMEOUT';
-  return { message, error };
-}
+// Timeout utilities moved to src/utils/timeoutUtils.js
 
 // ─── AwaitingExternalTurnEndState ──────────────────────────────────────────────
 export class AwaitingExternalTurnEndState extends AbstractTurnState {

--- a/src/utils/timeoutUtils.js
+++ b/src/utils/timeoutUtils.js
@@ -1,0 +1,26 @@
+// src/utils/timeoutUtils.js
+
+/**
+ * @file Utility helpers for timeout-related error handling.
+ */
+
+/**
+ * Builds a standardized timeout error message and Error object.
+ *
+ * @description
+ * When an expected external event does not occur within the allotted time,
+ * this helper can be used to create a descriptive error.
+ * @param {string} actorId - ID of the actor awaiting the event.
+ * @param {string} actionId - The action definition id.
+ * @param {number} timeoutMs - Timeout duration in milliseconds.
+ * @returns {{message: string, error: Error}} Object containing the error message
+ * and Error instance with `code` set to `TURN_END_TIMEOUT`.
+ */
+export function createTimeoutError(actorId, actionId, timeoutMs) {
+  const message =
+    `No rule ended the turn for actor ${actorId} after action ` +
+    `'${actionId}'. The engine timed out after ${timeoutMs} ms.`;
+  const error = new Error(message);
+  error.code = 'TURN_END_TIMEOUT';
+  return { message, error };
+}

--- a/tests/unit/utils/timeoutUtils.test.js
+++ b/tests/unit/utils/timeoutUtils.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { createTimeoutError } from '../../../src/utils/timeoutUtils.js';
+
+describe('createTimeoutError', () => {
+  it('returns error message and code', () => {
+    const result = createTimeoutError('a1', 'jump', 42);
+    expect(result.message).toBe(
+      "No rule ended the turn for actor a1 after action 'jump'. The engine timed out after 42 ms."
+    );
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.code).toBe('TURN_END_TIMEOUT');
+    expect(result.error.message).toBe(result.message);
+  });
+});


### PR DESCRIPTION
Summary: Move timeout error builder into utils for reuse and easier testing.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run

------
https://chatgpt.com/codex/tasks/task_e_68641c585dd483318e400268ba9608b5