### PR TITLE
[Agent] Expand GameEngineLoadAdapter coverage

### DIFF
--- a/tests/unit/adapters/gameEngineAdapters.test.js
+++ b/tests/unit/adapters/gameEngineAdapters.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import GameEngineLoadAdapter from '../../../src/adapters/GameEngineLoadAdapter.js';
 import GameEngineSaveAdapter from '../../../src/adapters/GameEngineSaveAdapter.js';
+import ILoadService from '../../../src/interfaces/ILoadService.js';
 
 describe('GameEngineLoadAdapter', () => {
   it('delegates load to the engine', async () => {
@@ -20,6 +21,24 @@ describe('GameEngineLoadAdapter', () => {
     await expect(adapter.load('broken-slot')).rejects.toBe(error);
     expect(engine.loadGame).toHaveBeenCalledTimes(1);
     expect(engine.loadGame).toHaveBeenCalledWith('broken-slot');
+  });
+
+  it('implements the ILoadService contract and forwards identifiers untouched', async () => {
+    const engine = { loadGame: jest.fn().mockResolvedValue({ ok: true }) };
+    const adapter = new GameEngineLoadAdapter(engine);
+
+    expect(adapter).toBeInstanceOf(ILoadService);
+
+    const identifier = { slot: 'alpha', metadata: { timestamp: 123 } };
+    await expect(adapter.load(identifier)).resolves.toEqual({ ok: true });
+    expect(engine.loadGame).toHaveBeenCalledWith(identifier);
+    expect(engine.loadGame.mock.calls[0][0]).toBe(identifier);
+  });
+
+  it('rejects when the engine does not expose a loadGame function', async () => {
+    const adapter = new GameEngineLoadAdapter({});
+
+    await expect(adapter.load('missing-method')).rejects.toBeInstanceOf(TypeError);
   });
 });
 


### PR DESCRIPTION
Summary:
- Augment GameEngineLoadAdapter unit tests to assert ILoadService compliance, identifier forwarding, and missing loadGame handling for better coverage.

Testing Done:
- [x] Root tests `NODE_OPTIONS='--max-old-space-size=4096' npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/adapters/gameEngineAdapters.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68df905ac94c833197565d3a853ef742