### PR TITLE
[Agent] Expand short-term memory service tests

### DIFF
--- a/tests/unit/services/shortTermMemoryService.infinity.test.js
+++ b/tests/unit/services/shortTermMemoryService.infinity.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import ShortTermMemoryService from '../../../src/ai/shortTermMemoryService.js';
+
+describe('ShortTermMemoryService additional branches', () => {
+  it('treats Infinity maxEntries as invalid and falls back to default', () => {
+    const service = new ShortTermMemoryService({ defaultMaxEntries: 2 });
+    const mem = { entityId: 'actor:1', thoughts: [], maxEntries: Infinity };
+
+    service.addThought(mem, 'a', new Date('2025-06-01T00:00:00Z'));
+    service.addThought(mem, 'b', new Date('2025-06-01T00:01:00Z'));
+    service.addThought(mem, 'c', new Date('2025-06-01T00:02:00Z'));
+
+    expect(mem.thoughts.map((t) => t.text)).toEqual(['b', 'c']);
+  });
+});


### PR DESCRIPTION
Summary: Added a new unit test covering the case where `maxEntries` is `Infinity` in `ShortTermMemoryService`. This ensures fallback to `defaultMaxEntries` occurs when an invalid limit is provided.

Testing Done:
- [x] Code formatted     `npm run format`
- [x] Lint passes        `npm run lint`
- [x] Root tests         `npm run test`
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [x] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686e8f069390833192fd3407d2535465