### PR TITLE
[Agent] fix lint in three modules

### DIFF
--- a/src/turns/turnManager.js
+++ b/src/turns/turnManager.js
@@ -43,10 +43,6 @@ import { safeDispatchError } from '../utils/safeDispatchErrorUtils.js';
  * Includes logic to stop if a round completes with no successful turns.
  */
 class TurnManager extends ITurnManager {
-  /** @type {ITurnOrderService} */
-  #turnOrderService;
-  /** @type {EntityManager} */
-  #entityManager;
   /** @type {ILogger} */
   #logger;
   /** @type {IValidatedEventDispatcher} */
@@ -57,8 +53,6 @@ class TurnManager extends ITurnManager {
   #roundManager;
   /** @type {TurnCycle} */
   #turnCycle;
-  /** @type {import('../scheduling').IScheduler} */
-  #scheduler;
 
   /** @type {boolean} */
   #isRunning = false;
@@ -150,15 +144,12 @@ class TurnManager extends ITurnManager {
     }
     // --- End Dependency Validation ---
 
-    this.#turnOrderService = turnOrderService;
-    this.#entityManager = entityManager;
     this.#logger = logger;
     this.#dispatcher = dispatcher;
     this.#turnHandlerResolver = turnHandlerResolver;
     this.#roundManager =
       roundManager || new RoundManager(turnOrderService, entityManager, logger);
     this.#turnCycle = new TurnCycle(turnOrderService, logger);
-    this.#scheduler = scheduler;
     this.#eventSubscription = new TurnEventSubscription(
       dispatcher,
       logger,

--- a/tests/core/cycleDetector.test.js
+++ b/tests/core/cycleDetector.test.js
@@ -31,21 +31,23 @@ describe('createCycleDetector', () => {
       detector.enter('scope2');
       detector.enter('scope3');
 
+      let caughtError;
       try {
         detector.enter('scope2');
-        fail('Should have thrown ScopeCycleError');
       } catch (error) {
-        expect(error).toBeInstanceOf(ScopeCycleError);
-        expect(error.message).toBe(
-          'Cycle: scope1 -> scope2 -> scope3 -> scope2'
-        );
-        expect(error.cyclePath).toEqual([
-          'scope1',
-          'scope2',
-          'scope3',
-          'scope2',
-        ]);
+        caughtError = error;
       }
+
+      expect(caughtError).toBeInstanceOf(ScopeCycleError);
+      expect(caughtError.message).toBe(
+        'Cycle: scope1 -> scope2 -> scope3 -> scope2'
+      );
+      expect(caughtError.cyclePath).toEqual([
+        'scope1',
+        'scope2',
+        'scope3',
+        'scope2',
+      ]);
     });
 
     it('should detect self-referencing cycles', () => {
@@ -118,7 +120,7 @@ describe('createCycleDetector', () => {
 
       try {
         detector.enter('scope1');
-      } catch (error) {
+      } catch {
         // Ignore the error
       }
 

--- a/tests/unit/visualizer/anatomyVisualizerInitialization.test.js
+++ b/tests/unit/visualizer/anatomyVisualizerInitialization.test.js
@@ -101,7 +101,7 @@ describe('Anatomy Visualizer Initialization', () => {
         includeAnatomyFormatting: true,
         postInitHook: expect.any(Function),
       });
-      
+
       // Verify UI was initialized
       expect(mockUIInitialize).toHaveBeenCalled();
     });
@@ -129,7 +129,9 @@ describe('Anatomy Visualizer Initialization', () => {
       await Promise.resolve();
 
       // Verify AnatomyDescriptionService was resolved from container
-      expect(containerMock.resolve).toHaveBeenCalledWith('AnatomyDescriptionService');
+      expect(containerMock.resolve).toHaveBeenCalledWith(
+        'AnatomyDescriptionService'
+      );
     });
 
     it('should handle bootstrap failure', async () => {
@@ -160,12 +162,7 @@ describe('Anatomy Visualizer Initialization', () => {
       // Mock bootstrap to still succeed but the postInitHook will throw
       mockBootstrap.mockImplementation(async (options) => {
         if (options && options.postInitHook) {
-          try {
-            await options.postInitHook(servicesMock, containerMock);
-          } catch (error) {
-            // This error will be caught by the try-catch in anatomy-visualizer.js
-            throw error;
-          }
+          await options.postInitHook(servicesMock, containerMock);
         }
         return { container: containerMock, services: servicesMock };
       });


### PR DESCRIPTION
Summary: Fixed ESLint errors in `turnManager.js`, `cycleDetector.test.js`, and anatomy visualizer initialization test. Removed unused private fields and cleaned up tests.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 3734 problems)*
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686a891f24c4833196ebf98cdc155703