### PR TITLE
[Agent] Fix warnUtils typedef path

### DIFF
--- a/src/utils/warnUtils.js
+++ b/src/utils/warnUtils.js
@@ -8,7 +8,10 @@
  * @description Helper for standardized warning messages when no active turn is present.
  */
 
-/** @typedef {import('./loggerUtils.js').Logger} Logger */
+/**
+ * @typedef {import('../interfaces/coreServices.js').ILogger} Logger
+ * Logger interface used throughout the application.
+ */
 
 /**
  * Logs a standardized warning when a method is invoked without an active turn.


### PR DESCRIPTION
## Summary
- fix reference to Logger interface in warnUtils

## Testing Done
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d43e8b470833186296cbb65bf4d36