### PR TITLE
[Agent] Extend salvage TTL configuration

### DIFF
--- a/llm-proxy-server/docs/RACE_CONDITION_FIX.md
+++ b/llm-proxy-server/docs/RACE_CONDITION_FIX.md
@@ -193,7 +193,7 @@ if (result.success) {
 
 ```bash
 # Salvage service configuration
-SALVAGE_DEFAULT_TTL=30000        # 30 seconds TTL for salvaged responses
+SALVAGE_DEFAULT_TTL=120000       # 2 minute TTL for salvaged responses
 SALVAGE_MAX_ENTRIES=1000         # Maximum cached responses
 
 # Timeout configuration
@@ -206,7 +206,7 @@ TIMEOUT_GRACE_PERIOD_MS=5000     # 5 second grace period after timeout
 ```javascript
 // Initialize salvage service
 const salvageService = new ResponseSalvageService(logger, {
-  defaultTtl: 30000,
+  defaultTtl: 120000,
   maxEntries: 1000,
 });
 

--- a/llm-proxy-server/src/config/appConfig.js
+++ b/llm-proxy-server/src/config/appConfig.js
@@ -12,6 +12,8 @@ import {
   HTTP_AGENT_FREE_SOCKET_TIMEOUT,
   HTTP_AGENT_MAX_TOTAL_SOCKETS,
   HTTP_AGENT_MAX_IDLE_TIME,
+  SALVAGE_DEFAULT_TTL,
+  SALVAGE_MAX_ENTRIES,
   DEBUG_LOGGING_ENABLED,
   DEBUG_LOGGING_DEFAULT_PATH,
   DEBUG_LOGGING_DEFAULT_RETENTION_DAYS,
@@ -89,6 +91,12 @@ class AppConfigService {
   _httpAgentMaxTotalSockets = 0;
   /** @type {number} @private */
   _httpAgentMaxIdleTime = 60000;
+
+  // Salvage configuration
+  /** @type {number} @private */
+  _salvageDefaultTtl = SALVAGE_DEFAULT_TTL;
+  /** @type {number} @private */
+  _salvageMaxEntries = SALVAGE_MAX_ENTRIES;
 
   // Debug Logging configuration
   /** @type {boolean} @private */
@@ -485,6 +493,49 @@ class AppConfigService {
     } else {
       this._logger.debug(
         `${servicePrefix}HTTP_AGENT_MAX_IDLE_TIME not set in environment. Using default: ${this._httpAgentMaxIdleTime}ms.`
+      );
+    }
+
+    // Salvage Configuration
+    const salvageTtlEnv = process.env.SALVAGE_DEFAULT_TTL;
+    const parsedSalvageTtl = salvageTtlEnv ? parseInt(salvageTtlEnv, 10) : NaN;
+    if (salvageTtlEnv !== undefined) {
+      if (!isNaN(parsedSalvageTtl) && parsedSalvageTtl > 0) {
+        this._salvageDefaultTtl = parsedSalvageTtl;
+        this._logger.debug(
+          `${servicePrefix}SALVAGE_DEFAULT_TTL found in environment: '${salvageTtlEnv}'. Effective value: ${this._salvageDefaultTtl}ms.`
+        );
+      } else {
+        this._salvageDefaultTtl = SALVAGE_DEFAULT_TTL;
+        this._logger.warn(
+          `${servicePrefix}SALVAGE_DEFAULT_TTL invalid: '${salvageTtlEnv}'. Using default: ${this._salvageDefaultTtl}ms.`
+        );
+      }
+    } else {
+      this._logger.debug(
+        `${servicePrefix}SALVAGE_DEFAULT_TTL not set in environment. Using default: ${this._salvageDefaultTtl}ms.`
+      );
+    }
+
+    const salvageMaxEntriesEnv = process.env.SALVAGE_MAX_ENTRIES;
+    const parsedSalvageMaxEntries = salvageMaxEntriesEnv
+      ? parseInt(salvageMaxEntriesEnv, 10)
+      : NaN;
+    if (salvageMaxEntriesEnv !== undefined) {
+      if (!isNaN(parsedSalvageMaxEntries) && parsedSalvageMaxEntries > 0) {
+        this._salvageMaxEntries = parsedSalvageMaxEntries;
+        this._logger.debug(
+          `${servicePrefix}SALVAGE_MAX_ENTRIES found in environment: '${salvageMaxEntriesEnv}'. Effective value: ${this._salvageMaxEntries}.`
+        );
+      } else {
+        this._salvageMaxEntries = SALVAGE_MAX_ENTRIES;
+        this._logger.warn(
+          `${servicePrefix}SALVAGE_MAX_ENTRIES invalid: '${salvageMaxEntriesEnv}'. Using default: ${this._salvageMaxEntries}.`
+        );
+      }
+    } else {
+      this._logger.debug(
+        `${servicePrefix}SALVAGE_MAX_ENTRIES not set in environment. Using default: ${this._salvageMaxEntries}.`
       );
     }
 
@@ -897,6 +948,35 @@ class AppConfigService {
       freeSocketTimeout: this._httpAgentFreeSocketTimeout,
       maxTotalSockets: this._httpAgentMaxTotalSockets,
       maxIdleTime: this._httpAgentMaxIdleTime,
+    };
+  }
+
+  // Salvage Configuration Getters
+
+  /**
+   * Gets the default salvage TTL in milliseconds.
+   * @returns {number} The salvage TTL.
+   */
+  getSalvageDefaultTtl() {
+    return this._salvageDefaultTtl;
+  }
+
+  /**
+   * Gets the maximum number of salvaged entries to retain.
+   * @returns {number} The maximum number of entries.
+   */
+  getSalvageMaxEntries() {
+    return this._salvageMaxEntries;
+  }
+
+  /**
+   * Gets the salvage configuration object.
+   * @returns {{defaultTtl: number, maxEntries: number}} Salvage configuration object.
+   */
+  getSalvageConfig() {
+    return {
+      defaultTtl: this._salvageDefaultTtl,
+      maxEntries: this._salvageMaxEntries,
     };
   }
 

--- a/llm-proxy-server/src/config/constants.js
+++ b/llm-proxy-server/src/config/constants.js
@@ -237,6 +237,19 @@ export const HTTP_AGENT_MEMORY_THRESHOLD_MB = 100;
 export const HTTP_AGENT_HIGH_LOAD_REQUESTS_PER_MIN = 60;
 
 /**
+ * Default TTL for salvaged responses in milliseconds - 2 minutes.
+ * Provides a wider recovery window for long-running completions.
+ * @type {number}
+ */
+export const SALVAGE_DEFAULT_TTL = 2 * 60 * 1000;
+
+/**
+ * Default maximum number of salvaged responses to retain in memory.
+ * @type {number}
+ */
+export const SALVAGE_MAX_ENTRIES = 1000;
+
+/**
  * Rate limiting configuration constants
  * Environment-aware settings: Development has much higher limits than production
  */

--- a/llm-proxy-server/src/core/server.js
+++ b/llm-proxy-server/src/core/server.js
@@ -198,10 +198,8 @@ const llmRequestService = new LlmRequestService(
 );
 
 // Initialize ResponseSalvageService for recovering failed LLM responses
-const salvageService = new ResponseSalvageService(proxyLogger, {
-  defaultTtl: 30000, // 30 seconds TTL for salvaged responses
-  maxEntries: 1000,
-});
+const salvageConfig = appConfigService.getSalvageConfig();
+const salvageService = new ResponseSalvageService(proxyLogger, salvageConfig);
 
 // PROXY_PROJECT_ROOT_PATH_FOR_API_KEY_FILES logging - Removed initial log, will be in summary
 // const PROXY_PROJECT_ROOT_PATH_FOR_API_KEY_FILES = appConfigService.getProxyProjectRootPathForApiKeyFiles();
@@ -480,6 +478,11 @@ process.on('beforeExit', async (_code) => {
         `LLM Proxy Server: Cache DISABLED - API keys will be read from source on every request`
       );
     }
+
+    const salvageSummary = appConfigService.getSalvageConfig();
+    proxyLogger.info(
+      `LLM Proxy Server: Response Salvage ENABLED - TTL: ${salvageSummary.defaultTtl}ms, Max Entries: ${salvageSummary.maxEntries}`
+    );
 
     // HTTP Agent Configuration Status
     if (appConfigService.isHttpAgentEnabled()) {

--- a/llm-proxy-server/src/services/responseSalvageService.js
+++ b/llm-proxy-server/src/services/responseSalvageService.js
@@ -4,6 +4,7 @@
  */
 
 import crypto from 'crypto';
+import { SALVAGE_DEFAULT_TTL, SALVAGE_MAX_ENTRIES } from '../config/constants.js';
 
 /**
  * Service for caching and salvaging successful LLM responses that couldn't be delivered
@@ -32,13 +33,13 @@ export class ResponseSalvageService {
     if (!logger) throw new Error('ResponseSalvageService: logger is required');
 
     this.#logger = logger;
-    this.#defaultTtl = options.defaultTtl || 30000; // 30 seconds default
+    this.#defaultTtl = options.defaultTtl || SALVAGE_DEFAULT_TTL;
     this.#salvageCache = new Map();
     this.#expirationTimers = new Map();
 
     this.#logger.debug('ResponseSalvageService: Instance created', {
       defaultTtl: this.#defaultTtl,
-      maxEntries: options.maxEntries || 1000,
+      maxEntries: options.maxEntries || SALVAGE_MAX_ENTRIES,
     });
   }
 

--- a/llm-proxy-server/tests/e2e/workflows/e2e-workflow.integration.test.js
+++ b/llm-proxy-server/tests/e2e/workflows/e2e-workflow.integration.test.js
@@ -39,6 +39,10 @@ const createMockAppConfigService = () => ({
     maxSize: 1000,
     apiKeyCacheTtl: 300000,
   })),
+  getSalvageConfig: jest.fn(() => ({
+    defaultTtl: 120000,
+    maxEntries: 1000,
+  })),
   getApiKeyCacheTtl: jest.fn(() => 300000),
   isHttpAgentEnabled: jest.fn(() => true),
   getHttpAgentConfig: jest.fn(() => ({

--- a/llm-proxy-server/tests/integration/performance-optimizations.integration.test.js
+++ b/llm-proxy-server/tests/integration/performance-optimizations.integration.test.js
@@ -56,6 +56,10 @@ describe('Performance Optimizations Integration Tests', () => {
           maxSize: 1000,
           apiKeyCacheTtl: 300000,
         }),
+        getSalvageConfig: jest.fn().mockReturnValue({
+          defaultTtl: 120000,
+          maxEntries: 1000,
+        }),
         getApiKeyCacheTtl: jest.fn().mockReturnValue(300000),
         isHttpAgentEnabled: jest.fn().mockReturnValue(true),
         getHttpAgentConfig: jest.fn().mockReturnValue({

--- a/llm-proxy-server/tests/memory/memory-usage.test.js
+++ b/llm-proxy-server/tests/memory/memory-usage.test.js
@@ -37,6 +37,10 @@ const createMockAppConfigService = () => ({
     maxSize: 1000,
     apiKeyCacheTtl: 300000,
   })),
+  getSalvageConfig: jest.fn(() => ({
+    defaultTtl: 120000,
+    maxEntries: 1000,
+  })),
   getApiKeyCacheTtl: jest.fn(() => 300000),
   isHttpAgentEnabled: jest.fn(() => true),
   getHttpAgentConfig: jest.fn(() => ({

--- a/llm-proxy-server/tests/performance/performance-benchmarks.test.js
+++ b/llm-proxy-server/tests/performance/performance-benchmarks.test.js
@@ -41,6 +41,10 @@ const createMockAppConfigService = () => ({
     maxSize: 1000,
     apiKeyCacheTtl: 300000,
   })),
+  getSalvageConfig: jest.fn(() => ({
+    defaultTtl: 120000,
+    maxEntries: 1000,
+  })),
   getApiKeyCacheTtl: jest.fn(() => 300000),
   isHttpAgentEnabled: jest.fn(() => true),
   getHttpAgentConfig: jest.fn(() => ({

--- a/llm-proxy-server/tests/server.errorHandler.test.js
+++ b/llm-proxy-server/tests/server.errorHandler.test.js
@@ -165,6 +165,10 @@ beforeEach(() => {
       maxSize: 1000,
       apiKeyCacheTtl: 300000,
     })),
+    getSalvageConfig: jest.fn(() => ({
+      defaultTtl: 120000,
+      maxEntries: 1000,
+    })),
     isHttpAgentEnabled: jest.fn(() => false),
     getHttpAgentConfig: jest.fn(() => ({
       enabled: false,

--- a/llm-proxy-server/tests/server.test.js
+++ b/llm-proxy-server/tests/server.test.js
@@ -85,6 +85,10 @@ beforeEach(() => {
       maxSize: 1000,
       apiKeyCacheTtl: 300000,
     })),
+    getSalvageConfig: jest.fn(() => ({
+      defaultTtl: 120000,
+      maxEntries: 1000,
+    })),
     isHttpAgentEnabled: jest.fn(() => false),
     getHttpAgentConfig: jest.fn(() => ({
       enabled: false,

--- a/llm-proxy-server/tests/unit/config/appConfig.test.js
+++ b/llm-proxy-server/tests/unit/config/appConfig.test.js
@@ -10,6 +10,10 @@ import {
   getAppConfigService,
   resetAppConfigServiceInstance,
 } from '../../../src/config/appConfig.js';
+import {
+  SALVAGE_DEFAULT_TTL,
+  SALVAGE_MAX_ENTRIES,
+} from '../../../src/config/constants.js';
 import { TestEnvironmentManager } from '../../common/testServerUtils.js';
 
 const createLogger = () => ({
@@ -303,6 +307,40 @@ describe('AppConfigService - Comprehensive Tests', () => {
         maxTotalSockets: 1000,
         maxIdleTime: 180000,
       });
+    });
+  });
+
+  describe('Salvage Configuration Getters', () => {
+    test('getSalvageDefaultTtl returns default value when not set', () => {
+      const service = getAppConfigService(logger);
+
+      expect(service.getSalvageDefaultTtl()).toBe(SALVAGE_DEFAULT_TTL);
+    });
+
+    test('getSalvageMaxEntries returns default value when not set', () => {
+      const service = getAppConfigService(logger);
+
+      expect(service.getSalvageMaxEntries()).toBe(SALVAGE_MAX_ENTRIES);
+    });
+
+    test('salvage configuration uses custom environment values when provided', () => {
+      process.env.SALVAGE_DEFAULT_TTL = '450000';
+      process.env.SALVAGE_MAX_ENTRIES = '2048';
+
+      const service = getAppConfigService(logger);
+
+      expect(service.getSalvageDefaultTtl()).toBe(450000);
+      expect(service.getSalvageMaxEntries()).toBe(2048);
+    });
+
+    test('getSalvageConfig returns complete salvage configuration object', () => {
+      process.env.SALVAGE_DEFAULT_TTL = '900000';
+      process.env.SALVAGE_MAX_ENTRIES = '4096';
+
+      const service = getAppConfigService(logger);
+      const config = service.getSalvageConfig();
+
+      expect(config).toEqual({ defaultTtl: 900000, maxEntries: 4096 });
     });
   });
 

--- a/llm-proxy-server/tests/unit/core/server.test.js
+++ b/llm-proxy-server/tests/unit/core/server.test.js
@@ -144,6 +144,10 @@ describe('Server - Comprehensive Tests', () => {
         maxSize: 1000,
         apiKeyCacheTtl: 300000,
       })),
+      getSalvageConfig: jest.fn(() => ({
+        defaultTtl: 120000,
+        maxEntries: 1000,
+      })),
       isHttpAgentEnabled: jest.fn(() => false),
       getHttpAgentConfig: jest.fn(() => ({
         enabled: false,
@@ -498,6 +502,20 @@ describe('Server - Comprehensive Tests', () => {
       // Verify cache disabled log message
       expect(consoleLoggerInstance.info).toHaveBeenCalledWith(
         'LLM Proxy Server: Cache DISABLED - API keys will be read from source on every request'
+      );
+    });
+
+    test('logs salvage configuration using AppConfigService values', async () => {
+      appConfigServiceMock.getSalvageConfig.mockReturnValue({
+        defaultTtl: 240000,
+        maxEntries: 2048,
+      });
+
+      await loadServer();
+
+      expect(appConfigServiceMock.getSalvageConfig).toHaveBeenCalled();
+      expect(consoleLoggerInstance.info).toHaveBeenCalledWith(
+        'LLM Proxy Server: Response Salvage ENABLED - TTL: 240000ms, Max Entries: 2048'
       );
     });
 


### PR DESCRIPTION
Summary:
- add configurable defaults for the response salvage TTL/max entries and surface them through AppConfigService
- initialize the salvage service with the configured values, log the settings at startup, and document the longer TTL in the race-condition guide
- align unit/integration tests with the new configuration surface and cover the salvage summary logging path

Testing Done:
- [x] `cd llm-proxy-server && npm run test:unit` *(fails global coverage threshold only)*

------
https://chatgpt.com/codex/tasks/task_e_68e51eaaae8c8331b724c1dd65a72326