### PR TITLE
[Agent] Add integration coverage for throttleUtils generateKey

### DIFF
--- a/tests/integration/utils/throttleUtils.integration.test.js
+++ b/tests/integration/utils/throttleUtils.integration.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { generateKey } from '../../../src/utils/throttleUtils.js';
+
+describe('throttleUtils.generateKey integration', () => {
+  it('combines message with status code and url details', () => {
+    const key = generateKey('Request failed', {
+      statusCode: 503,
+      url: '/api/status',
+    });
+
+    expect(key).toBe('Request failed::503::/api/status');
+  });
+
+  it('falls back to empty placeholders when details are missing', () => {
+    const key = generateKey('An unexpected issue occurred');
+
+    expect(key).toBe('An unexpected issue occurred::::');
+  });
+
+  it('uses empty segments for undefined detail fields', () => {
+    const key = generateKey('Partial details', {
+      statusCode: undefined,
+      url: '/health',
+    });
+
+    expect(key).toBe('Partial details::::/health');
+  });
+});


### PR DESCRIPTION
## Summary
- add an integration test suite for the throttleUtils generateKey helper
- cover combinations of alert details to ensure deduplication key segments are produced correctly

## Testing
- npx jest --config jest.config.integration.js --env=jsdom --coverage --collectCoverageFrom=src/utils/throttleUtils.js tests/integration/utils/throttleUtils.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cec808c8c88331ade58945261657c7