### PR TITLE
[Agent] Improve formatAction typedef coverage

### DIFF
--- a/tests/unit/actions/formatters/formatActionTypedefs.test.js
+++ b/tests/unit/actions/formatters/formatActionTypedefs.test.js
@@ -38,4 +38,22 @@ describe('formatActionTypedefs module', () => {
       )
     ).resolves.toMatchObject({ __formatActionTypedefs: true });
   });
+
+  it('registers statement coverage for the sentinel export', () => {
+    const coverageMap = globalThis.__coverage__ ?? {};
+    const coverageKey = Object.keys(coverageMap).find((key) =>
+      key.endsWith('src/actions/formatters/formatActionTypedefs.js')
+    );
+
+    expect(coverageKey).toBeDefined();
+
+    const fileCoverage = coverageMap[coverageKey];
+    expect(fileCoverage).toBeDefined();
+    expect(fileCoverage.s['0']).toBeGreaterThan(0);
+    expect(fileCoverage.statementMap['0']).toEqual(
+      expect.objectContaining({
+        start: expect.objectContaining({ line: 43 }),
+      })
+    );
+  });
 });


### PR DESCRIPTION
Summary: add an assertion that the `formatActionTypedefs` sentinel is registered in Istanbul coverage so the typedef-only module stays exercised.

Testing Done:
- [x] `npm run test:unit -- --runTestsByPath tests/unit/actions/formatters/formatActionTypedefs.test.js css.test.js`
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e22688c5388331bcedae3306bcf261