### PR TITLE
[Agent] Introduce ServiceLookupHelper

### DIFF
--- a/src/turns/states/helpers/commandProcessingWorkflow.js
+++ b/src/turns/states/helpers/commandProcessingWorkflow.js
@@ -15,10 +15,7 @@
  * @typedef {import('../../../types/commandResult.js').CommandResult} CommandResult
  */
 
-import {
-  getServiceFromContext,
-  ServiceLookupError,
-} from './getServiceFromContext.js';
+import { ServiceLookupError } from './getServiceFromContext.js';
 import { ProcessingExceptionHandler } from './processingExceptionHandler.js';
 import { finishProcessing } from './processingErrorUtils.js';
 import { getLogger } from './contextUtils.js';

--- a/src/turns/states/helpers/getServiceFromContext.js
+++ b/src/turns/states/helpers/getServiceFromContext.js
@@ -31,210 +31,176 @@ export class ServiceLookupError extends Error {
 }
 
 /**
- * Validates that the turn context and specified method exist.
- *
- * @param {ITurnContext|null} turnCtx - Current turn context.
- * @param {string} contextMethod - Name of method expected on the context.
- * @returns {boolean} `true` when valid, otherwise `false`.
+ * @class ServiceLookupHelper
+ * @description Encapsulates service lookup validation, logging and error handling.
  */
