### PR TITLE
[Test] Improve engineVersion coverage

### DIFF
--- a/tests/unit/engine/engineVersion.invalidVersion.test.js
+++ b/tests/unit/engine/engineVersion.invalidVersion.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach, jest } from '@jest/globals';
+
+/**
+ * Additional branch coverage for engineVersion.js
+ * Ensures invalid SemVer strings cause an error on import.
+ */
+describe('ENGINE_VERSION invalid version handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('../../../package.json');
+  });
+
+  it('throws an error when package.json version is not valid SemVer', async () => {
+    jest.doMock('../../../package.json', () => ({
+      default: { version: 'invalid' },
+    }));
+
+    await expect(
+      import('../../../src/engine/engineVersion.js')
+    ).rejects.toThrow('Invalid engine version');
+  });
+});


### PR DESCRIPTION
Summary: Adds a new test covering the invalid SemVer branch in `engineVersion.js` to ensure error handling logic is exercised.

Changes Made:
- Created `engineVersion.invalidVersion.test.js` under `tests/unit/engine/` to mock an invalid `package.json` version and assert that module import fails.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and proxy)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation (N/A)


------
https://chatgpt.com/codex/tasks/task_e_6868d61122708331b1e7f64b208b2824