### PR TITLE
[Agent] Add distress clothing clutch multi-target action

### DIFF
--- a/data/mods/distress/actions/clutch_onto_upper_clothing.action.json
+++ b/data/mods/distress/actions/clutch_onto_upper_clothing.action.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "distress:clutch_onto_upper_clothing",
+  "name": "Clutch Pleadingly Onto Clothing",
+  "description": "Desperately grab onto your companion's upper garment in a plea not to be left behind.",
+  "targets": {
+    "primary": {
+      "scope": "distress:close_actors_facing_each_other_with_torso_clothing",
+      "placeholder": "primary",
+      "description": "Person whose clothing you're clinging to"
+    },
+    "secondary": {
+      "scope": "clothing:target_topmost_torso_upper_clothing",
+      "placeholder": "secondary",
+      "description": "Upper garment being clutched",
+      "contextFrom": "primary"
+    }
+  },
+  "template": "clutch pleadingly onto {primary}'s {secondary}",
+  "required_components": {
+    "actor": ["positioning:closeness"]
+  },
+  "forbidden_components": {
+    "actor": [],
+    "primary": [],
+    "secondary": []
+  },
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#0b132b",
+    "textColor": "#f2f4f8",
+    "hoverBackgroundColor": "#1c2541",
+    "hoverTextColor": "#e0e7ff"
+  }
+}

--- a/data/mods/distress/conditions/event-is-action-clutch-onto-upper-clothing.condition.json
+++ b/data/mods/distress/conditions/event-is-action-clutch-onto-upper-clothing.condition.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "distress:event-is-action-clutch-onto-upper-clothing",
+  "description": "Checks if the triggering event is for the 'distress:clutch_onto_upper_clothing' action.",
+  "logic": {
+    "==": [
+      {
+        "var": "event.payload.actionId"
+      },
+      "distress:clutch_onto_upper_clothing"
+    ]
+  }
+}

--- a/data/mods/distress/mod-manifest.json
+++ b/data/mods/distress/mod-manifest.json
@@ -25,9 +25,9 @@
     }
   ],
   "content": {
-    "actions": [],
-    "conditions": [],
-    "rules": [],
-    "scopes": []
+    "actions": ["clutch_onto_upper_clothing.action.json"],
+    "conditions": ["event-is-action-clutch-onto-upper-clothing.condition.json"],
+    "rules": ["clutch_onto_upper_clothing.rule.json"],
+    "scopes": ["close_actors_facing_each_other_with_torso_clothing.scope"]
   }
 }

--- a/data/mods/distress/rules/clutch_onto_upper_clothing.rule.json
+++ b/data/mods/distress/rules/clutch_onto_upper_clothing.rule.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "handle_clutch_onto_upper_clothing",
+  "comment": "Handles the 'distress:clutch_onto_upper_clothing' action by generating matching log and success text before ending the turn.",
+  "event_type": "core:attempt_action",
+  "condition": {
+    "condition_ref": "distress:event-is-action-clutch-onto-upper-clothing"
+  },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "comment": "Resolve the actor name for messaging.",
+      "parameters": {
+        "entity_ref": "actor",
+        "result_variable": "actorName"
+      }
+    },
+    {
+      "type": "GET_NAME",
+      "parameters": {
+        "entity_ref": "primary",
+        "result_variable": "primaryName"
+      }
+    },
+    {
+      "type": "GET_NAME",
+      "parameters": {
+        "entity_ref": "secondary",
+        "result_variable": "garmentName"
+      }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "comment": "Capture the actor's position for perceptible event routing.",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "comment": "Construct the shared log and success messaging.",
+      "parameters": {
+        "variable_name": "perceptibleLogMessage",
+        "value": "{context.actorName} clutches pleadingly onto {context.primaryName}'s {context.garmentName}."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "successMessage",
+        "value": "{context.actorName} clutches pleadingly onto {context.primaryName}'s {context.garmentName}."
+      }
+    },
+    {
+      "type": "DISPATCH_PERCEPTIBLE_EVENT",
+      "comment": "Broadcast the action outcome to nearby observers.",
+      "parameters": {
+        "location_id": "{context.actorPosition.locationId}",
+        "description_text": "{context.perceptibleLogMessage}",
+        "perception_type": "action_target_general",
+        "actor_id": "{event.payload.actorId}",
+        "target_id": "{event.payload.primaryId}"
+      }
+    },
+    { "macro": "core:displaySuccessAndEndTurn" }
+  ]
+}

