### PR TITLE
[Agent] Add rest head on shoulder affection action

### DIFF
--- a/data/mods/affection/actions/rest_head_on_shoulder.action.json
+++ b/data/mods/affection/actions/rest_head_on_shoulder.action.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "affection:rest_head_on_shoulder",
+  "name": "Rest Head on Shoulder",
+  "description": "Lean your head on a companion's shoulder to offer comfort.",
+  "targets": "affection:close_actors_facing_each_other_or_behind_target",
+  "required_components": {
+    "actor": ["positioning:closeness"]
+  },
+  "forbidden_components": {
+    "actor": []
+  },
+  "template": "rest your head on {target}'s shoulder",
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#6a1b9a",
+    "textColor": "#f3e5f5",
+    "hoverBackgroundColor": "#8e24aa",
+    "hoverTextColor": "#ffffff"
+  }
+}

--- a/data/mods/affection/conditions/event-is-action-rest-head-on-shoulder.condition.json
+++ b/data/mods/affection/conditions/event-is-action-rest-head-on-shoulder.condition.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "affection:event-is-action-rest-head-on-shoulder",
+  "description": "Checks if the triggering event is for the 'affection:rest_head_on_shoulder' action.",
+  "logic": {
+    "==": [{ "var": "event.payload.actionId" }, "affection:rest_head_on_shoulder"]
+  }
+}

--- a/data/mods/affection/mod-manifest.json
+++ b/data/mods/affection/mod-manifest.json
@@ -24,6 +24,7 @@
     "actions": [
       "brush_hand.action.json",
       "hold_hand.action.json",
+      "rest_head_on_shoulder.action.json",
       "hug_tight.action.json",
       "massage_back.action.json",
       "massage_shoulders.action.json",
@@ -37,13 +38,13 @@
     "rules": [
       "brush_hand.rule.json",
       "handle_hold_hand.rule.json",
+      "handle_rest_head_on_shoulder.rule.json",
       "handle_hug_tight.rule.json",
       "handle_massage_shoulders.rule.json",
       "handle_ruffle_hair_playfully.rule.json",
       "massage_back.rule.json",
       "place_hand_on_waist.rule.json",
       "handle_push_target_playfully.rule.json",
-      "handle_ruffle_hair_playfully.rule.json",
       "handle_tickle_target_playfully.rule.json",
       "sling_arm_around_shoulders.rule.json",
       "wrap_arm_around_waist.rule.json"
@@ -51,6 +52,7 @@
     "conditions": [
       "event-is-action-brush-hand.condition.json",
       "event-is-action-hold-hand.condition.json",
+      "event-is-action-rest-head-on-shoulder.condition.json",
       "event-is-action-hug-tight.condition.json",
       "event-is-action-massage-back.condition.json",
       "event-is-action-massage-shoulders.condition.json",

--- a/data/mods/affection/rules/handle_rest_head_on_shoulder.rule.json
+++ b/data/mods/affection/rules/handle_rest_head_on_shoulder.rule.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "handle_rest_head_on_shoulder",
+  "comment": "Handles the 'affection:rest_head_on_shoulder' action. Dispatches descriptive text and ends the turn.",
+  "event_type": "core:attempt_action",
+  "condition": { "condition_ref": "affection:event-is-action-rest-head-on-shoulder" },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "actor", "result_variable": "actorName" }
+    },
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "target", "result_variable": "targetName" }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "logMessage",
+        "value": "{context.actorName} leans their head against {context.targetName}'s shoulder for comfort."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "perceptionType",
+        "value": "action_target_general"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "locationId",
+        "value": "{context.actorPosition.locationId}"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "targetId",
+        "value": "{event.payload.targetId}"
+      }
+    },
+    { "macro": "core:logSuccessAndEndTurn" }
+  ]
+}

