### PR TITLE
[Agent] Support actor target component validation

### DIFF
--- a/src/actions/validation/TargetRequiredComponentsValidator.js
+++ b/src/actions/validation/TargetRequiredComponentsValidator.js
@@ -69,8 +69,8 @@ class TargetRequiredComponentsValidator {
       }
     }
 
-    // Check multi-target format
-    const multiTargetRoles = ['primary', 'secondary', 'tertiary'];
+    // Check multi-target format (including actor requirements when provided)
+    const multiTargetRoles = ['actor', 'primary', 'secondary', 'tertiary'];
     for (const role of multiTargetRoles) {
       if (requirements[role] && requirements[role].length > 0) {
         const result = this.#validateTargetRole(

--- a/tests/unit/actions/validation/TargetRequiredComponentsValidator.test.js
+++ b/tests/unit/actions/validation/TargetRequiredComponentsValidator.test.js
@@ -57,10 +57,7 @@ describe('TargetRequiredComponentsValidator', () => {
       expect(result).toEqual({ valid: true });
     });
 
-    // NOTE: "actor" role is not currently implemented in the validator
-    // The validator only handles: target (legacy), primary, secondary, tertiary
-    // Skipping this test until "actor" role support is added to the implementation
-    it.skip('should return valid when actor has all required components', () => {
+    it('should return valid when actor has all required components', () => {
       const actionDef = {
         id: 'test:action',
         required_components: {


### PR DESCRIPTION
Summary:
- include the actor role when verifying required target components so actor requirements are enforced
- enable the actor validation unit test to cover the updated validator behavior

Testing Done:
- [x] npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/actions/validation/TargetRequiredComponentsValidator.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e41395b79883318db144013eb69d4f