### PR TITLE
[Agent] Add contract coverage tests for GameEngine adapters

### DIFF
--- a/tests/unit/adapters/gameEngineAdapters.contract.test.js
+++ b/tests/unit/adapters/gameEngineAdapters.contract.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import GameEngineLoadAdapter from '../../../src/adapters/GameEngineLoadAdapter.js';
+import GameEngineSaveAdapter from '../../../src/adapters/GameEngineSaveAdapter.js';
+import ILoadService from '../../../src/interfaces/ILoadService.js';
+import ISaveService from '../../../src/interfaces/ISaveService.js';
+
+describe('GameEngine adapters contract coverage', () => {
+  describe('GameEngineLoadAdapter', () => {
+    it('wraps a GameEngine instance and forwards load requests verbatim', async () => {
+      const expectedResult = { slot: 'alpha', state: { hero: 'Evelyn' } };
+      const engine = {
+        loadGame: jest.fn().mockResolvedValue(expectedResult),
+      };
+
+      const adapter = new GameEngineLoadAdapter(engine);
+
+      expect(adapter).toBeInstanceOf(ILoadService);
+      await expect(adapter.load('alpha')).resolves.toBe(expectedResult);
+      expect(engine.loadGame).toHaveBeenCalledTimes(1);
+      expect(engine.loadGame).toHaveBeenCalledWith('alpha');
+    });
+
+    it('surfaces thrown errors from the underlying engine load implementation', async () => {
+      const error = new Error('load failed');
+      const engine = {
+        loadGame: jest.fn(() => {
+          throw error;
+        }),
+      };
+      const adapter = new GameEngineLoadAdapter(engine);
+
+      await expect(adapter.load('beta')).rejects.toBe(error);
+      expect(engine.loadGame).toHaveBeenCalledWith('beta');
+    });
+
+    it('rejects when the provided engine does not implement loadGame', async () => {
+      const adapter = new GameEngineLoadAdapter({});
+
+      await expect(adapter.load('missing-method')).rejects.toBeInstanceOf(TypeError);
+    });
+  });
+
+  describe('GameEngineSaveAdapter', () => {
+    it('invokes triggerManualSave with the expected argument order', async () => {
+      const result = { ok: true };
+      const engine = {
+        triggerManualSave: jest.fn().mockResolvedValue(result),
+      };
+      const adapter = new GameEngineSaveAdapter(engine);
+
+      expect(adapter).toBeInstanceOf(ISaveService);
+      await expect(adapter.save('slot-3', 'Autosave')).resolves.toBe(result);
+      expect(engine.triggerManualSave).toHaveBeenCalledTimes(1);
+      expect(engine.triggerManualSave).toHaveBeenCalledWith('Autosave', 'slot-3');
+    });
+
+    it('propagates synchronous exceptions from triggerManualSave', async () => {
+      const error = new Error('save failure');
+      const engine = {
+        triggerManualSave: jest.fn(() => {
+          throw error;
+        }),
+      };
+      const adapter = new GameEngineSaveAdapter(engine);
+
+      await expect(adapter.save('slot-4', 'Manual Save')).rejects.toBe(error);
+      expect(engine.triggerManualSave).toHaveBeenCalledWith('Manual Save', 'slot-4');
+    });
+
+    it('rejects when the engine is missing triggerManualSave', async () => {
+      const adapter = new GameEngineSaveAdapter({});
+
+      await expect(adapter.save('slot-5', 'Broken')).rejects.toBeInstanceOf(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Added focused unit tests covering the GameEngine load/save adapters to ensure they forward results and errors correctly and achieve full coverage.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `node ./node_modules/jest/bin/jest.js --config jest.config.unit.js --runTestsByPath tests/unit/adapters/gameEngineAdapters.contract.test.js --coverage --coverageDirectory=coverage-adapter --collectCoverageFrom=src/adapters/GameEngineLoadAdapter.js --collectCoverageFrom=src/adapters/GameEngineSaveAdapter.js --runInBand`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e5196e991c8331b67c5e5c99d80f48