### PR TITLE
[Agent] Add coverage for throttleUtils generateKey

### DIFF
--- a/tests/unit/utils/throttleUtils.test.js
+++ b/tests/unit/utils/throttleUtils.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, test } from '@jest/globals';
+import { generateKey } from '../../../src/utils/throttleUtils.js';
+
+describe('throttleUtils.generateKey', () => {
+  test('combines message, status code, and url into dedupe key', () => {
+    const message = 'Request failed';
+    const details = { statusCode: 429, url: '/api/resource' };
+
+    const key = generateKey(message, details);
+
+    expect(key).toBe('Request failed::429::/api/resource');
+  });
+
+  test('omits missing details while keeping separators stable', () => {
+    const message = 'Partial details';
+    const details = { url: '/partial/only' };
+
+    const key = generateKey(message, details);
+
+    expect(key).toBe('Partial details::::/partial/only');
+  });
+
+  test('supports falsy status codes and undefined detail object', () => {
+    expect(generateKey('Zero status', { statusCode: 0 })).toBe('Zero status::0::');
+    expect(generateKey('No details')).toBe('No details::::');
+  });
+});


### PR DESCRIPTION
Summary: Add focused coverage for throttleUtils.generateKey

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/utils/throttleUtils.test.js --coverage --collectCoverageFrom='src/utils/throttleUtils.js' --coverageDirectory=coverage-temp/throttle --coverageReporters=json-summary --coverageReporters=text --silent`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e2d4b0fc048331bfd34ab8a2f1e200