### PR TITLE
[Agent] fix type errors in persistence utils

### DIFF
--- a/src/utils/persistenceErrorUtils.js
+++ b/src/utils/persistenceErrorUtils.js
@@ -39,8 +39,14 @@ export function executePersistenceOp({
   }
 
   if (asyncOperation) {
-    return safeExecute(op, logger, context).then(
-      ({ success, result, error }) => {
+    return /** @type {Promise<import('./safeExecutionUtils.js').ExecutionResult>} */ (
+      safeExecute(op, logger, context)
+    ).then(
+      /**
+       * @param {import('./safeExecutionUtils.js').ExecutionResult} res
+       */
+      (res) => {
+        const { success, result, error } = res;
         if (success) {
           return result;
         }
@@ -53,7 +59,10 @@ export function executePersistenceOp({
     );
   }
 
-  const { success, result, error } = safeExecute(op, logger, context);
+  const { success, result, error } =
+    /** @type {import('./safeExecutionUtils.js').ExecutionResult} */ (
+      safeExecute(op, logger, context)
+    );
 
   if (success) {
     return createPersistenceSuccess(result);


### PR DESCRIPTION
## Summary
- add typedef for ExecutionResult in safeExecutionUtils
- use ExecutionResult type in safeExecute and persistenceErrorUtils

## Testing Done
- `npm run test`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686e91aa7c9083319f53438f59feb120