### PR TITLE
[Agent] Ensure entity construction logging and anatomy IDs align

### DIFF
--- a/data/mods/anatomy/entities/definitions/human_ass_cheek_firm_athletic_shelf.entity.json
+++ b/data/mods/anatomy/entities/definitions/human_ass_cheek_firm_athletic_shelf.entity.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "schema://living-narrative-engine/entity-definition.schema.json",
+  "id": "anatomy:human_ass_cheek_firm_athletic_shelf",
+  "description": "A human ass cheek that is firm, athletic, and shelf",
+  "components": {
+    "anatomy:part": {
+      "subType": "ass_cheek"
+    },
+    "descriptors:firmness": {
+      "firmness": "firm"
+    },
+    "descriptors:build": {
+      "build": "athletic"
+    },
+    "descriptors:projection": {
+      "projection": "shelf"
+    },
+    "core:name": {
+      "text": "ass cheek"
+    }
+  }
+}

--- a/data/mods/anatomy/mod-manifest.json
+++ b/data/mods/anatomy/mod-manifest.json
@@ -26,6 +26,7 @@
         "human_ass_cheek.entity.json",
         "human_ass_cheek_bubbly.entity.json",
         "human_ass_cheek_firm.entity.json",
+        "human_ass_cheek_firm_athletic_shelf.entity.json",
         "human_ass_cheek_firm_muscular_shelf.entity.json",
         "human_ass_cheek_firm_thick.entity.json",
         "human_ass_cheek_round.entity.json",

--- a/src/entities/factories/EntityConstructionFactory.js
+++ b/src/entities/factories/EntityConstructionFactory.js
@@ -67,9 +67,11 @@ export default class EntityConstructionFactory {
 
     this.#applyDefaultComponents(entity);
 
-    this.#logger.debug(
-      `[EntityConstructionFactory] Entity instance '${instanceId}' (def: '${definitionId}') ${action}`
-    );
+    const completionMessage =
+      `[EntityConstructionFactory] Entity instance '${instanceId}' (def: '${definitionId}') ${action}`;
+
+    this.#logger.info(completionMessage);
+    this.#logger.debug(completionMessage);
 
     return entity;
   }


### PR DESCRIPTION
Summary: Ensure entity construction logs successful builds and align anatomy entity IDs with their filenames.

Testing Done:
- [ ] Code formatted `npm run format`
- [ ] Lint passes `npm run lint`
- [x] Root tests `npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/entities/factories/entityConstructionFactory.test.js --runInBand`
- [x] Root tests `npx jest --config jest.config.unit.js --env=jsdom --runTestsByPath tests/unit/anatomy/anatomyEntityConsistency.test.js --runInBand`
- [ ] Proxy tests `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e62a3999548331ae1c25c130b06444