### PR TITLE
[Agent] Add coverage tests for assertValidActionIndex

### DIFF
--- a/tests/unit/utils/actionIndexUtils.coverage.test.js
+++ b/tests/unit/utils/actionIndexUtils.coverage.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { assertValidActionIndex } from '../../../src/utils/actionIndexUtils.js';
+import { safeDispatchError } from '../../../src/utils/safeDispatchErrorUtils.js';
+
+jest.mock('../../../src/utils/safeDispatchErrorUtils.js', () => ({
+  __esModule: true,
+  safeDispatchError: jest.fn(),
+}));
+
+function createLogger() {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe('assertValidActionIndex', () => {
+  let dispatcher;
+  let logger;
+
+  beforeEach(() => {
+    dispatcher = { dispatch: jest.fn() };
+    logger = createLogger();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches and throws when chosen index is not an integer', () => {
+    expect(() =>
+      assertValidActionIndex(1.2, 4, 'provider', 'actor-1', dispatcher, logger)
+    ).toThrow('Could not resolve the chosen action to a valid index.');
+
+    expect(safeDispatchError).toHaveBeenCalledTimes(1);
+    expect(safeDispatchError).toHaveBeenCalledWith(
+      dispatcher,
+      "provider: Did not receive a valid integer 'chosenIndex' for actor actor-1.",
+      {},
+      logger
+    );
+  });
+
+  it('dispatches with merged debug data when index is outside bounds', () => {
+    const debugData = { reason: 'too-high' };
+
+    expect(() =>
+      assertValidActionIndex(5, 3, 'provider', 'actor-2', dispatcher, logger, debugData)
+    ).toThrow('Player chose an index that does not exist for this turn.');
+
+    expect(safeDispatchError).toHaveBeenCalledTimes(1);
+    const [, , details] = safeDispatchError.mock.calls[0];
+    expect(details).toEqual({ reason: 'too-high', actionsCount: 3 });
+    expect(details).not.toBe(debugData);
+    expect(debugData).toEqual({ reason: 'too-high' });
+  });
+
+  it('returns silently when the index is valid', () => {
+    expect(() =>
+      assertValidActionIndex(2, 5, 'provider', 'actor-3', dispatcher, logger)
+    ).not.toThrow();
+
+    expect(safeDispatchError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary:
- add a focused unit test suite for `assertValidActionIndex` covering invalid and valid index scenarios
- verify debug metadata is merged without mutating the original data when dispatching range errors

Testing Done:
- [x] `npx jest tests/unit/utils/actionIndexUtils.coverage.test.js --config jest.config.unit.js --env=jsdom --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e43d9c20bc83319bd4d931ee6bf54c