### PR TITLE
[Agent] Improve formatActionTypedefs coverage tests

### DIFF
--- a/tests/unit/actions/formatters/formatActionTypedefs.test.js
+++ b/tests/unit/actions/formatters/formatActionTypedefs.test.js
@@ -1,24 +1,16 @@
-/**
- * @file Unit tests for the action formatter typedef marker module.
- * @see src/actions/formatters/formatActionTypedefs.js
- */
-
-import { describe, it, expect } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import {
   __formatActionTypedefs,
 } from '../../../../src/actions/formatters/formatActionTypedefs.js';
 import * as formatActionTypedefsModule from '../../../../src/actions/formatters/formatActionTypedefs.js';
 
+const MODULE_RELATIVE_PATH = '../../../../src/actions/formatters/formatActionTypedefs.js';
+const MODULE_SUFFIX = 'src/actions/formatters/formatActionTypedefs.js';
+
 describe('formatActionTypedefs module', () => {
-  it('exposes the coverage sentinel as a stable boolean', () => {
+  it('exposes the coverage sentinel as a stable boolean export', () => {
     expect(typeof __formatActionTypedefs).toBe('boolean');
     expect(__formatActionTypedefs).toBe(true);
-  });
-
-  it('only exports the sentinel symbol for consumers', () => {
-    expect(Object.keys(formatActionTypedefsModule)).toEqual([
-      '__formatActionTypedefs',
-    ]);
 
     const descriptor = Object.getOwnPropertyDescriptor(
       formatActionTypedefsModule,
@@ -31,29 +23,33 @@ describe('formatActionTypedefs module', () => {
     });
   });
 
-  it('supports dynamic importing without throwing and exposes the sentinel', async () => {
-    await expect(
-      import(
-        '../../../../src/actions/formatters/formatActionTypedefs.js'
-      )
-    ).resolves.toMatchObject({ __formatActionTypedefs: true });
+  it('only exposes the sentinel export on the module namespace object', () => {
+    expect(Object.keys(formatActionTypedefsModule)).toEqual([
+      '__formatActionTypedefs',
+    ]);
+  });
+
+  it('supports dynamic import and resolves with the sentinel export intact', async () => {
+    const moduleNamespace = await import(MODULE_RELATIVE_PATH);
+
+    expect(moduleNamespace).toMatchObject({ __formatActionTypedefs: true });
+    expect(Object.keys(moduleNamespace)).toEqual(['__formatActionTypedefs']);
   });
 
   it('registers statement coverage for the sentinel export', () => {
-    const coverageMap = globalThis.__coverage__ ?? {};
-    const coverageKey = Object.keys(coverageMap).find((key) =>
-      key.endsWith('src/actions/formatters/formatActionTypedefs.js')
-    );
+    const coverageEntries = Object.entries(globalThis.__coverage__ ?? {});
+    const [coverageKey, fileCoverage] = coverageEntries.find(([key]) =>
+      key.endsWith(MODULE_SUFFIX),
+    ) ?? [undefined, undefined];
 
     expect(coverageKey).toBeDefined();
-
-    const fileCoverage = coverageMap[coverageKey];
     expect(fileCoverage).toBeDefined();
-    expect(fileCoverage.s['0']).toBeGreaterThan(0);
+    expect(Object.keys(fileCoverage.statementMap)).toEqual(['0']);
     expect(fileCoverage.statementMap['0']).toEqual(
       expect.objectContaining({
         start: expect.objectContaining({ line: 43 }),
-      })
+      }),
     );
+    expect(fileCoverage.s['0']).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- expand the formatActionTypedefs unit suite to assert the sentinel export, dynamic import behaviour, and collected coverage metadata
- use the shared coverage map to confirm instrumentation hits the module so the typedef-only file reports 100% coverage

## Testing
- npm run test:unit *(fails global coverage threshold checks only)*
- npx jest --config jest.config.unit.js --runTestsByPath tests/unit/actions/formatters/formatActionTypedefs.test.js --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e2a3a0419883319f0e8fa129da0812