### PR TITLE
[Agent] Cover formatActionTypedefs module

### DIFF
--- a/tests/unit/actions/formatters/formatActionTypedefs.test.js
+++ b/tests/unit/actions/formatters/formatActionTypedefs.test.js
@@ -1,3 +1,8 @@
+/**
+ * @file Unit tests for the action formatter typedef marker module.
+ * @see src/actions/formatters/formatActionTypedefs.js
+ */
+
 import { describe, it, expect } from '@jest/globals';
 import {
   __formatActionTypedefs,
@@ -24,5 +29,13 @@ describe('formatActionTypedefs module', () => {
       enumerable: true,
       value: true,
     });
+  });
+
+  it('supports dynamic importing without throwing and exposes the sentinel', async () => {
+    await expect(
+      import(
+        '../../../../src/actions/formatters/formatActionTypedefs.js'
+      )
+    ).resolves.toMatchObject({ __formatActionTypedefs: true });
   });
 });


### PR DESCRIPTION
## Summary
- add explicit unit tests for the formatActionTypedefs marker module to verify its exported contract
- ensure the typedef marker module can be dynamically imported while still exposing the sentinel export

## Testing
- [x] `npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/actions/formatters/formatActionTypedefs.test.js --coverage --collectCoverageFrom="src/actions/formatters/formatActionTypedefs.js"`


------
https://chatgpt.com/codex/tasks/task_e_68e0f44e2c788331ab591be23203f44c