### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/tests/integration/services/promptElementAssemblers/notesSectionAssembler.integration.test.js
+++ b/tests/integration/services/promptElementAssemblers/notesSectionAssembler.integration.test.js
@@ -160,7 +160,6 @@ describe('NotesSectionAssembler - Integration Tests', () => {
       const advancedResolver = {
         resolve: (str, context) => {
           return str
-            .replace(/\\n/g, '\\n')
             .replace('{{location}}', context.location)
             .replace('{{level}}', context.level);
         },


### PR DESCRIPTION
Potential fix for [https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/5](https://github.com/joeloverbeck/living-narrative-engine/security/code-scanning/5)

To resolve the issue, the redundant replacement operation should be removed or corrected to perform a meaningful transformation. Given that the resolver aims to manipulate strings based on the provided context, we will remove the `str.replace(/\\n/g, '\\n')` line entirely, as it does not contribute to the resolver's logic. No additional imports or dependencies are needed to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
