### PR TITLE
[Agent] Align anatomy cheek entity ID with filename

### DIFF
--- a/data/mods/anatomy/entities/definitions/human_ass_cheek_firm_athletic_shelf.entity.json
+++ b/data/mods/anatomy/entities/definitions/human_ass_cheek_firm_athletic_shelf.entity.json
@@ -1,6 +1,6 @@
 {
     "$schema": "schema://living-narrative-engine/entity-definition.schema.json",
-    "id": "anatomy:human_ass_cheek_athletic_muscular_shelf",
+  "id": "anatomy:human_ass_cheek_firm_athletic_shelf",
     "description": "A human ass cheek that is athletic, muscular, and shelf",
     "components": {
         "anatomy:part": {


### PR DESCRIPTION
Summary: Fix the human ass cheek athletic shelf entity ID so it matches its filename for consistency with the anatomy entity tests.

Testing Done:
- [ ] Code formatted     `npm run format`
- [ ] Lint passes        `npm run lint`
- [x] Root tests         `npm run test:unit -- --runTestsByPath tests/unit/anatomy/anatomyEntityConsistency.test.js --runInBand`
- [ ] Proxy tests        `cd llm-proxy-server && npm run test`
- [ ] Manual smoke run   `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68e643f06a1083319633863380142d9b