### PR TITLE
[Agent] Fix lint errors in selected tests

### DIFF
--- a/tests/integration/rules/turnAroundRule.integration.test.js
+++ b/tests/integration/rules/turnAroundRule.integration.test.js
@@ -155,11 +155,10 @@ describe('intimacy_handle_turn_around rule integration', () => {
 
       // Check that facing_away component was created
       const target = testEnv.entityManager.getEntityInstance('target1');
-      if (target?.components['intimacy:facing_away']) {
-        expect(
-          target.components['intimacy:facing_away'].facing_away_from
-        ).toContain('actor1');
-      }
+      expect(target?.components['intimacy:facing_away']).toBeDefined();
+      expect(
+        target.components['intimacy:facing_away'].facing_away_from
+      ).toContain('actor1');
 
       // Only check for events that should exist if rule worked
       expect(types).toContain('intimacy:actor_turned_around');

--- a/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
+++ b/tests/integration/scopes/actionDiscoveryIntegration.integration.test.js
@@ -24,7 +24,6 @@ import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionPars
 import {
   LEADING_COMPONENT_ID,
   POSITION_COMPONENT_ID,
-  NAME_COMPONENT_ID,
   EXITS_COMPONENT_ID,
   ACTOR_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
@@ -171,11 +170,9 @@ describe('Scope Integration Tests', () => {
       logger,
       gameDataRepository,
     });
-    const domainContextCompatibilityChecker = { check: () => true };
-
     // FIX: Create a valid mock for PrerequisiteEvaluationService
     const prerequisiteEvaluationService = {
-      evaluate: jest.fn((_p1, _p2, _p3, _p4) => true),
+      evaluate: jest.fn(() => true),
     };
 
     const validatedEventDispatcher = {

--- a/tests/integration/scopes/environmentScope.integration.test.js
+++ b/tests/integration/scopes/environmentScope.integration.test.js
@@ -23,7 +23,6 @@ import { parseScopeDefinitions } from '../../../src/scopeDsl/scopeDefinitionPars
 import DefaultDslParser from '../../../src/scopeDsl/parser/defaultDslParser.js';
 import {
   POSITION_COMPONENT_ID,
-  NAME_COMPONENT_ID,
   ACTOR_COMPONENT_ID,
 } from '../../../src/constants/componentIds.js';
 import fs from 'fs';
@@ -125,10 +124,9 @@ describe('Scope Integration Tests', () => {
       logger,
       gameDataRepository,
     });
-    const domainContextCompatibilityChecker = { check: () => true };
     // FIX: Ensure the mock has a function with the correct arity
     const prerequisiteEvaluationService = {
-      evaluate: (_p1, _p2, _p3, _p4) => true,
+      evaluate: () => true,
     };
     const validatedEventDispatcher = {
       dispatch: () => {},

--- a/tests/unit/anatomy/anatomyDescriptionService.entityFinder.test.js
+++ b/tests/unit/anatomy/anatomyDescriptionService.entityFinder.test.js
@@ -1,10 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { AnatomyDescriptionService } from '../../../src/anatomy/anatomyDescriptionService.js';
-import {
-  ANATOMY_BODY_COMPONENT_ID,
-  ANATOMY_PART_COMPONENT_ID,
-  DESCRIPTION_COMPONENT_ID,
-} from '../../../src/constants/componentIds.js';
 
 describe('AnatomyDescriptionService - EntityFinder method calls', () => {
   let service;


### PR DESCRIPTION
## Summary
- fix conditional expect in turnAroundRule test
- drop unused constants and mocks in scope integration tests
- clean unused imports in anatomyDescriptionService entityFinder test

## Testing Done
- `npm run lint` *(fails: 542 errors)*
- `npm run test` *(fails coverage thresholds but suites pass)*
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686f2497f0b48331916b2da44684db1e