### PR TITLE
[Agent] Fix lint warnings in error modules

### DIFF
--- a/src/errors/componentOverrideNotFoundError.js
+++ b/src/errors/componentOverrideNotFoundError.js
@@ -10,6 +10,8 @@
  */
 export class ComponentOverrideNotFoundError extends Error {
   /**
+   * Creates an instance of ComponentOverrideNotFoundError.
+   *
    * @param {string} instanceId - The ID of the entity instance.
    * @param {string} componentTypeId - The component type that was not found as an override.
    */

--- a/src/errors/definitionNotFoundError.js
+++ b/src/errors/definitionNotFoundError.js
@@ -11,6 +11,8 @@
  */
 export class DefinitionNotFoundError extends Error {
   /**
+   * Creates an instance of DefinitionNotFoundError.
+   *
    * @param {string} definitionId - The ID of the definition that was not found.
    */
   constructor(definitionId) {

--- a/src/errors/duplicateContentError.js
+++ b/src/errors/duplicateContentError.js
@@ -10,6 +10,8 @@
  */
 export class DuplicateContentError extends Error {
   /**
+   * Creates an instance of DuplicateContentError.
+   *
    * @param {string} contentType - The type of content (e.g., 'action', 'component', 'entity').
    * @param {string} qualifiedId - The fully qualified identifier (e.g., 'core:move').
    * @param {string} modId - The ID of the mod attempting to override.


### PR DESCRIPTION
## Summary
- add missing constructor descriptions for custom error classes
- keep eslint happy by adding blank lines

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686c14e67264833191a707e203f5a6d9