### PR TITLE
[Agent] Add stretch sexily seduction action

### DIFF
--- a/data/mods/seduction/actions/stretch_sexily.action.json
+++ b/data/mods/seduction/actions/stretch_sexily.action.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "seduction:stretch_sexily",
+  "name": "Stretch Sexily",
+  "description": "Roll your shoulders back and lengthen into a languid stretch, drawing attention to your body as you claim the space around you.",
+  "targets": "none",
+  "required_components": {},
+  "template": "stretch sexily",
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#f57f17",
+    "textColor": "#000000",
+    "hoverBackgroundColor": "#f9a825",
+    "hoverTextColor": "#212121"
+  }
+}

--- a/data/mods/seduction/conditions/event-is-action-stretch-sexily.condition.json
+++ b/data/mods/seduction/conditions/event-is-action-stretch-sexily.condition.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "seduction:event-is-action-stretch-sexily",
+  "description": "Checks if the triggering event is for the 'seduction:stretch_sexily' action.",
+  "logic": {
+    "==": [
+      { "var": "event.payload.actionId" },
+      "seduction:stretch_sexily"
+    ]
+  }
+}

--- a/data/mods/seduction/mod-manifest.json
+++ b/data/mods/seduction/mod-manifest.json
@@ -19,15 +19,18 @@
   "content": {
     "actions": [
       "draw_attention_to_ass.action.json",
-      "draw_attention_to_breasts.action.json"
+      "draw_attention_to_breasts.action.json",
+      "stretch_sexily.action.json"
     ],
     "rules": [
       "draw_attention_to_ass.rule.json",
-      "draw_attention_to_breasts.rule.json"
+      "draw_attention_to_breasts.rule.json",
+      "stretch_sexily.rule.json"
     ],
     "conditions": [
       "event-is-action-draw-attention-to-ass.condition.json",
-      "event-is-action-draw-attention-to-breasts.condition.json"
+      "event-is-action-draw-attention-to-breasts.condition.json",
+      "event-is-action-stretch-sexily.condition.json"
     ]
   }
 }

--- a/data/mods/seduction/rules/stretch_sexily.rule.json
+++ b/data/mods/seduction/rules/stretch_sexily.rule.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "stretch_sexily",
+  "comment": "Handles the 'seduction:stretch_sexily' action. Generates descriptive text about the actor stretching languidly to draw attention.",
+  "event_type": "core:attempt_action",
+  "condition": {
+    "condition_ref": "seduction:event-is-action-stretch-sexily"
+  },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "comment": "Get actor name for the messages.",
+      "parameters": {
+        "entity_ref": "actor",
+        "result_variable": "actorName"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Get location for the perceptible event.",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "comment": "Construct the perceptible log message for observers.",
+      "parameters": {
+        "variable_name": "logMessage",
+        "value": "{context.actorName} tilts head and spine, claiming space with a languid stretch, drawing attention to their body."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "perceptionType",
+        "value": "action_self_general"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "locationId",
+        "value": "{context.actorPosition.locationId}"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "targetId",
+        "value": null
+      }
+    },
+    { "macro": "core:logSuccessAndEndTurn" }
+  ]
+}

