### PR TITLE
[Agent] add test coverage for AppConfigService branches

### DIFF
--- a/llm-proxy-server/tests/appConfigService.branchCoverage.test.js
+++ b/llm-proxy-server/tests/appConfigService.branchCoverage.test.js
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import {
+  getAppConfigService,
+  resetAppConfigServiceInstance,
+} from '../src/config/appConfig.js';
+
+const createLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  resetAppConfigServiceInstance();
+  process.env = {};
+});
+
+describe('AppConfigService uncovered branches', () => {
+  test('_logStringEnvVarStatus logs all scenarios', () => {
+    const logger = createLogger();
+    const service = getAppConfigService(logger);
+
+    service._logStringEnvVarStatus('VAR', '', 'value', 'desc');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('found in environment but is empty')
+    );
+
+    logger.debug.mockClear();
+    service._logStringEnvVarStatus('VAR', 'abc', 'abc', 'desc');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('found in environment:')
+    );
+
+    logger.debug.mockClear();
+    service._logStringEnvVarStatus('VAR', undefined, null, 'desc');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('not set in environment')
+    );
+  });
+
+  test('getAppConfigService returns existing instance without logger', () => {
+    const logger = createLogger();
+    const instance1 = getAppConfigService(logger);
+    const instance2 = getAppConfigService();
+    expect(instance2).toBe(instance1);
+  });
+});


### PR DESCRIPTION
## Summary
- create `appConfigService.branchCoverage.test.js` covering `_logStringEnvVarStatus` and singleton reuse

## Testing Done
- `npm run test` (root)
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686a36355f74833189aaea0c557c07a0