### PR TITLE
[Agent] Add tests for dispatcher validation

### DIFF
--- a/tests/unit/services/gameStateValidationServiceForPrompting.constructorDispatch.test.js
+++ b/tests/unit/services/gameStateValidationServiceForPrompting.constructorDispatch.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { GameStateValidationServiceForPrompting } from '../../../src/validation/gameStateValidationServiceForPrompting.js';
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+const makeDispatcher = () => ({ dispatch: jest.fn() });
+
+describe('GameStateValidationServiceForPrompting constructor validation', () => {
+  it('throws when safeEventDispatcher is missing', () => {
+    expect(
+      () => new GameStateValidationServiceForPrompting({ logger: mockLogger })
+    ).toThrow(
+      'GameStateValidationServiceForPrompting: safeEventDispatcher with dispatch method is required.'
+    );
+  });
+
+  it('throws when safeEventDispatcher has no dispatch method', () => {
+    expect(
+      () =>
+        new GameStateValidationServiceForPrompting({
+          logger: mockLogger,
+          safeEventDispatcher: {},
+        })
+    ).toThrow(
+      'GameStateValidationServiceForPrompting: safeEventDispatcher with dispatch method is required.'
+    );
+  });
+
+  it('does not throw when safeEventDispatcher has a dispatch function', () => {
+    expect(
+      () =>
+        new GameStateValidationServiceForPrompting({
+          logger: mockLogger,
+          safeEventDispatcher: makeDispatcher(),
+        })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GameStateValidationServiceForPrompting constructor dispatcher validation

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6866ad069c748331ab14ab7ddc56ef8b