### PR TITLE
[Agent] Improve placeholder resolver skip key coverage

### DIFF
--- a/tests/unit/utils/placeholderResolverUtils.test.js
+++ b/tests/unit/utils/placeholderResolverUtils.test.js
@@ -329,6 +329,38 @@ describe('PlaceholderResolver', () => {
       expect(result).toBeUndefined();
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
+
+    it('should honor skipKeys when provided as an array', () => {
+      const input = {
+        visible: '{name}',
+        protected: '{secret}',
+      };
+      const result = resolver.resolveStructure(
+        input,
+        { name: 'Visible', secret: 'Hidden' },
+        {},
+        ['protected']
+      );
+
+      expect(result).toEqual({ visible: 'Visible', protected: '{secret}' });
+    });
+
+    it('should accept iterable skipKeys instances', () => {
+      const input = {
+        keep: '{name}',
+        omit: '{code}',
+      };
+      const skip = new Set(['omit']);
+
+      const result = resolver.resolveStructure(
+        input,
+        { name: 'Hero', code: 'XYZ' },
+        {},
+        skip
+      );
+
+      expect(result).toEqual({ keep: 'Hero', omit: '{code}' });
+    });
   });
 
   describe('buildResolutionSources', () => {


### PR DESCRIPTION
## Summary
- add unit tests for PlaceholderResolver to ensure skipKeys arrays skip resolution
- cover iterable skipKeys handling to exercise conversion logic and prevent regressions

## Testing
- npx jest --config jest.config.unit.js --env=jsdom --runInBand --collectCoverageFrom="src/utils/placeholderResolverUtils.js" --coverage tests/unit/utils/placeholderResolverUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4fa3a66648331b4fda03772428c9a