### PR TITLE
[Agent] resolve lint in integration tests

### DIFF
--- a/tests/integration/loaders/anatomyRecipeLoading.integration.test.js
+++ b/tests/integration/loaders/anatomyRecipeLoading.integration.test.js
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import DefaultPathResolver from '../../../src/pathing/defaultPathResolver.js';
 import StaticConfiguration from '../../../src/configuration/staticConfiguration.js';

--- a/tests/integration/loaders/loaderRegistry.integration.test.js
+++ b/tests/integration/loaders/loaderRegistry.integration.test.js
@@ -8,7 +8,6 @@ import {
 import ActionLoader from '../../../src/loaders/actionLoader.js';
 import ComponentLoader from '../../../src/loaders/componentLoader.js';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
-import { BaseManifestItemLoader } from '../../../src/loaders/baseManifestItemLoader.js';
 import { DuplicateContentError } from '../../../src/errors/duplicateContentError.js';
 
 // --- Mock Service Factories ---
@@ -458,11 +457,11 @@ describe('Integration: Loaders, Registry State, and Overrides (REFACTOR-8.6)', (
       expectedItems.forEach((expected) => {
         const retrievedItem = dataRegistry.get(expected.type, expected.key);
         expect(retrievedItem).toBeDefined();
-        if (expected.type === 'actions') {
-          expect(retrievedItem.id).toBe(expected.key);
-        } else {
-          expect(retrievedItem.id).toBe(expected.baseId || expected.key);
-        }
+        const expectedId =
+          expected.type === 'actions'
+            ? expected.key
+            : expected.baseId || expected.key;
+        expect(retrievedItem.id).toBe(expectedId);
         expect(retrievedItem._fullId).toBe(expected.key);
         expect(retrievedItem._modId).toBe(expected.modId);
       });

--- a/tests/integration/loaders/modsLoader.gameConfigPhase.integration.test.js
+++ b/tests/integration/loaders/modsLoader.gameConfigPhase.integration.test.js
@@ -1,13 +1,10 @@
 const ModsLoader = require('../../../src/loaders/modsLoader.js').default;
 const GameConfigPhase =
   require('../../../src/loaders/phases/GameConfigPhase.js').default;
-const ManifestPhase =
-  require('../../../src/loaders/phases/ManifestPhase.js').default;
 const {
   ModsLoaderPhaseError,
   ModsLoaderErrorCode,
 } = require('../../../src/errors/modsLoaderPhaseError.js');
-const { createLoadContext } = require('../../../src/loaders/LoadContext.js');
 const {
   makeRegistryCache,
 } = require('../../../src/loaders/registryCacheAdapter.js');
@@ -40,7 +37,6 @@ class FakeRegistry {
 
 describe('ModsLoader + GameConfigPhase integration', () => {
   let registry;
-  let context;
   let phases;
   let modsLoader;
   let fakeGameConfigLoader;
@@ -48,7 +44,6 @@ describe('ModsLoader + GameConfigPhase integration', () => {
 
   beforeEach(() => {
     registry = new FakeRegistry();
-    context = createLoadContext({ worldName: 'test', registry });
     fakeLogger.info.mockClear();
     fakeLogger.debug.mockClear();
     fakeLogger.warn.mockClear();
@@ -56,8 +51,10 @@ describe('ModsLoader + GameConfigPhase integration', () => {
   });
 
   /**
+   * Create a GameConfigPhase that resolves to the provided mods configuration.
    *
-   * @param config
+   * @param {string[]} config - Mods listed in game.json.
+   * @returns {GameConfigPhase} Configured phase instance.
    */
   function makeGameConfigPhaseWithConfig(config) {
     fakeGameConfigLoader = { loadConfig: jest.fn().mockResolvedValue(config) };
@@ -68,8 +65,10 @@ describe('ModsLoader + GameConfigPhase integration', () => {
   }
 
   /**
+   * Create a GameConfigPhase that rejects with the given error.
    *
-   * @param error
+   * @param {Error} error - Error thrown when loading game configuration.
+   * @returns {GameConfigPhase} Configured phase instance.
    */
   function makeGameConfigPhaseWithError(error) {
     fakeGameConfigLoader = { loadConfig: jest.fn().mockRejectedValue(error) };
@@ -95,8 +94,10 @@ describe('ModsLoader + GameConfigPhase integration', () => {
   }
 
   /**
+   * Build a simple session that executes provided phases in order.
    *
-   * @param phases
+   * @param {Array} phases - Phases to execute.
+   * @returns {{run: Function}} Session interface with run method.
    */
   function makeSession(phases) {
     return {


### PR DESCRIPTION
## Summary
- remove unused imports in integration tests
- clarify helper JSDoc for mods loader integration
- simplify loaderRegistry expectations

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686ab9435c248331adc5f5b4bbc42031