### PR TITLE
[Agent] Fix lint issues in three tests

### DIFF
--- a/tests/integration/actions/followActionCircularBug.test.js
+++ b/tests/integration/actions/followActionCircularBug.test.js
@@ -3,10 +3,7 @@
  * This test verifies that the scope correctly filters out followers as potential leaders.
  */
 
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { getValidActions } from '../../../src/actions/actionDiscoveryService.js';
-import { createRuleTestEnvironment } from '../../common/engine/systemLogicTestEnv.js';
-import { SimpleEntityManager } from '../../common/entities/index.js';
+import { describe, it, expect, jest } from '@jest/globals';
 import followAction from '../../../data/mods/core/actions/follow.action.json';
 import {
   FOLLOWING_COMPONENT_ID,
@@ -15,13 +12,9 @@ import {
   POSITION_COMPONENT_ID,
   ACTOR_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
-import ConsoleLogger from '../../../src/logging/consoleLogger.js';
 
 describe('Follow Action Circular Following Bug', () => {
   it('verifies the fix: Amaia cannot follow Iker when Iker already follows her', async () => {
-    // Create logger
-    const logger = new ConsoleLogger('DEBUG');
-    
     // Create entities matching the error log scenario
     const entities = [
       {
@@ -30,8 +23,10 @@ describe('Follow Action Circular Following Bug', () => {
           [NAME_COMPONENT_ID]: { text: 'Amaia Castillo' },
           [POSITION_COMPONENT_ID]: { locationId: 'room_test' },
           [ACTOR_COMPONENT_ID]: {},
-          [LEADING_COMPONENT_ID]: { followers: ['p_erotica:iker_aguirre_instance'] }
-        }
+          [LEADING_COMPONENT_ID]: {
+            followers: ['p_erotica:iker_aguirre_instance'],
+          },
+        },
       },
       {
         id: 'p_erotica:iker_aguirre_instance',
@@ -39,138 +34,155 @@ describe('Follow Action Circular Following Bug', () => {
           [NAME_COMPONENT_ID]: { text: 'Iker Aguirre' },
           [POSITION_COMPONENT_ID]: { locationId: 'room_test' },
           [ACTOR_COMPONENT_ID]: {},
-          [FOLLOWING_COMPONENT_ID]: { leaderId: 'p_erotica:amaia_castillo_instance' }
-        }
-      }
+          [FOLLOWING_COMPONENT_ID]: {
+            leaderId: 'p_erotica:amaia_castillo_instance',
+          },
+        },
+      },
     ];
-
-    const entityManager = new SimpleEntityManager(entities);
 
     // Log the entity states to verify setup
     console.log('\n=== Entity States ===');
     console.log('Amaia:', {
       id: entities[0].id,
-      leading: entities[0].components[LEADING_COMPONENT_ID]
+      leading: entities[0].components[LEADING_COMPONENT_ID],
     });
     console.log('Iker:', {
       id: entities[1].id,
-      following: entities[1].components[FOLLOWING_COMPONENT_ID]
+      following: entities[1].components[FOLLOWING_COMPONENT_ID],
     });
     console.log('');
 
     // Create mock services needed for action discovery
     const mockActionIndex = {
-      getCandidateActions: jest.fn(() => [followAction])
+      getCandidateActions: jest.fn(() => [followAction]),
     };
 
     const mockTargetResolutionService = {
       resolveTargets: jest.fn(({ actorId, scope }) => {
         console.log(`Resolving scope "${scope}" for actor "${actorId}"`);
-        
+
         // This mock simulates the fixed behavior - it correctly filters out Iker
         // because he is already following Amaia
-        if (scope === 'core:potential_leaders' && actorId === 'p_erotica:amaia_castillo_instance') {
-          console.log('Mock correctly filtering out Iker (he is already following Amaia)');
+        if (
+          scope === 'core:potential_leaders' &&
+          actorId === 'p_erotica:amaia_castillo_instance'
+        ) {
+          console.log(
+            'Mock correctly filtering out Iker (he is already following Amaia)'
+          );
           return []; // Empty array - no valid targets
         }
         return [];
-      })
-    };
-
-    const mockPrerequisiteEvaluationService = {
-      evaluate: jest.fn(() => true) // All prerequisites pass
+      }),
     };
 
     const mockActionCandidateProcessor = {
-      process: jest.fn(async ({ action, actorId, baseContext }) => {
+      process: jest.fn(async ({ action, actorId }) => {
         // Simulate processing the follow action
         if (action.id === 'core:follow') {
           const targets = await mockTargetResolutionService.resolveTargets({
             actorId,
-            scope: action.scope
+            scope: action.scope,
           });
-          
+
           if (targets.length > 0) {
-            return [{
-              id: action.id,
-              targets: targets.map(t => ({ id: t.id, name: t.components[NAME_COMPONENT_ID]?.text || t.id }))
-            }];
+            return [
+              {
+                id: action.id,
+                targets: targets.map((t) => ({
+                  id: t.id,
+                  name: t.components[NAME_COMPONENT_ID]?.text || t.id,
+                })),
+              },
+            ];
           }
         }
         return [];
-      })
+      }),
     };
 
     const mockActionDiscoveryService = {
       discoverActions: jest.fn(async (actorId) => {
         const actions = [];
         const candidateActions = mockActionIndex.getCandidateActions();
-        
+
         for (const action of candidateActions) {
           const processedActions = await mockActionCandidateProcessor.process({
             action,
             actorId,
-            baseContext: {}
           });
           actions.push(...processedActions);
         }
-        
+
         return actions;
-      })
+      }),
     };
 
     // Discover actions for Amaia
-    const validActions = await mockActionDiscoveryService.discoverActions('p_erotica:amaia_castillo_instance');
-    
+    const validActions = await mockActionDiscoveryService.discoverActions(
+      'p_erotica:amaia_castillo_instance'
+    );
+
     console.log('\n=== Action Discovery Results ===');
-    console.log('Valid actions:', validActions.map(a => ({
-      id: a.id,
-      targetCount: a.targets?.length || 0,
-      targets: a.targets?.map(t => t.id) || []
-    })));
+    console.log(
+      'Valid actions:',
+      validActions.map((a) => ({
+        id: a.id,
+        targetCount: a.targets?.length || 0,
+        targets: a.targets?.map((t) => t.id) || [],
+      }))
+    );
 
     // Find the follow action
-    const followActionResult = validActions.find(a => a.id === 'core:follow');
-    
-    if (followActionResult) {
-      console.log('\nFollow action found with targets:', followActionResult.targets);
-      
-      const hasIkerAsTarget = followActionResult.targets?.some(t => t.id === 'p_erotica:iker_aguirre_instance');
-      
-      if (hasIkerAsTarget) {
-        console.error('\n❌ UNEXPECTED: Amaia can follow Iker even though Iker is already following her!');
-        console.error('This would create a circular following relationship.');
-      } else {
-        console.log('\n✅ FIX VERIFIED: Iker was correctly filtered out as a potential leader');
-        console.log('The scope "core:potential_leaders" correctly used:');
-        console.log('1. The condition "core:entity-is-following-actor"');
-        console.log('2. The check for entity.id in actor.components.core:leading.followers');
-      }
-      
-      // This expectation verifies the fix is working
-      expect(hasIkerAsTarget).toBe(false);
+    const followActionResult = validActions.find((a) => a.id === 'core:follow');
+    const hasIkerAsTarget =
+      followActionResult?.targets?.some(
+        (t) => t.id === 'p_erotica:iker_aguirre_instance'
+      ) || false;
+
+    if (hasIkerAsTarget) {
+      console.error(
+        '\n❌ UNEXPECTED: Amaia can follow Iker even though Iker is already following her!'
+      );
+      console.error('This would create a circular following relationship.');
+    } else if (followActionResult) {
+      console.log(
+        '\n✅ FIX VERIFIED: Iker was correctly filtered out as a potential leader'
+      );
+      console.log('The scope "core:potential_leaders" correctly used:');
+      console.log('1. The condition "core:entity-is-following-actor"');
+      console.log(
+        '2. The check for entity.id in actor.components.core:leading.followers'
+      );
     } else {
       console.log('\n✅ No follow action available - this is correct behavior');
     }
+
+    // This expectation verifies the fix is working
+    expect(hasIkerAsTarget).toBe(false);
   });
 
   it('verifies the scope definition is correct', () => {
     // Load and verify the potential_leaders scope content
     const fs = require('fs');
     const path = require('path');
-    
+
     const scopeContent = fs.readFileSync(
-      path.resolve(__dirname, '../../../data/mods/core/scopes/potential_leaders.scope'),
+      path.resolve(
+        __dirname,
+        '../../../data/mods/core/scopes/potential_leaders.scope'
+      ),
       'utf8'
     );
-    
+
     console.log('\n=== Scope Definition ===');
     console.log(scopeContent);
-    
+
     // Verify the scope contains the necessary conditions
     expect(scopeContent).toContain('core:entity-is-following-actor');
     expect(scopeContent).toContain('actor.components.core:leading.followers');
-    
+
     // The scope should have BOTH conditions to prevent circular following:
     // 1. NOT entity-is-following-actor (entity's following.leaderId != actor.id)
     // 2. NOT entity.id in actor's leading.followers array

--- a/tests/integration/rules/turnEndedRule.integration.test.js
+++ b/tests/integration/rules/turnEndedRule.integration.test.js
@@ -52,9 +52,7 @@ describe('core_handle_turn_ended rule integration', () => {
   beforeEach(() => {
     const dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([turnEndedRule]),
-      getConditionDefinition: jest.fn((id) =>
-        id === 'core:event-is-turn-ended' ? eventIsTurnEnded : undefined
-      ),
+      getConditionDefinition: jest.fn(() => undefined),
       getEventDefinition: jest.fn((eventName) => {
         const commonEvents = {
           'core:turn_ended': { payloadSchema: null },

--- a/tests/unit/utils/llmUtils.parseAndRepairJson.test.js
+++ b/tests/unit/utils/llmUtils.parseAndRepairJson.test.js
@@ -304,6 +304,7 @@ describe('LlmJsonService.parseAndRepair', () => {
       const repairableJson = '{"baz": "qux",}';
       mockRepairJson.mockReturnValue('{"baz": "qux"}');
       await service.parseAndRepair(repairableJson, { logger: mockLogger });
+      expect(mockLogger.info).not.toHaveBeenCalled();
     });
 
     test('should call logger.error when repair attempt fails to produce valid JSON', async () => {


### PR DESCRIPTION
## Summary
- clean up unused variables in followActionCircularBug.test.js and avoid conditional expect
- stub condition definition in turnEndedRule integration test
- ensure llmUtils.parseAndRepairJson.test has an assertion

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d2ade272883318b66bc7187044436