### PR TITLE
[Agent] Add distress bury face in hands action

### DIFF
--- a/data/mods/distress/actions/bury_face_in_hands.action.json
+++ b/data/mods/distress/actions/bury_face_in_hands.action.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "distress:bury_face_in_hands",
+  "name": "Bury Face in Hands",
+  "description": "Collapse inward and hide your face behind your hands, shutting out the world as the weight of it all presses down.",
+  "targets": "none",
+  "required_components": {},
+  "template": "bury your face in your hands",
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#0b132b",
+    "textColor": "#f2f4f8",
+    "hoverBackgroundColor": "#1c2541",
+    "hoverTextColor": "#e0e7ff"
+  }
+}

--- a/data/mods/distress/conditions/event-is-action-bury-face-in-hands.condition.json
+++ b/data/mods/distress/conditions/event-is-action-bury-face-in-hands.condition.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "distress:event-is-action-bury-face-in-hands",
+  "description": "Checks if the triggering event is for the 'distress:bury_face_in_hands' action.",
+  "logic": {
+    "==": [
+      { "var": "event.payload.actionId" },
+      "distress:bury_face_in_hands"
+    ]
+  }
+}

--- a/data/mods/distress/mod-manifest.json
+++ b/data/mods/distress/mod-manifest.json
@@ -25,9 +25,15 @@
     }
   ],
   "content": {
-    "actions": [],
-    "conditions": [],
-    "rules": [],
+    "actions": [
+      "bury_face_in_hands.action.json"
+    ],
+    "conditions": [
+      "event-is-action-bury-face-in-hands.condition.json"
+    ],
+    "rules": [
+      "bury_face_in_hands.rule.json"
+    ],
     "scopes": []
   }
 }

--- a/data/mods/distress/rules/bury_face_in_hands.rule.json
+++ b/data/mods/distress/rules/bury_face_in_hands.rule.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "bury_face_in_hands",
+  "comment": "Handles the 'distress:bury_face_in_hands' action. Describes the actor folding in on themselves and hiding behind their hands.",
+  "event_type": "core:attempt_action",
+  "condition": {
+    "condition_ref": "distress:event-is-action-bury-face-in-hands"
+  },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "comment": "Get actor name for the messages.",
+      "parameters": {
+        "entity_ref": "actor",
+        "result_variable": "actorName"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Get location for the perceptible event.",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "comment": "Construct the perceptible log message for observers.",
+      "parameters": {
+        "variable_name": "logMessage",
+        "value": "{context.actorName} buries their face in their hands."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "perceptionType",
+        "value": "action_self_general"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "locationId",
+        "value": "{context.actorPosition.locationId}"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "targetId",
+        "value": null
+      }
+    },
+    { "macro": "core:logSuccessAndEndTurn" }
+  ]
+}

