### PR TITLE
[Agent] fix lint in selected tests

### DIFF
--- a/tests/unit/turns/states/turnIdleState.test.js
+++ b/tests/unit/turns/states/turnIdleState.test.js
@@ -6,14 +6,7 @@
  * handlers log & delegate correctly.
  */
 
-import {
-  describe,
-  it,
-  expect,
-  jest,
-  beforeEach,
-  afterEach,
-} from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { TurnIdleState } from '../../../../src/turns/states/turnIdleState.js';
 
 /* ------------------------------------------------------------------ */
@@ -144,6 +137,7 @@ describe('TurnIdleState “idle passthrough” methods', () => {
   };
 
   it('handleSubmittedCommand warns & delegates', async () => {
+    expect.assertions(2);
     const expected =
       "TurnIdleState: Command ('look') submitted by actor-1 but no turn is active (handler is Idle).";
     await expectWarnAndThrow(
@@ -153,6 +147,7 @@ describe('TurnIdleState “idle passthrough” methods', () => {
   });
 
   it('handleTurnEndedEvent warns & delegates (no throw)', async () => {
+    expect.assertions(1);
     const payload = { entityId: actor.id };
     await idle.handleTurnEndedEvent(handler, payload);
     expect(logger.warn).toHaveBeenCalledWith(
@@ -161,6 +156,7 @@ describe('TurnIdleState “idle passthrough” methods', () => {
   });
 
   it('processCommandResult warns & delegates', async () => {
+    expect.assertions(2);
     await expectWarnAndThrow(
       () =>
         idle.processCommandResult(handler, actor, { success: true }, 'look'),
@@ -169,6 +165,7 @@ describe('TurnIdleState “idle passthrough” methods', () => {
   });
 
   it('handleDirective warns & delegates', async () => {
+    expect.assertions(2);
     await expectWarnAndThrow(
       () => idle.handleDirective(handler, actor, 'ANY_DIRECTIVE', {}),
       'TurnIdleState: handleDirective called (for actor-1) but no turn is active.'

--- a/tests/unit/turns/turnOrder/queues/simpleRoundRobinQueue.isEmpty.test.js
+++ b/tests/unit/turns/turnOrder/queues/simpleRoundRobinQueue.isEmpty.test.js
@@ -20,14 +20,11 @@ describe('SimpleRoundRobinQueue', () => {
   let entityA;
   /** @type {Entity} */
   let entityB;
-  /** @type {Entity} */
-  let entityC;
 
   beforeEach(() => {
     queue = new SimpleRoundRobinQueue();
     entityA = { id: 'a', name: 'Entity A' };
     entityB = { id: 'b', name: 'Entity B' };
-    entityC = { id: 'c', name: 'Entity C' };
   });
 
   // --- Test Suite for isEmpty() and size() Methods (TEST-TURN-ORDER-001.10.5) ---

--- a/tests/unit/turns/turnOrder/queues/simpleRoundRobinQueue.peek.test.js
+++ b/tests/unit/turns/turnOrder/queues/simpleRoundRobinQueue.peek.test.js
@@ -18,14 +18,11 @@ describe('SimpleRoundRobinQueue', () => {
   let entityA;
   /** @type {Entity} */
   let entityB;
-  /** @type {Entity} */
-  let entityC;
 
   beforeEach(() => {
     queue = new SimpleRoundRobinQueue();
     entityA = { id: 'a', name: 'Entity A' };
     entityB = { id: 'b', name: 'Entity B' };
-    entityC = { id: 'c', name: 'Entity C' };
   });
 
   // --- Test Suite for peek() Method (TEST-TURN-ORDER-001.10.3) ---

--- a/tests/unit/turns/turnOrder/turnOrderService.getNextEntity.test.js
+++ b/tests/unit/turns/turnOrder/turnOrderService.getNextEntity.test.js
@@ -113,10 +113,6 @@ describe('TurnOrderService', () => {
       expect(mockSimpleQueueInstance.getNext).toHaveBeenCalledTimes(1);
       // Ensure the *other* queue type wasn't touched
       expect(InitiativePriorityQueue).not.toHaveBeenCalled();
-      if (mockInitiativeQueueInstance) {
-        // Check only if the other mock instance exists (it shouldn't)
-        expect(mockInitiativeQueueInstance.getNext).not.toHaveBeenCalled();
-      }
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: Advancing turn to entity "${expectedEntity.id}".`
@@ -153,10 +149,6 @@ describe('TurnOrderService', () => {
       expect(mockInitiativeQueueInstance.getNext).toHaveBeenCalledTimes(1);
       // Ensure the *other* queue type wasn't touched
       expect(SimpleRoundRobinQueue).not.toHaveBeenCalled();
-      if (mockSimpleQueueInstance) {
-        // Check only if the other mock instance exists (it shouldn't)
-        expect(mockSimpleQueueInstance.getNext).not.toHaveBeenCalled();
-      }
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `TurnOrderService: Advancing turn to entity "${expectedEntity.id}".`
@@ -185,9 +177,6 @@ describe('TurnOrderService', () => {
       // Assert
       expect(result).toBeNull();
       expect(mockSimpleQueueInstance.getNext).toHaveBeenCalledTimes(1);
-      if (mockInitiativeQueueInstance) {
-        expect(mockInitiativeQueueInstance.getNext).not.toHaveBeenCalled();
-      }
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: getNextEntity returned null (queue is likely empty).'
@@ -219,9 +208,6 @@ describe('TurnOrderService', () => {
       // Assert
       expect(result).toBeNull();
       expect(mockInitiativeQueueInstance.getNext).toHaveBeenCalledTimes(1);
-      if (mockSimpleQueueInstance) {
-        expect(mockSimpleQueueInstance.getNext).not.toHaveBeenCalled();
-      }
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'TurnOrderService: getNextEntity returned null (queue is likely empty).'
@@ -248,10 +234,6 @@ describe('TurnOrderService', () => {
       // Crucially, ensure no queue constructor or getNext was called
       expect(SimpleRoundRobinQueue).not.toHaveBeenCalled();
       expect(InitiativePriorityQueue).not.toHaveBeenCalled();
-      if (mockSimpleQueueInstance)
-        expect(mockSimpleQueueInstance.getNext).not.toHaveBeenCalled();
-      if (mockInitiativeQueueInstance)
-        expect(mockInitiativeQueueInstance.getNext).not.toHaveBeenCalled();
 
       expect(mockLogger.warn).toHaveBeenCalledTimes(1);
       expect(mockLogger.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- fix unused imports and add assertion counts in turnIdleState.test.js
- remove unused variables in round robin queue tests
- clean up conditional expects in getNextEntity tests

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d39a2bb1c833198ed3fa0b371313b