### PR TITLE
[Agent] Add integration coverage for BodyGraphService

### DIFF
--- a/tests/integration/anatomy/bodyGraphService.real.integration.test.js
+++ b/tests/integration/anatomy/bodyGraphService.real.integration.test.js
@@ -1,54 +1,70 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import BodyGraphService, {
   LIMB_DETACHED_EVENT_ID,
 } from '../../../src/anatomy/bodyGraphService.js';
 import { InvalidArgumentError } from '../../../src/errors/invalidArgumentError.js';
 
-/**
- * @description Creates a logger mock that mirrors the engine logger interface.
- * @returns {{debug: jest.Mock, info: jest.Mock, warn: jest.Mock, error: jest.Mock}}
- */
-function createLogger() {
-  return {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  };
-}
-
-/**
- * @description Minimal in-memory entity manager tailored for BodyGraphService integration tests.
- */
-class InMemoryEntityManager {
-  /**
-   * @description Constructs a new manager with optional preloaded entities.
-   * @param {Record<string, Record<string, any>>} [initialEntities] Entity component map keyed by entity id.
-   */
-  constructor(initialEntities = {}) {
-    /** @type {Map<string, Record<string, any>>} */
-    this.entities = new Map();
-    Object.entries(initialEntities).forEach(([id, components]) => {
-      this.entities.set(id, { ...components });
-    });
+class TestLogger {
+  constructor() {
+    this.debugCalls = [];
+    this.infoCalls = [];
+    this.warnCalls = [];
+    this.errorCalls = [];
   }
 
-  /**
-   * @description Adds or replaces an entity definition.
-   * @param {string} entityId Identifier of the entity.
-   * @param {Record<string, any>} components Component map for the entity.
-   * @returns {void}
-   */
-  addEntity(entityId, components) {
+  debug(...args) {
+    this.debugCalls.push(args);
+  }
+
+  info(...args) {
+    this.infoCalls.push(args);
+  }
+
+  warn(...args) {
+    this.warnCalls.push(args);
+  }
+
+  error(...args) {
+    this.errorCalls.push(args);
+  }
+
+  messages(level) {
+    const map = {
+      debug: this.debugCalls,
+      info: this.infoCalls,
+      warn: this.warnCalls,
+      error: this.errorCalls,
+    };
+    return (map[level] || []).map((entry) => entry[0]);
+  }
+}
+
+class TestEventDispatcher {
+  constructor() {
+    this.events = [];
+  }
+
+  async dispatch(eventId, payload) {
+    this.events.push({ eventId, payload });
+  }
+}
+
+class TestEntityManager {
+  constructor() {
+    this.entities = new Map();
+  }
+
+  createEntity(entityId, components = {}) {
     this.entities.set(entityId, { ...components });
   }
 
-  /**
-   * @description Retrieves component data for a given entity.
-   * @param {string} entityId Target entity identifier.
-   * @param {string} componentId Component identifier to fetch.
-   * @returns {any} Stored component data or null when absent.
-   */
+  setComponent(entityId, componentId, data) {
+    if (!this.entities.has(entityId)) {
+      this.entities.set(entityId, {});
+    }
+    this.entities.get(entityId)[componentId] = data;
+  }
+
   getComponentData(entityId, componentId) {
     const entity = this.entities.get(entityId);
     if (!entity) return null;
@@ -57,12 +73,6 @@ class InMemoryEntityManager {
       : null;
   }
 
-  /**
-   * @description Removes a component from an entity.
-   * @param {string} entityId Target entity identifier.
-   * @param {string} componentId Component identifier to remove.
-   * @returns {Promise<void>} Resolves after mutation completes.
-   */
   async removeComponent(entityId, componentId) {
     const entity = this.entities.get(entityId);
     if (entity && Object.prototype.hasOwnProperty.call(entity, componentId)) {
@@ -70,327 +80,341 @@ class InMemoryEntityManager {
     }
   }
 
-  /**
-   * @description Retrieves a lightweight entity instance.
-   * @param {string} entityId Target entity identifier.
-   * @returns {{id: string, getComponentData: (componentId: string) => any, hasComponent: (componentId: string) => boolean}}
-   */
+  getEntitiesWithComponent(componentId) {
+    const results = [];
+    for (const [entityId, components] of this.entities.entries()) {
+      if (Object.prototype.hasOwnProperty.call(components, componentId)) {
+        results.push({ id: entityId });
+      }
+    }
+    return results;
+  }
+
   getEntityInstance(entityId) {
     if (!this.entities.has(entityId)) {
-      throw new Error(`Entity ${entityId} not found`);
+      return null;
     }
     return {
       id: entityId,
-      getComponentData: (componentId) => this.getComponentData(entityId, componentId),
-      hasComponent: (componentId) =>
-        this.getComponentData(entityId, componentId) !== null,
+      getComponentData: (componentId) =>
+        this.getComponentData(entityId, componentId),
     };
-  }
-
-  /**
-   * @description Retrieves all entities that currently contain a component.
-   * @param {string} componentId Component identifier to search for.
-   * @returns {{id: string, getComponentData: (componentId: string) => any}[]} Matching entities.
-   */
-  getEntitiesWithComponent(componentId) {
-    const matches = [];
-    for (const [id, components] of this.entities.entries()) {
-      if (Object.prototype.hasOwnProperty.call(components, componentId)) {
-        matches.push({
-          id,
-          getComponentData: (requestedId) =>
-            this.getComponentData(id, requestedId),
-        });
-      }
-    }
-    return matches;
   }
 }
 
-/**
- * @description Builds a complete anatomy graph fixture used across the integration suite.
- * @returns {{entityManager: InMemoryEntityManager, service: BodyGraphService, bodyComponent: any, actorId: string, partIds: Record<string, string>, logger: ReturnType<typeof createLogger>, eventDispatcher: {dispatch: jest.Mock}}}
- */
-function createAnatomyFixture() {
-  const logger = createLogger();
-  const eventDispatcher = { dispatch: jest.fn().mockResolvedValue(undefined) };
-
-  const actorId = 'actor-1';
-  const partIds = {
-    torso: 'torso-1',
-    head: 'head-1',
-    leftArm: 'left-arm-1',
-    rightArm: 'right-arm-1',
-    leftHand: 'left-hand-1',
-    rightHand: 'right-hand-1',
-    heart: 'heart-1',
-  };
-
-  const bodyComponent = {
-    recipeId: 'test:humanoid',
-    body: {
-      root: partIds.torso,
-      parts: {
-        torso: partIds.torso,
-        head: partIds.head,
-        left_arm: partIds.leftArm,
-        right_arm: partIds.rightArm,
-        left_hand: partIds.leftHand,
-        right_hand: partIds.rightHand,
-        heart: partIds.heart,
-      },
+const populateAnatomy = (entityManager) => {
+  entityManager.createEntity('actor-1', {
+    'core:name': { text: 'Protagonist' },
+    'anatomy:body': {
+      recipeId: 'humanoid_base',
+      body: { root: 'torso' },
+      structure: { rootPartId: 'torso' },
     },
-    structure: { rootPartId: partIds.torso },
-  };
-
-  const entityManager = new InMemoryEntityManager();
-  entityManager.addEntity(actorId, {
-    'anatomy:body': bodyComponent,
-    'core:name': { text: 'Test Actor' },
   });
-  entityManager.addEntity(partIds.torso, {
+
+  entityManager.createEntity('torso', {
     'anatomy:part': { subType: 'torso' },
-    'anatomy:joint': { parentId: actorId, socketId: 'torso_socket' },
-    'custom:flag': { isImportant: true },
-  });
-  entityManager.addEntity(partIds.head, {
-    'anatomy:part': { subType: 'head' },
-    'anatomy:joint': { parentId: partIds.torso, socketId: 'neck_socket' },
-  });
-  entityManager.addEntity(partIds.leftArm, {
-    'anatomy:part': { subType: 'arm', orientation: 'left' },
-    'anatomy:joint': { parentId: partIds.torso, socketId: 'left_shoulder' },
-    'custom:status': { metadata: { functional: 'primary' } },
-  });
-  entityManager.addEntity(partIds.rightArm, {
-    'anatomy:part': { subType: 'arm', orientation: 'right' },
-    'anatomy:joint': { parentId: partIds.torso, socketId: 'right_shoulder' },
-    'custom:status': { metadata: { functional: 'secondary' } },
-  });
-  entityManager.addEntity(partIds.leftHand, {
-    'anatomy:part': { subType: 'hand', orientation: 'left' },
-    'anatomy:joint': { parentId: partIds.leftArm, socketId: 'left_wrist' },
-  });
-  entityManager.addEntity(partIds.rightHand, {
-    'anatomy:part': { subType: 'hand', orientation: 'right' },
-    'anatomy:joint': { parentId: partIds.rightArm, socketId: 'right_wrist' },
-  });
-  entityManager.addEntity(partIds.heart, {
-    'anatomy:part': { subType: 'heart' },
-    'anatomy:joint': { parentId: partIds.torso, socketId: 'inner_torso' },
-    'vital:stats': { status: { beating: true } },
+    'anatomy:joint': { parentId: 'actor-1', socketId: 'core-socket' },
   });
 
+  entityManager.createEntity('arm-left', {
+    'anatomy:part': { subType: 'arm' },
+    'anatomy:joint': { parentId: 'torso', socketId: 'arm-left-socket' },
+    'anatomy:tag': { strength: 8 },
+  });
+
+  entityManager.createEntity('hand-left', {
+    'anatomy:part': { subType: 'hand' },
+    'anatomy:joint': { parentId: 'arm-left', socketId: 'hand-left-socket' },
+  });
+
+  entityManager.createEntity('leg-left', {
+    'anatomy:part': { subType: 'leg' },
+    'anatomy:joint': { parentId: 'torso', socketId: 'leg-left-socket' },
+    'anatomy:sensors': { status: { active: true } },
+  });
+
+  entityManager.createEntity('foot-left', {
+    'anatomy:part': { subType: 'foot' },
+    'anatomy:joint': { parentId: 'leg-left', socketId: 'foot-left-socket' },
+  });
+
+  entityManager.createEntity('heart', {
+    'anatomy:part': { subType: 'heart' },
+    'anatomy:joint': { parentId: 'torso', socketId: 'heart-socket' },
+  });
+
+  entityManager.createEntity('floating', {
+    'anatomy:part': { subType: 'mystery' },
+  });
+};
+
+const createService = () => {
+  const entityManager = new TestEntityManager();
+  const logger = new TestLogger();
+  const eventDispatcher = new TestEventDispatcher();
   const service = new BodyGraphService({
     entityManager,
     logger,
     eventDispatcher,
   });
 
-  return {
-    entityManager,
-    service,
-    bodyComponent,
-    actorId,
-    partIds,
-    logger,
-    eventDispatcher,
-  };
-}
+  return { service, entityManager, logger, eventDispatcher };
+};
 
-describe('BodyGraphService real integration coverage', () => {
-  let entityManager;
+describe('BodyGraphService real module integration', () => {
   let service;
-  let bodyComponent;
-  let actorId;
-  let partIds;
+  let entityManager;
   let logger;
   let eventDispatcher;
 
   beforeEach(() => {
-    ({
+    ({ service, entityManager, logger, eventDispatcher } = createService());
+    populateAnatomy(entityManager);
+  });
+
+  it('validates constructor dependencies', () => {
+    const loggerOnly = new TestLogger();
+    const dispatcherOnly = new TestEventDispatcher();
+    expect(
+      () =>
+        new BodyGraphService({
+          logger: loggerOnly,
+          eventDispatcher: dispatcherOnly,
+        })
+    ).toThrow('entityManager is required');
+
+    expect(
+      () =>
+        new BodyGraphService({
+          entityManager: new TestEntityManager(),
+          eventDispatcher: dispatcherOnly,
+        })
+    ).toThrow('logger is required');
+
+    expect(
+      () =>
+        new BodyGraphService({
+          entityManager: new TestEntityManager(),
+          logger: loggerOnly,
+        })
+    ).toThrow('eventDispatcher is required');
+  });
+
+  it('builds adjacency cache and exposes navigation helpers', async () => {
+    await service.buildAdjacencyCache('actor-1');
+    expect(service.hasCache('actor-1')).toBe(true);
+    expect(service.getChildren('actor-1')).toEqual(['torso']);
+    expect(service.getChildren('torso')).toEqual(
+      expect.arrayContaining(['arm-left', 'leg-left', 'heart'])
+    );
+    expect(service.getParent('arm-left')).toBe('torso');
+    expect(service.getParent('unknown')).toBeNull();
+    expect(service.getAncestors('foot-left')).toEqual([
+      'leg-left',
+      'torso',
+      'actor-1',
+    ]);
+    expect(service.getAllDescendants('torso')).toEqual(
+      expect.arrayContaining(['arm-left', 'hand-left', 'leg-left', 'foot-left', 'heart'])
+    );
+    expect(service.getPath('hand-left', 'foot-left')).toEqual([
+      'hand-left',
+      'arm-left',
+      'torso',
+      'leg-left',
+      'foot-left',
+    ]);
+    expect(service.validateCache()).toEqual({ valid: true, issues: [] });
+
+    await service.buildAdjacencyCache('actor-1');
+    expect(service.getChildren('actor-1')).toEqual(['torso']);
+  });
+
+  it('falls back to entity manager when cache is empty for root lookup', () => {
+    const secondaryLogger = new TestLogger();
+    const fallbackService = new BodyGraphService({
       entityManager,
-      service,
-      bodyComponent,
-      actorId,
-      partIds,
-      logger,
-      eventDispatcher,
-    } = createAnatomyFixture());
-  });
-
-  it('traverses anatomy graphs and caches query results end-to-end', async () => {
-    await service.buildAdjacencyCache(actorId);
-    await service.buildAdjacencyCache(actorId);
-    expect(service.hasCache(actorId)).toBe(true);
-
-    expect(service.getAllParts(null)).toEqual([]);
-    expect(service.getAllParts({})).toEqual([]);
-
-    const blueprintParts = service.getAllParts(bodyComponent);
-    const expectedPartIds = Object.values(partIds);
-    expect([...blueprintParts].sort()).toEqual([...expectedPartIds].sort());
-
-    const actorParts = service.getAllParts(bodyComponent, actorId);
-    const expectedAllIds = [actorId, ...expectedPartIds];
-    expect([...actorParts].sort()).toEqual([...expectedAllIds].sort());
-
-    const cachedActorParts = service.getAllParts(bodyComponent, actorId);
-    expect(cachedActorParts).toBe(actorParts);
-
-    const directStructureParts = service.getAllParts({ root: partIds.torso });
-    expect([...directStructureParts].sort()).toEqual([...blueprintParts].sort());
-
-    const fallbackParts = service.getAllParts(bodyComponent, 'unseen-actor');
-    expect([...fallbackParts].sort()).toEqual([...blueprintParts].sort());
-
-    expect(
-      service.hasPartWithComponent(bodyComponent, 'custom:flag')
-    ).toBe(true);
-    expect(
-      service.hasPartWithComponent(bodyComponent, 'missing:component')
-    ).toBe(false);
-
-    const valueSearch = service.hasPartWithComponentValue(
-      bodyComponent,
-      'custom:status',
-      'metadata.functional',
-      'primary'
-    );
-    expect(valueSearch).toEqual({ found: true, partId: partIds.leftArm });
-    expect(
-      service.hasPartWithComponentValue(
-        bodyComponent,
-        'custom:status',
-        'metadata.functional',
-        'unknown'
-      )
-    ).toEqual({ found: false });
-
-    const handIds = service.findPartsByType(actorId, 'hand');
-    expect([...handIds].sort()).toEqual(
-      [partIds.leftHand, partIds.rightHand].sort()
-    );
-    const cachedHands = service.findPartsByType(actorId, 'hand');
-    expect(cachedHands).toBe(handIds);
-
-    expect(service.getAnatomyRoot(partIds.leftHand)).toBe(actorId);
-    expect(service.getPath(partIds.leftHand, partIds.head)).toEqual([
-      partIds.leftHand,
-      partIds.leftArm,
-      partIds.torso,
-      partIds.head,
-    ]);
-
-    const graph = await service.getBodyGraph(actorId);
-    expect(graph.getAllPartIds()).toEqual(actorParts);
-    expect([...graph.getConnectedParts(partIds.torso)].sort()).toEqual(
-      [
-        partIds.head,
-        partIds.leftArm,
-        partIds.rightArm,
-        partIds.heart,
-      ].sort()
-    );
-
-    await expect(service.getAnatomyData(actorId)).resolves.toEqual({
-      recipeId: bodyComponent.recipeId,
-      rootEntityId: actorId,
-    });
-    await expect(service.getAnatomyData(partIds.torso)).resolves.toBeNull();
-
-    const validation = service.validateCache();
-    expect(validation.valid).toBe(true);
-    expect(validation.issues).toHaveLength(0);
-
-    expect([...service.getChildren(actorId)]).toEqual([partIds.torso]);
-    expect([...service.getChildren(partIds.torso)].sort()).toEqual(
-      [
-        partIds.head,
-        partIds.leftArm,
-        partIds.rightArm,
-        partIds.heart,
-      ].sort()
-    );
-    expect(service.getChildren('unknown')).toEqual([]);
-
-    expect(service.getParent(actorId)).toBeNull();
-    expect(service.getParent(partIds.head)).toBe(partIds.torso);
-
-    expect(service.getAncestors(partIds.leftHand)).toEqual([
-      partIds.leftArm,
-      partIds.torso,
-      actorId,
-    ]);
-
-    expect(service.getAllDescendants(partIds.leftArm)).toEqual([
-      partIds.leftHand,
-    ]);
-    const actorDescendants = service.getAllDescendants(actorId);
-    expect(actorDescendants).toEqual(expect.arrayContaining(expectedPartIds));
-    expect(actorDescendants).not.toContain(actorId);
-  });
-
-  it('detaches limbs and invalidates caches using the real cache manager', async () => {
-    await service.buildAdjacencyCache(actorId);
-    const initialHands = service.findPartsByType(actorId, 'hand');
-    expect(initialHands).toHaveLength(2);
-
-    const result = await service.detachPart(partIds.leftArm, {
-      cascade: true,
-      reason: 'injury',
+      logger: secondaryLogger,
+      eventDispatcher: new TestEventDispatcher(),
     });
 
-    expect(result.detached).toEqual([partIds.leftArm, partIds.leftHand]);
-    expect(result.parentId).toBe(partIds.torso);
-    expect(result.socketId).toBe('left_shoulder');
-    expect(service.hasCache(actorId)).toBe(false);
-    expect(entityManager.getComponentData(partIds.leftArm, 'anatomy:joint')).toBeNull();
+    expect(fallbackService.getAnatomyRoot('hand-left')).toBe('actor-1');
+  });
 
-    expect(eventDispatcher.dispatch).toHaveBeenCalledWith(
-      LIMB_DETACHED_EVENT_ID,
+  it('detaches cascading parts, invalidates caches, and emits events', async () => {
+    await service.buildAdjacencyCache('actor-1');
+    const result = await service.detachPart('arm-left', { reason: 'injury' });
+
+    expect(result).toEqual({
+      detached: ['arm-left', 'hand-left'],
+      parentId: 'torso',
+      socketId: 'arm-left-socket',
+    });
+    expect(entityManager.getComponentData('arm-left', 'anatomy:joint')).toBeNull();
+    expect(service.hasCache('actor-1')).toBe(false);
+    expect(eventDispatcher.events).toHaveLength(1);
+    const [event] = eventDispatcher.events;
+    expect(event.eventId).toBe(LIMB_DETACHED_EVENT_ID);
+    expect(event.payload).toEqual(
       expect.objectContaining({
-        detachedEntityId: partIds.leftArm,
-        parentEntityId: partIds.torso,
-        socketId: 'left_shoulder',
+        detachedEntityId: 'arm-left',
         detachedCount: 2,
+        parentEntityId: 'torso',
         reason: 'injury',
       })
     );
-    expect(logger.info).toHaveBeenCalledWith(
-      `BodyGraphService: Detached 2 entities from parent '${partIds.torso}'`
-    );
-
-    await service.buildAdjacencyCache(actorId);
-    const rebuiltHands = service.findPartsByType(actorId, 'hand');
-    expect(rebuiltHands).toContain(partIds.rightHand);
-    expect(rebuiltHands).not.toContain(partIds.leftHand);
-    expect(rebuiltHands).toHaveLength(1);
+    expect(logger.messages('info').some((msg) => msg.includes('Detached 2 entities'))).toBe(true);
   });
 
-  it('supports non-cascading detachments and surfaces joint validation errors', async () => {
-    await service.buildAdjacencyCache(actorId);
-    const nonCascade = await service.detachPart(partIds.rightHand, {
+  it('supports non-cascading detach operations', async () => {
+    await service.buildAdjacencyCache('actor-1');
+    const result = await service.detachPart('leg-left', {
       cascade: false,
-      reason: 'maintenance',
+      reason: 'manual',
     });
 
-    expect(nonCascade.detached).toEqual([partIds.rightHand]);
-    expect(nonCascade.parentId).toBe(partIds.rightArm);
-    expect(nonCascade.socketId).toBe('right_wrist');
-    expect(service.hasCache(actorId)).toBe(false);
+    expect(result).toEqual({
+      detached: ['leg-left'],
+      parentId: 'torso',
+      socketId: 'leg-left-socket',
+    });
+    expect(entityManager.getComponentData('leg-left', 'anatomy:joint')).toBeNull();
+    expect(eventDispatcher.events).toHaveLength(1);
+    expect(eventDispatcher.events[0].payload.detachedCount).toBe(1);
+  });
 
-    const {
-      service: secondService,
-      partIds: secondIds,
-      entityManager: secondEntityManager,
-    } = createAnatomyFixture();
-    await secondEntityManager.removeComponent(
-      secondIds.head,
-      'anatomy:joint'
+  it('finds parts by type with caching and invalidation after detach', async () => {
+    await service.buildAdjacencyCache('actor-1');
+    const initial = service.findPartsByType('actor-1', 'arm');
+    expect(initial).toEqual(['arm-left']);
+
+    entityManager.setComponent('arm-left', 'anatomy:part', { subType: 'wing' });
+    const cached = service.findPartsByType('actor-1', 'arm');
+    expect(cached).toEqual(['arm-left']);
+
+    await service.detachPart('arm-left');
+    entityManager.setComponent('arm-right', 'anatomy:part', { subType: 'arm' });
+    entityManager.setComponent('arm-right', 'anatomy:joint', {
+      parentId: 'torso',
+      socketId: 'arm-right-socket',
+    });
+    entityManager.setComponent('hand-right', 'anatomy:part', { subType: 'hand' });
+    entityManager.setComponent('hand-right', 'anatomy:joint', {
+      parentId: 'arm-right',
+      socketId: 'hand-right-socket',
+    });
+
+    await service.buildAdjacencyCache('actor-1');
+    const updated = service.findPartsByType('actor-1', 'arm');
+    expect(updated).toEqual(['arm-right']);
+  });
+
+  it('caches all parts and prefers actor cache roots', async () => {
+    const bodyComponent = entityManager.getComponentData('actor-1', 'anatomy:body');
+    expect(service.getAllParts(null)).toEqual([]);
+    expect(service.getAllParts({ body: {} })).toEqual([]);
+
+    await service.buildAdjacencyCache('actor-1');
+    const actorParts = service.getAllParts(bodyComponent, 'actor-1');
+    expect(actorParts).toEqual(
+      expect.arrayContaining([
+        'actor-1',
+        'torso',
+        'arm-left',
+        'hand-left',
+        'leg-left',
+        'foot-left',
+        'heart',
+      ])
     );
-    await expect(secondService.detachPart(secondIds.head)).rejects.toThrow(
-      InvalidArgumentError
+
+    const blueprintParts = service.getAllParts({ body: { root: 'torso' } });
+    expect(blueprintParts).toEqual(
+      expect.arrayContaining(['torso', 'arm-left', 'hand-left', 'leg-left', 'foot-left', 'heart'])
+    );
+
+    entityManager.setComponent('heart', 'anatomy:joint', {
+      parentId: 'torso',
+      socketId: 'heart-socket',
+    });
+    const cached = service.getAllParts({ body: { root: 'torso' } });
+    entityManager.setComponent('heart', 'anatomy:joint', {
+      parentId: 'torso',
+      socketId: 'updated',
+    });
+    const cachedAgain = service.getAllParts({ body: { root: 'torso' } });
+    expect(cachedAgain).toEqual(cached);
+    expect(
+      logger.messages('debug').some((msg) =>
+        typeof msg === 'string' && msg.includes("Found cached result for root 'torso'")
+      )
+    ).toBe(true);
+
+    await service.detachPart('heart');
+    await service.buildAdjacencyCache('actor-1');
+    const actorAfterDetach = service.getAllParts(bodyComponent, 'actor-1');
+    expect(actorAfterDetach).not.toContain('heart');
+  });
+
+  it('detects components and nested values across the anatomy', async () => {
+    await service.buildAdjacencyCache('actor-1');
+    const bodyComponent = entityManager.getComponentData('actor-1', 'anatomy:body');
+    expect(service.hasPartWithComponent(bodyComponent, 'anatomy:tag')).toBe(true);
+
+    entityManager.setComponent('arm-left', 'anatomy:tag', {});
+    expect(service.hasPartWithComponent(bodyComponent, 'anatomy:tag')).toBe(false);
+
+    const valueMatch = service.hasPartWithComponentValue(
+      bodyComponent,
+      'anatomy:sensors',
+      'status.active',
+      true
+    );
+    expect(valueMatch).toEqual({ found: true, partId: 'leg-left' });
+
+    const noMatch = service.hasPartWithComponentValue(
+      bodyComponent,
+      'anatomy:sensors',
+      'status.disabled',
+      true
+    );
+    expect(noMatch).toEqual({ found: false });
+  });
+
+  it('retrieves body graphs and anatomy data while validating input', async () => {
+    await expect(service.getBodyGraph('')).rejects.toThrow(InvalidArgumentError);
+    await expect(service.getBodyGraph('missing')).rejects.toThrow(
+      'Entity missing has no anatomy:body component'
+    );
+
+    const bodyGraph = await service.getBodyGraph('actor-1');
+    expect(bodyGraph.getAllPartIds()).toEqual(
+      expect.arrayContaining(['actor-1', 'torso', 'arm-left', 'leg-left'])
+    );
+    expect(bodyGraph.getConnectedParts('torso')).toEqual(
+      expect.arrayContaining(['arm-left', 'leg-left', 'heart'])
+    );
+
+    await expect(service.getAnatomyData('')).rejects.toThrow(InvalidArgumentError);
+    const missingData = await service.getAnatomyData('missing');
+    expect(missingData).toBeNull();
+    expect(
+      logger.messages('debug').some((msg) =>
+        typeof msg === 'string' && msg.includes("has no anatomy:body component")
+      )
+    ).toBe(true);
+
+    const anatomyData = await service.getAnatomyData('actor-1');
+    expect(anatomyData).toEqual({
+      recipeId: 'humanoid_base',
+      rootEntityId: 'actor-1',
+    });
+  });
+
+  it('rejects detach attempts when part lacks a joint', async () => {
+    await expect(service.detachPart('floating')).rejects.toThrow(
+      "Entity 'floating' has no joint component"
     );
   });
 });


### PR DESCRIPTION
Summary:
- add a new integration suite that exercises BodyGraphService with the real cache/query/algorithm modules and an in-memory entity graph
- cover cache building, detachment flows, traversal helpers, query caching, and anatomy data access using realistic entity relationships

Testing Done:
- [x] `npx jest --config jest.config.integration.js --runTestsByPath tests/integration/anatomy/bodyGraphService.real.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e2c339d00883318aa9223532062c92