### PR TITLE
[Agent] Add targeted coverage tests for format action typedefs

### DIFF
--- a/tests/unit/actions/formatters/formatActionTypedefs.test.js
+++ b/tests/unit/actions/formatters/formatActionTypedefs.test.js
@@ -1,8 +1,28 @@
 import { describe, it, expect } from '@jest/globals';
-import { __formatActionTypedefs } from '../../../../src/actions/formatters/formatActionTypedefs.js';
+import {
+  __formatActionTypedefs,
+} from '../../../../src/actions/formatters/formatActionTypedefs.js';
+import * as formatActionTypedefsModule from '../../../../src/actions/formatters/formatActionTypedefs.js';
 
 describe('formatActionTypedefs module', () => {
-  it('exposes a marker constant to enforce module execution', () => {
+  it('exposes the coverage sentinel as a stable boolean', () => {
+    expect(typeof __formatActionTypedefs).toBe('boolean');
     expect(__formatActionTypedefs).toBe(true);
+  });
+
+  it('only exports the sentinel symbol for consumers', () => {
+    expect(Object.keys(formatActionTypedefsModule)).toEqual([
+      '__formatActionTypedefs',
+    ]);
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      formatActionTypedefsModule,
+      '__formatActionTypedefs',
+    );
+
+    expect(descriptor).toMatchObject({
+      enumerable: true,
+      value: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend the formatActionTypedefs unit test to validate the sentinel export and ensure the module exposes only the expected binding for consumers

## Testing
- `npm run test:unit` *(fails: performance threshold in TargetComponentValidationStage under CI load)*
- `npm run test:unit -- --runInBand` *(fails: memory usage check in commandProcessor compatibility suite exceeds environment limits)*
- `NODE_OPTIONS='--max-old-space-size=4096' npx jest tests/unit/actions/formatters/formatActionTypedefs.test.js --config jest.config.unit.js --env=jsdom --runTestsByPath --coverage --collectCoverageFrom='src/actions/formatters/formatActionTypedefs.js' --coverageReporters='text-summary' --coverageThreshold='{"global":{"statements":0,"branches":0,"functions":0,"lines":0}}'`


------
https://chatgpt.com/codex/tasks/task_e_68e0eecf77508331bd647416e24bfbfc