### PR TITLE
[Agent] Remove circular deps via JSDoc updates

### DIFF
--- a/src/turns/factories/concreteTurnContextFactory.js
+++ b/src/turns/factories/concreteTurnContextFactory.js
@@ -11,7 +11,7 @@ import { TurnContext } from '../context/turnContext.js';
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../../interfaces/coreServices.js').ILogger} ILogger
  * @typedef {import('../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} IActorTurnStrategy
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../interfaces/IWorldContext.js').IWorldContext} IWorldContext
  * @typedef {import('../ports/ITurnEndPort.js').ITurnEndPort} ITurnEndPort

--- a/src/turns/factories/concreteTurnStateFactory.js
+++ b/src/turns/factories/concreteTurnStateFactory.js
@@ -12,7 +12,7 @@ import TurnDirectiveStrategyResolver, {
 } from '../strategies/turnDirectiveStrategyResolver.js';
 
 /**
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../interfaces/IActorTurnStrategy.js').ITurnAction} ITurnAction
  * @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState
  * @typedef {import('../../commands/interfaces/ICommandProcessor.js').ICommandProcessor} ICommandProcessor

--- a/src/turns/interfaces/ITurnStateFactory.js
+++ b/src/turns/interfaces/ITurnStateFactory.js
@@ -73,7 +73,7 @@ export class ITurnStateFactory {
   /**
    * Creates an instance of the state responsible for processing a chosen command.
    *
-   * @param {BaseTurnHandler} handler - The handler managing the state.
+   * @param {ITurnStateHost} handler - The handler managing the state.
    * @param {string} commandString - The command string to process.
    * @param {ITurnAction} turnAction - The chosen turn action.
    * @param {Function} directiveResolver - Resolver for command directives.
@@ -83,7 +83,7 @@ export class ITurnStateFactory {
   /**
    * Creates an instance of the state responsible for processing a chosen command.
    *
-   * @param {BaseTurnHandler} handler - The handler managing the state.
+   * @param {ITurnStateHost} handler - The handler managing the state.
    * @param {string} commandString - The command string to process.
    * @param {ITurnAction} turnAction - The chosen turn action.
    * @param {Function} directiveResolver - Resolver for command directives.

--- a/src/turns/states/abstractTurnState.js
+++ b/src/turns/states/abstractTurnState.js
@@ -2,7 +2,7 @@
 // --- FILE START ---
 
 /**
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../../types/commandResult.js').CommandResult} CommandResult

--- a/src/turns/states/awaitingActorDecisionState.js
+++ b/src/turns/states/awaitingActorDecisionState.js
@@ -15,7 +15,7 @@ import { destroyCleanupStrategy } from './helpers/destroyCleanupStrategy.js';
 
 /**
  * @typedef {import('../interfaces/turnStateContextTypes.js').AwaitingActorDecisionStateContext} AwaitingActorDecisionStateContext
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  */
 import {
   validateActorInContext,

--- a/src/turns/states/awaitingExternalTurnEndState.js
+++ b/src/turns/states/awaitingExternalTurnEndState.js
@@ -16,7 +16,7 @@ import { safeDispatchError } from '../../utils/safeDispatchErrorUtils.js';
 import { createTimeoutError } from '../../utils/timeoutUtils.js';
 import { getLogger, getSafeEventDispatcher } from './helpers/contextUtils.js';
 
-/** @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler */
+/** @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler */
 
 /* global process */
 

--- a/src/turns/states/helpers/contextUtils.js
+++ b/src/turns/states/helpers/contextUtils.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../../logging/consoleLogger.js').default|Console} Logger
  * @typedef {import('../../../interfaces/ISafeEventDispatcher.js').ISafeEventDispatcher} ISafeEventDispatcher

--- a/src/turns/states/helpers/dispatchSpeechEvent.js
+++ b/src/turns/states/helpers/dispatchSpeechEvent.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {import('../../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  */
 import { ENTITY_SPOKE_ID } from '../../../constants/eventIds.js';

--- a/src/turns/states/processingCommandState.js
+++ b/src/turns/states/processingCommandState.js
@@ -1,6 +1,6 @@
 // src/turns/states/processingCommandState.js
 /**
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext} ITurnContext
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../../types/commandResult.js').CommandResult} CommandResult

--- a/src/turns/states/turnEndingState.js
+++ b/src/turns/states/turnEndingState.js
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------
 
 /**
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../interfaces/ITurnState.js').ITurnState}         ITurnState
  * @typedef {import('../interfaces/ITurnContext.js').ITurnContext}     ITurnContext
  */

--- a/src/turns/states/turnIdleState.js
+++ b/src/turns/states/turnIdleState.js
@@ -4,7 +4,7 @@
 /**
  * @typedef {import("../interfaces/ICommandHandlingState.js").ICommandHandlingState} ICommandHandlingState
  * @typedef {import("../interfaces/ITurnLifecycleState.js").ITurnLifecycleState} ITurnLifecycleState_Interface
- * @typedef {import('../handlers/baseTurnHandler.js').BaseTurnHandler} BaseTurnHandler
+ * @typedef {import('../interfaces/ITurnStateHost.js').ITurnStateHost} BaseTurnHandler
  * @typedef {import('../../entities/entity.js').default} Entity
  * @typedef {import('../interfaces/ITurnState.js').ITurnState} ITurnState_Interface
  * @typedef {import('./abstractTurnState.js').AbstractTurnState} AbstractTurnState_Base

--- a/src/turns/states/workflows/actionDecisionWorkflow.js
+++ b/src/turns/states/workflows/actionDecisionWorkflow.js
@@ -11,7 +11,7 @@ export class ActionDecisionWorkflow {
   /**
    * Constructs an instance of ActionDecisionWorkflow.
    *
-   * @param {import('../awaitingActorDecisionState.js').AwaitingActorDecisionState} state - Owning state instance.
+   * @param {object} state - Owning AwaitingActorDecisionState instance.
    * @param {import('../../interfaces/turnStateContextTypes.js').AwaitingActorDecisionStateContext} turnContext - Context for the turn.
    * @param {import('../../../entities/entity.js').default} actor - Actor making the decision.
    * @param {import('../../interfaces/IActorTurnStrategy.js').IActorTurnStrategy} strategy - Strategy used to decide the action.

--- a/src/turns/states/workflows/processingWorkflow.js
+++ b/src/turns/states/workflows/processingWorkflow.js
@@ -36,7 +36,7 @@ export class ProcessingWorkflow {
 
   /**
    * @description Acquire context and prepare the state for processing.
-   * @param {import('../../handlers/baseTurnHandler.js').BaseTurnHandler} handler - Owning handler.
+   * @param {import('../../interfaces/ITurnStateHost.js').ITurnStateHost} handler - Owning handler.
    * @param {import('../../interfaces/ITurnState.js').ITurnState|null} previousState - Previous state.
    * @returns {Promise<import('../../interfaces/ITurnContext.js').ITurnContext|null>} Context or null on failure.
    */
@@ -68,7 +68,7 @@ export class ProcessingWorkflow {
   /**
    * Runs the workflow.
    *
-   * @param {import('../../handlers/baseTurnHandler.js').BaseTurnHandler} handler - Owning handler.
+   * @param {import('../../interfaces/ITurnStateHost.js').ITurnStateHost} handler - Owning handler.
    * @param {import('../../interfaces/ITurnState.js').ITurnState|null} previousState - Previous state.
    * @returns {Promise<void>} Resolves when complete.
    */


### PR DESCRIPTION
Summary: refactored JSDoc references in turn state files to use `ITurnStateHost` instead of `BaseTurnHandler`. This removes runtime cycles detected by dependency-cruiser. Updated actionDecisionWorkflow docs as well.

Testing Done:
- [x] Code formatted (`npx prettier -w <files>`)
- [x] Lint passes (`npx eslint <files> --fix`)
- [x] Root tests (`npm test`)
- [x] Proxy tests (`cd llm-proxy-server && npm test`)


------
https://chatgpt.com/codex/tasks/task_e_6868fae9e9e08331acbb2c5e75d10ae0