### PR TITLE
[Agent] Resolve lint warnings in selected modules

### DIFF
--- a/scripts/updateManifest.js
+++ b/scripts/updateManifest.js
@@ -181,6 +181,7 @@ async function getAllModNames() {
  * Update the manifest for a specific mod
  *
  * @param {string} modName - The name of the mod to update
+ * @returns {Promise<boolean>} Resolves to true on success, false on failure
  */
 async function updateModManifest(modName) {
   console.log(`Starting manifest update for mod: "${modName}"`);

--- a/src/actions/tracing/traceContext.js
+++ b/src/actions/tracing/traceContext.js
@@ -11,16 +11,8 @@ export const TRACE_ERROR = 'error';
 export const TRACE_DATA = 'data';
 
 /**
- * @typedef {(
- *   typeof TRACE_INFO |
- *   typeof TRACE_SUCCESS |
- *   typeof TRACE_FAILURE |
- *   typeof TRACE_STEP |
- *   typeof TRACE_ERROR |
- *   typeof TRACE_DATA
- * )} LogEntryType
- * 'step' - A major stage in the process.
- * 'data' - Logs a significant data structure (e.g., context, AST).
+ * @typedef {'info' | 'success' | 'failure' | 'step' | 'error' | 'data'} LogEntryType
+ * Classification of a trace log entry.
  */
 
 /**

--- a/src/actions/validation/conditionReferenceResolver.js
+++ b/src/actions/validation/conditionReferenceResolver.js
@@ -3,7 +3,8 @@ import { resolveConditionRefs } from '../../utils/conditionRefResolver.js';
 /** @typedef {import("../../interfaces/coreServices.js").ILogger} ILogger */
 /** @typedef {import("../../data/gameDataRepository.js").GameDataRepository} GameDataRepository */
 /**
- * @description Recursively resolves condition references inside a JSON Logic rule.
+ * Recursively resolves condition references inside a JSON Logic rule.
+ *
  * @param {object | any} logic - The logic tree or value to resolve.
  * @param {GameDataRepository} gameDataRepository - Repository providing condition definitions.
  * @param {ILogger} logger - Logger used for debug output. Only the `debug` method is utilized.


### PR DESCRIPTION
## Summary
- add missing `@returns` annotation in updateManifest script
- simplify typedef in traceContext
- clean up JSDoc comment in conditionReferenceResolver

## Testing Done
- `npm run lint`
- `npm run test`
- `cd llm-proxy-server && npm run lint`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686f2dccd6008331b5dfe8a0dff31801