### PR TITLE
[Agent] Add integration coverage for formatActionTypedefs

### DIFF
--- a/tests/integration/actions/formatters/formatActionTypedefs.integration.test.js
+++ b/tests/integration/actions/formatters/formatActionTypedefs.integration.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from '@jest/globals';
+import { __formatActionTypedefs } from '../../../../src/actions/formatters/formatActionTypedefs.js';
+
+describe('formatActionTypedefs integration', () => {
+  it('exports typedef marker to ensure module execution in integration context', () => {
+    expect(__formatActionTypedefs).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated integration test to execute the formatActionTypedefs module
- assert the typedef marker export so the module is counted in integration coverage

## Testing
- npx jest --config jest.config.integration.js --runTestsByPath tests/integration/actions/formatters/formatActionTypedefs.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4079ff2f08331983aeb65b6969600