### PR TITLE
[Agent] Add coverage tests for InMemoryEntityRepository

### DIFF
--- a/tests/unit/adapters/inMemoryEntityRepository.uncoveredBranches.test.js
+++ b/tests/unit/adapters/inMemoryEntityRepository.uncoveredBranches.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import InMemoryEntityRepository from '../../../src/adapters/InMemoryEntityRepository.js';
+
+/**
+ * Additional branch coverage for InMemoryEntityRepository focusing on
+ * edge cases not covered elsewhere.
+ */
+describe('InMemoryEntityRepository uncovered branches', () => {
+  it('ignores entity objects with non-string id', () => {
+    const repo = new InMemoryEntityRepository();
+    repo.add({ id: 123, foo: 'bar' });
+    repo.add({ id: null });
+    expect(Array.from(repo.entities())).toEqual([]);
+  });
+
+  it('iterates over multiple valid entities in insertion order', () => {
+    const repo = new InMemoryEntityRepository();
+    repo.add({ id: 'a', val: 1 });
+    repo.add({ id: 'b', val: 2 });
+    expect([...repo.entities()].map((e) => e.id)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
- expand InMemoryEntityRepository branch tests to exercise non-string IDs
- verify iteration order when multiple entities are added

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686be08976a08331b2ed6a79ec520f6a