### PR TITLE
[Fix] Resolve lint issues in rule integration tests

### DIFF
--- a/tests/integration/rules/getCloseRule.integration.test.js
+++ b/tests/integration/rules/getCloseRule.integration.test.js
@@ -40,7 +40,6 @@ import OperationInterpreter from '../../../src/logic/operationInterpreter.js';
 import OperationRegistry from '../../../src/logic/operationRegistry.js';
 import JsonLogicEvaluationService from '../../../src/logic/jsonLogicEvaluationService.js';
 import { merge } from '../../../src/logic/services/closenessCircleService.js';
-import jsonLogic from 'json-logic-js';
 
 /**
  * Creates handlers needed for the get_close rule.

--- a/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
+++ b/tests/integration/rules/logPerceptibleEventsRule.integration.test.js
@@ -61,7 +61,7 @@ describe('core_handle_log_perceptible_events rule integration', () => {
     customEntityManager = new SimpleEntityManager([]);
     const dataRegistry = {
       getAllSystemRules: jest.fn().mockReturnValue([logPerceptibleEventsRule]),
-      getConditionDefinition: jest.fn((id) => undefined),
+      getConditionDefinition: jest.fn(() => undefined),
       getEventDefinition: jest.fn((eventName) => {
         // Return a basic event definition for common events
         const commonEvents = {

--- a/tests/integration/rules/turnStartedRule.integration.test.js
+++ b/tests/integration/rules/turnStartedRule.integration.test.js
@@ -10,6 +10,9 @@ import AddComponentHandler from '../../../src/logic/operationHandlers/addCompone
 import { TURN_STARTED_ID } from '../../../src/constants/eventIds.js';
 import { createRuleTestEnvironment } from '../../common/engine/systemLogicTestEnv.js';
 
+// Minimal condition definition used by tests
+const eventIsTurnStarted = { id: 'core:event-is-turn-started' };
+
 /**
  * Creates handlers needed for the turn_started rule.
  *


### PR DESCRIPTION
Summary: Fixed ESLint errors in three integration test modules by removing an unused import, eliminating an unused function parameter, and defining a missing constant.

Changes Made:
- Removed unused `json-logic-js` import from `getCloseRule.integration.test.js`.
- Adjusted `getConditionDefinition` mock in `logPerceptibleEventsRule.integration.test.js` to avoid unused parameter.
- Added minimal `eventIsTurnStarted` definition in `turnStartedRule.integration.test.js`.

Testing Done:
- [x] Code formatted (`npx prettier -w <files>`)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [ ] Proxy server tests pass (`cd llm-proxy-server && npm run test`) *(none required)*
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_686d5457b5ac8331af9fe9125dcf6674