--- a/tests/integration/mods/seduction/rules/stretchSexilyRule.integration.test.js
+++ b/tests/integration/mods/seduction/rules/stretchSexilyRule.integration.test.js
@@ -1,0 +1,127 @@
+/**
+ * @file Integration tests for the seduction:stretch_sexily rule.
+ * @description Validates rule triggering, messaging, and structural schema compliance for the stretch sexily action.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ModTestFixture } from '../../../../common/mods/ModTestFixture.js';
+
+const ACTION_ID = 'seduction:stretch_sexily';
+const EXPECTED_MESSAGE =
+  '{context.actorName} tilts head and spine, claiming space with a languid stretch, drawing attention to their body.';
+
+describe('Seduction Mod: Stretch Sexily Rule', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('seduction', ACTION_ID);
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Rule Execution', () => {
+    it('logs success and ends the turn for the stretch action', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Nina', 'Lucas']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertActionSuccess(
+        'Nina tilts head and spine, claiming space with a languid stretch, drawing attention to their body.'
+      );
+    });
+
+    it('emits perceptible event with null target', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Ivy', 'Owen']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertPerceptibleEvent({
+        descriptionText:
+          'Ivy tilts head and spine, claiming space with a languid stretch, drawing attention to their body.',
+        locationId: 'room1',
+        actorId: scenario.actor.id,
+        targetId: null,
+        perceptionType: 'action_self_general',
+      });
+    });
+
+    it('ignores unrelated actions', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Zoe', 'Ethan']);
+
+      const payload = {
+        eventName: 'core:attempt_action',
+        actorId: scenario.actor.id,
+        actionId: 'core:wait',
+        originalInput: 'wait',
+      };
+
+      await testFixture.eventBus.dispatch('core:attempt_action', payload);
+
+      testFixture.assertOnlyExpectedEvents(['core:attempt_action']);
+    });
+  });
+
+  describe('Rule Structure Validation', () => {
+    it('should identify rule metadata correctly', () => {
+      expect(testFixture.ruleFile.rule_id).toBe('stretch_sexily');
+      expect(testFixture.ruleFile.comment).toBe(
+        "Handles the 'seduction:stretch_sexily' action. Generates descriptive text about the actor stretching languidly to draw attention."
+      );
+    });
+
+    it('should process core:attempt_action events only', () => {
+      expect(testFixture.ruleFile.event_type).toBe('core:attempt_action');
+    });
+
+    it('should reference the stretch action condition', () => {
+      expect(testFixture.ruleFile.condition.condition_ref).toBe(
+        'seduction:event-is-action-stretch-sexily'
+      );
+    });
+  });
+
+  describe('Action sequence validation', () => {
+    it('should include required variables and macro', () => {
+      const actions = testFixture.ruleFile.actions;
+      expect(actions).toHaveLength(7);
+
+      const [getName, queryComponent, messageAction, perceptionType, locationId, targetId, macro] = actions;
+
+      expect(getName.type).toBe('GET_NAME');
+      expect(getName.parameters.entity_ref).toBe('actor');
+      expect(getName.parameters.result_variable).toBe('actorName');
+
+      expect(queryComponent.type).toBe('QUERY_COMPONENT');
+      expect(queryComponent.parameters.component_type).toBe('core:position');
+      expect(queryComponent.parameters.result_variable).toBe('actorPosition');
+
+      expect(messageAction.type).toBe('SET_VARIABLE');
+      expect(messageAction.parameters.variable_name).toBe('logMessage');
+      expect(messageAction.parameters.value).toBe(EXPECTED_MESSAGE);
+
+      expect(perceptionType.parameters.variable_name).toBe('perceptionType');
+      expect(perceptionType.parameters.value).toBe('action_self_general');
+
+      expect(locationId.parameters.variable_name).toBe('locationId');
+      expect(locationId.parameters.value).toBe('{context.actorPosition.locationId}');
+
+      expect(targetId.parameters.variable_name).toBe('targetId');
+      expect(targetId.parameters.value).toBeNull();
+
+      expect(macro.macro).toBe('core:logSuccessAndEndTurn');
+    });
+  });
+
+  describe('Condition logic validation', () => {
+    it('should match only the stretch action id', () => {
+      expect(testFixture.conditionFile.logic['==']).toEqual([
+        { var: 'event.payload.actionId' },
+        ACTION_ID,
+      ]);
+    });
+  });
+});

--- a/tests/integration/mods/seduction/stretch_sexily_action_discovery.test.js
+++ b/tests/integration/mods/seduction/stretch_sexily_action_discovery.test.js
@@ -1,0 +1,71 @@
+/**
+ * @file Integration tests for seduction:stretch_sexily action discovery.
+ * @description Ensures the stretch sexily action is available without prerequisites and advertises expected styling.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import stretchSexilyAction from '../../../../data/mods/seduction/actions/stretch_sexily.action.json';
+
+const ACTION_ID = 'seduction:stretch_sexily';
+
+describe('seduction:stretch_sexily action discovery', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('seduction', ACTION_ID);
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Action metadata validation', () => {
+    it('should define the correct core metadata', () => {
+      expect(stretchSexilyAction).toBeDefined();
+      expect(stretchSexilyAction.id).toBe(ACTION_ID);
+      expect(stretchSexilyAction.name).toBe('Stretch Sexily');
+      expect(stretchSexilyAction.description).toBe(
+        'Roll your shoulders back and lengthen into a languid stretch, drawing attention to your body as you claim the space around you.'
+      );
+      expect(stretchSexilyAction.template).toBe('stretch sexily');
+    });
+
+    it('should be a self-targeting action', () => {
+      expect(stretchSexilyAction.targets).toBe('none');
+      expect(stretchSexilyAction.required_components).toEqual({});
+    });
+  });
+
+  describe('Visual styling validation', () => {
+    it('should reuse the seduction orange palette', () => {
+      expect(stretchSexilyAction.visual).toBeDefined();
+      expect(stretchSexilyAction.visual.backgroundColor).toBe('#f57f17');
+      expect(stretchSexilyAction.visual.textColor).toBe('#000000');
+      expect(stretchSexilyAction.visual.hoverBackgroundColor).toBe('#f9a825');
+      expect(stretchSexilyAction.visual.hoverTextColor).toBe('#212121');
+    });
+  });
+
+  describe('Prerequisite handling', () => {
+    it('should expose an empty prerequisites array', () => {
+      expect(stretchSexilyAction.prerequisites).toBeDefined();
+      expect(Array.isArray(stretchSexilyAction.prerequisites)).toBe(true);
+      expect(stretchSexilyAction.prerequisites).toHaveLength(0);
+    });
+  });
+
+  describe('Action discoverability scenarios', () => {
+    it('should be executable without any special setup', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Ava', 'Marcus']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertActionSuccess(
+        'Ava tilts head and spine, claiming space with a languid stretch, drawing attention to their body.'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Summary: Add a self-targeting "stretch sexily" seduction action, condition, and rule with supporting integration tests.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npx jest --config=jest.config.integration.js tests/integration/mods/seduction/stretch_sexily_action_discovery.test.js tests/integration/mods/seduction/rules/stretchSexilyRule.integration.test.js`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e4c2c7f4208331a8c7501f97fc9d0c