### PR TITLE
[Agent] Exercise short-term memory edge case

### DIFF
--- a/tests/unit/actions/tracing/metrics/errorMetricsService.test.js
+++ b/tests/unit/actions/tracing/metrics/errorMetricsService.test.js
@@ -176,9 +176,14 @@ describe('ErrorMetricsService', () => {
 
   describe('resetMetrics', () => {
     beforeEach(() => {
+      jest.useFakeTimers();
       metricsService = new ErrorMetricsService({
         logger: mockLogger,
       });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     it('should clear all metrics', () => {

--- a/tests/unit/ai/shortTermMemoryService.test.js
+++ b/tests/unit/ai/shortTermMemoryService.test.js
@@ -45,6 +45,28 @@ describe('ShortTermMemoryService', () => {
       expect(mem.thoughts).toHaveLength(3);
     });
 
+    it('skips non-string entries when scanning for duplicates', () => {
+      const service = new ShortTermMemoryService();
+      const mem = {
+        thoughts: [
+          { text: 42, timestamp: '2024-01-01T00:00:00.000Z' },
+          { text: { nested: 'value' }, timestamp: '2024-01-02T00:00:00.000Z' },
+        ],
+        maxEntries: 5,
+      };
+      const now = new Date('2024-03-04T12:34:56.000Z');
+
+      const result = service.addThought(mem, 'Fresh insight', now);
+
+      expect(result).toEqual({
+        mem,
+        wasAdded: true,
+        entry: { text: 'Fresh insight', timestamp: now.toISOString() },
+      });
+      expect(mem.thoughts).toHaveLength(3);
+      expect(mem.thoughts[2]).toEqual(result.entry);
+    });
+
     it('initialises the thoughts array when needed and records ISO timestamps', () => {
       const service = new ShortTermMemoryService();
       const mem = { maxEntries: 3 };


### PR DESCRIPTION
Summary: Add coverage to ShortTermMemoryService and stabilise error metrics test timers.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test:unit`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68dfb5eb32c08331afd34fcd4b2621ef