### PR TITLE
[Agent] Add RetryManager edge case tests

### DIFF
--- a/tests/unit/utils/httpRetryManager.additionalBranches.test.js
+++ b/tests/unit/utils/httpRetryManager.additionalBranches.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { RetryManager } from '../../../src/utils/httpRetryManager.js';
+
+jest.useFakeTimers();
+
+/** @type {ReturnType<import('../../common/mockFactories/loggerMocks.js').createMockLogger>} */
+let logger;
+
+beforeEach(() => {
+  const {
+    createMockLogger,
+  } = require('../../common/mockFactories/loggerMocks.js');
+  logger = createMockLogger();
+});
+
+describe('RetryManager additional branches', () => {
+  it('returns false when error is not a network error', async () => {
+    const manager = new RetryManager(2, 50, 200, logger);
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const result = await manager.handleNetworkError(new Error('boom'), 1);
+    expect(result).toEqual({ retried: false });
+    expect(timeoutSpy).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns false when attempt exceeds maxRetries', async () => {
+    const manager = new RetryManager(1, 50, 200, logger);
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    const err = new TypeError('network request failed');
+    const result = await manager.handleNetworkError(err, 1);
+    expect(result).toEqual({ retried: false });
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('calculates retry delay with jitter within bounds', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const delayLow = RetryManager.calculateRetryDelay(2, 100, 500);
+    jest.spyOn(Math, 'random').mockReturnValue(1);
+    const delayHigh = RetryManager.calculateRetryDelay(2, 100, 500);
+    expect(delayLow).toBeGreaterThanOrEqual(0);
+    expect(delayHigh).toBeLessThanOrEqual(500);
+    expect(delayHigh).toBeGreaterThan(delayLow);
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `RetryManager` covering non-network errors, max retry handling, and jitter calculation

## Testing Done
- `npm run format`
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d579f46948331889f09c3027f1a48