### PR TITLE
[Agent] Fix typecheck for service initializer utils

### DIFF
--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -104,12 +104,6 @@ export function setupServiceLogger(serviceName, logger) {
  * @returns {void}
  */
 
-/**
- *
- * @param serviceName
- * @param logger
- * @param deps
- */
 export function validateServiceDeps(serviceName, logger, deps) {
   _defaultServiceSetup.validateDeps(serviceName, logger, deps);
 }
@@ -169,9 +163,11 @@ export function initializeServiceLogger(serviceName, logger, deps) {
 }
 
 /**
+ * Resolve the logger to use for an execution context.
  *
- * @param defaultLogger
- * @param executionContext
+ * @param {import('../interfaces/coreServices.js').ILogger} defaultLogger - The default logger.
+ * @param {import('../logic/defs.js').ExecutionContext} [executionContext] - Optional execution context.
+ * @returns {import('../interfaces/coreServices.js').ILogger} Logger for execution.
  */
 export function resolveExecutionLogger(defaultLogger, executionContext) {
   return _defaultServiceSetup.resolveExecutionLogger(


### PR DESCRIPTION
## Summary
- add missing JSDoc type annotations in `serviceInitializerUtils`

## Testing Done
- `npm run format`
- `npm run lint` *(fails: Cannot find package 'globals' )*
- `npm run test`
- `cd llm-proxy-server && npm run test`
- `npm run typecheck` *(fails: several existing errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_686d5fdefd00833197a140fc8cd11621