### PR TITLE
[Agent] Cover invalid actor branch in turn state validation

### DIFF
--- a/tests/unit/utils/turnStateValidationUtils.additionalBranches.test.js
+++ b/tests/unit/utils/turnStateValidationUtils.additionalBranches.test.js
@@ -38,6 +38,18 @@ describe('validationUtils additional branches', () => {
     ).toThrow(/does not provide getStrategy/);
   });
 
+  test('retrieveStrategyFromContext throws when actor is invalid', () => {
+    const ctx = {
+      getStrategy: () => ({
+        decideAction: () => {},
+      }),
+    };
+
+    expect(() =>
+      retrieveStrategyFromContext(ctx, null, 'State')
+    ).toThrow('State: invalid actorEntity.');
+  });
+
   test('validateCommandString reports non-string input', () => {
     const onError = jest.fn();
     validateCommandString(5, onError);


### PR DESCRIPTION
Summary:
- add a regression test for `retrieveStrategyFromContext` to cover the invalid actor branch in turn state validation utils.

Testing Done:
- [ ] npm run test:unit (fails: TargetComponentValidationStage performance expectation exceeded under heavy load)
- [x] npx jest --config jest.config.unit.js --runTestsByPath tests/unit/utils/turnStateValidationUtils.additionalBranches.test.js --runInBand --forceExit
- [x] npx jest --config jest.config.unit.js --runTestsByPath tests/unit/actions/pipeline/stages/TargetComponentValidationStage.test.js --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68e5260a123083319a0a95e6f5c5b8f5