### PR TITLE
[Agent] expand validator coverage

### DIFF
--- a/tests/unit/anatomy/graphIntegrityValidator.branches.test.js
+++ b/tests/unit/anatomy/graphIntegrityValidator.branches.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { GraphIntegrityValidator } from '../../../src/anatomy/graphIntegrityValidator.js';
+import { ValidationRuleChain } from '../../../src/anatomy/validation/validationRuleChain.js';
+
+/**
+ * Additional branch coverage tests for GraphIntegrityValidator
+ */
+
+describe('GraphIntegrityValidator branch cases', () => {
+  let mockEntityManager;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockEntityManager = {};
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+  });
+
+  it('logs warning when validation ends with multiple warnings', async () => {
+    const validator = new GraphIntegrityValidator({
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+    });
+
+    const executeSpy = jest
+      .spyOn(ValidationRuleChain.prototype, 'execute')
+      .mockImplementation(async (context) => {
+        context.addIssues([
+          { severity: 'warning', message: 'w1' },
+          { severity: 'warning', message: 'w2' },
+        ]);
+      });
+
+    const result = await validator.validateGraph(['e1'], {}, new Set());
+
+    executeSpy.mockRestore();
+
+    expect(result).toEqual({ valid: true, errors: [], warnings: ['w1', 'w2'] });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'GraphIntegrityValidator: Validation passed with 2 warnings'
+    );
+  });
+
+  it('logs error when validation produces errors', async () => {
+    const validator = new GraphIntegrityValidator({
+      entityManager: mockEntityManager,
+      logger: mockLogger,
+    });
+
+    const executeSpy = jest
+      .spyOn(ValidationRuleChain.prototype, 'execute')
+      .mockImplementation(async (context) => {
+        context.addIssues([{ severity: 'error', message: 'boom' }]);
+      });
+
+    const result = await validator.validateGraph(['e2'], {}, new Set());
+
+    executeSpy.mockRestore();
+
+    expect(result).toEqual({ valid: false, errors: ['boom'], warnings: [] });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'GraphIntegrityValidator: Validation failed with 1 errors'
+    );
+  });
+});


### PR DESCRIPTION
Summary: Added new unit tests to cover additional warning and error branches in `GraphIntegrityValidator`. These tests mock the rule chain to simulate multiple warnings and errors, exercising logger paths not previously covered.

Testing Done:
- [x] Code formatted `npm run format`
- [x] Lint passes `npm run lint`
- [x] Root tests `npm run test`
- [x] Proxy tests `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686e7cafeaec8331926c0c99c563e5ff