### PR TITLE
[Agent] Add place hands on shoulders affection action

### DIFF
--- a/data/mods/affection/actions/place_hands_on_shoulders.action.json
+++ b/data/mods/affection/actions/place_hands_on_shoulders.action.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "schema://living-narrative-engine/action.schema.json",
+  "id": "affection:place_hands_on_shoulders",
+  "name": "Place Hands on Shoulders",
+  "description": "Rest both hands on someone's shoulders in an affectionate gesture",
+  "targets": "affection:close_actors_facing_each_other_or_behind_target",
+  "required_components": {
+    "actor": ["positioning:closeness"]
+  },
+  "forbidden_components": {
+    "actor": []
+  },
+  "template": "place your hands on {target}'s shoulders",
+  "prerequisites": [],
+  "visual": {
+    "backgroundColor": "#6a1b9a",
+    "textColor": "#f3e5f5",
+    "hoverBackgroundColor": "#8e24aa",
+    "hoverTextColor": "#ffffff"
+  }
+}

--- a/data/mods/affection/conditions/event-is-action-place-hands-on-shoulders.condition.json
+++ b/data/mods/affection/conditions/event-is-action-place-hands-on-shoulders.condition.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "schema://living-narrative-engine/condition.schema.json",
+  "id": "affection:event-is-action-place-hands-on-shoulders",
+  "description": "Checks if the triggering event is for the 'affection:place_hands_on_shoulders' action.",
+  "logic": {
+    "==": [{ "var": "event.payload.actionId" }, "affection:place_hands_on_shoulders"]
+  }
+}

--- a/data/mods/affection/mod-manifest.json
+++ b/data/mods/affection/mod-manifest.json
@@ -33,6 +33,7 @@
       "massage_back.action.json",
       "massage_shoulders.action.json",
       "place_hand_on_waist.action.json",
+      "place_hands_on_shoulders.action.json",
       "push_target_playfully.action.json",
       "rest_head_on_shoulder.action.json",
       "ruffle_hair_playfully.action.json",
@@ -56,6 +57,7 @@
       "handle_warm_hands_between_yours.rule.json",
       "massage_back.rule.json",
       "place_hand_on_waist.rule.json",
+      "place_hands_on_shoulders.rule.json",
       "sling_arm_around_shoulders.rule.json",
       "wrap_arm_around_waist.rule.json"
     ],
@@ -67,6 +69,7 @@
       "event-is-action-massage-back.condition.json",
       "event-is-action-massage-shoulders.condition.json",
       "event-is-action-place-hand-on-waist.condition.json",
+      "event-is-action-place-hands-on-shoulders.condition.json",
       "event-is-action-push-target-playfully.condition.json",
       "event-is-action-rest-head-on-shoulder.condition.json",
       "event-is-action-ruffle-hair-playfully.condition.json",

--- a/data/mods/affection/rules/place_hands_on_shoulders.rule.json
+++ b/data/mods/affection/rules/place_hands_on_shoulders.rule.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "schema://living-narrative-engine/rule.schema.json",
+  "rule_id": "handle_place_hands_on_shoulders",
+  "comment": "Handles the 'affection:place_hands_on_shoulders' action. Dispatches descriptive text and ends the turn.",
+  "event_type": "core:attempt_action",
+  "condition": {
+    "condition_ref": "affection:event-is-action-place-hands-on-shoulders"
+  },
+  "actions": [
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "actor", "result_variable": "actorName" }
+    },
+    {
+      "type": "GET_NAME",
+      "parameters": { "entity_ref": "target", "result_variable": "targetName" }
+    },
+    {
+      "type": "QUERY_COMPONENT",
+      "parameters": {
+        "entity_ref": "actor",
+        "component_type": "core:position",
+        "result_variable": "actorPosition"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "logMessage",
+        "value": "{context.actorName} places their hands on {context.targetName}'s shoulders."
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "perceptionType",
+        "value": "action_target_general"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "locationId",
+        "value": "{context.actorPosition.locationId}"
+      }
+    },
+    {
+      "type": "SET_VARIABLE",
+      "parameters": {
+        "variable_name": "targetId",
+        "value": "{event.payload.targetId}"
+      }
+    },
+    { "macro": "core:logSuccessAndEndTurn" }
+  ]
+}

