### PR TITLE
[Agent] Fix type errors in ruleCacheUtils

### DIFF
--- a/src/utils/ruleCacheUtils.js
+++ b/src/utils/ruleCacheUtils.js
@@ -31,7 +31,7 @@ export function buildRuleCache(rules, logger) {
       continue;
     }
 
-    /** @type {RuleBucket} */
+    /** @type {RuleBucket | undefined} */
     let bucket = cache.get(rule.event_type);
     if (!bucket) {
       bucket = { catchAll: [], byAction: new Map() };
@@ -54,10 +54,12 @@ export function buildRuleCache(rules, logger) {
     }
 
     if (rule.event_type === ATTEMPT_ACTION_ID && constId) {
-      (
-        bucket.byAction.get(constId) ??
-        bucket.byAction.set(constId, []).get(constId)
-      ).push(rule);
+      let rulesForId = bucket.byAction.get(constId);
+      if (!rulesForId) {
+        rulesForId = [];
+        bucket.byAction.set(constId, rulesForId);
+      }
+      rulesForId.push(rule);
     } else {
       bucket.catchAll.push(rule);
     }


### PR DESCRIPTION
## Summary
- fix type inference for rule buckets in `ruleCacheUtils`
- ensure arrays exist before pushing rules

## Testing Done
- `npm run format`
- `npx eslint src/utils/ruleCacheUtils.js`
- `node_modules/.bin/jest --runInBand --env=jsdom --silent`
- `cd llm-proxy-server && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686f2dc622088331894a5b76383eefd7