### PR TITLE
[Test] Increase ShortTermMemoryService coverage

### DIFF
--- a/tests/unit/services/shortTermMemoryService.moreCoverage.test.js
+++ b/tests/unit/services/shortTermMemoryService.moreCoverage.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+import ShortTermMemoryService from '../../../src/ai/shortTermMemoryService.js';
+
+describe('ShortTermMemoryService maxEntries logic', () => {
+  it('falls back to defaultMaxEntries when maxEntries is negative', () => {
+    const service = new ShortTermMemoryService({ defaultMaxEntries: 2 });
+    const mem = {
+      entityId: 'actor:neg',
+      thoughts: [
+        { text: 'a', timestamp: '2025-06-03T10:00:00.000Z' },
+        { text: 'b', timestamp: '2025-06-03T10:01:00.000Z' },
+        { text: 'c', timestamp: '2025-06-03T10:02:00.000Z' },
+      ],
+      maxEntries: -1,
+    };
+    service.addThought(mem, 'd', new Date('2025-06-03T10:03:00.000Z'));
+    expect(mem.thoughts.map((t) => t.text)).toEqual(['c', 'd']);
+  });
+
+  it('falls back to defaultMaxEntries when maxEntries is not an integer', () => {
+    const service = new ShortTermMemoryService({ defaultMaxEntries: 3 });
+    const mem = {
+      entityId: 'actor:str',
+      thoughts: [
+        { text: 'a', timestamp: '2025-06-03T10:00:00.000Z' },
+        { text: 'b', timestamp: '2025-06-03T10:01:00.000Z' },
+      ],
+      maxEntries: 'foo',
+    };
+    service.addThought(mem, 'c', new Date('2025-06-03T10:02:00.000Z'));
+    service.addThought(mem, 'd', new Date('2025-06-03T10:03:00.000Z'));
+    expect(mem.thoughts.map((t) => t.text)).toEqual(['b', 'c', 'd']);
+  });
+});


### PR DESCRIPTION
Summary: Added unit tests to cover additional edge cases in ShortTermMemoryService's maxEntries logic.

Changes Made:
- Added `shortTermMemoryService.moreCoverage.test.js` to verify negative and non-integer maxEntries values fall back to defaults.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` - existing warnings remain)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_686a5cf0aa74833191da04b9430d8584