### PR TITLE
[Agent] Fix typecheck errors in StringAccumulator

### DIFF
--- a/src/utils/stringAccumulatorUtils.js
+++ b/src/utils/stringAccumulatorUtils.js
@@ -12,14 +12,12 @@
  */
 export class StringAccumulator {
   /**
-   * @private
    * @type {string[]}
    * @description Internal array of string parts.
    */
   #parts = [];
 
   /**
-   * @private
    * @type {number}
    * @description Cached total length of all parts.
    */


### PR DESCRIPTION
## Summary
- remove `@private` tags that caused typecheck errors in `StringAccumulator`

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d3688768c83318461c212fc07cebc