### PR TITLE
[Agent] Improve validationErrorUtils branch coverage

### DIFF
--- a/tests/unit/actions/validation/validationErrorUtils.test.js
+++ b/tests/unit/actions/validation/validationErrorUtils.test.js
@@ -36,4 +36,10 @@ describe('formatValidationError', () => {
     const err = formatValidationError(otherErr, 'Source.fn', {});
     expect(err.message).toBe('Source.fn: something else');
   });
+
+  test('handles missing error message gracefully', () => {
+    const noMsgErr = new Error();
+    const err = formatValidationError(noMsgErr, 'Source.fn', {});
+    expect(err.message).toBe('Source.fn: invalid input');
+  });
 });


### PR DESCRIPTION
## Summary
- add test for missing message to cover remaining branch in validationErrorUtils

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686a8fb198608331838e4a9ca883a7e3