### PR TITLE
[Agent] Fix type error in objectPathUtils

### DIFF
--- a/src/utils/objectPathUtils.js
+++ b/src/utils/objectPathUtils.js
@@ -3,7 +3,7 @@
  *
  * @description Creates intermediate objects as needed but will not overwrite
  *  non-object values along the path.
- * @param {object} root - Object to modify.
+ * @param {Record<string, any>} root - Object to modify.
  * @param {string} path - Dot-separated path (e.g., 'a.b.c').
  * @param {*} value - Value to assign.
  * @returns {boolean} True if the assignment succeeded, false otherwise.


### PR DESCRIPTION
## Summary
- address type errors in objectPathUtils by specifying Record type

## Testing Done
- `npm run lint` *(fails: 576 errors, 3014 warnings)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d6d1bc5848331bdbbc7906fe3a3d8