### PR TITLE
[Agent] Fix type errors in save file utilities

### DIFF
--- a/src/utils/saveFileReadUtils.js
+++ b/src/utils/saveFileReadUtils.js
@@ -31,7 +31,8 @@ export async function readSaveFile(storageProvider, logger, filePath) {
       } catch (error) {
         const userMsg = MSG_FILE_READ_ERROR;
         logger.error(`Error reading file ${filePath}:`, error);
-        const details = error?.code || error?.message;
+        const errObj = /** @type {{code?: string; message?: string}} */ (error);
+        const details = errObj?.code || errObj?.message;
         const errMsg = details ? `${userMsg} (${details})` : userMsg;
         return {
           ...createPersistenceFailure(
@@ -97,7 +98,11 @@ export async function readAndDeserialize(
       const readRes = await readSaveFile(storageProvider, logger, filePath);
       if (!readRes.success) return readRes;
 
-      return deserializeAndDecompress(serializer, logger, readRes.data);
+      return deserializeAndDecompress(
+        serializer,
+        logger,
+        /** @type {Uint8Array} */ (readRes.data)
+      );
     },
     logger,
   });


### PR DESCRIPTION
## Summary
- improve error handling types in `saveFileReadUtils`
- cast data after checking read result

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686f24a0ee388331abf28a3d5241bc74