### PR TITLE
[Agent] Scaffold distress mod structure

### DIFF
--- a/data/mods/distress/README.md
+++ b/data/mods/distress/README.md
@@ -1,0 +1,13 @@
+# Distress Mod
+
+This directory houses the assets for the Distress mod, focused on body language that conveys vulnerability, pleading, or internalized overwhelm. Action, rule, condition, and scope definitions will be added in future iterations following the patterns established by the Affection, Caressing, and Kissing mods.
+
+## Planned Palettes
+- **Primary**: Dark Red Alert
+- **Secondary**: Obsidian Frost (shared with the distress mod entry in the WCAG palette spec)
+
+The subdirectories mirror the standard mod layout:
+- `actions/` – Gesture interaction definitions.
+- `conditions/` – Condition builders for triggering distress states.
+- `rules/` – Narrative rule handling for distress gestures.
+- `scopes/` – Spatial and relational scopes relevant to distressed poses.

--- a/data/mods/distress/actions/README.md
+++ b/data/mods/distress/actions/README.md
@@ -1,0 +1,3 @@
+# Distress Mod – Actions Directory
+
+This placeholder file marks the future home for Distress mod action definitions.

--- a/data/mods/distress/conditions/README.md
+++ b/data/mods/distress/conditions/README.md
@@ -1,0 +1,3 @@
+# Distress Mod – Conditions Directory
+
+This placeholder file marks the future home for Distress mod condition schemas.

--- a/data/mods/distress/mod-manifest.json
+++ b/data/mods/distress/mod-manifest.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "schema://living-narrative-engine/mod-manifest.schema.json",
+  "id": "distress",
+  "version": "0.1.0",
+  "name": "Distress – Vulnerable Gestures",
+  "description": "Emotionally charged gestures that express desperation, pleading, or internalized overwhelm.",
+  "author": "Living Narrative Engine",
+  "gameVersion": ">=0.0.1",
+  "dependencies": [
+    {
+      "id": "anatomy",
+      "version": "^1.0.0"
+    },
+    {
+      "id": "positioning",
+      "version": "^1.0.0"
+    },
+    {
+      "id": "descriptors",
+      "version": "^1.0.0"
+    },
+    {
+      "id": "clothing",
+      "version": "^1.0.0"
+    }
+  ],
+  "content": {
+    "actions": [],
+    "conditions": [],
+    "rules": [],
+    "scopes": []
+  }
+}

--- a/data/mods/distress/rules/README.md
+++ b/data/mods/distress/rules/README.md
@@ -1,0 +1,3 @@
+# Distress Mod – Rules Directory
+
+This placeholder file marks the future home for Distress mod rule handlers.

--- a/data/mods/distress/scopes/README.md
+++ b/data/mods/distress/scopes/README.md
@@ -1,0 +1,3 @@
+# Distress Mod – Scopes Directory
+
+This placeholder file marks the future home for Distress mod scope definitions.

--- a/specs/wcag-compliant-color-combinations.spec.md
+++ b/specs/wcag-compliant-color-combinations.spec.md
@@ -667,7 +667,7 @@ This specification provides a curated collection of pre-validated color combinat
 - **Hover Contrast**: 12.26:1 🌟 AAA
 - **Use Cases**: High-clarity command centers, tactical overviews
 - **Theme**: Frozen night sky, crystalline focus
-- 🟢 **AVAILABLE**
+- ✅ **USED BY**: Distress mod (distress gestures)
 
 #### 11.8 Arctic Steel
 


### PR DESCRIPTION
Summary:
- add the distress mod directory with placeholder documentation and manifest scaffolding
- record that the distress mod now uses the Obsidian Frost palette in the WCAG spec

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e627b25c9883319b008aa5f822e1f2