### PR TITLE
[Agent] expand validation error tests

### DIFF
--- a/tests/unit/actions/validation/validationErrorUtils.additionalBranches.test.js
+++ b/tests/unit/actions/validation/validationErrorUtils.additionalBranches.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatValidationError } from '../../../../src/actions/validation/validationErrorUtils.js';
+
+// Custom dummy error classes so instanceof checks are false
+class SomeOtherError {}
+
+/**
+ * Additional branch coverage for formatValidationError.
+ */
+describe('formatValidationError additional branches', () => {
+  it('handles plain object errors with message property', () => {
+    const customErr = { message: 'Custom Failure' };
+    const result = formatValidationError(customErr, 'source', {});
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('source: custom Failure');
+  });
+
+  it('handles object errors lacking a message', () => {
+    const result = formatValidationError({}, 'source', {});
+    expect(result.message).toBe('source: invalid input');
+  });
+});


### PR DESCRIPTION
Summary: Added extra unit tests to exercise additional branches in `formatValidationError`, ensuring plain-object errors and missing message cases are handled.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686d5fe77e388331b5f40876f99a613e