### PR TITLE
[Agent] Add integration coverage for Pipeline

### DIFF
--- a/tests/integration/actions/pipeline/Pipeline.integration.test.js
+++ b/tests/integration/actions/pipeline/Pipeline.integration.test.js
@@ -1,5 +1,7 @@
 /**
- * @file Integration tests for the Pipeline module to ensure stage coordination and error handling.
+ * @file Integration tests for the Pipeline executor
+ * @description Exercises Pipeline behaviour with real PipelineStage implementations and trace contexts
+ * @see src/actions/pipeline/Pipeline.js
  */
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
@@ -7,208 +9,197 @@ import { Pipeline } from '../../../../src/actions/pipeline/Pipeline.js';
 import { PipelineStage } from '../../../../src/actions/pipeline/PipelineStage.js';
 import { PipelineResult } from '../../../../src/actions/pipeline/PipelineResult.js';
 
-class RecordingStage extends PipelineStage {
-  constructor(name, handler) {
+class TestStage extends PipelineStage {
+  /**
+   * @param {string} name
+   * @param {(context: any) => Promise<PipelineResult>} executor
+   */
+  constructor(name, executor) {
     super(name);
-    this.handler = handler;
-    this.calls = [];
+    this.executor = executor;
+    this.contexts = [];
   }
 
   async executeInternal(context) {
-    this.calls.push(context);
-    return this.handler(context);
+    this.contexts.push(context);
+    return this.executor(context);
   }
 }
 
-describe('Pipeline integration', () => {
+const createLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+const createStructuredTrace = () => {
+  const trace = {
+    info: jest.fn(),
+    step: jest.fn(),
+    success: jest.fn(),
+    failure: jest.fn(),
+    withSpanAsync: jest.fn(async (_name, handler) => handler()),
+  };
+  return trace;
+};
+
+describe('Pipeline integration behaviour', () => {
   let logger;
-  let trace;
 
   beforeEach(() => {
-    logger = {
-      debug: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
-
-    trace = {
-      recordedSpans: [],
-      steps: [],
-      infos: [],
-      successes: [],
-      failures: [],
-      withSpanAsync: jest.fn(async (name, executor, metadata) => {
-        trace.recordedSpans.push({ name, metadata });
-        return executor();
-      }),
-      step: jest.fn((message) => trace.steps.push(message)),
-      info: jest.fn((message) => trace.infos.push(message)),
-      success: jest.fn((message) => trace.successes.push(message)),
-      failure: jest.fn((message) => trace.failures.push(message)),
-    };
+    logger = createLogger();
   });
 
-  it('validates that at least one stage is provided', () => {
+  it('throws when constructed with no stages', () => {
     expect(() => new Pipeline([], logger)).toThrow(
       'Pipeline requires at least one stage'
     );
   });
 
-  it('executes stages sequentially, merges their results, and reports via structured tracing', async () => {
-    const stageOne = new RecordingStage('ComponentFiltering', () =>
+  it('wraps execution in structured trace spans and aggregates stage results', async () => {
+    const trace = createStructuredTrace();
+
+    const gatherStage = new TestStage('Gather', async () =>
       PipelineResult.success({
-        actions: [{ id: 'alpha' }],
-        data: { stageOne: true },
+        actions: [{ id: 'action-1' }],
+        data: { gathered: true },
       })
     );
 
-    const stageTwo = new RecordingStage('Formatting', (context) => {
-      expect(context.stageOne).toBe(true);
-      expect(context.actions).toHaveLength(1);
-
-      return PipelineResult.success({
-        actions: [{ id: 'beta' }],
-        errors: [{ message: 'minor' }],
-        data: { stageTwo: true },
+    const validationStage = new TestStage('Validate', async (context) => {
+      expect(context.actions).toEqual([{ id: 'action-1' }]);
+      return new PipelineResult({
+        success: false,
+        continueProcessing: true,
+        errors: [
+          {
+            error: 'validation failed',
+            phase: 'VALIDATION',
+            stageName: 'Validate',
+          },
+        ],
+        data: { validated: true },
       });
     });
 
-    const pipeline = new Pipeline([stageOne, stageTwo], logger);
+    const enrichmentStage = new TestStage('Enrich', async (context) => {
+      expect(context.errors).toHaveLength(1);
+      return PipelineResult.success({
+        data: { enriched: context.gathered && context.validated },
+      });
+    });
+
+    const pipeline = new Pipeline(
+      [gatherStage, validationStage, enrichmentStage],
+      logger
+    );
 
     const result = await pipeline.execute({
-      actor: { id: 'actor-1' },
-      actionContext: { mood: 'curious' },
-      candidateActions: [],
+      actor: { id: 'actor-42' },
+      actionContext: { turnId: 'turn-1' },
+      candidateActions: [{ id: 'candidate-a' }],
       trace,
     });
 
-    expect(trace.withSpanAsync).toHaveBeenCalledTimes(1);
-    expect(trace.recordedSpans[0]).toEqual({
-      name: 'Pipeline',
-      metadata: { stageCount: 2 },
-    });
-
-    expect(stageOne.calls).toHaveLength(1);
-    expect(stageTwo.calls).toHaveLength(1);
-
-    expect(result.success).toBe(true);
-    expect(result.actions).toEqual([
-      { id: 'alpha' },
-      { id: 'beta' },
-    ]);
-    expect(result.errors).toEqual([{ message: 'minor' }]);
-    expect(result.data).toMatchObject({ stageOne: true, stageTwo: true });
-
-    expect(trace.success).toHaveBeenCalled();
-    expect(trace.info).toHaveBeenCalledWith(
-      expect.stringContaining('Pipeline execution completed.'),
+    expect(trace.withSpanAsync).toHaveBeenCalledWith(
+      'Pipeline',
+      expect.any(Function),
+      { stageCount: 3 }
+    );
+    expect(trace.step).toHaveBeenCalledTimes(3);
+    expect(trace.success).toHaveBeenCalledWith(
+      'Stage Gather completed successfully',
       'Pipeline.execute'
     );
+    expect(trace.failure).toHaveBeenCalledWith(
+      'Stage Validate encountered errors',
+      'Pipeline.execute'
+    );
+    expect(logger.debug).toHaveBeenCalledWith('Executing pipeline stage: Gather');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Stage Validate completed with errors'
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.data).toEqual({ gathered: true, validated: true, enriched: true });
+    expect(result.actions).toEqual([{ id: 'action-1' }]);
   });
 
-  it('stops processing when a stage requests termination and logs the halt', async () => {
-    const stageOne = new RecordingStage('ComponentFiltering', () =>
+  it('halts further stages when continueProcessing is false', async () => {
+    const trace = createStructuredTrace();
+
+    const haltingStage = new TestStage('ShortCircuit', async () =>
       PipelineResult.success({
-        data: { ready: true },
+        data: { halted: true },
+        errors: [],
+        actions: [],
         continueProcessing: false,
       })
     );
 
-    const stageTwo = new RecordingStage('Formatting', () =>
-      PipelineResult.success({
-        actions: [{ id: 'gamma' }],
-      })
+    const skippedStage = new TestStage('Skipped', async () =>
+      PipelineResult.success({ data: { reached: true } })
     );
 
-    const pipeline = new Pipeline([stageOne, stageTwo], logger);
+    const pipeline = new Pipeline([haltingStage, skippedStage], logger);
 
     const result = await pipeline.execute({
-      actor: { id: 'actor-2' },
-      actionContext: {},
-      candidateActions: [],
-    });
-
-    expect(stageTwo.calls).toHaveLength(0);
-    expect(logger.debug).toHaveBeenCalledWith(
-      'Stage ComponentFiltering indicated to stop processing'
-    );
-    expect(result.success).toBe(true);
-    expect(result.actions).toEqual([]);
-    expect(result.data).toEqual({ ready: true });
-  });
-
-  it('logs warnings and continues when a stage reports errors but allows further processing', async () => {
-    const failingStage = new RecordingStage('PrerequisiteEvaluation', () =>
-      new PipelineResult({
-        success: false,
-        errors: [{ message: 'prerequisite failed' }],
-        continueProcessing: true,
-      })
-    );
-
-    const recoveryStage = new RecordingStage('Formatting', () =>
-      PipelineResult.success({ actions: [{ id: 'recovered' }] })
-    );
-
-    const pipeline = new Pipeline([failingStage, recoveryStage], logger);
-
-    const result = await pipeline.execute({
-      actor: { id: 'actor-4' },
+      actor: { id: 'actor-99' },
       actionContext: {},
       candidateActions: [],
       trace,
     });
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Stage PrerequisiteEvaluation completed with errors'
-    );
-    expect(trace.failure).toHaveBeenCalledWith(
-      'Stage PrerequisiteEvaluation encountered errors',
+    expect(result.success).toBe(true);
+    expect(result.continueProcessing).toBe(false);
+    expect(skippedStage.contexts).toHaveLength(0);
+    expect(trace.info).toHaveBeenCalledWith(
+      'Pipeline halted at stage: ShortCircuit',
       'Pipeline.execute'
     );
-    expect(recoveryStage.calls).toHaveLength(1);
-    expect(result.success).toBe(false);
-    expect(result.errors).toEqual([{ message: 'prerequisite failed' }]);
-    expect(result.actions).toEqual([{ id: 'recovered' }]);
   });
 
-  it('captures thrown stage errors, logs them, and returns a failure PipelineResult', async () => {
-    const stageOne = new RecordingStage('ComponentFiltering', () =>
+  it('returns merged failure result when a stage throws', async () => {
+    const trace = createStructuredTrace();
+
+    const passingStage = new TestStage('Pass', async () =>
       PipelineResult.success({
-        actions: [{ id: 'delta' }],
+        actions: [{ id: 'action-pass' }],
+        data: { passed: true },
       })
     );
 
-    const stageTwo = new RecordingStage('Formatting', () => {
-      throw new Error('formatting exploded');
+    const failingStage = new TestStage('Boom', async () => {
+      throw new Error('unexpected failure');
     });
 
-    const pipeline = new Pipeline([stageOne, stageTwo], logger);
+    const pipeline = new Pipeline([passingStage, failingStage], logger);
 
     const result = await pipeline.execute({
-      actor: { id: 'actor-3' },
+      actor: { id: 'actor-7' },
       actionContext: {},
       candidateActions: [],
       trace,
     });
 
     expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Pipeline stage Formatting threw an error: formatting exploded'),
+      'Pipeline stage Boom threw an error: unexpected failure',
       expect.any(Error)
     );
-
     expect(trace.failure).toHaveBeenCalledWith(
-      expect.stringContaining('Formatting'),
+      'Stage Boom threw an error: unexpected failure',
       'Pipeline.execute'
     );
-
     expect(result.success).toBe(false);
-    expect(result.actions).toEqual([{ id: 'delta' }]);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toMatchObject({
-      error: 'formatting exploded',
-      phase: 'PIPELINE_EXECUTION',
-      stageName: 'Formatting',
-    });
+    expect(result.errors).toEqual([
+      {
+        error: 'unexpected failure',
+        phase: 'PIPELINE_EXECUTION',
+        stageName: 'Boom',
+        context: expect.objectContaining({ error: expect.stringContaining('Error: unexpected failure') }),
+      },
+    ]);
+    expect(result.actions).toEqual([{ id: 'action-pass' }]);
   });
 });


### PR DESCRIPTION
Summary: Add integration coverage targeting the action Pipeline orchestration and error handling

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npx jest --config jest.config.integration.js --env=jsdom tests/integration/actions/pipeline/Pipeline.integration.test.js`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e191fe66d083319e3db8ae0c5ad987