### PR TITLE
[Agent] add tests for safeDispatchErrorUtils

### DIFF
--- a/tests/unit/utils/safeDispatchErrorUtils.test.js
+++ b/tests/unit/utils/safeDispatchErrorUtils.test.js
@@ -53,3 +53,35 @@ describe('dispatchValidationError', () => {
     expect(result).toEqual({ ok: false, error: 'oops' });
   });
 });
+
+describe('additional coverage', () => {
+  it('defaults details to empty object in InvalidDispatcherError', () => {
+    const err = new InvalidDispatcherError('boom');
+    expect(err.details).toEqual({});
+  });
+
+  it('logs and throws when dispatcher is null', () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    expect(() =>
+      safeDispatchError(null, 'no dispatcher', undefined, logger)
+    ).toThrow(InvalidDispatcherError);
+    expect(logger.error).toHaveBeenCalledWith(
+      "Invalid or missing method 'dispatch' on dependency 'safeDispatchError: dispatcher'."
+    );
+  });
+
+  it('handles null details in dispatchValidationError', () => {
+    const dispatcher = { dispatch: jest.fn() };
+    const result = dispatchValidationError(dispatcher, 'bad', null);
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(SYSTEM_ERROR_OCCURRED_ID, {
+      message: 'bad',
+      details: null,
+    });
+    expect(result).toEqual({ ok: false, error: 'bad', details: null });
+  });
+});


### PR DESCRIPTION
## Summary
- improve branch coverage in safeDispatchErrorUtils

## Testing Done
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868c499c1188331b94e8fd2dd7bd037