### PR TITLE
[Test] Increase coverage for load slot utilities

### DIFF
--- a/tests/unit/utils/compareLoadSlots.test.js
+++ b/tests/unit/utils/compareLoadSlots.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from '@jest/globals';
+import { compareLoadSlots } from '../../../src/utils/loadSlotUtils.js';
+
+describe('compareLoadSlots', () => {
+  it('places corrupted slots after non-corrupted ones', () => {
+    const a = { isCorrupted: true };
+    const b = { isCorrupted: false };
+    expect(compareLoadSlots(a, b)).toBe(1);
+    expect(compareLoadSlots(b, a)).toBe(-1);
+  });
+
+  it('orders corrupted slots alphabetically', () => {
+    const first = { isCorrupted: true, identifier: 'b' };
+    const second = { isCorrupted: true, saveName: 'a' };
+    // 'b' should come after 'a'
+    expect(compareLoadSlots(first, second)).toBeGreaterThan(0);
+    expect(compareLoadSlots(second, first)).toBeLessThan(0);
+  });
+
+  it('orders by timestamp when neither slot is corrupted', () => {
+    const older = { isCorrupted: false, timestamp: '2023-01-01T00:00:00Z' };
+    const newer = { isCorrupted: false, timestamp: '2023-02-01T00:00:00Z' };
+    expect(compareLoadSlots(older, newer)).toBeGreaterThan(0);
+    expect(compareLoadSlots(newer, older)).toBeLessThan(0);
+  });
+
+  it('returns 0 when timestamp access throws', () => {
+    const throwing = {
+      isCorrupted: false,
+      get timestamp() {
+        throw new Error('bad');
+      },
+    };
+    const other = { isCorrupted: false, timestamp: '2023-01-01T00:00:00Z' };
+    expect(compareLoadSlots(throwing, other)).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary: Added missing unit tests for `compareLoadSlots` to improve branch coverage of load slot utilities.

Changes Made:
- Created `tests/unit/utils/compareLoadSlots.test.js` covering corrupted slot ordering, timestamp ordering, and error handling branches.

Testing Done:
- [x] Code formatted (`npm run format`)
- [x] Lint passes (`npm run lint` in root and `llm-proxy-server`)
- [x] Root tests pass (`npx jest` with coverage thresholds disabled)
- [x] Proxy server tests pass (`cd llm-proxy-server && npm run test`)
- [ ] Manual smoke test / User validation


------
https://chatgpt.com/codex/tasks/task_e_686f355ba03883319af62b9e26d6a10e