### PR TITLE
[Agent] add missing branch tests for TargetResolutionService

### DIFF
--- a/tests/unit/actions/targetResolutionService.missingBranches.test.js
+++ b/tests/unit/actions/targetResolutionService.missingBranches.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { TargetResolutionService } from '../../../src/actions/targetResolutionService.js';
+import { ActionTargetContext } from '../../../src/models/actionTargetContext.js';
+import { generateMockAst } from '../../common/scopeDsl/mockAstGenerator.js';
+
+// Additional tests to cover branches not exercised in other suites
+
+describe('TargetResolutionService uncovered branches', () => {
+  let service;
+  let mockScopeRegistry;
+  let mockScopeEngine;
+  let mockEntityManager;
+  let mockLogger;
+  let mockDispatcher;
+  let mockJsonLogic;
+  let mockDslParser;
+
+  beforeEach(() => {
+    mockScopeRegistry = { getScope: jest.fn() };
+    mockScopeEngine = { resolve: jest.fn() };
+    mockEntityManager = { getComponentData: jest.fn() };
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    mockDispatcher = { dispatch: jest.fn() };
+    mockJsonLogic = { evaluate: jest.fn() };
+    mockDslParser = { parse: jest.fn((expr) => generateMockAst(expr)) };
+
+    service = new TargetResolutionService({
+      scopeRegistry: mockScopeRegistry,
+      scopeEngine: mockScopeEngine,
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+      safeEventDispatcher: mockDispatcher,
+      jsonLogicEvaluationService: mockJsonLogic,
+      dslParser: mockDslParser,
+    });
+  });
+
+  it('creates empty components when componentTypeIds are missing', () => {
+    const expr = 'actor';
+    const scopeDef = {
+      name: 'core:test',
+      expr,
+      ast: generateMockAst(expr),
+      modId: 'core',
+      source: 'file',
+    };
+    mockScopeRegistry.getScope.mockReturnValue(scopeDef);
+    mockScopeEngine.resolve.mockReturnValue(new Set(['e1']));
+
+    const actor = { id: 'hero' }; // no componentTypeIds
+    const trace = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    const result = service.resolveTargets(
+      'core:test',
+      actor,
+      {
+        currentLocation: { id: 'loc' },
+      },
+      trace
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.targets).toEqual([ActionTargetContext.forEntity('e1')]);
+    expect(trace.warn).toHaveBeenCalled();
+    expect(mockEntityManager.getComponentData).not.toHaveBeenCalled();
+  });
+
+  it('logs component data errors without throwing', () => {
+    const expr = 'actor';
+    const scopeDef = {
+      name: 'core:test',
+      expr,
+      ast: generateMockAst(expr),
+      modId: 'core',
+      source: 'file',
+    };
+    mockScopeRegistry.getScope.mockReturnValue(scopeDef);
+    const error = new Error('fail');
+    mockEntityManager.getComponentData.mockImplementation(() => {
+      throw error;
+    });
+    mockScopeEngine.resolve.mockReturnValue(new Set(['e2']));
+    const trace = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+    const actor = { id: 'hero', componentTypeIds: ['c1'] };
+    const result = service.resolveTargets(
+      'core:test',
+      actor,
+      { currentLocation: {} },
+      trace
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.targets).toEqual([ActionTargetContext.forEntity('e2')]);
+    expect(trace.error).toHaveBeenCalledWith(
+      `Failed to get component data for c1 on actor hero: ${error.message}`,
+      'TargetResolutionService.#resolveScopeToIds'
+    );
+  });
+});


### PR DESCRIPTION
Summary:
- add a new test suite covering extra branches in TargetResolutionService

Testing Done:
- [x] `npm run format`
- [x] `npm run lint` *(fails: 648 errors, 3032 warnings)*
- [x] `npm run test`
- [x] `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d4500d67c8331a9760f38a4af9752