### PR TITLE
[Agent] increase throttler branch coverage

### DIFF
--- a/tests/unit/alerting/throttler.test.js
+++ b/tests/unit/alerting/throttler.test.js
@@ -220,4 +220,25 @@ describe('Throttler', () => {
       'Throttler: A valid ISafeEventDispatcher instance is required.'
     );
   });
+
+  it('clears stale entries when the timer did not fire', () => {
+    const throttler = new Throttler(mockDispatcher, 'warning');
+    const setSpy = jest.spyOn(global, 'setTimeout').mockImplementation(() => 1);
+    const clearSpy = jest
+      .spyOn(global, 'clearTimeout')
+      .mockImplementation(() => {});
+
+    jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(throttleWindowMs + 1);
+
+    expect(throttler.allow(key, payload)).toBe(true);
+    expect(throttler.allow(key, payload)).toBe(true);
+    expect(clearSpy).toHaveBeenCalledWith(1);
+
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
Summary: Adds a new test covering the stale entry cleanup path in Throttler to improve branch coverage.

Changes Made:
- Added test case to ensure old entries are cleared when timer callbacks do not fire.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_686aa6fd012483319da017a96fb836ad