### PR TITLE
[Agent] Add unit tests for production path configuration

### DIFF
--- a/tests/unit/configuration/productionPathConfiguration.test.js
+++ b/tests/unit/configuration/productionPathConfiguration.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from '@jest/globals';
+import { ProductionPathConfiguration } from '../../../src/configuration/productionPathConfiguration.js';
+import { IPathConfiguration } from '../../../src/interfaces/IPathConfiguration.js';
+
+describe('ProductionPathConfiguration', () => {
+  /** @returns {ProductionPathConfiguration} */
+  const createConfig = () => new ProductionPathConfiguration();
+
+  it('implements the IPathConfiguration contract', () => {
+    const config = createConfig();
+    expect(config).toBeInstanceOf(IPathConfiguration);
+  });
+
+  it('provides the production LLM configuration path', () => {
+    const config = createConfig();
+    expect(config.getLLMConfigPath()).toBe('./config/llm-configs.json');
+  });
+
+  it('exposes the production prompt text filename', () => {
+    const config = createConfig();
+    expect(config.getPromptTextFilename()).toBe('corePromptText.json');
+  });
+
+  it('returns the production configuration directory', () => {
+    const config = createConfig();
+    expect(config.getConfigDirectory()).toBe('./config');
+  });
+
+  it('returns the production prompts directory', () => {
+    const config = createConfig();
+    expect(config.getPromptsDirectory()).toBe('./data/prompts');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering ProductionPathConfiguration behavior to ensure production paths stay correct

## Testing
- npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/configuration/productionPathConfiguration.test.js --coverage --collectCoverageFrom=src/configuration/productionPathConfiguration.js

------
https://chatgpt.com/codex/tasks/task_e_68d0071f3ce88331b528c4ac074ae796