### PR TITLE
[Agent] Improve loggerUtils coverage

### DIFF
--- a/llm-proxy-server/tests/utils/loggerUtils.branchCoverage.test.js
+++ b/llm-proxy-server/tests/utils/loggerUtils.branchCoverage.test.js
@@ -1,0 +1,33 @@
+import {
+  describe,
+  test,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import { ensureValidLogger } from '../../src/utils/loggerUtils.js';
+
+describe('ensureValidLogger additional branch coverage', () => {
+  let consoleSpies;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpies = {
+      info: jest.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: jest.spyOn(console, 'error').mockImplementation(() => {}),
+      debug: jest.spyOn(console, 'debug').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    Object.values(consoleSpies).forEach((spy) => spy.mockRestore());
+  });
+
+  test('handles empty prefix without prepending colon', () => {
+    const fallback = ensureValidLogger(null, '');
+    fallback.info('test');
+    expect(consoleSpies.info).toHaveBeenCalledWith('', 'test');
+  });
+});


### PR DESCRIPTION
Summary: Added a new Jest test in the proxy server to exercise the empty prefix branch in `loggerUtils.ensureValidLogger`, achieving 100% branch coverage for that module.

Changes Made:
- Created `loggerUtils.branchCoverage.test.js` to verify behavior when the fallback prefix is an empty string.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test


------
https://chatgpt.com/codex/tasks/task_e_686a3ce01bd88331b538b35e45ad4d3f