### PR TITLE
[Agent] Add parser error snippet tests

### DIFF
--- a/tests/unit/scopeDsl/parser/errorSnippet.test.js
+++ b/tests/unit/scopeDsl/parser/errorSnippet.test.js
@@ -1,0 +1,35 @@
+import generateErrorSnippet, {
+  generateErrorSnippet as namedGenerateErrorSnippet,
+} from '../../../../src/scopeDsl/parser/errorSnippet.js';
+
+describe('generateErrorSnippet', () => {
+  it('returns snippet with caret at provided column for existing line', () => {
+    const source = ['const a = 1;', 'const b = 2;'].join('\n');
+    const snippet = generateErrorSnippet(source, 2, 8);
+    expect(snippet).toBe('const b = 2;\n       ^');
+  });
+
+  it('handles column at beginning of line', () => {
+    const snippet = generateErrorSnippet('return value;', 1, 1);
+    expect(snippet).toBe('return value;\n^');
+  });
+
+  it('pads caret when column exceeds line length', () => {
+    const snippet = generateErrorSnippet('short', 1, 10);
+    expect(snippet).toBe('short\n         ^');
+  });
+
+  it('falls back to empty line content when line is out of range', () => {
+    const snippet = generateErrorSnippet('first line\nsecond line', 5, 3);
+    expect(snippet).toBe('\n  ^');
+  });
+
+  it('supports empty source strings', () => {
+    const snippet = generateErrorSnippet('', 1, 1);
+    expect(snippet).toBe('\n^');
+  });
+
+  it('exports the same function as default and named export', () => {
+    expect(namedGenerateErrorSnippet).toBe(generateErrorSnippet);
+  });
+});


### PR DESCRIPTION
Summary:
- add unit coverage for the parser error snippet helper, covering caret positioning and export wiring

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npx jest tests/unit/scopeDsl/parser/errorSnippet.test.js --config jest.config.unit.js --env=jsdom --runInBand --collectCoverageFrom='src/scopeDsl/parser/errorSnippet.js' --coverage`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e6441728088331a0e1b445c51c1e8e