### PR TITLE
[Agent] Fix lint issues in three modules

### DIFF
--- a/src/actions/actionFormatter.js
+++ b/src/actions/actionFormatter.js
@@ -30,7 +30,8 @@ import { targetFormatterMap } from './formatters/targetFormatters.js';
 /** @typedef {import('./formatters/formatActionTypedefs.js').TargetFormatterMap} TargetFormatterMap */
 
 /**
- * @description Builds a standardized formatting error result.
+ * Builds a standardized formatting error result.
+ *
  * @param {string} message - Human readable error message.
  * @param {object} [details] - Additional error details.
  * @returns {FormatActionError} Result object describing the error.
@@ -40,7 +41,8 @@ function buildFormatError(message, details) {
 }
 
 /**
- * @description Normalizes formatter results to a standard object shape.
+ * Normalizes formatter results to a standard object shape.
+ *
  * @param {string | FormatActionCommandResult} result - Raw formatter result.
  * @returns {FormatActionCommandResult} Normalized result.
  */
@@ -49,7 +51,8 @@ function normalizeFormatResult(result) {
 }
 
 /**
- * @description Checks required inputs for {@link formatActionCommand}.
+ * Checks required inputs for {@link formatActionCommand}.
+ *
  * @param {ActionDefinition} actionDefinition - Action definition to check.
  * @param {ActionTargetContext} targetContext - Target context for formatting.
  * @param {EntityManager} entityManager - Entity manager for lookups.
@@ -100,7 +103,8 @@ function checkFormatInputs(
 }
 
 /**
- * @description Applies the appropriate target formatter and handles errors.
+ * Applies the appropriate target formatter and handles errors.
+ *
  * @param {string} command - The command template string.
  * @param {ActionTargetContext} targetContext - Context describing the target.
  * @param {object} options - Bundled options.
@@ -159,7 +163,8 @@ function applyTargetFormatter(command, targetContext, options) {
 }
 
 /**
- * @description Finalizes a formatted command result.
+ * Finalizes a formatted command result.
+ *
  * @param {string} command - Command string to return.
  * @param {ILogger} logger - Logger for debug output.
  * @param {boolean} debug - If true, debug logging is enabled.
@@ -259,7 +264,7 @@ function formatActionCommand(
  * Default implementation of {@link IActionCommandFormatter}.
  *
  * @class ActionCommandFormatter
- * @description Formats action commands using the standard logic.
+ * Formats action commands using the standard logic.
  * @augments IActionCommandFormatter
  */
 export default class ActionCommandFormatter extends IActionCommandFormatter {

--- a/src/actions/formatters/targetFormatters.js
+++ b/src/actions/formatters/targetFormatters.js
@@ -19,7 +19,8 @@ import {
 /** @typedef {import('./formatActionTypedefs.js').TargetFormatterMap} TargetFormatterMap */
 
 /**
- * @description Replaces the `{target}` placeholder using entity information.
+ * Replaces the `{target}` placeholder using entity information.
+ *
  * @param {string} command - The command template string.
  * @param {ActionTargetContext} context - Target context with `entityId`.
  * @param {{
@@ -62,7 +63,8 @@ export function formatEntityTarget(
 }
 
 /**
- * @description Handles templates without a target.
+ * Handles templates without a target.
+ *
  * @param {string} command - The command template string.
  * @param {ActionTargetContext} _context - Context of type `none` (unused).
  * @param {{ actionId: string, logger: ILogger, debug: boolean }} deps - Logger and flags.
@@ -92,7 +94,7 @@ export function formatNoneTarget(
  * correspond to constants in {@link ../constants/actionTargetTypes.js}.
  *
  * Consumers may provide their own map as the final argument to
- * {@link formatActionCommand} to customize how placeholders are resolved.
+ * See `formatActionCommand` to customize how placeholders are resolved.
  *
  * Example:
  * ```js

--- a/src/ai/thoughtPersistenceHook.js
+++ b/src/ai/thoughtPersistenceHook.js
@@ -24,7 +24,8 @@ import { isNonBlankString } from '../utils/textUtils.js';
  *   – Optional dispatcher for error events.
  * @param {ShortTermMemoryService} [stmService] – Optional STM service instance.
  * @param {Date} [now] – Date provider for timestamping.
- * @param componentAccess
+ * @param {ComponentAccessService} [componentAccess]
+ *   – Service used to fetch and apply entity components.
  */
 export function persistThoughts(
   action,


### PR DESCRIPTION
## Summary
- update JSDoc for component access in `thoughtPersistenceHook`
- remove unused `@description` tags in `actionFormatter` and `targetFormatters`
- clarify doc link in `targetFormatters`

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm install && npm run format && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e953f3018833182051a269ad0965c