### PR TITLE
[Agent] Add tests for validation types module

### DIFF
--- a/tests/unit/validation/types.test.js
+++ b/tests/unit/validation/types.test.js
@@ -1,0 +1,17 @@
+/**
+ * @file Tests for validation type definitions module
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import * as validationTypes from '../../../src/validation/types.js';
+
+describe('validation/types module', () => {
+  it('should expose no runtime exports', () => {
+    expect(Object.keys(validationTypes)).toHaveLength(0);
+    expect('default' in validationTypes).toBe(false);
+  });
+
+  it('should load cleanly via dynamic import', async () => {
+    await expect(import('../../../src/validation/types.js')).resolves.toBe(validationTypes);
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused unit test covering the validation type definition module
- verify the module exposes no runtime exports and can be dynamically imported without errors

## Testing
- npx jest tests/unit/validation/types.test.js --config jest.config.unit.js --env=jsdom

------
https://chatgpt.com/codex/tasks/task_e_68d41192557083318da98ff66dc8aa96