--- a/tests/integration/mods/affection/place_hands_on_shoulders_action.test.js
+++ b/tests/integration/mods/affection/place_hands_on_shoulders_action.test.js
@@ -1,0 +1,119 @@
+/**
+ * @file Integration tests for the affection:place_hands_on_shoulders action and rule.
+ * @description Verifies successful execution, perception metadata, and guard conditions for the shoulders placement action.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import placeHandsOnShouldersRule from '../../../../data/mods/affection/rules/place_hands_on_shoulders.rule.json';
+import eventIsActionPlaceHandsOnShoulders from '../../../../data/mods/affection/conditions/event-is-action-place-hands-on-shoulders.condition.json';
+
+const ACTION_ID = 'affection:place_hands_on_shoulders';
+const EXPECTED_SENTENCE = "{actor} places their hands on {target}'s shoulders.";
+
+describe('affection:place_hands_on_shoulders action integration', () => {
+  let testFixture;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction(
+      'affection',
+      ACTION_ID,
+      placeHandsOnShouldersRule,
+      eventIsActionPlaceHandsOnShoulders
+    );
+  });
+
+  afterEach(() => {
+    testFixture.cleanup();
+  });
+
+  const findSuccessMessage = () =>
+    testFixture.events.find(
+      (event) => event.eventType === 'core:display_successful_action_result'
+    );
+
+  const findPerceptibleEvent = () =>
+    testFixture.events.find(
+      (event) => event.eventType === 'core:perceptible_event'
+    );
+
+  it('produces matching success and perceptible messages with proper metadata', async () => {
+    const scenario = testFixture.createCloseActors(['Alice', 'Bob'], {
+      location: 'sunroom',
+    });
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent).toBeDefined();
+    expect(successEvent.payload.message).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Alice').replace('{target}', 'Bob')
+    );
+
+    testFixture.assertPerceptibleEvent({
+      descriptionText: EXPECTED_SENTENCE.replace('{actor}', 'Alice').replace(
+        '{target}',
+        'Bob'
+      ),
+      locationId: 'sunroom',
+      perceptionType: 'action_target_general',
+      actorId: scenario.actor.id,
+      targetId: scenario.target.id,
+    });
+
+    const turnEndedEvent = testFixture.events.find(
+      (event) => event.eventType === 'core:turn_ended'
+    );
+    expect(turnEndedEvent).toBeDefined();
+    expect(turnEndedEvent.payload.entityId).toBe(scenario.actor.id);
+    expect(turnEndedEvent.payload.success).toBe(true);
+  });
+
+  it('formats messages correctly with different names', async () => {
+    const scenario = testFixture.createCloseActors(
+      ['Serena', 'Miguel'],
+      {
+        location: 'balcony',
+      }
+    );
+
+    await testFixture.executeAction(scenario.actor.id, scenario.target.id);
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent.payload.message).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Serena').replace(
+        '{target}',
+        'Miguel'
+      )
+    );
+
+    const perceptibleEvent = findPerceptibleEvent();
+    expect(perceptibleEvent.payload.descriptionText).toBe(
+      EXPECTED_SENTENCE.replace('{actor}', 'Serena').replace('{target}', 'Miguel')
+    );
+  });
+
+  it('does not fire when a different action is attempted', async () => {
+    const scenario = testFixture.createCloseActors(['Tina', 'Ravi'], {
+      location: 'lounge',
+    });
+
+    await testFixture.eventBus.dispatch('core:attempt_action', {
+      eventName: 'core:attempt_action',
+      actorId: scenario.actor.id,
+      actionId: 'affection:place_hand_on_waist',
+      targetId: scenario.target.id,
+      originalInput: 'place_hand_on_waist target',
+    });
+
+    const successEvent = findSuccessMessage();
+    expect(successEvent).toBeUndefined();
+
+    const perceptibleEvent = findPerceptibleEvent();
+    if (perceptibleEvent) {
+      expect(perceptibleEvent.payload.descriptionText).not.toBe(
+        EXPECTED_SENTENCE.replace('{actor}', 'Tina').replace('{target}', 'Ravi')
+      );
+    }
+  });
+});

--- a/tests/integration/mods/affection/place_hands_on_shoulders_action_discovery.test.js
+++ b/tests/integration/mods/affection/place_hands_on_shoulders_action_discovery.test.js
@@ -1,0 +1,190 @@
+/**
+ * @file Integration tests for affection:place_hands_on_shoulders action discovery.
+ * @description Ensures the shoulders placement action is discoverable only when requirements are met.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { ModTestFixture } from '../../../common/mods/ModTestFixture.js';
+import { ModEntityScenarios } from '../../../common/mods/ModEntityBuilder.js';
+import placeHandsOnShouldersAction from '../../../../data/mods/affection/actions/place_hands_on_shoulders.action.json';
+
+const ACTION_ID = 'affection:place_hands_on_shoulders';
+
+describe('affection:place_hands_on_shoulders action discovery', () => {
+  let testFixture;
+  let configureActionDiscovery;
+
+  beforeEach(async () => {
+    testFixture = await ModTestFixture.forAction('affection', ACTION_ID);
+
+    configureActionDiscovery = () => {
+      const { testEnv } = testFixture;
+      if (!testEnv) {
+        return;
+      }
+
+      testEnv.actionIndex.buildIndex([placeHandsOnShouldersAction]);
+
+      const scopeResolver = testEnv.unifiedScopeResolver;
+      const originalResolve =
+        scopeResolver.__placeHandsOnShouldersOriginalResolve ||
+        scopeResolver.resolveSync.bind(scopeResolver);
+
+      scopeResolver.__placeHandsOnShouldersOriginalResolve = originalResolve;
+      scopeResolver.resolveSync = (scopeName, context) => {
+        if (
+          scopeName ===
+          'affection:close_actors_facing_each_other_or_behind_target'
+        ) {
+          const actorId = context?.actor?.id;
+          if (!actorId) {
+            return { success: true, value: new Set() };
+          }
+
+          const { entityManager } = testEnv;
+          const actorEntity = entityManager.getEntityInstance(actorId);
+          if (!actorEntity) {
+            return { success: true, value: new Set() };
+          }
+
+          const closeness =
+            actorEntity.components?.['positioning:closeness']?.partners;
+          if (!Array.isArray(closeness) || closeness.length === 0) {
+            return { success: true, value: new Set() };
+          }
+
+          const actorFacingAway =
+            actorEntity.components?.['positioning:facing_away']
+              ?.facing_away_from || [];
+
+          const validTargets = closeness.reduce((acc, partnerId) => {
+            const partner = entityManager.getEntityInstance(partnerId);
+            if (!partner) {
+              return acc;
+            }
+
+            const partnerFacingAway =
+              partner.components?.['positioning:facing_away']
+                ?.facing_away_from || [];
+            const facingEachOther =
+              !actorFacingAway.includes(partnerId) &&
+              !partnerFacingAway.includes(actorId);
+            const actorBehind = partnerFacingAway.includes(actorId);
+
+            if (facingEachOther || actorBehind) {
+              acc.add(partnerId);
+            }
+
+            return acc;
+          }, new Set());
+
+          return { success: true, value: validTargets };
+        }
+
+        return originalResolve(scopeName, context);
+      };
+    };
+  });
+
+  afterEach(() => {
+    if (testFixture) {
+      testFixture.cleanup();
+    }
+  });
+
+  describe('Action structure validation', () => {
+    it('matches the expected affection action schema', () => {
+      expect(placeHandsOnShouldersAction).toBeDefined();
+      expect(placeHandsOnShouldersAction.id).toBe(ACTION_ID);
+      expect(placeHandsOnShouldersAction.name).toBe(
+        'Place Hands on Shoulders'
+      );
+      expect(placeHandsOnShouldersAction.template).toBe(
+        "place your hands on {target}'s shoulders"
+      );
+      expect(placeHandsOnShouldersAction.targets).toBe(
+        'affection:close_actors_facing_each_other_or_behind_target'
+      );
+    });
+
+    it('requires actor closeness, no forbidden components, and uses the affection color palette', () => {
+      expect(placeHandsOnShouldersAction.required_components.actor).toEqual([
+        'positioning:closeness',
+      ]);
+      expect(placeHandsOnShouldersAction.forbidden_components.actor).toEqual([]);
+      expect(placeHandsOnShouldersAction.visual).toEqual({
+        backgroundColor: '#6a1b9a',
+        textColor: '#f3e5f5',
+        hoverBackgroundColor: '#8e24aa',
+        hoverTextColor: '#ffffff',
+      });
+    });
+  });
+
+  describe('Action discovery scenarios', () => {
+    it('is available for close actors facing each other', () => {
+      const scenario = testFixture.createCloseActors(['Alice', 'Bob']);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is available when the actor stands behind the target', () => {
+      const scenario = testFixture.createCloseActors(['Maya', 'Noah']);
+      scenario.target.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.actor.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).toContain(ACTION_ID);
+    });
+
+    it('is not available when actors are not in closeness', () => {
+      const scenario = testFixture.createCloseActors(['Ivy', 'Liam']);
+      delete scenario.actor.components['positioning:closeness'];
+      delete scenario.target.components['positioning:closeness'];
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+
+    it('is not available when the actor faces away from the target', () => {
+      const scenario = testFixture.createCloseActors(['Chloe', 'Evan']);
+      scenario.actor.components['positioning:facing_away'] = {
+        facing_away_from: [scenario.target.id],
+      };
+
+      const room = ModEntityScenarios.createRoom('room1', 'Test Room');
+      testFixture.reset([room, scenario.actor, scenario.target]);
+      configureActionDiscovery();
+
+      const availableActions = testFixture.testEnv.getAvailableActions(
+        scenario.actor.id
+      );
+      const ids = availableActions.map((action) => action.id);
+
+      expect(ids).not.toContain(ACTION_ID);
+    });
+  });
+});


### PR DESCRIPTION
Summary: add the affection place_hands_on_shoulders action with matching condition, rule, and integration coverage.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [ ] Root tests         `npm run test`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`
- [x] Targeted integration tests `npx jest --config jest.config.integration.js --runInBand tests/integration/mods/affection/place_hands_on_shoulders_action.test.js`
- [x] Targeted integration tests `npx jest --config jest.config.integration.js --runInBand tests/integration/mods/affection/place_hands_on_shoulders_action_discovery.test.js`
- [x] Targeted integration tests `npx jest --config jest.config.integration.js --runInBand tests/integration/anatomy/anatomyInitializationService.realModules.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e64221d73c8331b15351fc13f3b150