--- a/tests/integration/mods/affection/rest_head_on_shoulder_action.test.js
+++ b/tests/integration/mods/affection/rest_head_on_shoulder_action.test.js
@@ -1,0 +1,134 @@
+/**
+ * @file Integration tests for the affection:rest_head_on_shoulder action and rule.
+ * @description Tests the rule execution after the rest_head_on_shoulder action is performed.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import handleRestHeadOnShoulderRule from '../../../../data/mods/affection/rules/handle_rest_head_on_shoulder.rule.json';
+import eventIsActionRestHeadOnShoulder from '../../../../data/mods/affection/conditions/event-is-action-rest-head-on-shoulder.condition.json';
+
+const EXPECTED_SENTENCE =
+  "{actor} leans their head against {target}'s shoulder for comfort.";
+
+describe('affection:rest_head_on_shoulder action integration', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction(
+      'affection',
+      'affection:rest_head_on_shoulder',
+      handleRestHeadOnShoulderRule,
+      eventIsActionRestHeadOnShoulder
+    );
+  });
+
+  afterEach(() => {
+    testFixture.cleanup();
+  });
+
+  const findSuccessMessage = () =>
+    testFixture.events.find(
+      (event) => event.eventType === 'core:display_successful_action_result'
+    );
+
+  const findPerceptibleEvent = () =>
+    testFixture.events.find(
+      (event) => event.eventType === 'core:perceptible_event'
+    );
+
+  it('successfully executes rest head on shoulder between close actors', async () => {
+    const scenario = testFixture.createCloseActors(['Alice', 'Bob'], {
+      location: 'living_room',
+    });
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent).toBeDefined();
+    expect(successEvent.payload.message).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Alice').replace('{target}', 'Bob')
+    );
+
+    testFixture.assertPerceptibleEvent({
+      descriptionText: EXPECTED_SENTENCE.replace('{actor}', 'Alice').replace(
+        '{target}',
+        'Bob'
+      ),
+      locationId: 'living_room',
+      perceptionType: 'action_target_general',
+      actorId: scenario.actor.id,
+      targetId: scenario.target.id,
+    });
+
+    const turnEndedEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:turn_ended'
+    );
+    expect(turnEndedEvent).toBeDefined();
+    expect(turnEndedEvent.payload.entityId).toBe(scenario.actor.id);
+    expect(turnEndedEvent.payload.success).toBe(true);
+  });
+
+  it('formats message correctly with different names', async () => {
+    const scenario = testFixture.createCloseActors(
+      ['Sir Lancelot', 'Lady Guinevere'],
+      {
+        location: 'castle_hall',
+      }
+    );
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent.payload.message).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Sir Lancelot').replace(
+        '{target}',
+        'Lady Guinevere'
+      )
+    );
+  });
+
+  it('emits perceptible event with correct metadata', async () => {
+    const scenario = testFixture.createCloseActors(['Elena', 'Marcus'], {
+      location: 'garden',
+    });
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const perceptibleEvent = findPerceptibleEvent();
+    expect(perceptibleEvent).toBeDefined();
+    expect(perceptibleEvent.payload.perceptionType).toBe(
+      'action_target_general'
+    );
+    expect(perceptibleEvent.payload.locationId).toBe('garden');
+    expect(perceptibleEvent.payload.targetId).toBe(scenario.target.id);
+    expect(perceptibleEvent.payload.actorId).toBe(scenario.actor.id);
+    expect(perceptibleEvent.payload.descriptionText).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Elena').replace('{target}', 'Marcus')
+    );
+  });
+
+  it('action only fires for the correct action ID', async () => {
+    const scenario = testFixture.createCloseActors(['Alice', 'Bob'], {
+      location: 'room1',
+    });
+
+    await testFixture.eventBus.dispatch('core:attempt_action', {
+      eventName: 'core:attempt_action',
+      actorId: scenario.actor.id,
+      actionId: 'affection:hug_tight',
+      targetId: scenario.target.id,
+      originalInput: 'hug_tight target',
+    });
+
+    const perceptibleEvent = findPerceptibleEvent();
+    if (perceptibleEvent) {
+      expect(perceptibleEvent.payload.descriptionText).not.toContain(
+        "leans their head against"
+      );
+    }
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent).toBeUndefined();
+  });
+});

--- a/tests/integration/mods/affection/rest_head_on_shoulder_action_discovery.test.js
+++ b/tests/integration/mods/affection/rest_head_on_shoulder_action_discovery.test.js
@@ -1,0 +1,187 @@
+/**
+ * @file Integration tests for affection:rest_head_on_shoulder action discovery.
+ * @description Ensures the comforting head rest action is discoverable only when requirements are met.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import { ModEntityScenarios } from '../../../common/mods/ModEntityBuilder.js';
+import restHeadOnShoulderAction from '../../../../data/mods/affection/actions/rest_head_on_shoulder.action.json';
+
+const ACTION_ID = 'affection:rest_head_on_shoulder';
+
+describe('affection:rest_head_on_shoulder action discovery', () => {
+  let testFixture;
+  let configureActionDiscovery;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('affection', ACTION_ID);
+
+    configureActionDiscovery = () => {
+      const { testEnv } = testFixture;
+      if (!testEnv) {
+        return;
+      }
+
+      testEnv.actionIndex.buildIndex([restHeadOnShoulderAction]);
+
+      const scopeResolver = testEnv.unifiedScopeResolver;
+      const originalResolve =
+        scopeResolver.__restHeadOnShoulderOriginalResolve ||
+        scopeResolver.resolveSync.bind(scopeResolver);
+
+      scopeResolver.__restHeadOnShoulderOriginalResolve = originalResolve;
+      scopeResolver.resolveSync = (scopeName, context) => {
+        if (
+          scopeName ===
+          'affection:close_actors_facing_each_other_or_behind_target'
+        ) {
+          const actorId = context?.actor?.id;
+          if (!actorId) {
+            return { success: true, value: new Set() };
+          }
+
+          const { entityManager } = testEnv;
+          const actorEntity = entityManager.getEntityInstance(actorId);
+          if (!actorEntity) {
+            return { success: true, value: new Set() };
+          }
+
+          const closeness =
+            actorEntity.components?.['positioning:closeness']?.partners;
+          if (!Array.isArray(closeness) || closeness.length === 0) {
+            return { success: true, value: new Set() };
+          }
+
+          const actorFacingAway =
+            actorEntity.components?.['positioning:facing_away']
+              ?.facing_away_from || [];
+
+          const validTargets = closeness.reduce((acc, partnerId) => {
+            const partner = entityManager.getEntityInstance(partnerId);
+            if (!partner) {
+              return acc;
+            }
+
+            const partnerFacingAway =
+              partner.components?.['positioning:facing_away']
+                ?.facing_away_from || [];
+            const facingEachOther =
+              !actorFacingAway.includes(partnerId) &&
+              !partnerFacingAway.includes(actorId);
+            const actorBehind = partnerFacingAway.includes(actorId);
+
+            if (facingEachOther || actorBehind) {
+              acc.add(partnerId);
+            }
+
+            return acc;
+          }, new Set());
+
+          return { success: true, value: validTargets };
+        }
+
+        return originalResolve(scopeName, context);
+      };
+    };
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Action structure validation', () => {
+    it('matches the expected affection action schema', () => {
+      expect(restHeadOnShoulderAction).toBeDefined();
+      expect(restHeadOnShoulderAction.id).toBe(ACTION_ID);
+      expect(restHeadOnShoulderAction.name).toBe('Rest Head on Shoulder');
+      expect(restHeadOnShoulderAction.template).toBe(
+        "rest your head on {target}'s shoulder"
+      );
+      expect(restHeadOnShoulderAction.targets).toBe(
+        'affection:close_actors_facing_each_other_or_behind_target'
+      );
+    });
+
+    it('requires actor closeness and uses the affection color palette', () => {
+      expect(restHeadOnShoulderAction.required_components.actor).toEqual([
+        'positioning:closeness',
+      ]);
+      expect(restHeadOnShoulderAction.visual).toEqual({
+        backgroundColor: '#6a1b9a',
+        textColor: '#f3e5f5',
+        hoverBackgroundColor: '#8e24aa',
+        hoverTextColor: '#ffffff',
+      });
+    });
+  });
+
+  describe('Action discovery scenarios', () => {
+    it('is available for close actors facing each other', () => {
+      const scenario = testFixture.createCloseActors(['Alice', 'Bob']);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is available when the actor stands behind the target', () => {
+      const scenario = testFixture.createCloseActors(['Maya', 'Noah']);
+      scenario.target.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.actor.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is not available when actors are not in closeness', () => {
+      const scenario = testFixture.createCloseActors(['Ivy', 'Liam']);
+      delete scenario.actor.components['positioning:closeness'];
+      delete scenario.target.components['positioning:closeness'];
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+
+    it('is not available when the actor faces away from the target', () => {
+      const scenario = testFixture.createCloseActors(['Chloe', 'Evan']);
+      scenario.actor.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.target.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+  });
+});


### PR DESCRIPTION
Summary: add the rest head on shoulder affection interaction with supporting assets and tests.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test:integration -- --maxWorkers=4` (fails coverage threshold only)
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`
- [x] Targeted tests     `npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/mods/affection/rest_head_on_shoulder_action.test.js tests/integration/mods/affection/rest_head_on_shoulder_action_discovery.test.js`
- [x] Targeted tests     `npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/scripts/validateMods.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68e50dc656708331b8c6906a814b38e6