### PR TITLE
[Agent] Add unit tests for IScheduler interface

### DIFF
--- a/tests/unit/scheduling/IScheduler.spec.js
+++ b/tests/unit/scheduling/IScheduler.spec.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { IScheduler } from '../../../src/scheduling/IScheduler.js';
+
+describe('IScheduler interface contract', () => {
+  it('throws an error when setTimeout is not implemented', () => {
+    const scheduler = new IScheduler();
+    expect(() => scheduler.setTimeout(() => {}, 10)).toThrow('not implemented');
+  });
+
+  it('throws an error when clearTimeout is not implemented', () => {
+    const scheduler = new IScheduler();
+    expect(() => scheduler.clearTimeout(123)).toThrow('not implemented');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test suite for IScheduler to ensure its abstract methods throw when not implemented

## Testing
- npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/scheduling/IScheduler.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e292a87458833189b9ed100fdeab84