--- a/tests/integration/mods/distress/bury_face_in_hands_action_discovery.test.js
+++ b/tests/integration/mods/distress/bury_face_in_hands_action_discovery.test.js
@@ -1,0 +1,69 @@
+/**
+ * @file Integration tests for distress:bury_face_in_hands action discovery.
+ * @description Ensures the bury face in hands action is available without prerequisites and presents the distress palette.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import buryFaceInHandsAction from '../../../../data/mods/distress/actions/bury_face_in_hands.action.json';
+
+const ACTION_ID = 'distress:bury_face_in_hands';
+
+describe('distress:bury_face_in_hands action discovery', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('distress', ACTION_ID);
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Action metadata validation', () => {
+    it('should define the correct core metadata', () => {
+      expect(buryFaceInHandsAction).toBeDefined();
+      expect(buryFaceInHandsAction.id).toBe(ACTION_ID);
+      expect(buryFaceInHandsAction.name).toBe('Bury Face in Hands');
+      expect(buryFaceInHandsAction.description).toBe(
+        'Collapse inward and hide your face behind your hands, shutting out the world as the weight of it all presses down.'
+      );
+      expect(buryFaceInHandsAction.template).toBe('bury your face in your hands');
+    });
+
+    it('should be a self-targeting action', () => {
+      expect(buryFaceInHandsAction.targets).toBe('none');
+      expect(buryFaceInHandsAction.required_components).toEqual({});
+    });
+  });
+
+  describe('Visual styling validation', () => {
+    it('should use the distress obsidian frost palette', () => {
+      expect(buryFaceInHandsAction.visual).toBeDefined();
+      expect(buryFaceInHandsAction.visual.backgroundColor).toBe('#0b132b');
+      expect(buryFaceInHandsAction.visual.textColor).toBe('#f2f4f8');
+      expect(buryFaceInHandsAction.visual.hoverBackgroundColor).toBe('#1c2541');
+      expect(buryFaceInHandsAction.visual.hoverTextColor).toBe('#e0e7ff');
+    });
+  });
+
+  describe('Prerequisite handling', () => {
+    it('should expose an empty prerequisites array', () => {
+      expect(buryFaceInHandsAction.prerequisites).toBeDefined();
+      expect(Array.isArray(buryFaceInHandsAction.prerequisites)).toBe(true);
+      expect(buryFaceInHandsAction.prerequisites).toHaveLength(0);
+    });
+  });
+
+  describe('Action discoverability scenarios', () => {
+    it('should be executable without any special setup', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Ava', 'Marcus']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertActionSuccess('Ava buries their face in their hands.');
+    });
+  });
+});

--- a/tests/integration/mods/distress/rules/buryFaceInHandsRule.integration.test.js
+++ b/tests/integration/mods/distress/rules/buryFaceInHandsRule.integration.test.js
@@ -1,0 +1,122 @@
+/**
+ * @file Integration tests for the distress:bury_face_in_hands rule.
+ * @description Validates rule triggering, messaging, and structural schema compliance for the bury face in hands action.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ModTestFixture } from '../../../../common/mods/ModTestFixture.js';
+
+const ACTION_ID = 'distress:bury_face_in_hands';
+const EXPECTED_MESSAGE = '{context.actorName} buries their face in their hands.';
+
+describe('Distress Mod: Bury Face in Hands Rule', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('distress', ACTION_ID);
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Rule Execution', () => {
+    it('logs success and ends the turn for the bury face in hands action', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Nina', 'Lucas']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertActionSuccess('Nina buries their face in their hands.');
+    });
+
+    it('emits perceptible event with null target', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Ivy', 'Owen']);
+
+      await testFixture.executeAction(scenario.actor.id, null);
+
+      testFixture.assertPerceptibleEvent({
+        descriptionText: 'Ivy buries their face in their hands.',
+        locationId: 'room1',
+        actorId: scenario.actor.id,
+        targetId: null,
+        perceptionType: 'action_self_general',
+      });
+    });
+
+    it('ignores unrelated actions', async () => {
+      const scenario = testFixture.createStandardActorTarget(['Zoe', 'Ethan']);
+      const payload = {
+        eventName: 'core:attempt_action',
+        actorId: scenario.actor.id,
+        actionId: 'core:wait',
+        originalInput: 'wait',
+      };
+
+      await testFixture.eventBus.dispatch('core:attempt_action', payload);
+
+      testFixture.assertOnlyExpectedEvents(['core:attempt_action']);
+    });
+  });
+
+  describe('Rule Structure Validation', () => {
+    it('should identify rule metadata correctly', () => {
+      expect(testFixture.ruleFile.rule_id).toBe('bury_face_in_hands');
+      expect(testFixture.ruleFile.comment).toBe(
+        "Handles the 'distress:bury_face_in_hands' action. Describes the actor folding in on themselves and hiding behind their hands."
+      );
+    });
+
+    it('should process core:attempt_action events only', () => {
+      expect(testFixture.ruleFile.event_type).toBe('core:attempt_action');
+    });
+
+    it('should reference the bury face in hands condition', () => {
+      expect(testFixture.ruleFile.condition.condition_ref).toBe(
+        'distress:event-is-action-bury-face-in-hands'
+      );
+    });
+  });
+
+  describe('Action sequence validation', () => {
+    it('should include required variables and macro', () => {
+      const actions = testFixture.ruleFile.actions;
+      expect(actions).toHaveLength(7);
+
+      const [getName, queryComponent, messageAction, perceptionType, locationId, targetId, macro] = actions;
+
+      expect(getName.type).toBe('GET_NAME');
+      expect(getName.parameters.entity_ref).toBe('actor');
+      expect(getName.parameters.result_variable).toBe('actorName');
+
+      expect(queryComponent.type).toBe('QUERY_COMPONENT');
+      expect(queryComponent.parameters.component_type).toBe('core:position');
+      expect(queryComponent.parameters.result_variable).toBe('actorPosition');
+
+      expect(messageAction.type).toBe('SET_VARIABLE');
+      expect(messageAction.parameters.variable_name).toBe('logMessage');
+      expect(messageAction.parameters.value).toBe(EXPECTED_MESSAGE);
+
+      expect(perceptionType.parameters.variable_name).toBe('perceptionType');
+      expect(perceptionType.parameters.value).toBe('action_self_general');
+
+      expect(locationId.parameters.variable_name).toBe('locationId');
+      expect(locationId.parameters.value).toBe('{context.actorPosition.locationId}');
+
+      expect(targetId.parameters.variable_name).toBe('targetId');
+      expect(targetId.parameters.value).toBeNull();
+
+      expect(macro.macro).toBe('core:logSuccessAndEndTurn');
+    });
+  });
+
+  describe('Condition logic validation', () => {
+    it('should match only the bury face in hands action id', () => {
+      expect(testFixture.conditionFile.logic['==']).toEqual([
+        { var: 'event.payload.actionId' },
+        ACTION_ID,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Summary: Add a distress self-comfort action, condition, rule, and integration tests covering the new "bury face in hands" sequence.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`
- [x] Other: `npx jest --config jest.config.integration.js --env=jsdom --runInBand --silent --reporters=default --runTestsByPath tests/integration/mods/distress/bury_face_in_hands_action_discovery.test.js tests/integration/mods/distress/rules/buryFaceInHandsRule.integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68e6372160708331884134b58a3b9532