-export function validateContextForService(turnCtx, contextMethod) {
-  return Boolean(turnCtx) && typeof turnCtx[contextMethod] === 'function';
-}
-
-/**
- * Reports a failure when retrieving a service from the context.
- * Logs the error, dispatches a system event and optionally invokes the
- * {@link ProcessingExceptionHandler}.
- *
- * @param {ProcessingCommandStateLike} state - Owning state instance.
- * @param {ITurnContext|null} turnCtx - Current turn context.
- * @param {string} contextMethod - Method name used for lookup.
- * @param {string} serviceLabel - Human readable service label.
- * @param {string} actorIdForLog - Actor ID for logging context.
- * @param {string} errorMsg - Message describing the failure.
- * @param {Error} [error] - Underlying error, if any.
- * @param {boolean} [invokeHandler] - Whether to invoke the exception handler.
- * @param {ProcessingExceptionHandler} [exceptionHandler] - Optional handler to use.
- * @returns {Promise<void>} Resolves when reporting completes.
- */
-export async function logServiceLookupFailure(
-  state,
-  turnCtx,
-  contextMethod,
-  serviceLabel,
-  actorIdForLog,
-  errorMsg,
-  error
-) {
-  const logger = getLogger(turnCtx, state._handler);
-  const dispatcher = getSafeEventDispatcher(turnCtx, state._handler);
-
-  if (error) {
-    if (error.cause) {
-      logger.error(errorMsg, error, error.cause);
-    } else {
-      logger.error(errorMsg, error);
-    }
-  } else {
-    logger.error(errorMsg);
+export class ServiceLookupHelper {
+  /**
+   * Creates the helper instance.
+   *
+   * @param {ProcessingCommandStateLike} state - Owning state instance.
+   * @param {ProcessingExceptionHandler} [exceptionHandler] - Optional handler for errors.
+   */
+  constructor(state, exceptionHandler = state._exceptionHandler) {
+    this._state = state;
+    this._exceptionHandler =
+      exceptionHandler || new ProcessingExceptionHandler(state);
   }
 
-  if (dispatcher) {
-    safeDispatchError(
-      dispatcher,
-      errorMsg,
-      {
-        actorId: actorIdForLog,
-        service: serviceLabel,
-        method: contextMethod,
-        error: error?.message,
-        stack: error?.stack,
-        cause: error?.cause?.message,
-        causeStack: error?.cause?.stack,
-      },
-      logger
-    );
+  /**
+   * Validates that the turn context and specified method exist.
+   *
+   * @param {ITurnContext|null} turnCtx - Current turn context.
+   * @param {string} contextMethod - Name of method expected on the context.
+   * @returns {boolean} `true` when valid, otherwise `false`.
+   */
+  validateContextForService(turnCtx, contextMethod) {
+    return Boolean(turnCtx) && typeof turnCtx[contextMethod] === 'function';
   }
-}
 
-/**
- *
- * @param state
- * @param turnCtx
- * @param actorIdForLog
- * @param errorMsg
- * @param invokeHandler
- * @param exceptionHandler
- */
-export async function handleServiceLookupFailure(
-  state,
-  turnCtx,
-  actorIdForLog,
-  errorMsg,
-  invokeHandler = false,
-  exceptionHandler = state._exceptionHandler
-) {
-  if (invokeHandler) {
-    const handler = exceptionHandler || new ProcessingExceptionHandler(state);
-    await handler.handle(turnCtx, new Error(errorMsg), actorIdForLog);
-  } else if (state.isProcessing) {
-    finishProcessing(state);
-  }
-}
-
-/**
- *
- * @param state
- * @param turnCtx
- * @param contextMethod
- * @param serviceLabel
- * @param actorIdForLog
- * @param errorMsg
- * @param error
- * @param invokeHandler
- * @param exceptionHandler
- */
-export async function reportServiceLookupFailure(
-  state,
-  turnCtx,
-  contextMethod,
-  serviceLabel,
-  actorIdForLog,
-  errorMsg,
-  error,
-  invokeHandler = false,
-  exceptionHandler = state._exceptionHandler
-) {
-  await logServiceLookupFailure(
-    state,
+  /**
+   * Reports a failure when retrieving a service from the context.
+   * Logs the error and dispatches a system event.
+   *
+   * @param {ITurnContext|null} turnCtx - Current turn context.
+   * @param {string} contextMethod - Method name used for lookup.
+   * @param {string} serviceLabel - Human readable service label.
+   * @param {string} actorIdForLog - Actor ID for logging context.
+   * @param {string} errorMsg - Message describing the failure.
+   * @param {Error} [error] - Underlying error, if any.
+   * @returns {Promise<void>} Resolves when reporting completes.
+   */
+  async logServiceLookupFailure(
     turnCtx,
     contextMethod,
     serviceLabel,
     actorIdForLog,
     errorMsg,
     error
-  );
+  ) {
+    const logger = getLogger(turnCtx, this._state._handler);
+    const dispatcher = getSafeEventDispatcher(turnCtx, this._state._handler);
 
-  await handleServiceLookupFailure(
-    state,
+    if (error) {
+      if (error.cause) {
+        logger.error(errorMsg, error, error.cause);
+      } else {
+        logger.error(errorMsg, error);
+      }
+    } else {
+      logger.error(errorMsg);
+    }
+
+    if (dispatcher) {
+      safeDispatchError(
+        dispatcher,
+        errorMsg,
+        {
+          actorId: actorIdForLog,
+          service: serviceLabel,
+          method: contextMethod,
+          error: error?.message,
+          stack: error?.stack,
+          cause: error?.cause?.message,
+          causeStack: error?.cause?.stack,
+        },
+        logger
+      );
+    }
+  }
+
+  /**
+   * Handles a lookup failure by invoking the exception handler or clearing processing.
+   *
+   * @param {ITurnContext|null} turnCtx - Current turn context.
+   * @param {string} actorIdForLog - Actor ID for logging context.
+   * @param {string} errorMsg - Message describing the failure.
+   * @param {boolean} [invokeHandler] - Whether to invoke the exception handler.
+   * @param {ProcessingExceptionHandler} [exceptionHandler] - Optional handler to use.
+   * @returns {Promise<void>} Resolves when handling completes.
+   */
+  async handleServiceLookupFailure(
     turnCtx,
     actorIdForLog,
     errorMsg,
-    invokeHandler,
-    exceptionHandler
-  );
-}
-
-/**
- * Safely obtains a service from the turn context.
- *
- * @param {ProcessingCommandStateLike} state - Owning state instance.
- * @param {ITurnContext} turnCtx - Current turn context.
- * @param {string} contextMethod - Method name on ITurnContext used to retrieve the service.
- * @param {string} serviceLabel - Label for logging when retrieval fails.
- * @param {string} actorIdForLog - Actor ID for logging context.
- * @param {ProcessingExceptionHandler} [exceptionHandler] - Handler for errors.
- * @returns {Promise<*>} The requested service instance.
- * @throws {ServiceLookupError} When the service cannot be retrieved.
- */
-export async function getServiceFromContext(
-  state,
-  turnCtx,
-  contextMethod,
-  serviceLabel,
-  actorIdForLog,
-  exceptionHandler = state._exceptionHandler
-) {
-  if (!validateContextForService(turnCtx, contextMethod)) {
-    const errorMsg = `${state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceLabel}, actor ${actorIdForLog}.`;
-    await logServiceLookupFailure(
-      state,
-      turnCtx,
-      contextMethod,
-      serviceLabel,
-      actorIdForLog,
-      errorMsg
-    );
-
-    await handleServiceLookupFailure(state, turnCtx, actorIdForLog, errorMsg);
-    throw new ServiceLookupError(errorMsg);
-  }
-
-  try {
-    const service = turnCtx[contextMethod]();
-    if (!service) {
-      throw new Error(
-        `Method turnCtx.${contextMethod}() returned null or undefined.`
-      );
+    invokeHandler = false,
+    exceptionHandler = this._exceptionHandler
+  ) {
+    if (invokeHandler) {
+      const handler =
+        exceptionHandler || new ProcessingExceptionHandler(this._state);
+      await handler.handle(turnCtx, new Error(errorMsg), actorIdForLog);
+    } else if (this._state.isProcessing) {
+      finishProcessing(this._state);
     }
-    return service;
-  } catch (error) {
-    const serviceError =
-      error instanceof Error ? error : new Error(String(error));
-    const errorMsg = `${state.getStateName()}: Failed to retrieve ${serviceLabel} for actor ${actorIdForLog}. Error: ${serviceError.message}`;
-    const lookupError = new ServiceLookupError(errorMsg, {
-      cause: serviceError,
-    });
-    await logServiceLookupFailure(
-      state,
-      turnCtx,
-      contextMethod,
-      serviceLabel,
-      actorIdForLog,
-      errorMsg,
-      lookupError
-    );
+  }
 
-    await handleServiceLookupFailure(
-      state,
-      turnCtx,
-      actorIdForLog,
-      errorMsg,
-      true,
-      exceptionHandler
-    );
-    throw lookupError;
+  /**
+   * Safely obtains a service from the turn context.
+   *
+   * @param {ITurnContext|null} turnCtx - Current turn context.
+   * @param {string} contextMethod - Method name on ITurnContext used to retrieve the service.
+   * @param {string} serviceLabel - Label for logging when retrieval fails.
+   * @param {string} actorIdForLog - Actor ID for logging context.
+   * @param {ProcessingExceptionHandler} [exceptionHandler] - Handler for errors.
+   * @returns {Promise<*>} The requested service instance.
+   * @throws {ServiceLookupError} When the service cannot be retrieved.
+   */
+  async getServiceFromContext(
+    turnCtx,
+    contextMethod,
+    serviceLabel,
+    actorIdForLog,
+    exceptionHandler = this._exceptionHandler
+  ) {
+    if (!this.validateContextForService(turnCtx, contextMethod)) {
+      const errorMsg = `${this._state.getStateName()}: Invalid turnCtx in _getServiceFromContext for ${serviceLabel}, actor ${actorIdForLog}.`;
+      await this.logServiceLookupFailure(
+        turnCtx,
+        contextMethod,
+        serviceLabel,
+        actorIdForLog,
+        errorMsg
+      );
+
+      await this.handleServiceLookupFailure(turnCtx, actorIdForLog, errorMsg);
+      throw new ServiceLookupError(errorMsg);
+    }
+
+    try {
+      const service = turnCtx[contextMethod]();
+      if (!service) {
+        throw new Error(
+          `Method turnCtx.${contextMethod}() returned null or undefined.`
+        );
+      }
+      return service;
+    } catch (error) {
+      const serviceError =
+        error instanceof Error ? error : new Error(String(error));
+      const errorMsg = `${this._state.getStateName()}: Failed to retrieve ${serviceLabel} for actor ${actorIdForLog}. Error: ${serviceError.message}`;
+      const lookupError = new ServiceLookupError(errorMsg, {
+        cause: serviceError,
+      });
+      await this.logServiceLookupFailure(
+        turnCtx,
+        contextMethod,
+        serviceLabel,
+        actorIdForLog,
+        errorMsg,
+        lookupError
+      );
+
+      await this.handleServiceLookupFailure(
+        turnCtx,
+        actorIdForLog,
+        errorMsg,
+        true,
+        exceptionHandler
+      );
+      throw lookupError;
+    }
   }
 }
 
-export default getServiceFromContext;
+export default ServiceLookupHelper;

--- a/tests/unit/turns/helpers/getServiceFromContext.test.js
+++ b/tests/unit/turns/helpers/getServiceFromContext.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import {
-  getServiceFromContext,
+  ServiceLookupHelper,
   ServiceLookupError,
 } from '../../../../src/turns/states/helpers/getServiceFromContext.js';
 import { safeDispatchError } from '../../../../src/utils/safeDispatchErrorUtils.js';
@@ -36,12 +36,14 @@ describe('getServiceFromContext', () => {
   let logger;
   let dispatcher;
   let state;
+  let helper;
 
   beforeEach(() => {
     jest.clearAllMocks();
     logger = { error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
     dispatcher = { dispatch: jest.fn() };
     state = createState(logger, dispatcher);
+    helper = new ServiceLookupHelper(state);
   });
 
   test('returns service when context provides it', async () => {
@@ -51,8 +53,7 @@ describe('getServiceFromContext', () => {
       getCommandProcessor: jest.fn(() => service),
     };
 
-    const result = await getServiceFromContext(
-      state,
+    const result = await helper.getServiceFromContext(
       turnCtx,
       'getCommandProcessor',
       'ICommandProcessor',
@@ -73,8 +74,7 @@ describe('getServiceFromContext', () => {
     };
 
     await expect(
-      getServiceFromContext(
-        state,
+      helper.getServiceFromContext(
         turnCtx,
         'getCommandProcessor',
         'ICommandProcessor',

--- a/tests/unit/turns/states/helpers/getServiceFromContext.cause.test.js
+++ b/tests/unit/turns/states/helpers/getServiceFromContext.cause.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import {
-  getServiceFromContext,
+  ServiceLookupHelper,
   ServiceLookupError,
 } from '../../../../../src/turns/states/helpers/getServiceFromContext.js';
 import { safeDispatchError } from '../../../../../src/utils/safeDispatchErrorUtils.js';
@@ -14,6 +14,7 @@ describe('getServiceFromContext cause chain', () => {
   let dispatcher;
   let handler;
   let state;
+  let helper;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -32,6 +33,7 @@ describe('getServiceFromContext cause chain', () => {
         state.isProcessing = false;
       }),
     };
+    helper = new ServiceLookupHelper(state);
   });
 
   test('throws ServiceLookupError with cause when service method throws', async () => {
@@ -46,8 +48,7 @@ describe('getServiceFromContext cause chain', () => {
 
     let caught;
     try {
-      await getServiceFromContext(
-        state,
+      await helper.getServiceFromContext(
         turnCtx,
         'getCommandProcessor',
         'ICommandProcessor',

--- a/tests/unit/turns/states/processingCommandState.coverage.test.js
+++ b/tests/unit/turns/states/processingCommandState.coverage.test.js
@@ -18,8 +18,8 @@ import TurnDirectiveStrategyResolver, {
   DEFAULT_STRATEGY_MAP,
 } from '../../../../src/turns/strategies/turnDirectiveStrategyResolver.js';
 import {
+  ServiceLookupHelper,
   ServiceLookupError,
-  getServiceFromContext,
 } from '../../../../src/turns/states/helpers/getServiceFromContext.js';
 
 class MockActor {
@@ -41,6 +41,7 @@ const mockLogger = {
 
 let mockHandler;
 let processingState;
+let lookupHelper;
 let consoleErrorSpy;
 let consoleWarnSpy;
 let mockCommandProcessor;
@@ -101,6 +102,7 @@ beforeEach(() => {
     directiveResolver: resolver,
   });
   mockHandler._currentState = processingState;
+  lookupHelper = new ServiceLookupHelper(processingState);
 
   consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -504,8 +506,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
   test('should throw ServiceLookupError and clear _isProcessing when turnCtx is null', async () => {
     processingState.startProcessing();
     await expect(
-      getServiceFromContext(
-        processingState,
+      lookupHelper.getServiceFromContext(
         null,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -530,8 +531,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     const dummyCtx = {};
 
     await expect(
-      getServiceFromContext(
-        processingState,
+      lookupHelper.getServiceFromContext(
         dummyCtx,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -562,8 +562,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     await expect(
-      getServiceFromContext(
-        processingState,
+      lookupHelper.getServiceFromContext(
         mockTurnContext,
         'getCommandProcessor',
         'ICommandProcessor',
@@ -599,8 +598,7 @@ describe('ProcessingCommandState._getServiceFromContext – error branches', () 
     mockHandler.getTurnContext.mockReturnValue(mockTurnContext);
 
     await expect(
-      getServiceFromContext(
-        processingState,
+      lookupHelper.getServiceFromContext(
         mockTurnContext,
         'getCommandProcessor',
         'ICommandProcessor',


### PR DESCRIPTION
## Summary
- encapsulate service retrieval in new `ServiceLookupHelper` class
- update commandProcessingWorkflow import
- adjust helpers tests to use the new helper

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_686436f947888331bc4be975105ce8ce