### PR TITLE
[Agent] Fix typecheck error in service initializer

### DIFF
--- a/src/utils/serviceInitializerUtils.js
+++ b/src/utils/serviceInitializerUtils.js
@@ -41,7 +41,8 @@ export class ServiceSetup {
     if (!deps) return;
 
     const checks = [];
-    for (const [depName, spec] of Object.entries(deps)) {
+    for (const depName of Object.keys(deps)) {
+      const spec = deps[depName];
       if (!spec) continue;
       checks.push({
         dependency: spec.value,


### PR DESCRIPTION
## Summary
- replace `Object.entries` usage in `ServiceSetup.validateDeps` to avoid ES2017 API

## Testing Done
- `npm run format`
- `npx eslint src/utils/serviceInitializerUtils.js`
- `npm run test` *(fails coverage thresholds)*
- `npm run test` in `llm-proxy-server`


------
https://chatgpt.com/codex/tasks/task_e_686e7cbbff588331acf2b9a00ffc10ab