### PR TITLE
[Agent] Add ActionSequenceService tests and stabilize timing

### DIFF
--- a/tests/unit/actions/tracing/timing/executionPhaseTimer.test.js
+++ b/tests/unit/actions/tracing/timing/executionPhaseTimer.test.js
@@ -121,6 +121,11 @@ describe('ExecutionPhaseTimer', () => {
       for (let i = 0; i < 100000; i++) {
         sum += i;
       }
+      // Add an additional deterministic delay to avoid rare timing inversions on busy CI agents.
+      const minimumEndTime = performance.now() + 20;
+      while (performance.now() < minimumEndTime) {
+        sum += 1;
+      }
       timer.endPhase('slow_phase');
 
       timer.endExecution();

--- a/tests/unit/domUI/helpers/buildSpeechMeta.test.js
+++ b/tests/unit/domUI/helpers/buildSpeechMeta.test.js
@@ -1,0 +1,136 @@
+/**
+ * @file Unit tests for buildSpeechMeta helper.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { buildSpeechMeta } from '../../../../src/domUI/helpers/buildSpeechMeta.js';
+
+jest.mock('../../../../src/domUI/icons.js', () => ({
+  getIcon: jest.fn(),
+}));
+
+jest.mock('../../../../src/domUI/helpers/noteTooltipFormatter.js', () => ({
+  formatNotesAsRichHtml: jest.fn(),
+}));
+
+const { getIcon } = jest.requireMock('../../../../src/domUI/icons.js');
+const { formatNotesAsRichHtml } = jest.requireMock('../../../../src/domUI/helpers/noteTooltipFormatter.js');
+
+describe('buildSpeechMeta', () => {
+  let doc;
+  let domFactory;
+
+  const createDomFactory = (document) => ({
+    create: jest.fn((tagName, options = {}) => {
+      const element = document.createElement(tagName);
+
+      if (options.cls) {
+        element.className = options.cls;
+      }
+
+      if (options.attrs) {
+        for (const [name, value] of Object.entries(options.attrs)) {
+          element.setAttribute(name, value);
+        }
+      }
+
+      if (options.text) {
+        element.textContent = options.text;
+      }
+
+      return element;
+    }),
+  });
+
+  beforeEach(() => {
+    doc = document.implementation.createHTMLDocument();
+    domFactory = createDomFactory(doc);
+
+    getIcon.mockImplementation((name) => `<svg data-icon="${name}"></svg>`);
+    formatNotesAsRichHtml.mockImplementation((notes) => `<div class="rich">${notes.subject}</div>`);
+  });
+
+  afterEach(() => {
+    doc.body.innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  it('returns null when neither thoughts nor notes are provided', () => {
+    expect(buildSpeechMeta(doc, domFactory, {})).toBeNull();
+    expect(domFactory.create).not.toHaveBeenCalled();
+    expect(getIcon).not.toHaveBeenCalled();
+    expect(formatNotesAsRichHtml).not.toHaveBeenCalled();
+  });
+
+  it('creates only the thoughts button when thoughts text is present', () => {
+    const fragment = buildSpeechMeta(doc, domFactory, { thoughts: 'Quiet reflection' });
+
+    expect(fragment).not.toBeNull();
+    doc.body.appendChild(fragment);
+
+    const container = doc.body.querySelector('.speech-meta');
+    expect(container).not.toBeNull();
+
+    const thoughtsButton = container.querySelector('.meta-btn.thoughts');
+    expect(thoughtsButton).not.toBeNull();
+    expect(thoughtsButton.getAttribute('aria-label')).toBe('View inner thoughts');
+    expect(thoughtsButton.style.getPropertyValue('--clr')).toBe('var(--thoughts-icon-color)');
+    expect(thoughtsButton.innerHTML).toContain('data-icon="thoughts"');
+
+    const tooltip = thoughtsButton.querySelector('.meta-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.textContent).toBe('Quiet reflection');
+
+    expect(container.querySelector('.meta-btn.notes')).toBeNull();
+    expect(getIcon).toHaveBeenCalledWith('thoughts');
+    expect(formatNotesAsRichHtml).not.toHaveBeenCalled();
+  });
+
+  it('creates only the notes button when notes metadata is provided', () => {
+    const notes = { text: 'Hidden note', subject: 'Agent', subjectType: 'observation' };
+    const fragment = buildSpeechMeta(doc, domFactory, { notes });
+
+    expect(fragment).not.toBeNull();
+    doc.body.appendChild(fragment);
+
+    const container = doc.body.querySelector('.speech-meta');
+    expect(container).not.toBeNull();
+
+    const notesButton = container.querySelector('.meta-btn.notes');
+    expect(notesButton).not.toBeNull();
+    expect(notesButton.getAttribute('aria-label')).toBe('View private notes');
+    expect(notesButton.style.getPropertyValue('--clr')).toBe('var(--notes-icon-color)');
+    expect(notesButton.innerHTML).toContain('data-icon="notes"');
+
+    const tooltip = notesButton.querySelector('.meta-tooltip.meta-tooltip--notes');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.innerHTML).toBe(`<div class="rich">${notes.subject}</div>`);
+
+    expect(container.querySelector('.meta-btn.thoughts')).toBeNull();
+    expect(getIcon).toHaveBeenCalledWith('notes');
+    expect(formatNotesAsRichHtml).toHaveBeenCalledWith(notes);
+  });
+
+  it('renders both buttons when both thoughts and notes are provided', () => {
+    const notes = { text: 'Strategy', subject: 'Team', subjectType: 'goal' };
+    const fragment = buildSpeechMeta(doc, domFactory, { thoughts: 'Plan ahead', notes });
+
+    doc.body.appendChild(fragment);
+
+    const buttons = doc.body.querySelectorAll('.speech-meta .meta-btn');
+    expect(buttons).toHaveLength(2);
+
+    const [thoughtsButton, notesButton] = buttons;
+    expect(thoughtsButton.classList.contains('thoughts')).toBe(true);
+    expect(notesButton.classList.contains('notes')).toBe(true);
+
+    expect(thoughtsButton.querySelector('.meta-tooltip').textContent).toBe('Plan ahead');
+    expect(notesButton.querySelector('.meta-tooltip').innerHTML).toBe(
+      `<div class="rich">${notes.subject}</div>`
+    );
+
+    expect(getIcon).toHaveBeenCalledWith('thoughts');
+    expect(getIcon).toHaveBeenCalledWith('notes');
+    expect(formatNotesAsRichHtml).toHaveBeenCalledWith(notes);
+  });
+});

--- a/tests/unit/logic/actionSequenceService.test.js
+++ b/tests/unit/logic/actionSequenceService.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, jest, beforeEach, beforeAll } from '@jest/globals';
+
+let mockExecuteActionSequence;
+
+jest.mock('../../../src/logic/actionSequence.js', () => {
+  mockExecuteActionSequence = jest.fn();
+  return {
+    __esModule: true,
+    executeActionSequence: mockExecuteActionSequence,
+    default: mockExecuteActionSequence,
+  };
+});
+
+let ActionSequenceService;
+
+function createMockLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe('ActionSequenceService', () => {
+  beforeAll(async () => {
+    ({ default: ActionSequenceService } = await import(
+      '../../../src/logic/actionSequenceService.js'
+    ));
+  });
+
+  let logger;
+  let operationInterpreter;
+  let service;
+
+  beforeEach(() => {
+    mockExecuteActionSequence.mockReset();
+    logger = createMockLogger();
+    operationInterpreter = { execute: jest.fn() };
+    service = new ActionSequenceService({
+      logger,
+      operationInterpreter,
+    });
+  });
+
+  describe('constructor validation', () => {
+    it('throws when provided logger is missing required methods', () => {
+      const badLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+      expect(
+        () =>
+          new ActionSequenceService({
+            logger: badLogger,
+            operationInterpreter,
+          })
+      ).toThrow("Invalid or missing method 'debug' on dependency 'logger'.");
+    });
+
+    it('throws when operation interpreter lacks execute method', () => {
+      const invalidInterpreter = {};
+
+      expect(
+        () =>
+          new ActionSequenceService({
+            logger,
+            operationInterpreter: invalidInterpreter,
+          })
+      ).toThrow("Invalid or missing method 'execute' on dependency 'ActionSequenceService: operationInterpreter'.");
+    });
+  });
+
+  describe('execute', () => {
+    it('throws when sequence lacks an actions array', async () => {
+      await expect(
+        service.execute({ notActions: [] }, { jsonLogic: {}, evaluationContext: {} })
+      ).rejects.toThrow(
+        "ActionSequenceService.execute: sequence must have an actions array"
+      );
+      expect(mockExecuteActionSequence).not.toHaveBeenCalled();
+    });
+
+    it('throws when execution context is missing or invalid', async () => {
+      await expect(
+        service.execute({ actions: [] }, null)
+      ).rejects.toThrow('ActionSequenceService.execute: context is required');
+      expect(mockExecuteActionSequence).not.toHaveBeenCalled();
+    });
+
+    it('forwards actions and enhanced context to executeActionSequence', async () => {
+      const actions = [{ type: 'TEST_OP' }];
+      const context = {
+        jsonLogic: { name: 'logic' },
+        evaluationContext: { foo: 'bar' },
+      };
+      mockExecuteActionSequence.mockResolvedValueOnce(undefined);
+
+      await service.execute({ actions }, context);
+
+      expect(mockExecuteActionSequence).toHaveBeenCalledTimes(1);
+      const [passedActions, passedContext, passedLogger, passedInterpreter] =
+        mockExecuteActionSequence.mock.calls[0];
+
+      expect(passedActions).toBe(actions);
+      expect(passedContext).toMatchObject({
+        evaluationContext: context.evaluationContext,
+        scopeLabel: 'ActionSequenceService',
+        jsonLogic: context.jsonLogic,
+      });
+      expect(passedLogger).toBeDefined();
+      expect(typeof passedLogger.debug).toBe('function');
+      expect(passedInterpreter).toBe(operationInterpreter);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Sequence execution completed successfully')
+      );
+    });
+
+    it('logs and rethrows errors from executeActionSequence', async () => {
+      const actions = [{ type: 'FAIL_OP' }];
+      const context = {
+        jsonLogic: {},
+        evaluationContext: {},
+      };
+      const failure = new Error('sequence failure');
+      mockExecuteActionSequence.mockRejectedValueOnce(failure);
+
+      await expect(service.execute({ actions }, context)).rejects.toThrow(
+        'sequence failure'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Sequence execution failed'),
+        failure
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated ActionSequenceService test suite covering dependency validation, execution path wiring, and error handling behavior
- stabilize the ExecutionPhaseTimer performance summary test by ensuring the slow phase includes a deterministic delay

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68d41cdf37f88331b44a86005f55dba1