### PR TITLE
[Agent] Improve PlaytimeTracker test coverage

### DIFF
--- a/tests/unit/engine/playtimeTracker.additional.test.js
+++ b/tests/unit/engine/playtimeTracker.additional.test.js
@@ -1,0 +1,63 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
+import PlaytimeTracker from '../../../src/engine/playtimeTracker.js';
+import { SYSTEM_ERROR_OCCURRED_ID } from '../../../src/constants/eventIds.js';
+
+/** @type {jest.Mocked<import('../../../src/interfaces/coreServices.js').ILogger>} */
+let mockLogger;
+let mockDispatcher;
+let tracker;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(1000);
+  mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  mockDispatcher = { dispatch: jest.fn() };
+  tracker = new PlaytimeTracker({
+    logger: mockLogger,
+    safeEventDispatcher: mockDispatcher,
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('PlaytimeTracker additional branches', () => {
+  test('setAccumulatedPlaytime stores value and resets session start', () => {
+    tracker.startSession();
+    expect(tracker._getSessionStartTime()).not.toBe(0);
+    tracker.setAccumulatedPlaytime(42);
+    expect(tracker._getAccumulatedPlaytimeSeconds()).toBe(42);
+    expect(tracker._getSessionStartTime()).toBe(0);
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      'PlaytimeTracker: Accumulated playtime set to 42s.'
+    );
+  });
+
+  test('setAccumulatedPlaytime dispatches error events for invalid input', () => {
+    expect(() => tracker.setAccumulatedPlaytime('bad')).toThrow(TypeError);
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({ message: expect.stringContaining('number') })
+    );
+
+    mockDispatcher.dispatch.mockClear();
+    expect(() => tracker.setAccumulatedPlaytime(-5)).toThrow(RangeError);
+    expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+      SYSTEM_ERROR_OCCURRED_ID,
+      expect.objectContaining({ message: expect.stringContaining('-5') })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage tests for `setAccumulatedPlaytime` in PlaytimeTracker

## Testing Done
- `npm run format`
- `npm run lint` *(fails: 706 errors, 2951 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686bf90978d08331996968d021afcd0b