### PR TITLE
[Agent] Add playful tickle affection interaction

### DIFF
--- a/data/mods/affection/actions/tickle_target_playfully.action.json
+++ b/data/mods/affection/actions/tickle_target_playfully.action.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "affection:tickle_target_playfully",
+  "name": "Tickle target playfully",
+  "description": "Lightly tickle the target in a playful, affectionate gesture.",
+  "targets": "affection:close_actors_facing_each_other_or_behind_target",
+  "required_components": {
+    "actor": ["positioning:closeness"]
+  },
+  "template": "tickle {target}",
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#6a1b9a",
+    "textColor": "#f3e5f5",
+    "hoverBackgroundColor": "#8e24aa",
+    "hoverTextColor": "#ffffff"
+  }
+}

--- a/data/mods/affection/conditions/event-is-action-tickle-target-playfully.condition.json
+++ b/data/mods/affection/conditions/event-is-action-tickle-target-playfully.condition.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "affection:event-is-action-tickle-target-playfully",
+  "description": "Checks if the triggering event is for the 'affection:tickle_target_playfully' action.",
+  "logic": {
+    "==": [{ "var": "event.payload.actionId" }, "affection:tickle_target_playfully"]
+  }
+}

--- a/data/mods/affection/mod-manifest.json
+++ b/data/mods/affection/mod-manifest.json
@@ -29,6 +29,7 @@
       "massage_shoulders.action.json",
       "place_hand_on_waist.action.json",
       "ruffle_hair_playfully.action.json",
+      "tickle_target_playfully.action.json",
       "sling_arm_around_shoulders.action.json",
       "wrap_arm_around_waist.action.json"
     ],
@@ -40,6 +41,7 @@
       "massage_back.rule.json",
       "place_hand_on_waist.rule.json",
       "handle_ruffle_hair_playfully.rule.json",
+      "handle_tickle_target_playfully.rule.json",
       "sling_arm_around_shoulders.rule.json",
       "wrap_arm_around_waist.rule.json"
     ],
@@ -51,6 +53,7 @@
       "event-is-action-massage-shoulders.condition.json",
       "event-is-action-place-hand-on-waist.condition.json",
       "event-is-action-ruffle-hair-playfully.condition.json",
+      "event-is-action-tickle-target-playfully.condition.json",
       "event-is-action-sling_arm_around_shoulders.condition.json",
       "event-is-action-wrap-arm-around-waist.condition.json"
     ],

--- a/data/mods/affection/rules/handle_tickle_target_playfully.rule.json
+++ b/data/mods/affection/rules/handle_tickle_target_playfully.rule.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "handle_tickle_target_playfully",
+  "comment": "Handles the 'affection:tickle_target_playfully' action. Dispatches descriptive text and ends the turn.",
+  "event_type": "core:attempt_action",
+  "condition": {
+    "condition_ref": "affection:event-is-action-tickle-target-playfully"
+  },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "actor", "result_variable": "actorName" }
+    },
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "target", "result_variable": "targetName" }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "logMessage",
+        "value": "{context.actorName} drives a playful tickle up {context.targetName}'s sides."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "perceptionType",
+        "value": "action_target_general"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "locationId",
+        "value": "{context.actorPosition.locationId}"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "targetId",
+        "value": "{event.payload.targetId}"
+      }
+    },
+    { "macro": "core:logSuccessAndEndTurn" }
+  ]
+}

