### PR TITLE
[Agent] Improve responseUtils branch coverage

### DIFF
--- a/llm-proxy-server/tests/utils/responseUtils.test.js
+++ b/llm-proxy-server/tests/utils/responseUtils.test.js
@@ -349,5 +349,39 @@ describe('sendProxyError', () => {
       expect(mockRes.send).not.toHaveBeenCalled();
     });
   });
+
+  test('should handle null details by substituting an empty object', () => {
+    const httpStatusCode = 418;
+    const stage = 'null_details';
+    const errorMessage = 'Nothing here';
+    const llmIdForLog = 'null-branch';
+    const originalLoggerPassedToFunction = { name: 'null-test' };
+
+    sendProxyError(
+      mockRes,
+      httpStatusCode,
+      stage,
+      errorMessage,
+      null,
+      llmIdForLog,
+      originalLoggerPassedToFunction
+    );
+
+    expect(ensureValidLogger).toHaveBeenCalledWith(
+      originalLoggerPassedToFunction,
+      'sendProxyError'
+    );
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: true,
+      message: errorMessage,
+      stage,
+      details: {},
+      originalStatusCode: httpStatusCode,
+    });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      `LLM Proxy Server: Sending error to client. LLM ID for log: ${llmIdForLog}, Status: ${httpStatusCode}, Stage: "${stage}", Message: "${errorMessage}"`,
+      { errorDetailsSentToClient: {} }
+    );
+  });
 });
 // --- FILE END ---


### PR DESCRIPTION
Summary: Added a test for handling `null` details in `sendProxyError` to reach 100% branch coverage.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686a3274c46883318ac2b6c85f00f681