### PR TITLE
[Test] Improve validation utils branch coverage

### DIFF
--- a/tests/unit/turns/states/helpers/validationUtils.additionalBranches.test.js
+++ b/tests/unit/turns/states/helpers/validationUtils.additionalBranches.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+  assertMatchingActor,
+  validateContextMethods,
+  validateActorInContext,
+  retrieveStrategyFromContext,
+  validateCommandString,
+  validateTurnAction,
+} from '../../../../../src/turns/states/helpers/validationUtils.js';
+
+const makeActor = (id = 'a1') => ({ id });
+
+describe('validationUtils additional branches', () => {
+  test('assertMatchingActor detects invalid expected actor', () => {
+    const result = assertMatchingActor(null, makeActor(), 'State');
+    expect(result).toMatch(/invalid actorEntity/);
+  });
+
+  test('assertMatchingActor detects invalid context actor', () => {
+    const result = assertMatchingActor(makeActor(), null, 'State');
+    expect(result).toMatch(/invalid actorEntity/);
+  });
+
+  test('validateContextMethods returns all when context missing', () => {
+    expect(validateContextMethods(null, ['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  test('validateActorInContext throws on mismatched actor', () => {
+    const ctx = { getActor: () => makeActor('a2') };
+    expect(() => validateActorInContext(ctx, makeActor('a1'), 'State')).toThrow(
+      /does not match/
+    );
+  });
+
+  test('retrieveStrategyFromContext throws when context invalid', () => {
+    expect(() =>
+      retrieveStrategyFromContext({}, makeActor('a1'), 'State')
+    ).toThrow(/does not provide getStrategy/);
+  });
+
+  test('validateCommandString reports non-string input', () => {
+    const onError = jest.fn();
+    validateCommandString(5, onError);
+    expect(onError).toHaveBeenCalledWith(
+      'commandString must be a non-empty string.'
+    );
+  });
+
+  test('validateCommandString reports blank string', () => {
+    const onError = jest.fn();
+    validateCommandString('   ', onError);
+    expect(onError).toHaveBeenCalledWith(
+      'commandString must be a non-empty string.'
+    );
+  });
+
+  test('validateCommandString passes valid string', () => {
+    const onError = jest.fn();
+    validateCommandString('go', onError);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('validateTurnAction handles null', () => {
+    const onError = jest.fn();
+    validateTurnAction(null, onError);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('validateTurnAction handles non-object', () => {
+    const onError = jest.fn();
+    validateTurnAction('bad', onError);
+    expect(onError).toHaveBeenCalledWith('turnAction must be an object.');
+  });
+
+  test('validateTurnAction validates actionDefinitionId', () => {
+    const onError = jest.fn();
+    validateTurnAction({}, onError);
+    expect(onError).toHaveBeenCalledWith(
+      'turnAction.actionDefinitionId must be a non-empty string.'
+    );
+  });
+
+  test('validateTurnAction accepts valid action', () => {
+    const onError = jest.fn();
+    validateTurnAction({ actionDefinitionId: 'id1' }, onError);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary: Added comprehensive tests for validation utils functions covering invalid parameter branches and edge cases.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` - existing warnings)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke run (`npm run start`)


------
https://chatgpt.com/codex/tasks/task_e_686e8974f2888331963179a90fb04585