### PR TITLE
[Agent] Fix lint errors in test modules

### DIFF
--- a/tests/unit/utils/actorLocationUtils.test.js
+++ b/tests/unit/utils/actorLocationUtils.test.js
@@ -4,9 +4,10 @@ import { getActorLocation } from '../../../src/utils/actorLocationUtils.js';
 /** @typedef {import('../../../src/interfaces/IEntityManager.js').IEntityManager} IEntityManager */
 
 /**
- * Simple mock entity class
+ * Creates a mock entity for tests.
  *
- * @param id
+ * @param {string} id - Identifier for the entity.
+ * @returns {{id: string, getComponentData: jest.Mock}} Mock entity.
  */
 function createMockEntity(id) {
   return { id, getComponentData: jest.fn() };

--- a/tests/unit/utils/contextVariableUtils.branches.test.js
+++ b/tests/unit/utils/contextVariableUtils.branches.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { writeContextVariable } from '../../../src/utils/contextVariableUtils.js';
-import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
 import * as safeDispatchModule from '../../../src/utils/safeDispatchErrorUtils.js';
 
 jest.mock('../../../src/utils/safeDispatchErrorUtils.js');

--- a/tests/unit/utils/engineVersionSatisfies.test.js
+++ b/tests/unit/utils/engineVersionSatisfies.test.js
@@ -62,9 +62,7 @@ describe('engineVersionSatisfies Utility', () => {
     });
 
     // Example tests if ENGINE_VERSION were '1.5.2' (as per ticket examples)
-    // it('should return true for 1.5.x', () => expect(engineVersionSatisfies('1.5.x')).toBe(true));
-    // it('should return true for ^1.4.0', () => expect(engineVersionSatisfies('^1.4.0')).toBe(true));
-    // it('should return true for >=1.0.0', () => expect(engineVersionSatisfies('>=1.0.0')).toBe(true));
+    // These examples are omitted in this test suite since ENGINE_VERSION is 0.0.1
   });
 
   describe('Failure Paths (Returns false)', () => {


### PR DESCRIPTION
## Summary
- resolve jsdoc warnings in actorLocationUtils test
- clean up commented-out tests in engineVersionSatisfies test
- remove unused import in contextVariableUtils.branches test

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686ac7df7a8c83318331737302f16b89