### PR TITLE
[Agent] Refactor resolver helpers

### DIFF
--- a/src/scopeDsl/nodes/sourceResolver.js
+++ b/src/scopeDsl/nodes/sourceResolver.js
@@ -21,6 +21,23 @@ export default function createSourceResolver({
   entitiesGateway,
   locationProvider,
 }) {
+  /**
+   * Collects entity IDs lacking the specified component.
+   *
+   * @description Iterates all entities and filters out those with the component.
+   * @param {string} componentName - Component identifier without '!'.
+   * @returns {Set<string>} IDs of entities without the component.
+   */
+  function collectEntitiesWithoutComponent(componentName) {
+    const resultSet = new Set();
+    const allEntities = entitiesGateway.getEntities();
+    for (const entity of allEntities) {
+      if (!entitiesGateway.hasComponent(entity.id, componentName)) {
+        resultSet.add(entity.id);
+      }
+    }
+    return resultSet;
+  }
   return {
     /**
      * Determines if this resolver can handle the given node
@@ -69,15 +86,7 @@ export default function createSourceResolver({
           if (componentId.startsWith('!')) {
             // Negated component - entities WITHOUT the component
             const componentName = componentId.slice(1);
-            const resultSet = new Set();
-            const allEntities = entitiesGateway.getEntities();
-
-            for (const entity of allEntities) {
-              if (!entitiesGateway.hasComponent(entity.id, componentName)) {
-                resultSet.add(entity.id);
-              }
-            }
-            result = resultSet;
+            result = collectEntitiesWithoutComponent(componentName);
           } else {
             // Positive component - entities WITH the component
             const entities =

--- a/tests/nodes/sourceResolver.test.js
+++ b/tests/nodes/sourceResolver.test.js
@@ -9,13 +9,13 @@ describe('sourceResolver', () => {
   beforeEach(() => {
     // Create stub gateways with deterministic data
     entitiesGateway = {
-      getEntities: () => [
+      getEntities: jest.fn(() => [
         { id: 'entity1' },
         { id: 'entity2' },
         { id: 'entity3' },
         { id: 'entity4' },
-      ],
-      getEntitiesWithComponent: (componentId) => {
+      ]),
+      getEntitiesWithComponent: jest.fn((componentId) => {
         // Deterministic component assignments
         if (componentId === 'core:name') {
           return [{ id: 'entity1' }, { id: 'entity2' }];
@@ -24,8 +24,8 @@ describe('sourceResolver', () => {
           return [{ id: 'entity1' }, { id: 'entity3' }];
         }
         return [];
-      },
-      hasComponent: (entityId, componentId) => {
+      }),
+      hasComponent: jest.fn((entityId, componentId) => {
         // Deterministic component checks
         const componentMap = {
           entity1: ['core:name', 'core:position'],
@@ -34,7 +34,7 @@ describe('sourceResolver', () => {
           entity4: [],
         };
         return componentMap[entityId]?.includes(componentId) || false;
-      },
+      }),
       getComponentData: () => null,
       getEntityInstance: () => null,
     };
@@ -130,6 +130,10 @@ describe('sourceResolver', () => {
         expect(result.size).toBe(2);
         expect(result.has('entity3')).toBe(true);
         expect(result.has('entity4')).toBe(true);
+        // verify internal calls for negated path
+        expect(entitiesGateway.getEntities).toHaveBeenCalled();
+        const entityCount = entitiesGateway.getEntities().length;
+        expect(entitiesGateway.hasComponent).toHaveBeenCalledTimes(entityCount);
       });
 
       it('should return empty set when no component param is provided', () => {


### PR DESCRIPTION
## Summary
- simplify StepResolver resolve by extracting helpers
- clean SourceResolver negated component branch
- add unit test expectations for negated component path

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 3652 problems)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686442bd1c5c8331b3a811f68ec250e0