--- a/data/mods/distress/scopes/close_actors_facing_each_other_with_torso_clothing.scope
+++ b/data/mods/distress/scopes/close_actors_facing_each_other_with_torso_clothing.scope
@@ -1,0 +1,8 @@
+// Scope for distressed actors in closeness facing each other with upper torso clothing available
+// Mirrors caressing scope but namespaced for distress mod targeting torso_upper garments
+distress:close_actors_facing_each_other_with_torso_clothing := actor.components.positioning:closeness.partners[][{
+  "and": [
+    {"condition_ref": "positioning:both-actors-facing-each-other"},
+    {"hasClothingInSlot": [".", "torso_upper"]}
+  ]
+}]

--- a/tests/common/mods/ModTestFixture.js
+++ b/tests/common/mods/ModTestFixture.js
@@ -7,6 +7,7 @@ import { jest } from '@jest/globals';
 import { createRuleTestEnvironment } from '../engine/systemLogicTestEnv.js';
 import { expandMacros } from '../../../src/utils/macroUtils.js';
 import logSuccessMacro from '../../../data/mods/core/macros/logSuccessAndEndTurn.macro.json';
+import displaySuccessMacro from '../../../data/mods/core/macros/displaySuccessAndEndTurn.macro.json';
 import { ATTEMPT_ACTION_ID } from '../../../src/constants/eventIds.js';
 import { promises as fs } from 'fs';
 import { resolve } from 'path';
