### PR TITLE
[Fix] Resolve typecheck errors in utils

### DIFF
--- a/src/utils/schemaValidationUtils.js
+++ b/src/utils/schemaValidationUtils.js
@@ -78,7 +78,7 @@ export function validateAgainstSchema(
   if (!validationResult.isValid) {
     const computedFailureMsg =
       typeof failureMessage === 'function'
-        ? failureMessage(validationResult.errors)
+        ? failureMessage(validationResult.errors ?? [])
         : failureMessage;
     const errorDetails = formatAjvErrors(validationResult.errors);
     if (computedFailureMsg) {

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -54,11 +54,22 @@ export function snakeToCamel(str) {
 /**
  * Checks that a string is non-empty after trimming.
  *
- * @param {any} str
- * @returns {boolean}
+ * @param {any} str - Value to evaluate.
+ * @returns {boolean} True if `str` is a non-blank string.
  */
 export function isNonBlankString(str) {
   return typeof str === 'string' && Boolean(str.trim());
+}
+
+/**
+ * Pads a number with leading zeros to at least two digits.
+ *
+ * @param {number} num - Number to pad.
+ * @returns {string} Padded string representation.
+ */
+function padTwo(num) {
+  const str = String(num);
+  return str.length < 2 ? '0'.repeat(2 - str.length) + str : str;
 }
 
 /**
@@ -80,13 +91,7 @@ export function formatPlaytime(totalSeconds) {
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = Math.floor(totalSeconds % 60);
 
-  return (
-    String(hours).padStart(2, '0') +
-    ':' +
-    String(minutes).padStart(2, '0') +
-    ':' +
-    String(seconds).padStart(2, '0')
-  );
+  return padTwo(hours) + ':' + padTwo(minutes) + ':' + padTwo(seconds);
 }
 
 /**


### PR DESCRIPTION
Summary: Addressed issues flagged by `npm run typecheck`.

Changes Made:
- `schemaValidationUtils.js` now safely passes an empty array when `ValidationResult.errors` is null.
- Added `padTwo` helper in `textUtils.js` and updated `formatPlaytime` to use it.
- Improved JSDoc for `isNonBlankString`.

Testing Done:
- [x] Code formatted (`npx prettier` on changed files)
- [x] Lint passes (`npm run lint`)
- [x] Root tests pass (`npm run test`)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)


------
https://chatgpt.com/codex/tasks/task_e_686ea8e34e188331aab0d2b309d790fe