### PR TITLE
[Agent] Fix lint issues in error modules

### DIFF
--- a/src/errors/duplicateEntityError.js
+++ b/src/errors/duplicateEntityError.js
@@ -10,6 +10,8 @@
  */
 export class DuplicateEntityError extends Error {
   /**
+   * Create a new DuplicateEntityError instance.
+   *
    * @param {string} entityId - The ID of the entity that already exists.
    * @param {string} [message] - Optional custom error message.
    */

--- a/src/errors/entityNotFoundError.js
+++ b/src/errors/entityNotFoundError.js
@@ -11,6 +11,8 @@
  */
 export class EntityNotFoundError extends Error {
   /**
+   * Create a new EntityNotFoundError instance.
+   *
    * @param {string} instanceId - The ID of the instance that was not found.
    */
   constructor(instanceId) {

--- a/src/errors/fetchError.js
+++ b/src/errors/fetchError.js
@@ -10,6 +10,8 @@
  */
 export class FetchError extends Error {
   /**
+   * Create a new FetchError instance.
+   *
    * @param {string} message - Description of the fetch failure.
    * @param {string} [path] - Path or URL that failed to fetch.
    */


### PR DESCRIPTION
## Summary
- correct missing constructor descriptions in error classes

## Testing
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686e7cb6b3f883319da25c1fa9dbe42d