### PR TITLE
[Agent] Improve AjvSchemaValidator branch coverage

### DIFF
--- a/tests/unit/services/ajvSchemaValidator.branchCoverage.test.js
+++ b/tests/unit/services/ajvSchemaValidator.branchCoverage.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach, jest } from '@jest/globals';
+import { createMockLogger } from '../testUtils.js';
+
+/**
+ * Helper to create a validator instance with mocked Ajv internals.
+ *
+ * @param {object} [options] - Setup options.
+ * @param {object} [options.ajv] - Ajv instance to use.
+ * @returns {{validator: any, logger: any, ajv: any}} - The constructed validator and mocks.
+ */
+function setup({ ajv } = {}) {
+  jest.doMock('ajv', () =>
+    jest.fn(
+      () =>
+        ajv || {
+          addSchema: jest.fn(),
+          getSchema: jest.fn(),
+          removeSchema: jest.fn(),
+        }
+    )
+  );
+  jest.doMock('ajv-formats', () => jest.fn());
+  const AjvSchemaValidator =
+    require('../../../src/validation/ajvSchemaValidator.js').default;
+  const logger = createMockLogger();
+  const validator = new AjvSchemaValidator({ logger, ajvInstance: ajv });
+  return { validator, logger, ajv };
+}
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock('ajv');
+  jest.dontMock('ajv-formats');
+});
+
+describe('AjvSchemaValidator additional branch coverage', () => {
+  it('throws when constructed without params (default arg branch)', () => {
+    const AjvSchemaValidator =
+      require('../../../src/validation/ajvSchemaValidator.js').default;
+    expect(() => new AjvSchemaValidator()).toThrow(/logger/);
+  });
+
+  it('preloadSchemas ignores non-array input', () => {
+    const addSchema = jest.fn();
+    const ajv = { addSchema, getSchema: jest.fn(), removeSchema: jest.fn() };
+    const { validator, logger } = setup({ ajv });
+    validator.preloadSchemas(null);
+    expect(addSchema).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('getLoadedSchemaIds handles missing schema map', () => {
+    const ajv = {
+      addSchema: jest.fn(),
+      getSchema: jest.fn(),
+      removeSchema: jest.fn(),
+    };
+    Object.defineProperty(ajv, 'schemas', { get: () => undefined });
+    const { validator } = setup({ ajv });
+    expect(validator.getLoadedSchemaIds()).toEqual([]);
+  });
+
+  it('validate handles undefined error list', () => {
+    const validationFn = jest.fn(() => false);
+    validationFn.errors = undefined;
+    const ajv = {
+      addSchema: jest.fn(),
+      getSchema: jest.fn(() => validationFn),
+      removeSchema: jest.fn(),
+    };
+    const { validator } = setup({ ajv });
+    const result = validator.validate('id', {});
+    expect(result).toEqual({ isValid: false, errors: [] });
+  });
+});


### PR DESCRIPTION
Summary: Add tests exercising under-covered branches in AjvSchemaValidator.

Changes Made:
- New `ajvSchemaValidator.branchCoverage.test.js` verifies default constructor behavior, preload handling for non-array input, missing schema maps, and undefined validation error lists.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npx eslint tests/unit/services/ajvSchemaValidator.branchCoverage.test.js`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation



------
https://chatgpt.com/codex/tasks/task_e_68682cfc0e70833193c1d9a48bb1b92d