### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/src/entities/config/EntityConfigProvider.js
+++ b/src/entities/config/EntityConfigProvider.js
@@ -219,13 +219,20 @@ export default class EntityConfigProvider {
     
     for (let i = 0; i < parts.length - 1; i++) {
       const part = parts[i];
+      if (part === '__proto__' || part === 'constructor') {
+        throw new Error(`Invalid configuration path: '${part}' is a reserved property name.`);
+      }
       if (!(part in current) || typeof current[part] !== 'object') {
         current[part] = {};
       }
       current = current[part];
     }
     
-    current[parts[parts.length - 1]] = value;
+    const lastPart = parts[parts.length - 1];
+    if (lastPart === '__proto__' || lastPart === 'constructor') {
+      throw new Error(`Invalid configuration path: '${lastPart}' is a reserved property name.`);
+    }
+    current[lastPart] = value;
     
     this.#logger.debug(`Configuration value set: ${path} = ${value}`);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/4](https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/4)

The `setValue` method should be modified to validate property names during recursive assignment. Specifically, reserved property names like `__proto__` and `constructor` should be blocked to prevent prototype pollution. This can be achieved by adding a check within the loop iterating over `parts`. If any property name matches the reserved keywords, the method should throw an error or ignore the assignment.

Additionally, the code should ensure that the `#config` object is created using `Object.create(null)` or similarly isolated from `Object.prototype` to further mitigate risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
