### PR TITLE
[Agent] Add coverage tests for dependency utils and port interfaces

### DIFF
--- a/tests/unit/turns/ports/interfaces.test.js
+++ b/tests/unit/turns/ports/interfaces.test.js
@@ -39,6 +39,32 @@ describe('Turn port interface classes', () => {
   it('IActionIndexer.index rejects when not implemented', () => {
     const indexer = new IActionIndexer();
     expect(() => indexer.index([], 'id')).toThrow('Interface method');
+
+    try {
+      indexer.index([], 'id');
+      throw new Error('Expected interface method to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Interface method');
+    }
+  });
+
+  it('IActionIndexer.resolve rejects when not implemented', () => {
+    const indexer = new IActionIndexer();
+    expect(() => indexer.resolve('actor', 0)).toThrow('Interface method');
+
+    try {
+      indexer.resolve('actor', 0);
+      throw new Error('Expected interface method to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Interface method');
+    }
+  });
+
+  it('IActionIndexer.beginTurn is a no-op hook by default', () => {
+    const indexer = new IActionIndexer();
+    expect(indexer.beginTurn('actor')).toBeUndefined();
   });
 
   it('ILLMChooser.choose rejects when not implemented', () => {


### PR DESCRIPTION
Summary: Improve unit test coverage for dependency utilities and port interfaces.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test:unit`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e2ab3c290483319fa746a3f92a398d