### PR TITLE
[Fix] Resolve lint errors in validation modules

### DIFF
--- a/src/actions/validation/prerequisiteEvaluationService.js
+++ b/src/actions/validation/prerequisiteEvaluationService.js
@@ -222,9 +222,10 @@ export class PrerequisiteEvaluationService extends BaseService {
                 `has ${componentCount} components available.`
             );
           }
-        } catch (error) {
+        } catch (err) {
           this.#logger.debug(
-            `${this.#logPrefix(actionId)}: Could not serialize components for validation logging`
+            `${this.#logPrefix(actionId)}: Could not serialize components for validation logging`,
+            err
           );
         }
       }

--- a/src/actions/validation/validationErrorUtils.js
+++ b/src/actions/validation/validationErrorUtils.js
@@ -3,23 +3,16 @@
  * @description Helper utilities for formatting action validation errors.
  */
 
+import { InvalidActionDefinitionError } from '../../errors/invalidActionDefinitionError.js';
+import { InvalidActorEntityError } from '../../errors/invalidActorEntityError.js';
+
 /**
  * Formats an Error thrown by validateActionInputs for a consistent message.
  *
  * @param {Error} err - The original error.
  * @param {string} source - Label for the calling function.
- * @param {{actionId?: string, actorId?: string}} ids
- * Identifier info used in the message. The `contextType` property is no longer used.
+ * @param {{actionId?: string, actorId?: string}} ids Identifier info used in the message. The `contextType` property is no longer used.
  * @returns {Error} A new Error instance with the formatted message.
- */
-import { InvalidActionDefinitionError } from '../../errors/invalidActionDefinitionError.js';
-import { InvalidActorEntityError } from '../../errors/invalidActorEntityError.js';
-
-/**
- *
- * @param err
- * @param source
- * @param ids
  */
 export function formatValidationError(err, source, ids) {
   let idInfo = '';

--- a/src/errors/invalidActionDefinitionError.js
+++ b/src/errors/invalidActionDefinitionError.js
@@ -10,6 +10,8 @@
  */
 export class InvalidActionDefinitionError extends Error {
   /**
+   * Constructs a new InvalidActionDefinitionError instance.
+   
    * @param {string} [message] - Optional custom message.
    */
   constructor(message = 'Invalid actionDefinition') {

--- a/tests/unit/services/prerequisiteEvaluationService.serialization.test.js
+++ b/tests/unit/services/prerequisiteEvaluationService.serialization.test.js
@@ -83,7 +83,8 @@ describe('PrerequisiteEvaluationService serialization edge cases', () => {
     );
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      'PrerequisiteEvaluationService: PrereqEval[act]: Could not serialize components for validation logging'
+      'PrerequisiteEvaluationService: PrereqEval[act]: Could not serialize components for validation logging',
+      expect.any(Error)
     );
   });
 });


### PR DESCRIPTION
Summary: Addressed ESLint warnings in key validation modules and updated corresponding tests.

Changes Made:
- Added missing JSDoc and corrected tag formatting in `validationErrorUtils.js`.
- Updated error handling in `prerequisiteEvaluationService.js` to log serialization errors with the caught exception.
- Documented constructor in `invalidActionDefinitionError.js`.
- Adjusted serialization test to expect the logged Error argument.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npm run test` in root)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation

------
https://chatgpt.com/codex/tasks/task_e_686f35602ff083318f51cb5c6c939230