### PR TITLE
[Agent] Fix lint errors in selected tests

### DIFF
--- a/tests/core/entityHelpers.test.js
+++ b/tests/core/entityHelpers.test.js
@@ -16,7 +16,8 @@ describe('entityHelpers', () => {
       const entity = {
         id: 'e1',
         componentTypeIds: ['core:name'],
-        getComponentData: (id) => ({ value: 'Entity One' }),
+        // This mocked helper ignores the id argument
+        getComponentData: () => ({ value: 'Entity One' }),
       };
       const gateway = {
         getEntityInstance: jest.fn(() => entity),

--- a/tests/integration/anatomy/errorHandling.integration.test.js
+++ b/tests/integration/anatomy/errorHandling.integration.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import AnatomyIntegrationTestBed from '../../common/anatomy/anatomyIntegrationTestBed.js';
 import { AnatomyGenerationService } from '../../../src/anatomy/anatomyGenerationService.js';
-import { BodyBlueprintFactory } from '../../../src/anatomy/bodyBlueprintFactory.js';
 import { AnatomyInitializationService } from '../../../src/anatomy/anatomyInitializationService.js';
 import { BodyGraphService } from '../../../src/anatomy/bodyGraphService.js';
 import { ENTITY_CREATED_ID } from '../../../src/constants/eventIds.js';
@@ -16,7 +15,6 @@ const ANATOMY_JOINT_COMPONENT_ID = 'anatomy:joint';
 describe('Anatomy Error Handling Integration', () => {
   let testBed;
   let anatomyGenerationService;
-  let bodyBlueprintFactory;
 
   beforeEach(() => {
     testBed = new AnatomyIntegrationTestBed();
@@ -29,8 +27,6 @@ describe('Anatomy Error Handling Integration', () => {
       anatomyDescriptionService: testBed.mockAnatomyDescriptionService,
       bodyGraphService: testBed.bodyGraphService,
     });
-
-    bodyBlueprintFactory = testBed.bodyBlueprintFactory;
 
     // Load test anatomy components
     testBed.loadComponents({
@@ -643,17 +639,11 @@ describe('Anatomy Error Handling Integration', () => {
       // Either one succeeds and others return false (already generated)
       // Or all succeed (if they don't check for existing anatomy atomically)
       const fulfilled = results.filter((r) => r.status === 'fulfilled');
-      const rejected = results.filter((r) => r.status === 'rejected');
 
       // At least some should complete without throwing
       expect(fulfilled.length).toBeGreaterThan(0);
 
-      // If any succeeded with true, that's good
-      const successCount = fulfilled.filter((r) => r.value === true).length;
-      // If any returned false (already generated), that's also expected
-      const alreadyGeneratedCount = fulfilled.filter(
-        (r) => r.value === false
-      ).length;
+      // If any succeeded with true or returned false (already generated), that's ok
 
       // The important thing is the anatomy was generated
       const bodyComponent = testBed.entityManager.getComponentData(
@@ -806,6 +796,7 @@ describe('Anatomy Error Handling Integration', () => {
         expect(typeof result).toBe('boolean');
       } catch (error) {
         // It's ok if it throws an error for deep nesting
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(error).toBeDefined();
       }
     });

--- a/tests/integration/humanDecisionFlow.test.js
+++ b/tests/integration/humanDecisionFlow.test.js
@@ -9,7 +9,6 @@ import { HumanDecisionProvider } from '../../src/turns/providers/humanDecisionPr
 import { TurnActionFactory } from '../../src/turns/factories/turnActionFactory.js';
 import { GenericTurnStrategy } from '../../src/turns/strategies/genericTurnStrategy.js';
 // Import the adapter, which is the key to the fix
-import { ActionIndexerAdapter } from '../../src/turns/adapters/actionIndexerAdapter.js';
 
 /**
  * Integration test verifying that the human decision flow


### PR DESCRIPTION
## Summary
- fix unused id parameter in entityHelpers test
- clean up Anatomy Error Handling integration test
- remove unused import in humanDecisionFlow test

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686a97b7c2f48331bcdc1a6de502eaa8