### PR TITLE
[Agent] fix lint in body utils and tests

### DIFF
--- a/src/logic/utils/bodyComponentUtils.js
+++ b/src/logic/utils/bodyComponentUtils.js
@@ -17,15 +17,20 @@ export function getBodyComponent(entityManager, entityId) {
     return null;
   }
 
-  const bodyComponent = entityManager.getComponentData(entityId, 'anatomy:body');
+  const bodyComponent = entityManager.getComponentData(
+    entityId,
+    'anatomy:body'
+  );
 
   if (!bodyComponent) {
     return null;
   }
 
   // Validate that the component has a valid structure
-  const hasDirectRoot = bodyComponent.root != null;
-  const hasNestedRoot = bodyComponent.body?.root != null;
+  const hasDirectRoot =
+    bodyComponent.root !== undefined && bodyComponent.root !== null;
+  const hasNestedRoot =
+    bodyComponent.body?.root !== undefined && bodyComponent.body?.root !== null;
 
   if (!hasDirectRoot && !hasNestedRoot) {
     return null;
@@ -49,11 +54,15 @@ export function extractRootId(bodyComponent) {
   // Support both formats for backward compatibility
   // Legacy format: { body: { root: 'entity123' } }
   // Current format: { root: 'entity123' }
-  if (bodyComponent.body && bodyComponent.body.root != null) {
+  if (
+    bodyComponent.body &&
+    bodyComponent.body.root !== undefined &&
+    bodyComponent.body.root !== null
+  ) {
     return bodyComponent.body.root;
   }
 
-  if (bodyComponent.root != null) {
+  if (bodyComponent.root !== undefined && bodyComponent.root !== null) {
     return bodyComponent.root;
   }
 
@@ -69,7 +78,7 @@ export function extractRootId(bodyComponent) {
  */
 export function getRootIdFromEntity(entityManager, entityId) {
   const bodyComponent = getBodyComponent(entityManager, entityId);
-  
+
   if (!bodyComponent) {
     return { rootId: null, hasBody: false };
   }

--- a/src/logic/utils/entityPathResolver.js
+++ b/src/logic/utils/entityPathResolver.js
@@ -19,7 +19,10 @@ export function resolveEntityPath(context, pathString) {
   // Special handling for "." which means the current entity in filter context
   if (pathString === '.') {
     const entity = context?.entity;
-    return { entity, isValid: entity != null };
+    return {
+      entity,
+      isValid: entity !== undefined && entity !== null,
+    };
   }
 
   // Navigate the nested path
@@ -28,13 +31,20 @@ export function resolveEntityPath(context, pathString) {
 
   for (const part of pathParts) {
     // Check if we can continue navigating
-    if (current == null || typeof current !== 'object') {
+    if (
+      current === undefined ||
+      current === null ||
+      typeof current !== 'object'
+    ) {
       return { entity: null, isValid: false };
     }
     current = current[part];
   }
 
-  return { entity: current, isValid: current != null };
+  return {
+    entity: current,
+    isValid: current !== undefined && current !== null,
+  };
 }
 
 /**
@@ -44,5 +54,10 @@ export function resolveEntityPath(context, pathString) {
  * @returns {boolean} True if entity has a valid ID
  */
 export function hasValidEntityId(entity) {
-  return entity != null && entity.id != null;
+  return (
+    entity !== undefined &&
+    entity !== null &&
+    entity.id !== undefined &&
+    entity.id !== null
+  );
 }

--- a/tests/unit/turns/turnOrder/turnOrderService.peekNextEntity.test.js
+++ b/tests/unit/turns/turnOrder/turnOrderService.peekNextEntity.test.js
@@ -109,9 +109,7 @@ describe('TurnOrderService', () => {
 
       // Ensure the *other* queue type wasn't touched
       expect(InitiativePriorityQueue).not.toHaveBeenCalled();
-      if (mockInitiativeQueueInstance) {
-        expect(mockInitiativeQueueInstance.peek).not.toHaveBeenCalled();
-      }
+      expect(mockInitiativeQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
 
       // Assert no logs were made by peekNextEntity itself
       expect(mockLogger.info).not.toHaveBeenCalled();
@@ -145,9 +143,7 @@ describe('TurnOrderService', () => {
 
       // Ensure the *other* queue type wasn't touched
       expect(SimpleRoundRobinQueue).not.toHaveBeenCalled();
-      if (mockSimpleQueueInstance) {
-        expect(mockSimpleQueueInstance.peek).not.toHaveBeenCalled();
-      }
+      expect(mockSimpleQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
 
       // Assert no logs were made by peekNextEntity itself
       expect(mockLogger.info).not.toHaveBeenCalled();
@@ -174,9 +170,7 @@ describe('TurnOrderService', () => {
       expect(mockSimpleQueueInstance.peek).toHaveBeenCalledWith();
 
       // Ensure the *other* queue type wasn't touched
-      if (mockInitiativeQueueInstance) {
-        expect(mockInitiativeQueueInstance.peek).not.toHaveBeenCalled();
-      }
+      expect(mockInitiativeQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
 
       // Assert no logs were made by peekNextEntity itself
       expect(mockLogger.info).not.toHaveBeenCalled();
@@ -208,9 +202,7 @@ describe('TurnOrderService', () => {
       expect(mockInitiativeQueueInstance.peek).toHaveBeenCalledWith();
 
       // Ensure the *other* queue type wasn't touched
-      if (mockSimpleQueueInstance) {
-        expect(mockSimpleQueueInstance.peek).not.toHaveBeenCalled();
-      }
+      expect(mockSimpleQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
 
       // Assert no logs were made by peekNextEntity itself
       expect(mockLogger.info).not.toHaveBeenCalled();
@@ -234,10 +226,8 @@ describe('TurnOrderService', () => {
       // Crucially, ensure no queue constructor or peek was called
       expect(SimpleRoundRobinQueue).not.toHaveBeenCalled();
       expect(InitiativePriorityQueue).not.toHaveBeenCalled();
-      if (mockSimpleQueueInstance)
-        expect(mockSimpleQueueInstance.peek).not.toHaveBeenCalled();
-      if (mockInitiativeQueueInstance)
-        expect(mockInitiativeQueueInstance.peek).not.toHaveBeenCalled();
+      expect(mockSimpleQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
+      expect(mockInitiativeQueueInstance?.peek?.mock.calls.length ?? 0).toBe(0);
 
       // Assert NO logs were made (unlike getNextEntity, peek is silent when no round)
       expect(mockLogger.info).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- fix equality checks in bodyComponentUtils
- fix null checks in entityPathResolver
- update peekNextEntity tests to avoid conditional expects

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686ac3c28e688331a8f32fddd9f4f2bf