### PR TITLE
[Agent] Improve NotesService branch coverage

### DIFF
--- a/tests/unit/ai/notesService.branches.test.js
+++ b/tests/unit/ai/notesService.branches.test.js
@@ -1,0 +1,33 @@
+import { describe, test, expect, jest, afterEach } from '@jest/globals';
+import NotesService from '../../../src/ai/notesService.js';
+
+/**
+ * Additional branch coverage for NotesService.addNotes.
+ */
+
+describe('NotesService.addNotes additional branches', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns early when newNotesText is not an array', () => {
+    const service = new NotesService();
+    const component = { notes: [] };
+
+    const result = service.addNotes(component, 'not-an-array');
+
+    expect(result).toEqual({ wasModified: false, component, addedNotes: [] });
+    expect(component.notes).toHaveLength(0);
+  });
+
+  test('ignores blank note entries', () => {
+    const service = new NotesService();
+    const component = { notes: [] };
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('TS');
+
+    const result = service.addNotes(component, ['  ', ' Valid Note ', '']);
+
+    expect(result.wasModified).toBe(true);
+    expect(component.notes).toEqual([{ text: 'Valid Note', timestamp: 'TS' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add new test file for NotesService to cover early return and blank note handling

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868236717888331823f6c273e4cd1a6