### PR TITLE
[Agent] improve llm config branch tests

### DIFF
--- a/llm-proxy-server/tests/llmConfigService.test.js
+++ b/llm-proxy-server/tests/llmConfigService.test.js
@@ -176,4 +176,29 @@ describe('LlmConfigService', () => {
       configs.configs.gpt4.newProp = 'fail';
     }).toThrow();
   });
+
+  test('initialize handles loader error without originalError', async () => {
+    mockLoader.mockResolvedValue({
+      error: true,
+      message: 'fail',
+      stage: 'loader',
+      pathAttempted: '/tmp/llm.json',
+    });
+
+    const returnedErr = await service.initialize();
+
+    expect(returnedErr).toEqual({
+      message: 'fail',
+      stage: 'loader',
+      details: { pathAttempted: '/tmp/llm.json' },
+    });
+    expect(returnedErr.originalError).toBeUndefined();
+    const err = service.getInitializationErrorDetails();
+    expect(err).toEqual({
+      message: 'fail',
+      stage: 'loader',
+      details: { pathAttempted: '/tmp/llm.json' },
+    });
+    expect(service.isOperational()).toBe(false);
+  });
 });

--- a/llm-proxy-server/tests/unit/apiKeyService.remainingBranches.test.js
+++ b/llm-proxy-server/tests/unit/apiKeyService.remainingBranches.test.js
@@ -89,4 +89,16 @@ describe('ApiKeyService remaining branch coverage', () => {
     expect(res.errorDetails.stage).toBe('api_key_all_sources_failed');
     expect(res.errorDetails.details.reason).toContain('see previous logs');
   });
+
+  test('_createErrorDetails logs N/A when llmId missing', () => {
+    const err = new Error('oops');
+    const details = {};
+    const res = service._createErrorDetails('msg', 'stage', details, err);
+    expect(res).toEqual({
+      message: 'msg',
+      stage: 'stage',
+      details: { originalErrorMessage: 'oops' },
+    });
+    expect(logger.warn.mock.calls[0][0]).toContain('N/A');
+  });
 });


### PR DESCRIPTION
## Summary
- add branch coverage for loader error without original error
- test ApiKeyService._createErrorDetails when llmId is missing

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686a75671dfc8331ba23e0e393a52f04