### PR TITLE
[Agent] Add tests for character concepts entry

### DIFF
--- a/tests/unit/character-concepts-manager-entry.test.js
+++ b/tests/unit/character-concepts-manager-entry.test.js
@@ -1,0 +1,88 @@
+import { describe, beforeAll, afterAll, beforeEach, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../src/character-concepts-manager-main.js', () => ({
+  __esModule: true,
+  initializeApp: jest.fn(),
+}));
+
+let readyStateValue = 'complete';
+const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'readyState');
+
+const setReadyState = (value) => {
+  readyStateValue = value;
+};
+
+beforeAll(() => {
+  Object.defineProperty(document, 'readyState', {
+    configurable: true,
+    get: () => readyStateValue,
+  });
+});
+
+afterAll(() => {
+  if (originalDescriptor) {
+    Object.defineProperty(document, 'readyState', originalDescriptor);
+  } else {
+    delete document.readyState;
+  }
+});
+
+describe('character-concepts-manager-entry', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    setReadyState('complete');
+  });
+
+  it('initializes immediately when the DOM is already ready', async () => {
+    const { initializeApp } = await import('../../src/character-concepts-manager-main.js');
+    initializeApp.mockResolvedValue();
+    setReadyState('complete');
+
+    await import('../../src/character-concepts-manager-entry.js');
+    // Allow queued microtasks to run so the promise chain resolves
+    await Promise.resolve();
+
+    expect(initializeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for DOMContentLoaded when the DOM is still loading', async () => {
+    const { initializeApp } = await import('../../src/character-concepts-manager-main.js');
+    initializeApp.mockResolvedValue();
+    setReadyState('loading');
+
+    await import('../../src/character-concepts-manager-entry.js');
+    // Module should have registered listener but not called initializer yet
+    expect(initializeApp).not.toHaveBeenCalled();
+
+    // Simulate DOM content loading finishing
+    setReadyState('interactive');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Flush microtasks queued by waitForDOM
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(initializeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs an error when initialization fails', async () => {
+    const error = new Error('boom');
+    const { initializeApp } = await import('../../src/character-concepts-manager-main.js');
+    initializeApp.mockRejectedValue(error);
+    setReadyState('complete');
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('../../src/character-concepts-manager-entry.js');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to initialize application:',
+      error
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Summary:
- add unit coverage for the `character-concepts-manager-entry` bootstrap flow
- verify DOM-ready, DOMContentLoaded, and error logging paths for the entry initializer

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test:unit -- --runTestsByPath tests/unit/character-concepts-manager-entry.test.js`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e26fbd59908331b06cc666c7ad0dda