### PR TITLE
[Fix] expose cache.max in lruCache

### DIFF
--- a/src/scopeDsl/cache/lruCache.js
+++ b/src/scopeDsl/cache/lruCache.js
@@ -1,12 +1,26 @@
 /**
+ * Create a lightweight least-recently-used (LRU) cache.
  *
- * @param max
+ * @description Provides simple get/set semantics with automatic eviction of
+ * the least recently used entry once the maximum size is reached.
+ * @param {number} [max] - Maximum number of entries to keep.
+ * @returns {{
+ *   get: (key: string) => any,
+ *   set: (key: string, value: any) => void,
+ *   clear: () => void,
+ *   readonly size: number,
+ *   readonly max: number
+ * }} Cache instance with basic LRU semantics.
  */
 export default function createLruCache(max = 256) {
   const map = new Map();
+
   /**
+   * Retrieve a value from the cache.
    *
-   * @param k
+   * @description Moves the key to the most recently used position.
+   * @param {string} k - Cache key
+   * @returns {*} Cached value or `undefined` if not present
    */
   function get(k) {
     if (!map.has(k)) return undefined;
@@ -15,22 +29,30 @@ export default function createLruCache(max = 256) {
     map.set(k, v);
     return v;
   }
+
   /**
+   * Store a value in the cache.
    *
-   * @param k
-   * @param v
+   * @description Evicts the least recently used entry when capacity is exceeded.
+   * @param {string} k - Cache key
+   * @param {*} v - Value to store
+   * @returns {void}
    */
   function set(k, v) {
     if (map.has(k)) map.delete(k);
     else if (map.size >= max) map.delete(map.keys().next().value);
     map.set(k, v);
   }
+
   return {
     get,
     set,
     clear: () => map.clear(),
     get size() {
       return map.size;
+    },
+    get max() {
+      return max;
     },
   };
 }

--- a/tests/cache/lruCache.test.js
+++ b/tests/cache/lruCache.test.js
@@ -50,4 +50,10 @@ describe('createLruCache', () => {
     cache.clear();
     expect(cache.size).toBe(0);
   });
+
+  test('exposes configured max size', () => {
+    const cache = createLruCache(4);
+
+    expect(cache.max).toBe(4);
+  });
 });

--- a/tests/unit/scopeDsl/cache.test.js
+++ b/tests/unit/scopeDsl/cache.test.js
@@ -4,6 +4,7 @@
  */
 
 import { LRUCache } from 'lru-cache';
+import createLruCache from '../../../src/scopeDsl/cache/lruCache.js';
 import ScopeCache from '../../../src/scopeDsl/cache.js';
 import { TURN_STARTED_ID } from '../../../src/constants/eventIds.js';
 
@@ -330,6 +331,24 @@ describe('ScopeCache', () => {
       expect(stats).toEqual({
         size: 0,
         maxSize: 128,
+        subscribed: true,
+      });
+    });
+
+    test('returns maxSize for custom LRU cache implementation', () => {
+      const lruCache = createLruCache(64);
+      const scopeCache = new ScopeCache({
+        cache: lruCache,
+        scopeEngine: mockScopeEngine,
+        safeEventDispatcher: mockSafeEventDispatcher,
+        logger: mockLogger,
+      });
+
+      const stats = scopeCache.getStats();
+
+      expect(stats).toEqual({
+        size: 0,
+        maxSize: 64,
         subscribed: true,
       });
     });


### PR DESCRIPTION
Summary: expose max property from the custom LRU cache and document it. Updated tests to verify maxSize reporting.

Changes Made:
- added `max` getter to `createLruCache` and expanded JSDoc
- new tests verifying `max` property and ScopeCache stats
- updated imports for new tests

Testing Done:
- [x] Code formatted (`npm run format` from root)
- [x] Lint passes (`npm run lint` in root AND `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (Describe what was tested)


------
https://chatgpt.com/codex/tasks/task_e_68642a346c608331b677e9fd987a0bb5