--- a/tests/integration/mods/affection/tickle_target_playfully_action.test.js
+++ b/tests/integration/mods/affection/tickle_target_playfully_action.test.js
@@ -1,0 +1,68 @@
+/**
+ * @file Integration tests for the affection:tickle_target_playfully action and rule.
+ * @description Verifies the playful tickling action produces the expected narrative output and event flow.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import handleTickleTargetPlayfullyRule from '../../../../data/mods/affection/rules/handle_tickle_target_playfully.rule.json';
+import eventIsActionTickleTargetPlayfully from '../../../../data/mods/affection/conditions/event-is-action-tickle-target-playfully.condition.json';
+
+const ACTION_ID = 'affection:tickle_target_playfully';
+
+const EXPECTED_ALLOWED_EVENTS = [
+  'core:attempt_action',
+  'core:perceptible_event',
+  'core:display_successful_action_result',
+  'core:turn_ended',
+];
+
+describe('affection:tickle_target_playfully action integration', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction(
+      'affection',
+      ACTION_ID,
+      handleTickleTargetPlayfullyRule,
+      eventIsActionTickleTargetPlayfully
+    );
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  it('emits matching success and perceptible messages when executed', async () => {
+    const scenario = testFixture.createCloseActors(['Amelia', 'Jonah'], {
+      location: 'garden',
+    });
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const successEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:display_successful_action_result'
+    );
+    const perceptibleEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:perceptible_event'
+    );
+
+    expect(successEvent).toBeDefined();
+    expect(perceptibleEvent).toBeDefined();
+
+    const expectedMessage =
+      "Amelia drives a playful tickle up Jonah's sides.";
+    expect(successEvent.payload.message).toBe(expectedMessage);
+    expect(perceptibleEvent.payload.descriptionText).toBe(expectedMessage);
+    expect(perceptibleEvent.payload.perceptionType).toBe(
+      'action_target_general'
+    );
+    expect(perceptibleEvent.payload.locationId).toBe('garden');
+    expect(perceptibleEvent.payload.targetId).toBe(scenario.target.id);
+    expect(perceptibleEvent.payload.actorId).toBe(scenario.actor.id);
+
+    testFixture.assertOnlyExpectedEvents(EXPECTED_ALLOWED_EVENTS);
+  });
+});

--- a/tests/integration/mods/affection/tickle_target_playfully_action_discovery.test.js
+++ b/tests/integration/mods/affection/tickle_target_playfully_action_discovery.test.js
@@ -1,0 +1,184 @@
+/**
+ * @file Integration tests for affection:tickle_target_playfully action discovery.
+ * @description Ensures the playful tickling action is only discoverable when proximity requirements are met.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import { ModEntityScenarios } from '../../../common/mods/ModEntityBuilder.js';
+import tickleTargetPlayfullyAction from '../../../../data/mods/affection/actions/tickle_target_playfully.action.json';
+
+const ACTION_ID = 'affection:tickle_target_playfully';
+
+describe('affection:tickle_target_playfully action discovery', () => {
+  let testFixture;
+  let configureActionDiscovery;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('affection', ACTION_ID);
+
+    configureActionDiscovery = () => {
+      const { testEnv } = testFixture;
+      if (!testEnv) {
+        return;
+      }
+
+      testEnv.actionIndex.buildIndex([tickleTargetPlayfullyAction]);
+
+      const scopeResolver = testEnv.unifiedScopeResolver;
+      const originalResolve =
+        scopeResolver.__tickleTargetOriginalResolve ||
+        scopeResolver.resolveSync.bind(scopeResolver);
+
+      scopeResolver.__tickleTargetOriginalResolve = originalResolve;
+      scopeResolver.resolveSync = (scopeName, context) => {
+        if (
+          scopeName ===
+          'affection:close_actors_facing_each_other_or_behind_target'
+        ) {
+          const actorId = context?.actor?.id;
+          if (!actorId) {
+            return { success: true, value: new Set() };
+          }
+
+          const { entityManager } = testEnv;
+          const actorEntity = entityManager.getEntityInstance(actorId);
+          if (!actorEntity) {
+            return { success: true, value: new Set() };
+          }
+
+          const closeness =
+            actorEntity.components?.['positioning:closeness']?.partners;
+          if (!Array.isArray(closeness) || closeness.length === 0) {
+            return { success: true, value: new Set() };
+          }
+
+          const actorFacingAway =
+            actorEntity.components?.['positioning:facing_away']
+              ?.facing_away_from || [];
+
+          const validTargets = closeness.reduce((acc, partnerId) => {
+            const partner = entityManager.getEntityInstance(partnerId);
+            if (!partner) {
+              return acc;
+            }
+
+            const partnerFacingAway =
+              partner.components?.['positioning:facing_away']
+                ?.facing_away_from || [];
+            const facingEachOther =
+              !actorFacingAway.includes(partnerId) &&
+              !partnerFacingAway.includes(actorId);
+            const actorBehind = partnerFacingAway.includes(actorId);
+
+            if (facingEachOther || actorBehind) {
+              acc.add(partnerId);
+            }
+
+            return acc;
+          }, new Set());
+
+          return { success: true, value: validTargets };
+        }
+
+        return originalResolve(scopeName, context);
+      };
+    };
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Action structure validation', () => {
+    it('matches the expected affection action schema', () => {
+      expect(tickleTargetPlayfullyAction).toBeDefined();
+      expect(tickleTargetPlayfullyAction.id).toBe(ACTION_ID);
+      expect(tickleTargetPlayfullyAction.template).toBe('tickle {target}');
+      expect(tickleTargetPlayfullyAction.targets).toBe(
+        'affection:close_actors_facing_each_other_or_behind_target'
+      );
+    });
+
+    it('requires actor closeness and uses the affection color palette', () => {
+      expect(tickleTargetPlayfullyAction.required_components.actor).toEqual([
+        'positioning:closeness',
+      ]);
+      expect(tickleTargetPlayfullyAction.visual).toEqual({
+        backgroundColor: '#6a1b9a',
+        textColor: '#f3e5f5',
+        hoverBackgroundColor: '#8e24aa',
+        hoverTextColor: '#ffffff',
+      });
+    });
+  });
+
+  describe('Action discovery scenarios', () => {
+    it('is available for close actors facing each other', () => {
+      const scenario = testFixture.createCloseActors(['Alice', 'Bob']);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is available when the actor stands behind the target', () => {
+      const scenario = testFixture.createCloseActors(['Maya', 'Noah']);
+      scenario.target.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.actor.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is not available when actors are not in closeness', () => {
+      const scenario = testFixture.createCloseActors(['Ivy', 'Liam']);
+      delete scenario.actor.components['positioning:closeness'];
+      delete scenario.target.components['positioning:closeness'];
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+
+    it('is not available when the actor faces away from the target', () => {
+      const scenario = testFixture.createCloseActors(['Chloe', 'Evan']);
+      scenario.actor.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.target.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Add a playful tickle action to the affection mod, wiring its manifest entries, rule, condition, and integration coverage.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`
- [x] Targeted integration tests `npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/mods/affection/tickle_target_playfully_action_discovery.test.js tests/integration/mods/affection/tickle_target_playfully_action.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e4cbca337c83318ce7a982dfbdc72e