### PR TITLE
[Agent] Fix lint in selected tests

### DIFF
--- a/tests/integration/scopes/entityComponentAccessInScopes.integration.test.js
+++ b/tests/integration/scopes/entityComponentAccessInScopes.integration.test.js
@@ -193,16 +193,13 @@ describe('Entity Component Access in Scope Filtering Integration', () => {
       });
 
       // Create NPC at same location
-      const targetEntity = entityManager.createEntityInstance(
-        'test:character',
-        {
-          instanceId: targetId,
-          componentOverrides: {
-            [POSITION_COMPONENT_ID]: { locationId },
-            [NAME_COMPONENT_ID]: { text: 'Friendly NPC' },
-          },
-        }
-      );
+      entityManager.createEntityInstance('test:character', {
+        instanceId: targetId,
+        componentOverrides: {
+          [POSITION_COMPONENT_ID]: { locationId },
+          [NAME_COMPONENT_ID]: { text: 'Friendly NPC' },
+        },
+      });
 
       // Manually build spatial index to ensure it's populated
       spatialIndexManager.buildIndex(entityManager);

--- a/tests/integration/scopes/realInfrastructureActionDiscovery.integration.test.js
+++ b/tests/integration/scopes/realInfrastructureActionDiscovery.integration.test.js
@@ -16,7 +16,6 @@ import ValidatedEventDispatcher from '../../../src/events/validatedEventDispatch
 import EventBus from '../../../src/events/eventBus.js';
 import { GameDataRepository } from '../../../src/data/gameDataRepository.js';
 import InMemoryDataRegistry from '../../../src/data/inMemoryDataRegistry.js';
-import AjvSchemaValidator from '../../../src/validation/ajvSchemaValidator.js';
 import EntityDefinition from '../../../src/entities/entityDefinition.js';
 import {
   POSITION_COMPONENT_ID,
@@ -220,7 +219,7 @@ describe('Spatial Index Synchronization Timing Bug', () => {
     });
 
     // CONNECT SpatialIndexSynchronizer FIRST (this is the correct order)
-    const synchronizer = new SpatialIndexSynchronizer({
+    new SpatialIndexSynchronizer({
       spatialIndexManager,
       safeEventDispatcher: sharedEventDispatcher,
       logger,

--- a/tests/unit/actions/validation/validationErrorUtils.additionalBranches.test.js
+++ b/tests/unit/actions/validation/validationErrorUtils.additionalBranches.test.js
@@ -1,9 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { formatValidationError } from '../../../../src/actions/validation/validationErrorUtils.js';
 
-// Custom dummy error classes so instanceof checks are false
-class SomeOtherError {}
-
 /**
  * Additional branch coverage for formatValidationError.
  */


### PR DESCRIPTION
Summary: Fixed lint issues in three test modules by removing unused variables and imports. This cleans up ESLint warnings/errors without altering test behavior.

Testing Done:
- [x] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint` *(fails: 538 errors remain)*
- [ ] Root tests         `npm run test` *(fails)*
- [x] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

🚫 tests failing—needs human review

------
https://chatgpt.com/codex/tasks/task_e_686fd1ccefb0833193c6c43fe8eda31e