### PR TITLE
[Agent] Add debug flag integration coverage for target formatters

### DIFF
--- a/tests/integration/actions/formatters/targetFormatters.debugFlag.integration.test.js
+++ b/tests/integration/actions/formatters/targetFormatters.debugFlag.integration.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { formatEntityTarget } from '../../../../src/actions/formatters/targetFormatters.js';
+
+const createLogger = () => ({
+  warn: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('targetFormatters debug flag integration', () => {
+  let logger;
+  let entityManager;
+  let displayNameFn;
+
+  beforeEach(() => {
+    logger = createLogger();
+    entityManager = { getEntityInstance: jest.fn() };
+    displayNameFn = jest.fn();
+  });
+
+  it('suppresses debug logging when the entity exists but debug flag is false', () => {
+    const context = { entityId: 'npc-007' };
+    const entity = { id: 'npc-007' };
+    entityManager.getEntityInstance.mockReturnValue(entity);
+    displayNameFn.mockReturnValue('Silent Operative');
+
+    const result = formatEntityTarget('Shadow {target}', context, {
+      actionId: 'stealth:shadow-strike',
+      entityManager,
+      displayNameFn,
+      logger,
+      debug: false,
+    });
+
+    expect(result).toEqual({ ok: true, value: 'Shadow Silent Operative' });
+    expect(entityManager.getEntityInstance).toHaveBeenCalledWith('npc-007');
+    expect(displayNameFn).toHaveBeenCalledWith(entity, 'npc-007', logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a targeted integration test suite for `formatEntityTarget` that exercises the debug=false code path
- verify that entity lookup succeeds without emitting debug logs when debugging is disabled, increasing branch coverage to 100%

## Testing
- npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/actions/formatters/targetFormatters.integration.test.js tests/integration/actions/formatters/targetFormatters.debugFlag.integration.test.js --coverage --collectCoverageFrom='src/actions/formatters/targetFormatters.js'

------
https://chatgpt.com/codex/tasks/task_e_68cfd394d8648331b660818a664043d9