### PR TITLE
Potential fix for code scanning alert no. 3: Exception text reinterpreted as HTML

### DIFF
--- a/src/domUI/AnatomyVisualizerUI.js
+++ b/src/domUI/AnatomyVisualizerUI.js
@@ -322,12 +322,35 @@ class AnatomyVisualizerUI {
    * @private
    * @param {string} message
    */
+  /**
+   * Escape HTML characters in a string to prevent XSS
+   *
+   * @private
+   * @param {string} unsafeString
+   * @returns {string} Escaped string
+   */
+  _escapeHtml(unsafeString) {
+    return unsafeString
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  /**
+   * Show a message in the graph panel
+   *
+   * @private
+   * @param {string} message
+   */
   _showMessage(message) {
     const graphContainer = this._document.getElementById(
       'anatomy-graph-container'
     );
     if (graphContainer) {
-      graphContainer.innerHTML = `<div class="message">${message}</div>`;
+      const escapedMessage = this._escapeHtml(message);
+      graphContainer.innerHTML = `<div class="message">${escapedMessage}</div>`;
     }
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/3](https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/3)

To fix the issue, the `message` variable should be sanitized or escaped before being interpolated into HTML. The best approach is to use a utility function that escapes HTML meta-characters (`<`, `>`, `&`, etc.) to ensure that the rendered content is safe. This can be achieved by introducing a helper function for escaping HTML or using an existing library like `he` (HTML entities library).

Changes required:
1. Add a utility function to escape HTML characters.
2. Update the `_showMessage` method to escape the `message` variable before setting `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
