### PR TITLE
[Agent] Lower rotation complete log level

### DIFF
--- a/src/actions/tracing/storageRotationManager.js
+++ b/src/actions/tracing/storageRotationManager.js
@@ -182,7 +182,7 @@ export class StorageRotationManager {
       results.duration = Date.now() - startTime;
       this.#lastRotation = Date.now();
 
-      this.#logger.info('StorageRotationManager: Rotation complete', results);
+      this.#logger.debug('StorageRotationManager: Rotation complete', results);
     } catch (error) {
       this.#logger.error('StorageRotationManager: Rotation error', error);
       results.errors++;


### PR DESCRIPTION
Summary: Lower the StorageRotationManager rotation completion log level to debug to reduce info noise.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e5496d994883318e759a22dfcdf0b5