### PR TITLE
[Agent] Improve StructureResolver coverage

### DIFF
--- a/tests/unit/utils/structureResolver.branches.test.js
+++ b/tests/unit/utils/structureResolver.branches.test.js
@@ -51,4 +51,27 @@ describe('StructureResolver uncovered branches', () => {
     expect(value).toBe(obj);
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('uses skip keys when provided as a Set', () => {
+    const logger = createLogger();
+    const resolver = new StructureResolver(resolvePath, logger);
+    const input = { a: '{foo}', b: '{bar}' };
+    const context = { foo: 'x', bar: 'y' };
+    const result = resolver.resolveStructure(
+      input,
+      context,
+      {},
+      new Set(['b'])
+    );
+    expect(result).toEqual({ a: 'x', b: '{bar}' });
+  });
+
+  it('defaults to an empty Set when skipKeys is not an array or Set', () => {
+    const logger = createLogger();
+    const resolver = new StructureResolver(resolvePath, logger);
+    const input = { a: '{foo}' };
+    const context = { foo: 'x' };
+    const result = resolver.resolveStructure(input, context, {}, null);
+    expect(result).toEqual({ a: 'x' });
+  });
 });


### PR DESCRIPTION
## Summary
- add test coverage for StructureResolver skipKeys handling

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868facc56248331889eed8103a32180