### PR TITLE
[Agent] Improve beginGame load UI coverage

### DIFF
--- a/tests/unit/main/main.coverage.test.js
+++ b/tests/unit/main/main.coverage.test.js
@@ -181,6 +181,47 @@ describe('main.js uncovered branches', () => {
     exerciseDomHelpers(helpers);
   });
 
+  it('shows the load game UI when requested and supported by the engine', async () => {
+    window.history.pushState({}, '', '?start=false');
+    document.body.innerHTML = `
+      <div id="outputDiv"></div>
+    `;
+    const uiElements = {
+      outputDiv: document.querySelector('#outputDiv'),
+      errorDiv: null,
+      inputElement: null,
+      titleElement: null,
+      document,
+    };
+    const logger = { info: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    const showLoadGameUI = jest.fn().mockResolvedValue(undefined);
+
+    mockEnsure.mockResolvedValue({ success: true, payload: uiElements });
+    mockSetupDI.mockResolvedValue({ success: true, payload: {} });
+    mockResolveCore.mockResolvedValue({ success: true, payload: { logger } });
+    mockInitGlobalConfig.mockResolvedValue({ success: true });
+    mockInitEngine.mockResolvedValue({
+      success: true,
+      payload: { showLoadGameUI },
+    });
+    mockInitAux.mockResolvedValue({ success: true });
+    mockMenu.mockResolvedValue({ success: true });
+    mockGlobal.mockResolvedValue({ success: true });
+    mockStartGame.mockResolvedValue({ success: true });
+
+    const main = await import('../../../src/main.js');
+    await main.bootstrapApp();
+    await Promise.resolve();
+    jest.runAllTimers();
+
+    await main.beginGame(true);
+    await Promise.resolve();
+    jest.runAllTimers();
+
+    expect(mockStartGame).toHaveBeenCalled();
+    expect(showLoadGameUI).toHaveBeenCalledTimes(1);
+  });
+
   it('falls back to default UI helpers when bootstrap fails early', async () => {
     const originalAlert = window.alert;
     const originalConsoleError = console.error;


### PR DESCRIPTION
Summary:
- Add a focused unit test to ensure beginGame triggers the load-game UI path when the engine exposes showLoadGameUI.

Testing:
- npx jest --config jest.config.unit.js --env=jsdom --runInBand tests/unit/main/main.coverage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df8b3f2afc8331bd0a65bcc49c5c1b