### PR TITLE
[Agent] Resolve typecheck issue in service initializer

### DIFF
--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -103,13 +103,6 @@ export function setupServiceLogger(serviceName, logger) {
  * @param {Record<string, DependencySpec>} deps - Dependency map.
  * @returns {void}
  */
-
-/**
- *
- * @param serviceName
- * @param logger
- * @param deps
- */
 export function validateServiceDeps(serviceName, logger, deps) {
   _defaultServiceSetup.validateDeps(serviceName, logger, deps);
 }


### PR DESCRIPTION
## Summary
- clean up duplicate JSDoc for `validateServiceDeps`

## Testing Done
- `npm run lint` *(fails: 574 errors)*
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686d7ed41f948331b55891ebf3fa1b2f