### PR TITLE
[Test] Extend AnatomyInitializationService coverage

### DIFF
--- a/tests/unit/anatomy/anatomyInitializationService.coverage.test.js
+++ b/tests/unit/anatomy/anatomyInitializationService.coverage.test.js
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AnatomyInitializationService } from '../../../src/anatomy/anatomyInitializationService.js';
+import { ENTITY_CREATED_ID } from '../../../src/constants/eventIds.js';
+
+// Additional tests focused on rarely executed branches
+
+describe('AnatomyInitializationService coverage additions', () => {
+  let service;
+  let mockEventDispatcher;
+  let mockLogger;
+  let mockAnatomyGenerationService;
+
+  beforeEach(() => {
+    mockEventDispatcher = {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    mockAnatomyGenerationService = {
+      generateAnatomyIfNeeded: jest.fn().mockResolvedValue(false),
+    };
+    service = new AnatomyInitializationService({
+      eventDispatcher: mockEventDispatcher,
+      logger: mockLogger,
+      anatomyGenerationService: mockAnatomyGenerationService,
+    });
+  });
+
+  it('dispose should handle missing unsubscribe function gracefully', () => {
+    // Subscribe returns undefined which leaves #unsubscribeEntityCreated falsy
+    mockEventDispatcher.subscribe.mockReturnValueOnce(undefined);
+
+    service.initialize();
+
+    // Calling dispose should not throw even though unsubscribe fn is missing
+    expect(() => service.dispose()).not.toThrow();
+
+    // After disposal we can initialize again meaning internal state reset
+    service.initialize();
+
+    expect(mockEventDispatcher.subscribe).toHaveBeenCalledTimes(2);
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      'AnatomyInitializationService: Removing event listeners'
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'AnatomyInitializationService: Disposed'
+    );
+  });
+});


### PR DESCRIPTION
Summary:
- add a new test to ensure `AnatomyInitializationService.dispose` handles missing unsubscribe callbacks

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` in root and llm-proxy-server
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686844cb2cf0833198cc92e03f930e75