### PR TITLE
[Agent] fix typecheck error in placeholderSources

### DIFF
--- a/src/utils/placeholderSources.js
+++ b/src/utils/placeholderSources.js
@@ -6,9 +6,13 @@
 import { resolveEntityNameFallback } from './entityNameFallbackUtils.js';
 
 /**
+ * @typedef {import('../logic/defs.js').ExecutionContext} ExecutionContext
+ */
+
+/**
  * Builds the data sources for placeholder resolution.
  *
- * @param {object} executionContext - Execution context supplying actor, target,
+ * @param {ExecutionContext & {context?: object}} executionContext - Execution context supplying actor, target,
  *   and evaluationContext data.
  * @returns {{sources: object[], fallback: object}} Sources array and fallback
  *   object for use with PlaceholderResolver.


### PR DESCRIPTION
## Summary
- define `ExecutionContext` type for `buildResolutionSources`
- annotate parameter so TypeScript recognizes properties

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d4f23e0f4833199da94c44d85a947