### PR TITLE
[Agent] Fix lint in test modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jest": "^29.0.1",
         "eslint-plugin-jsdoc": "^51.3.3",
-        "globals": "^16.2.0",
+        "globals": "^16.3.0",
         "http-server": "^14.1.1",
         "jest": "^30.0.4",
         "jest-environment-jsdom": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
-    "@babel/preset-env": "^7.26.9",
     "@babel/eslint-parser": "^7.22.15",
+    "@babel/preset-env": "^7.26.9",
     "@eslint/compat": "^1.2.8",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.25.1",
@@ -39,7 +39,7 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsdoc": "^51.3.3",
-    "globals": "^16.2.0",
+    "globals": "^16.3.0",
     "http-server": "^14.1.1",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^29.7.0",

--- a/tests/integration/domUI/AnatomyVisualizerUI.integration.test.js
+++ b/tests/integration/domUI/AnatomyVisualizerUI.integration.test.js
@@ -55,9 +55,6 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
   let entityManager;
   let anatomyDescriptionService;
   let eventDispatcher;
-  let modsLoader;
-  let anatomyFormattingService;
-  let systemInitializer;
   let originalFetch;
 
   beforeEach(() => {
@@ -102,11 +99,6 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
       tokens.AnatomyDescriptionService
     );
     eventDispatcher = container.resolve(tokens.ISafeEventDispatcher);
-    modsLoader = container.resolve(tokens.ModsLoader);
-    anatomyFormattingService = container.resolve(
-      tokens.AnatomyFormattingService
-    );
-    systemInitializer = container.resolve(tokens.SystemInitializer);
 
     // Pre-load essential components and entities into registry
     loadTestData();
@@ -131,7 +123,7 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
   });
 
   /**
-   *
+   * Load component and entity definitions used throughout the tests.
    */
   function loadTestData() {
     // Load component definitions
@@ -686,7 +678,7 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
 
       // Check viewBox is square (for radial layout)
       const viewBox = svg.getAttribute('viewBox');
-      const [x, y, width, height] = viewBox.split(' ').map(Number);
+      const [, , width, height] = viewBox.split(' ').map(Number);
       expect(width).toBeCloseTo(height, 0); // Should be square
 
       // Verify nodes are positioned radially
@@ -840,7 +832,7 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
       });
 
       // Act
-      const loadPromise = visualizerUI._loadEntity(entityDefId);
+      visualizerUI._loadEntity(entityDefId);
 
       // Trigger entity created event without anatomy
       setTimeout(() => {
@@ -987,7 +979,6 @@ describe('AnatomyVisualizerUI Integration Tests', () => {
       // The important thing is that the entity loads without errors
 
       // Verify cleanup happens on subsequent selections
-      const previousEntities = [...visualizerUI._createdEntities];
 
       // Act 3: Select a different entity
       selector.value = 'anatomy:human_female';

--- a/tests/unit/data/textDataFetcher.test.js
+++ b/tests/unit/data/textDataFetcher.test.js
@@ -163,14 +163,16 @@ environment := entities(core:position)[
 
         global.fetch.mockResolvedValue(mockResponse);
 
+        let caughtError;
         try {
           await fetcher.fetch('./test.scope');
-          fail('Expected an error to be thrown');
         } catch (error) {
-          // Verify that the error message contains the truncated response body
-          expect(error.message).toContain('Response body:');
-          expect(error.message.length).toBeLessThan(700); // Original would be ~900+ chars
+          caughtError = error;
         }
+
+        expect(caughtError).toBeDefined();
+        expect(caughtError.message).toContain('Response body:');
+        expect(caughtError.message.length).toBeLessThan(700); // Original would be ~900+ chars
       });
     });
 

--- a/tests/unit/domUI/inputStateController.test.js
+++ b/tests/unit/domUI/inputStateController.test.js
@@ -48,7 +48,7 @@ describe('InputStateController', () => {
     mockLogger = new ConsoleLogger();
     mockSubscriptions = [];
     mockDispatcher = {
-      subscribe: jest.fn((_eventType, _handler) => {
+      subscribe: jest.fn(() => {
         const subscription = { unsubscribe: jest.fn() };
         mockSubscriptions.push(subscription);
         return subscription;
@@ -433,7 +433,7 @@ describe('InputStateController', () => {
 
   describe('Event Handling (VED)', () => {
     it('should handle valid core:disable_input event object', () => {
-      const controller = createController();
+      createController();
       const disableHandler = getVedHandler('core:disable_input');
       expect(disableHandler).toBeInstanceOf(Function);
 
@@ -460,7 +460,7 @@ describe('InputStateController', () => {
     });
 
     it('should handle core:disable_input with missing payload (use default message)', () => {
-      const controller = createController();
+      createController();
       const disableHandler = getVedHandler('core:disable_input');
       inputElement.disabled = false;
       inputElement.placeholder = 'start';
@@ -487,7 +487,7 @@ describe('InputStateController', () => {
     });
 
     it('should handle core:disable_input with payload missing message property (use default message)', () => {
-      const controller = createController();
+      createController();
       const disableHandler = getVedHandler('core:disable_input');
       inputElement.disabled = false;
       inputElement.placeholder = 'start';
@@ -517,7 +517,7 @@ describe('InputStateController', () => {
     });
 
     it('should handle valid core:enable_input event object', () => {
-      const controller = createController();
+      createController();
       const enableHandler = getVedHandler('core:enable_input');
       expect(enableHandler).toBeInstanceOf(Function);
 
@@ -545,7 +545,7 @@ describe('InputStateController', () => {
 
     // Ticket 3.1: Test updated for new default placeholder
     it('should handle core:enable_input with missing payload (use default placeholder)', () => {
-      const controller = createController();
+      createController();
       const enableHandler = getVedHandler('core:enable_input');
       inputElement.disabled = true;
       inputElement.placeholder = 'Initial';
@@ -569,7 +569,7 @@ describe('InputStateController', () => {
 
     // Ticket 3.1: Test updated for new default placeholder
     it('should handle core:enable_input with payload missing placeholder property (use default placeholder)', () => {
-      const controller = createController();
+      createController();
       const enableHandler = getVedHandler('core:enable_input');
       inputElement.disabled = true;
       inputElement.placeholder = 'Initial';
@@ -595,7 +595,7 @@ describe('InputStateController', () => {
     });
 
     it('should not log state changes if event handler does not change state', () => {
-      const controller = createController();
+      createController();
       const disableHandler = getVedHandler('core:disable_input');
       inputElement.disabled = true;
       inputElement.placeholder = 'Already Disabled';


### PR DESCRIPTION
## Summary
- install `globals` dev dependency for lint
- fix TextDataFetcher test error handling to avoid conditional expects
- tidy InputStateController tests to remove unused variables
- clean up AnatomyVisualizerUI integration test unused vars and add comments

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686aa7ad94cc8331aefc113452b3313b