### PR TITLE
[Agent] Strengthen action formatter integration coverage

### DIFF
--- a/tests/integration/actions/actionFormatter.unexpectedValidation.integration.test.js
+++ b/tests/integration/actions/actionFormatter.unexpectedValidation.integration.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+jest.mock('../../../src/utils/dependencyUtils.js', () => {
+  const actual = jest.requireActual('../../../src/utils/dependencyUtils.js');
+  return {
+    ...actual,
+    validateDependencies: jest.fn(() => {
+      throw new Error('unexpected dependency failure');
+    }),
+  };
+});
+
+import ActionCommandFormatter from '../../../src/actions/actionFormatter.js';
+import { ENTITY as TARGET_TYPE_ENTITY } from '../../../src/constants/actionTargetTypes.js';
+
+const { validateDependencies } = jest.requireMock('../../../src/utils/dependencyUtils.js');
+
+describe('ActionCommandFormatter resilience to dependency validator failures', () => {
+  let formatter;
+  let logger;
+  let dispatcher;
+  let entityManager;
+  let formatterMap;
+
+  beforeEach(() => {
+    formatter = new ActionCommandFormatter();
+    logger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    };
+    dispatcher = { dispatch: jest.fn() };
+    entityManager = {
+      getEntityInstance: jest.fn((id) => ({
+        id,
+        getComponentData: jest.fn(() => ({ text: 'Resilient Target' })),
+      })),
+    };
+
+    formatterMap = {
+      [TARGET_TYPE_ENTITY]: jest.fn((command, context, helpers) => {
+        const resolvedName = helpers.displayNameFn(
+          entityManager.getEntityInstance(context.entityId),
+          context.entityId,
+          logger
+        );
+        return command.replace('{target}', resolvedName);
+      }),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('continues formatting when dependency validation throws an unknown error', () => {
+    const result = formatter.format(
+      { id: 'action:resilience', template: 'salute {target}' },
+      { type: TARGET_TYPE_ENTITY, entityId: 'entity-7' },
+      entityManager,
+      { logger, safeEventDispatcher: dispatcher },
+      { formatterMap }
+    );
+
+    expect(validateDependencies).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, value: 'salute Resilient Target' });
+    expect(formatterMap[TARGET_TYPE_ENTITY]).toHaveBeenCalledWith(
+      'salute {target}',
+      { type: TARGET_TYPE_ENTITY, entityId: 'entity-7' },
+      expect.objectContaining({ actionId: 'action:resilience' })
+    );
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add an integration test covering unexpected dependency validation errors for the action formatter

## Testing Done
- `npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/actions/actionFormatter.coverage.integration.test.js tests/integration/actions/actionFormatter.unexpectedValidation.integration.test.js --coverage --collectCoverageFrom=src/actions/actionFormatter.js`


------
https://chatgpt.com/codex/tasks/task_e_68e01f3d3f5c833193938d1d7e2c8943