### PR TITLE
[Test] Improve LocationQueryService coverage

### DIFF
--- a/tests/unit/entities/locationQueryService.test.js
+++ b/tests/unit/entities/locationQueryService.test.js
@@ -14,6 +14,12 @@ describe('LocationQueryService', () => {
     service = new LocationQueryService({ spatialIndexManager, logger });
   });
 
+  it('logs initialization message', () => {
+    expect(logger.debug).toHaveBeenCalledWith(
+      'LocationQueryService initialized.'
+    );
+  });
+
   it('delegates queries to the spatial index manager for valid IDs', () => {
     const set = new Set(['a']);
     spatialIndexManager.getEntitiesInLocation.mockReturnValue(set);
@@ -32,6 +38,20 @@ describe('LocationQueryService', () => {
     expect(spatialIndexManager.getEntitiesInLocation).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       "LocationQueryService.getEntitiesInLocation called with invalid locationId: ''"
+    );
+    expect(result).toEqual(new Set());
+  });
+
+  it('returns an empty set and logs error on spatial index failure', () => {
+    spatialIndexManager.getEntitiesInLocation.mockImplementation(() => {
+      throw new Error('db failure');
+    });
+
+    const result = service.getEntitiesInLocation('loc1');
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "LocationQueryService.getEntitiesInLocation: Error querying spatial index for location 'loc1':",
+      expect.any(Error)
     );
     expect(result).toEqual(new Set());
   });


### PR DESCRIPTION
Summary: Added new tests for LocationQueryService covering initialization logging and error handling when the spatial index manager throws. This raises branch coverage for the service.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test

------
https://chatgpt.com/codex/tasks/task_e_6868c852526c8331b8931b2497cffbc2