### PR TITLE
[Agent] fix lint issues in select modules

### DIFF
--- a/tests/integration/scopes/closenessCircleScope.test.js
+++ b/tests/integration/scopes/closenessCircleScope.test.js
@@ -2,7 +2,7 @@
  * @file Focused test for closeness circle scope resolution
  */
 
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import ScopeEngine from '../../../src/scopeDsl/engine.js';
 import ScopeRegistry from '../../../src/scopeDsl/scopeRegistry.js';
 import { parseDslExpression } from '../../../src/scopeDsl/parser/parser.js';

--- a/tests/registrations/registerAI.test.js
+++ b/tests/registrations/registerAI.test.js
@@ -3,7 +3,6 @@ import AppContainer from '../../src/dependencyInjection/appContainer.js';
 import { registerAI } from '../../src/dependencyInjection/registrations/aiRegistrations.js';
 import { tokens } from '../../src/dependencyInjection/tokens.js';
 import { ConfigurableLLMAdapter } from '../../src/turns/adapters/configurableLLMAdapter.js';
-import ActorTurnHandler from '../../src/turns/handlers/actorTurnHandler.js';
 
 describe('registerAI', () => {
   /** @type {AppContainer} */

--- a/tests/registrations/registerTurnLifecycle.test.js
+++ b/tests/registrations/registerTurnLifecycle.test.js
@@ -3,7 +3,6 @@ import AppContainer from '../../src/dependencyInjection/appContainer.js';
 import { registerTurnLifecycle } from '../../src/dependencyInjection/registrations/turnLifecycleRegistrations.js';
 import { tokens } from '../../src/dependencyInjection/tokens.js';
 import TurnManager from '../../src/turns/turnManager.js';
-import { TurnOrderService } from '../../src/turns/order/turnOrderService.js';
 import TurnHandlerResolver from '../../src/turns/services/turnHandlerResolver.js';
 import { ConcreteTurnStateFactory } from '../../src/turns/factories/concreteTurnStateFactory.js';
 


### PR DESCRIPTION
## Summary
- clean up unused imports in test modules to fix lint errors

## Testing
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686e8f0d88cc83319dd8e55b1c812e7a