### PR TITLE
[Agent] Add GameEngineLoadAdapter unit tests

### DIFF
--- a/tests/unit/adapters/gameEngineLoadAdapter.unit.test.js
+++ b/tests/unit/adapters/gameEngineLoadAdapter.unit.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import GameEngineLoadAdapter from '../../../src/adapters/GameEngineLoadAdapter.js';
+import ILoadService from '../../../src/interfaces/ILoadService.js';
+
+describe('GameEngineLoadAdapter', () => {
+  it('extends the ILoadService contract and returns the engine result', async () => {
+    const engine = { loadGame: jest.fn().mockResolvedValue({ ok: true }) };
+    const adapter = new GameEngineLoadAdapter(engine);
+
+    expect(adapter).toBeInstanceOf(ILoadService);
+
+    const identifier = { slot: 'alpha' };
+    await expect(adapter.load(identifier)).resolves.toEqual({ ok: true });
+    expect(engine.loadGame).toHaveBeenCalledTimes(1);
+    expect(engine.loadGame).toHaveBeenCalledWith(identifier);
+  });
+
+  it('propagates rejections from the underlying engine', async () => {
+    const error = new Error('boom');
+    const engine = { loadGame: jest.fn().mockRejectedValue(error) };
+    const adapter = new GameEngineLoadAdapter(engine);
+
+    await expect(adapter.load('save-42')).rejects.toBe(error);
+    expect(engine.loadGame).toHaveBeenCalledWith('save-42');
+  });
+
+  it('throws a TypeError when the engine does not expose loadGame', async () => {
+    const adapter = new GameEngineLoadAdapter({});
+
+    await expect(adapter.load('missing')).rejects.toBeInstanceOf(TypeError);
+  });
+});


### PR DESCRIPTION
Summary: add focused unit tests that exercise GameEngineLoadAdapter success, rejection, and missing-method paths to raise its coverage.

Testing Done:
- [x] npx jest --config jest.config.unit.js --runTestsByPath tests/unit/adapters/gameEngineLoadAdapter.unit.test.js --coverage --collectCoverageFrom='src/adapters/GameEngineLoadAdapter.js'

------
https://chatgpt.com/codex/tasks/task_e_68e42685792c8331b5598fd31928b2a4