@@ -502,7 +503,10 @@ class BaseModTestFixture {
    * @param {string} conditionId - Condition identifier
    */
   setupEnvironment(ruleFile, conditionFile, conditionId) {
-    const macros = { 'core:logSuccessAndEndTurn': logSuccessMacro };
+    const macros = {
+      'core:logSuccessAndEndTurn': logSuccessMacro,
+      'core:displaySuccessAndEndTurn': displaySuccessMacro,
+    };
     const expanded = expandMacros(ruleFile.actions, {
       get: (type, id) => (type === 'macros' ? macros[id] : undefined),
     });
@@ -587,7 +591,6 @@ class BaseModTestFixture {
   get logger() {
     return this.testEnv?.logger;
   }
-
 }
 
 /**
@@ -721,7 +724,11 @@ export class ModActionTestFixture extends BaseModTestFixture {
    * @returns {Promise} Promise that resolves when action is dispatched
    */
   async executeAction(actorId, targetId, options = {}) {
-    const { skipDiscovery = false, originalInput, additionalPayload = {} } = options;
+    const {
+      skipDiscovery = false,
+      originalInput,
+      additionalPayload = {},
+    } = options;
 
     // Ensure actionId is properly namespaced
     const fullActionId = this.actionId.includes(':')
@@ -736,7 +743,8 @@ export class ModActionTestFixture extends BaseModTestFixture {
         actionId: fullActionId,
         targetId,
         originalInput:
-          originalInput || `${this.actionId.split(':')[1] || this.actionId} ${targetId}`,
+          originalInput ||
+          `${this.actionId.split(':')[1] || this.actionId} ${targetId}`,
         ...additionalPayload,
       };
 
@@ -808,7 +816,8 @@ export class ModActionTestFixture extends BaseModTestFixture {
       actionId: fullActionId,
       targetId,
       originalInput:
-        originalInput || `${this.actionId.split(':')[1] || this.actionId} ${targetId}`,
+        originalInput ||
+        `${this.actionId.split(':')[1] || this.actionId} ${targetId}`,
       ...additionalPayload,
     };
 

--- a/tests/integration/mods/distress/clutch_onto_upper_clothing_action.test.js
+++ b/tests/integration/mods/distress/clutch_onto_upper_clothing_action.test.js
@@ -1,0 +1,122 @@
+/**
+ * @file Integration tests for the distress:clutch_onto_upper_clothing rule behavior.
+ * @description Validates the full multi-target pipeline, ensuring perceptible messaging, success text, and turn handling all align.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import { ModEntityScenarios } from '../../../common/mods/ModEntityBuilder.js';
+import { ModAssertionHelpers } from '../../../common/mods/ModAssertionHelpers.js';
+import clutchOntoUpperClothingRule from '../../../../data/mods/distress/rules/clutch_onto_upper_clothing.rule.json';
+import eventIsActionClutchOntoUpperClothing from '../../../../data/mods/distress/conditions/event-is-action-clutch-onto-upper-clothing.condition.json';
+
+const ACTION_ID = 'distress:clutch_onto_upper_clothing';
+
+describe('distress:clutch_onto_upper_clothing rule execution', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction(
+      'distress',
+      ACTION_ID,
+      clutchOntoUpperClothingRule,
+      eventIsActionClutchOntoUpperClothing
+    );
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  it('dispatches matching perceptible and success messages while ending the turn', async () => {
+    const scenario = testFixture.createCloseActors(['Evelyn', 'Marco'], {
+      location: 'sanctuary',
+    });
+
+    const garment = {
+      id: 'garment-distress-1',
+      components: {
+        'core:name': { text: 'wool coat' },
+        'core:position': { locationId: 'sanctuary' },
+      },
+    };
+
+    scenario.target.components['clothing:equipment'] = {
+      equipped: {
+        torso_upper: { base: garment.id },
+      },
+    };
+
+    const room = ModEntityScenarios.createRoom('sanctuary', 'Sanctuary');
+    testFixture.reset([room, scenario.actor, scenario.target, garment]);
+
+    await testFixture.eventBus.dispatch('core:attempt_action', {
+      eventName: 'core:attempt_action',
+      actorId: scenario.actor.id,
+      actionId: ACTION_ID,
+      primaryId: scenario.target.id,
+      secondaryId: garment.id,
+      originalInput: 'clutch clothing',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const expectedMessage =
+      "Evelyn clutches pleadingly onto Marco's wool coat.";
+
+    ModAssertionHelpers.assertActionSuccess(
+      testFixture.events,
+      expectedMessage
+    );
+    ModAssertionHelpers.assertPerceptibleEvent(testFixture.events, {
+      descriptionText: expectedMessage,
+      locationId: 'sanctuary',
+      actorId: scenario.actor.id,
+      targetId: scenario.target.id,
+      perceptionType: 'action_target_general',
+    });
+  });
+
+  it('only triggers for the distress clothing clutch action id', async () => {
+    const scenario = testFixture.createCloseActors(['Nova', 'Quinn']);
+
+    const garment = {
+      id: 'garment-distress-2',
+      components: {
+        'core:name': { text: 'cotton blouse' },
+      },
+    };
+
+    scenario.target.components['clothing:equipment'] = {
+      equipped: {
+        torso_upper: { base: garment.id },
+      },
+    };
+
+    const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+    testFixture.reset([room, scenario.actor, scenario.target, garment]);
+
+    await testFixture.eventBus.dispatch('core:attempt_action', {
+      eventName: 'core:attempt_action',
+      actorId: scenario.actor.id,
+      actionId: 'distress:nonexistent_action',
+      primaryId: scenario.target.id,
+      secondaryId: garment.id,
+      originalInput: 'clutch clothing',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const successEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:display_successful_action_result'
+    );
+    const perceptibleEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:perceptible_event'
+    );
+
+    expect(successEvent).toBeUndefined();
+    expect(perceptibleEvent).toBeUndefined();
+  });
+});

--- a/tests/integration/mods/distress/clutch_onto_upper_clothing_discovery.test.js
+++ b/tests/integration/mods/distress/clutch_onto_upper_clothing_discovery.test.js
@@ -1,0 +1,382 @@
+/**
+ * @file Integration tests for distress:clutch_onto_upper_clothing action discovery.
+ * @description Ensures the pleading clothing clutch action is discoverable only when closeness, facing, and clothing requirements are satisfied.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import { ModEntityScenarios } from '../../../common/mods/ModEntityBuilder.js';
+import clutchOntoUpperClothingAction from '../../../../data/mods/distress/actions/clutch_onto_upper_clothing.action.json';
+import clutchOntoUpperClothingRule from '../../../../data/mods/distress/rules/clutch_onto_upper_clothing.rule.json';
+import eventIsActionClutchOntoUpperClothing from '../../../../data/mods/distress/conditions/event-is-action-clutch-onto-upper-clothing.condition.json';
+
+const ACTION_ID = 'distress:clutch_onto_upper_clothing';
+
+function extractGarmentIdsFromSlot(slot) {
+  if (!slot) {
+    return [];
+  }
+
+  if (typeof slot === 'string') {
+    return [slot];
+  }
+
+  if (Array.isArray(slot)) {
+    return slot.flatMap((entry) => extractGarmentIdsFromSlot(entry));
+  }
+
+  if (typeof slot === 'object') {
+    if (Array.isArray(slot.base)) {
+      return slot.base.flatMap((entry) => extractGarmentIdsFromSlot(entry));
+    }
+
+    if (slot.base) {
+      return extractGarmentIdsFromSlot(slot.base);
+    }
+
+    if (slot.id) {
+      return [slot.id];
+    }
+  }
+
+  return [];
+}
+
+describe('distress:clutch_onto_upper_clothing action discovery', () => {
+  let testFixture;
+  let configureActionDiscovery;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction(
+      'distress',
+      ACTION_ID,
+      clutchOntoUpperClothingRule,
+      eventIsActionClutchOntoUpperClothing
+    );
+
+    configureActionDiscovery = () => {
+      const { testEnv } = testFixture;
+      if (!testEnv) {
+        return;
+      }
+
+      testEnv.actionIndex.buildIndex([clutchOntoUpperClothingAction]);
+
+      const resolver = testEnv.unifiedScopeResolver;
+      if (!resolver) {
+        return;
+      }
+
+      if (!resolver.__distressOriginalResolve) {
+        resolver.__distressOriginalResolve =
+          resolver.resolveSync.bind(resolver);
+      }
+
+      resolver.resolveSync = (scopeName, context) => {
+        const { entityManager } = testEnv;
+        const resolveEntity = (entry) => {
+          if (!entry) {
+            return null;
+          }
+
+          if (typeof entry === 'string') {
+            return entityManager.getEntityInstance(entry);
+          }
+
+          if (entry.id) {
+            return entityManager.getEntityInstance(entry.id);
+          }
+
+          return null;
+        };
+        if (
+          scopeName ===
+          'distress:close_actors_facing_each_other_with_torso_clothing'
+        ) {
+          const actorContext = context?.actor;
+          const actorId = actorContext?.id || actorContext || context;
+          const actorEntity = resolveEntity(actorId);
+
+          if (!actorEntity) {
+            return { success: true, value: new Set() };
+          }
+
+          const closenessPartners =
+            actorEntity.components?.['positioning:closeness']?.partners || [];
+          const actorFacingAway = new Set(
+            actorEntity.components?.['positioning:facing_away']
+              ?.facing_away_from || []
+          );
+
+          const validTargets = new Set();
+
+          for (const partnerId of closenessPartners) {
+            if (actorFacingAway.has(partnerId)) {
+              continue;
+            }
+
+            const partnerEntity = entityManager.getEntityInstance(partnerId);
+            if (!partnerEntity) {
+              continue;
+            }
+
+            const partnerFacingAway = new Set(
+              partnerEntity.components?.['positioning:facing_away']
+                ?.facing_away_from || []
+            );
+            if (partnerFacingAway.has(actorEntity.id || actorId)) {
+              continue;
+            }
+
+            const equipment =
+              partnerEntity.components?.['clothing:equipment']?.equipped || {};
+            const torsoUpper = equipment.torso_upper;
+            const garmentIds = extractGarmentIdsFromSlot(torsoUpper);
+
+            if (garmentIds.length > 0) {
+              validTargets.add(partnerId);
+            }
+          }
+
+          return { success: true, value: validTargets };
+        }
+
+        if (scopeName === 'clothing:target_topmost_torso_upper_clothing') {
+          const targetContext =
+            context?.target || context?.primary || context?.entity || context;
+          const targetEntity = resolveEntity(targetContext);
+
+          if (!targetEntity) {
+            return { success: true, value: new Set() };
+          }
+
+          const equipment =
+            targetEntity.components?.['clothing:equipment']?.equipped || {};
+          const torsoUpper = equipment.torso_upper;
+          const garmentIds = extractGarmentIdsFromSlot(torsoUpper);
+
+          return { success: true, value: new Set(garmentIds) };
+        }
+
+        return resolver.__distressOriginalResolve.call(
+          resolver,
+          scopeName,
+          context
+        );
+      };
+    };
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      const resolver = testFixture.testEnv?.unifiedScopeResolver;
+      if (resolver?.__distressOriginalResolve) {
+        resolver.resolveSync = resolver.__distressOriginalResolve;
+        delete resolver.__distressOriginalResolve;
+      }
+      testFixture.cleanup();
+    }
+  });
+
+  const discoverActionForActor = (actorId) => {
+    const { testEnv } = testFixture;
+    if (!testEnv) {
+      return false;
+    }
+
+    const actorEntity = testEnv.entityManager.getEntityInstance(actorId);
+    if (!actorEntity) {
+      return false;
+    }
+
+    const candidateActions = testEnv.actionIndex.getCandidateActions({
+      id: actorId,
+    });
+    const resolver = testEnv.unifiedScopeResolver;
+
+    return candidateActions.some((action) => {
+      if (action.id !== ACTION_ID) {
+        return false;
+      }
+
+      const baseContext = {
+        actor: { id: actorId, components: actorEntity.components },
+      };
+
+      const primaryResult = resolver.resolveSync(
+        action.targets.primary.scope,
+        baseContext
+      );
+
+      if (!primaryResult.success || primaryResult.value.size === 0) {
+        return false;
+      }
+
+      return Array.from(primaryResult.value).some((primaryId) => {
+        const primaryEntity =
+          testEnv.entityManager.getEntityInstance(primaryId);
+        const secondaryContext = {
+          actor: baseContext.actor,
+          target: primaryEntity
+            ? { id: primaryId, components: primaryEntity.components }
+            : { id: primaryId, components: {} },
+          primary: primaryEntity
+            ? { id: primaryId, components: primaryEntity.components }
+            : { id: primaryId, components: {} },
+        };
+
+        const secondaryResult = resolver.resolveSync(
+          action.targets.secondary.scope,
+          secondaryContext
+        );
+
+        return secondaryResult.success && secondaryResult.value.size > 0;
+      });
+    });
+  };
+
+  describe('Action metadata validation', () => {
+    it('matches the expected distress action schema and template', () => {
+      expect(clutchOntoUpperClothingAction).toBeDefined();
+      expect(clutchOntoUpperClothingAction.id).toBe(ACTION_ID);
+      expect(clutchOntoUpperClothingAction.name).toBe(
+        'Clutch Pleadingly Onto Clothing'
+      );
+      expect(clutchOntoUpperClothingAction.template).toBe(
+        "clutch pleadingly onto {primary}'s {secondary}"
+      );
+      expect(clutchOntoUpperClothingAction.targets.primary.scope).toBe(
+        'distress:close_actors_facing_each_other_with_torso_clothing'
+      );
+      expect(clutchOntoUpperClothingAction.targets.secondary.scope).toBe(
+        'clothing:target_topmost_torso_upper_clothing'
+      );
+    });
+
+    it('requires closeness and uses the Obsidian Frost palette', () => {
+      expect(clutchOntoUpperClothingAction.required_components.actor).toEqual([
+        'positioning:closeness',
+      ]);
+      expect(clutchOntoUpperClothingAction.forbidden_components).toEqual({
+        actor: [],
+        primary: [],
+        secondary: [],
+      });
+      expect(clutchOntoUpperClothingAction.visual).toEqual({
+        backgroundColor: '#0b132b',
+        textColor: '#f2f4f8',
+        hoverBackgroundColor: '#1c2541',
+        hoverTextColor: '#e0e7ff',
+      });
+    });
+  });
+
+  describe('Action discovery scenarios', () => {
+    it('is available when actors are close, facing, and the target has torso clothing', () => {
+      const scenario = testFixture.createCloseActors(['Iris', 'Jonah'], {
+        location: 'atrium',
+      });
+
+      const garment = {
+        id: 'garment1',
+        components: {
+          'core:name': { text: 'wool coat' },
+          'core:position': { locationId: 'atrium' },
+        },
+      };
+
+      scenario.target.components['clothing:equipment'] = {
+        equipped: {
+          torso_upper: { base: garment.id },
+        },
+      };
+
+      const room = ModEntityScenarios.createRoom('atrium', 'Atrium');
+      testFixture.reset([room, scenario.actor, scenario.target, garment]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+      expect(discoverActionForActor(scenario.actor.id)).toBe(true);
+    });
+
+    it('is not available when actors lack closeness', () => {
+      const scenario = testFixture.createCloseActors(['Kara', 'Leon']);
+      delete scenario.actor.components['positioning:closeness'];
+      delete scenario.target.components['positioning:closeness'];
+
+      const garment = {
+        id: 'garment2',
+        components: {
+          'core:name': { text: 'linen shirt' },
+        },
+      };
+
+      scenario.target.components['clothing:equipment'] = {
+        equipped: {
+          torso_upper: { base: garment.id },
+        },
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target, garment]);
+      configureActionDiscovery();
+
+      expect(discoverActionForActor(scenario.actor.id)).toBe(false);
+    });
+
+    it('is not available when actors are facing away from each other', () => {
+      const scenario = testFixture.createCloseActors(['Mira', 'Noah']);
+
+      scenario.actor.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.target.id],
+      };
+
+      const garment = {
+        id: 'garment3',
+        components: {
+          'core:name': { text: 'denim jacket' },
+        },
+      };
+
+      scenario.target.components['clothing:equipment'] = {
+        equipped: {
+          torso_upper: { base: garment.id },
+        },
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target, garment]);
+      configureActionDiscovery();
+
+      expect(discoverActionForActor(scenario.actor.id)).toBe(false);
+    });
+
+    it('is not available when the target lacks torso-upper clothing', () => {
+      const scenario = testFixture.createCloseActors(['Olivia', 'Preston']);
+
+      scenario.target.components['clothing:equipment'] = {
+        equipped: {
+          torso_lower: { base: 'pants1' },
+        },
+      };
+
+      const garment = {
+        id: 'pants1',
+        components: {
+          'core:name': { text: 'casual slacks' },
+        },
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target, garment]);
+      configureActionDiscovery();
+
+      expect(discoverActionForActor(scenario.actor.id)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- Add the distress clutch_onto_upper_clothing multi-target action along with its scope, condition, and rule.
- Register the new distress content in the manifest and load displaySuccessAndEndTurn for tests.
- Cover discovery and execution behaviors with focused integration tests.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Targeted distress tests `npx jest --config jest.config.integration.js --env=jsdom --runTestsByPath tests/integration/mods/distress/clutch_onto_upper_clothing_discovery.test.js tests/integration/mods/distress/clutch_onto_upper_clothing_action.test.js --no-coverage`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68e63517d0948331a62a4ac0ebbe4e2b